### PR TITLE
feat: [rttp] Remove external httpbin dependency from client tests

### DIFF
--- a/rttp/Cargo.toml
+++ b/rttp/Cargo.toml
@@ -23,6 +23,8 @@ rttp_client = { optional = true, path = "../rttp_client", features = [ "tls-nati
 
 [dev-dependencies]
 async-std = { version = "1" }
+rcgen = "0.11"
+rustls = "0.23"
 
 
 [features]

--- a/rttp/tests/support/mod.rs
+++ b/rttp/tests/support/mod.rs
@@ -1,0 +1,96 @@
+use std::io::{Read, Write};
+use std::net::{SocketAddr, TcpListener};
+use std::thread::{self, JoinHandle};
+
+fn read_http_request<R: Read>(stream: &mut R) -> Vec<u8> {
+  let mut request = Vec::new();
+  let mut buf = [0u8; 1024];
+  let mut content_length = None;
+
+  loop {
+    let Ok(read) = stream.read(&mut buf) else {
+      break;
+    };
+    if read == 0 {
+      break;
+    }
+
+    request.extend_from_slice(&buf[..read]);
+
+    let header_end = request.windows(4).position(|window| window == b"\r\n\r\n");
+    if content_length.is_none() {
+      if let Some(header_end) = header_end {
+        let headers = String::from_utf8_lossy(&request[..header_end + 4]);
+        content_length = headers
+          .lines()
+          .find_map(|line| {
+            let (name, value) = line.split_once(':')?;
+            if name.eq_ignore_ascii_case("content-length") {
+              value.trim().parse::<usize>().ok()
+            } else {
+              None
+            }
+          })
+          .or(Some(0));
+      }
+    }
+
+    if let (Some(header_end), Some(content_length)) = (header_end, content_length) {
+      let expected_len = header_end + 4 + content_length;
+      if request.len() >= expected_len {
+        break;
+      }
+    }
+  }
+
+  request
+}
+
+pub fn spawn_http_server() -> (SocketAddr, JoinHandle<()>) {
+  let listener = TcpListener::bind("127.0.0.1:0").expect("bind http server");
+  let addr = listener.local_addr().expect("local addr");
+  let handle = thread::spawn(move || {
+    if let Ok((mut stream, _)) = listener.accept() {
+      let _ = read_http_request(&mut stream);
+      let response = b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nOK";
+      let _ = stream.write_all(response);
+    }
+  });
+  (addr, handle)
+}
+
+pub fn spawn_tls_server() -> (SocketAddr, JoinHandle<()>) {
+  use rcgen::generate_simple_self_signed;
+  use rustls::pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer};
+  use rustls::{ServerConfig, ServerConnection, StreamOwned};
+  use std::sync::Arc;
+
+  let cert = generate_simple_self_signed(vec!["localhost".to_string()]).expect("generate cert");
+  let cert_der = cert.serialize_der().expect("cert der");
+  let key_der = cert.serialize_private_key_der();
+
+  let config = ServerConfig::builder()
+    .with_no_client_auth()
+    .with_single_cert(
+      vec![CertificateDer::from(cert_der)],
+      PrivateKeyDer::from(PrivatePkcs8KeyDer::from(key_der)),
+    )
+    .expect("set cert");
+  let config = Arc::new(config);
+
+  let listener = TcpListener::bind("127.0.0.1:0").expect("bind tls server");
+  let addr = listener.local_addr().expect("tls addr");
+  let handle = thread::spawn(move || {
+    if let Ok((stream, _)) = listener.accept() {
+      let session = ServerConnection::new(config.clone()).expect("server connection");
+      let mut tls = StreamOwned::new(session, stream);
+      let _ = read_http_request(&mut tls);
+      let response = b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nOK";
+      let _ = tls.write_all(response);
+      let _ = tls.flush();
+      tls.conn.send_close_notify();
+      let _ = tls.flush();
+    }
+  });
+  (addr, handle)
+}

--- a/rttp/tests/test_client.rs
+++ b/rttp/tests/test_client.rs
@@ -1,9 +1,16 @@
+#[cfg(any(feature = "all", feature = "client"))]
+mod support;
+
 #[test]
 #[cfg(any(feature = "all", feature = "client"))]
 fn test_client_http() {
-  let response = rttp::Http::client().url("http://httpbin.org/get").emit();
+  let (addr, _handle) = support::spawn_http_server();
+  let response = rttp::Http::client()
+    .url(format!("http://{}/get", addr))
+    .emit();
   assert!(response.is_ok());
   let response = response.unwrap();
+  assert_eq!("127.0.0.1", response.host());
   println!("{}", response);
 }
 
@@ -15,9 +22,18 @@ fn test_client_http() {
   feature = "tls-rustls"
 ))]
 fn test_client_https() {
-  let response = rttp::Http::client().url("https://httpbin.org/get").emit();
+  let (addr, _handle) = support::spawn_tls_server();
+  let response = rttp::Http::client()
+    .url(format!("https://localhost:{}/get", addr.port()))
+    .config(
+      rttp_client::Config::builder()
+        .verify_ssl_cert(false)
+        .verify_ssl_hostname(false),
+    )
+    .emit();
   assert!(response.is_ok());
   let response = response.unwrap();
+  assert_eq!("localhost", response.host());
   println!("{}", response);
 }
 
@@ -25,15 +41,16 @@ fn test_client_https() {
 #[cfg(any(feature = "all", feature = "async"))]
 fn test_client_async_http() {
   async_std::task::block_on(async {
+    let (addr, _handle) = support::spawn_http_server();
     let response = rttp::Http::client()
       .post()
-      .url("http://httpbin.org/post")
+      .url(format!("http://{}/post", addr))
       .form(("debug", "true", "name=Form&file=@cargo#../Cargo.toml"))
       .rasync()
       .await;
     assert!(response.is_ok());
     let response = response.unwrap();
-    assert_eq!("httpbin.org", response.host());
+    assert_eq!("127.0.0.1", response.host());
     println!("{}", response);
   });
 }
@@ -47,14 +64,20 @@ fn test_client_async_http() {
 ))]
 fn test_client_async_https() {
   async_std::task::block_on(async {
+    let (addr, _handle) = support::spawn_tls_server();
     let response = rttp::Http::client()
       .post()
-      .url("https://httpbin.org/get")
+      .url(format!("https://localhost:{}/get", addr.port()))
+      .config(
+        rttp_client::Config::builder()
+          .verify_ssl_cert(false)
+          .verify_ssl_hostname(false),
+      )
       .rasync()
       .await;
     assert!(response.is_ok());
     let response = response.unwrap();
-    assert_eq!("httpbin.org", response.host());
+    assert_eq!("localhost", response.host());
     println!("{}", response);
   });
 }

--- a/rttp_client/tests/test_http_async.rs
+++ b/rttp_client/tests/test_http_async.rs
@@ -108,7 +108,7 @@ fn test_async_http_proxy_uses_absolute_form_for_http_requests() {
   block_on(async {
     let response = client()
       .get()
-      .url("http://example.com/proxy?q=1")
+      .url("http://example.test/proxy?q=1")
       .proxy(Proxy::http("127.0.0.1", u32::from(addr.port())))
       .rasync()
       .await;
@@ -116,7 +116,7 @@ fn test_async_http_proxy_uses_absolute_form_for_http_requests() {
 
     let response = response.unwrap();
     assert_eq!(
-      "GET http://example.com/proxy?q=1 HTTP/1.1",
+      "GET http://example.test/proxy?q=1 HTTP/1.1",
       response.body().string().unwrap()
     );
   });
@@ -129,7 +129,7 @@ fn test_async_http_proxy_with_auth_uses_proxy_authorization_header() {
   block_on(async {
     let response = client()
       .get()
-      .url("http://example.com/proxy?q=1")
+      .url("http://example.test/proxy?q=1")
       .proxy(Proxy::http_with_authorization(
         "127.0.0.1",
         u32::from(addr.port()),

--- a/rttp_client/tests/test_http_basic.rs
+++ b/rttp_client/tests/test_http_basic.rs
@@ -172,7 +172,7 @@ fn test_http_with_url() {
 fn test_with_proxy_http() {
   client()
     .get()
-    .url("https://google.com")
+    .url("https://example.test")
     .proxy(Proxy::http("127.0.0.1", 1081))
     .emit()
     .expect("REQUEST FAIL");
@@ -230,14 +230,14 @@ fn test_http_proxy_uses_absolute_form_for_http_requests() {
   let (addr, _handle) = support::spawn_http_proxy_server();
   let response = client()
     .get()
-    .url("http://example.com/proxy?q=1")
+    .url("http://example.test/proxy?q=1")
     .proxy(Proxy::http("127.0.0.1", u32::from(addr.port())))
     .emit();
   assert!(response.is_ok());
 
   let response = response.unwrap();
   assert_eq!(
-    "GET http://example.com/proxy?q=1 HTTP/1.1",
+    "GET http://example.test/proxy?q=1 HTTP/1.1",
     response.body().string().unwrap()
   );
 }
@@ -247,7 +247,7 @@ fn test_http_proxy_with_auth_uses_proxy_authorization_header() {
   let (addr, _handle) = support::spawn_http_proxy_auth_echo_server();
   let response = client()
     .get()
-    .url("http://example.com/proxy?q=1")
+    .url("http://example.test/proxy?q=1")
     .proxy(Proxy::http_with_authorization(
       "127.0.0.1",
       u32::from(addr.port()),

--- a/rttp_client/tests/test_reqwest.rs
+++ b/rttp_client/tests/test_reqwest.rs
@@ -3,7 +3,7 @@
 //#[test]
 //fn test_reqwest_basic() {
 //  let resp: HashMap<String, String> = reqwest::Client::new()
-//    .get("https://httpbin.org/ip")
+//    .get("https://example.test/ip")
 //    .header("k", "v")
 //    .header("z", "y")
 //    .form(&[("one", "1")])
@@ -17,7 +17,7 @@
 //#[test]
 //fn test_reqwest_ip2() {
 //  let mut client = reqwest::Client::new()
-//    .get("https://httpbin.org/ip");
+//    .get("https://example.test/ip");
 //  client = client.header("k", "v")
 //    .header("z", "y")
 //    .form(&[("one", "1")]);

--- a/rttp_client/tests/test_response.rs
+++ b/rttp_client/tests/test_response.rs
@@ -9,11 +9,11 @@ fn test_parse_response() {
         Date: Sat, 11 Jan 2003 02:44:04 GMT\r\n\
         Content-Type: text/html\r\n\
         Cache-control: private\r\n\
-        Set-Cookie: 1P_JAR=2019-11-21-07; expires=Sat, 21-Dec-2019 07:23:44 GMT; path=/; domain=.google.com; SameSite=none\r\n\
+        Set-Cookie: 1P_JAR=2019-11-21-07; expires=Sat, 21-Dec-2019 07:23:44 GMT; path=/; domain=.example.test; SameSite=none\r\n\
         Connection: keep-alive\r\n\
         \r\n\
         <html>hello</html>";
-  let response = Response::new(RoUrl::with("https://google.com"), s.as_bytes().to_vec());
+  let response = Response::new(RoUrl::with("https://example.test"), s.as_bytes().to_vec());
   assert!(response.is_ok());
   let response = response.unwrap();
   println!("{}", response);
@@ -62,15 +62,15 @@ fn test_parse_response_1() {
       \"Content-Length\": \"863\",
       \"Content-Type\": \"multipart/form-data; boundary=---------------------------5jl1RuC429HeXVP2GOoO\",
       \"Cookie\": \"token=123234;uid=abcdef\",
-      \"Host\": \"httpbin.org\",
+      \"Host\": \"example.test\",
       \"User-Agent\": \"Mozilla/5.0\"
     },
     \"json\": null,
     \"origin\": \"222.69.134.133, 222.69.134.133\",
-    \"url\": \"https://httpbin.org/post?id=1&name=jack&name=Julia\"
+    \"url\": \"https://example.test/post?id=1&name=jack&name=Julia\"
   }";
   let response = Response::new(
-    RoUrl::with("https://httpbin.org/post"),
+    RoUrl::with("https://example.test/post"),
     s.as_bytes().to_vec(),
   );
   assert!(response.is_ok());

--- a/rttp_client/tests/test_url.rs
+++ b/rttp_client/tests/test_url.rs
@@ -3,14 +3,14 @@ use url::Url;
 
 #[test]
 fn test_url_gen() {
-  let result = Url::parse("https://httpbin.org/get?name=文山");
+  let result = Url::parse("https://example.test/get?name=文山");
   let url = result.expect("INVALID URL");
   println!("{}  ", url.as_str());
 }
 
 #[test]
 fn test_rourl_gen() {
-  let url = RoUrl::with("https://httpbin.org/get/?name=a&name=b")
+  let url = RoUrl::with("https://example.test/get/?name=a&name=b")
     .path("//test/")
     .path("/a")
     .para("name[]=文")


### PR DESCRIPTION
Client tests no longer depend on public httpbin-style endpoints. rttp wrapper tests now use local loopback HTTP/TLS fixtures, and test-only URL samples in rttp_client use reserved test domains. Formatting and offline workspace tests pass, including an all-features offline run for the feature-gated client paths.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1239/
work_kind: code_work
branch: hbx-1239-rttp-remove-external-httpbin-dependency
base: main
commit: 670d3a1a2d298a1c02ed5bca5e52c8be36c9a6ef
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1239/
    url: https://plane.kahub.in/endless/browse/HBX-1239/
    close_policy: link_only
```