### PR TITLE
feat: [rttp] Add HTTP server request/response model tests before expanding features

### DIFF
--- a/rttp/src/lib.rs
+++ b/rttp/src/lib.rs
@@ -1,5 +1,7 @@
 pub struct Http {}
 
+pub mod server;
+
 impl Http {
   #[cfg(feature = "client")]
   pub fn client() -> rttp_client::HttpClient {

--- a/rttp/src/server.rs
+++ b/rttp/src/server.rs
@@ -19,7 +19,7 @@ impl HttpRequest {
       .ok_or_else(|| HttpParseError::new("request is missing header terminator"))?;
     let head = std::str::from_utf8(&raw[..header_end])
       .map_err(|_| HttpParseError::new("request headers are not valid UTF-8"))?;
-    let body = raw[(header_end + 4)..].to_vec();
+    let body_bytes = &raw[(header_end + 4)..];
 
     let mut lines = head.split("\r\n");
     let request_line = lines
@@ -52,6 +52,35 @@ impl HttpRequest {
         .ok_or_else(|| HttpParseError::new("header line is missing ':'"))?;
       headers.push(HttpHeader::new(name.trim(), value.trim()));
     }
+
+    let body = match headers
+      .iter()
+      .find(|header| header.name.eq_ignore_ascii_case("Content-Length"))
+    {
+      Some(header) => {
+        let content_length = header
+          .value
+          .parse::<usize>()
+          .map_err(|_| HttpParseError::new("Content-Length is not a valid length"))?;
+        if body_bytes.len() != content_length {
+          return Err(HttpParseError::new(
+            "request body length does not match Content-Length",
+          ));
+        }
+        body_bytes.to_vec()
+      }
+      None => {
+        if headers
+          .iter()
+          .any(|header| header.name.eq_ignore_ascii_case("Transfer-Encoding"))
+        {
+          return Err(HttpParseError::new(
+            "Transfer-Encoding request bodies are not supported",
+          ));
+        }
+        body_bytes.to_vec()
+      }
+    };
 
     Ok(Self {
       method: method.to_string(),
@@ -117,6 +146,10 @@ impl HttpResponse {
   }
 
   pub fn header<N: AsRef<str>, V: AsRef<str>>(mut self, name: N, value: V) -> Self {
+    let name = name.as_ref();
+    let value = value.as_ref();
+    assert_valid_header_component(name);
+    assert_valid_header_component(value);
     self.headers.push(HttpHeader::new(name, value));
     self
   }
@@ -138,9 +171,14 @@ impl HttpResponse {
       }
     }
 
-    bytes.extend_from_slice(format!("Content-Length: {}\r\n", self.body.len()).as_bytes());
+    let allows_body = response_status_allows_body(self.status_code);
+    if allows_body {
+      bytes.extend_from_slice(format!("Content-Length: {}\r\n", self.body.len()).as_bytes());
+    }
     bytes.extend_from_slice(b"\r\n");
-    bytes.extend_from_slice(&self.body);
+    if allows_body {
+      bytes.extend_from_slice(&self.body);
+    }
     bytes
   }
 }
@@ -188,3 +226,14 @@ impl fmt::Display for HttpParseError {
 }
 
 impl Error for HttpParseError {}
+
+fn assert_valid_header_component(component: &str) {
+  assert!(
+    !component.contains('\r') && !component.contains('\n'),
+    "response headers must not contain CR or LF"
+  );
+}
+
+fn response_status_allows_body(status_code: u16) -> bool {
+  !(status_code / 100 == 1 || status_code == 204 || status_code == 304)
+}

--- a/rttp/src/server.rs
+++ b/rttp/src/server.rs
@@ -1,0 +1,190 @@
+use std::error::Error;
+use std::fmt;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct HttpRequest {
+  method: String,
+  path: String,
+  query: Option<String>,
+  version: String,
+  headers: Vec<HttpHeader>,
+  body: Vec<u8>,
+}
+
+impl HttpRequest {
+  pub fn parse(raw: &[u8]) -> Result<Self, HttpParseError> {
+    let header_end = raw
+      .windows(4)
+      .position(|window| window == b"\r\n\r\n")
+      .ok_or_else(|| HttpParseError::new("request is missing header terminator"))?;
+    let head = std::str::from_utf8(&raw[..header_end])
+      .map_err(|_| HttpParseError::new("request headers are not valid UTF-8"))?;
+    let body = raw[(header_end + 4)..].to_vec();
+
+    let mut lines = head.split("\r\n");
+    let request_line = lines
+      .next()
+      .ok_or_else(|| HttpParseError::new("request line is missing"))?;
+    let mut request_parts = request_line.split_whitespace();
+    let method = request_parts
+      .next()
+      .ok_or_else(|| HttpParseError::new("request method is missing"))?;
+    let target = request_parts
+      .next()
+      .ok_or_else(|| HttpParseError::new("request target is missing"))?;
+    let version = request_parts
+      .next()
+      .ok_or_else(|| HttpParseError::new("request version is missing"))?;
+
+    if request_parts.next().is_some() {
+      return Err(HttpParseError::new("request line has too many parts"));
+    }
+
+    let (path, query) = match target.split_once('?') {
+      Some((path, query)) => (path.to_string(), Some(query.to_string())),
+      None => (target.to_string(), None),
+    };
+
+    let mut headers = Vec::new();
+    for line in lines {
+      let (name, value) = line
+        .split_once(':')
+        .ok_or_else(|| HttpParseError::new("header line is missing ':'"))?;
+      headers.push(HttpHeader::new(name.trim(), value.trim()));
+    }
+
+    Ok(Self {
+      method: method.to_string(),
+      path,
+      query,
+      version: version.to_string(),
+      headers,
+      body,
+    })
+  }
+
+  pub fn method(&self) -> &str {
+    &self.method
+  }
+
+  pub fn path(&self) -> &str {
+    &self.path
+  }
+
+  pub fn query(&self) -> Option<&str> {
+    self.query.as_deref()
+  }
+
+  pub fn version(&self) -> &str {
+    &self.version
+  }
+
+  pub fn headers(&self) -> &[HttpHeader] {
+    &self.headers
+  }
+
+  pub fn header<S: AsRef<str>>(&self, name: S) -> Option<&str> {
+    self
+      .headers
+      .iter()
+      .find(|header| header.name.eq_ignore_ascii_case(name.as_ref()))
+      .map(|header| header.value.as_str())
+  }
+
+  pub fn body(&self) -> &[u8] {
+    &self.body
+  }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct HttpResponse {
+  version: String,
+  status_code: u16,
+  reason: String,
+  headers: Vec<HttpHeader>,
+  body: Vec<u8>,
+}
+
+impl HttpResponse {
+  pub fn new<S: AsRef<str>>(status_code: u16, reason: S) -> Self {
+    Self {
+      version: "HTTP/1.1".to_string(),
+      status_code,
+      reason: reason.as_ref().to_string(),
+      headers: Vec::new(),
+      body: Vec::new(),
+    }
+  }
+
+  pub fn header<N: AsRef<str>, V: AsRef<str>>(mut self, name: N, value: V) -> Self {
+    self.headers.push(HttpHeader::new(name, value));
+    self
+  }
+
+  pub fn body<B: AsRef<[u8]>>(mut self, body: B) -> Self {
+    self.body = body.as_ref().to_vec();
+    self
+  }
+
+  pub fn to_bytes(&self) -> Vec<u8> {
+    let mut bytes = Vec::new();
+    bytes.extend_from_slice(
+      format!("{} {} {}\r\n", self.version, self.status_code, self.reason).as_bytes(),
+    );
+
+    for header in &self.headers {
+      if !header.name.eq_ignore_ascii_case("Content-Length") {
+        bytes.extend_from_slice(format!("{}: {}\r\n", header.name, header.value).as_bytes());
+      }
+    }
+
+    bytes.extend_from_slice(format!("Content-Length: {}\r\n", self.body.len()).as_bytes());
+    bytes.extend_from_slice(b"\r\n");
+    bytes.extend_from_slice(&self.body);
+    bytes
+  }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct HttpHeader {
+  name: String,
+  value: String,
+}
+
+impl HttpHeader {
+  pub fn new<N: AsRef<str>, V: AsRef<str>>(name: N, value: V) -> Self {
+    Self {
+      name: name.as_ref().to_string(),
+      value: value.as_ref().to_string(),
+    }
+  }
+
+  pub fn name(&self) -> &str {
+    &self.name
+  }
+
+  pub fn value(&self) -> &str {
+    &self.value
+  }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct HttpParseError {
+  message: String,
+}
+
+impl HttpParseError {
+  fn new<S: AsRef<str>>(message: S) -> Self {
+    Self {
+      message: message.as_ref().to_string(),
+    }
+  }
+}
+
+impl fmt::Display for HttpParseError {
+  fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+    formatter.write_str(&self.message)
+  }
+}
+
+impl Error for HttpParseError {}

--- a/rttp/src/server.rs
+++ b/rttp/src/server.rs
@@ -53,6 +53,15 @@ impl HttpRequest {
       headers.push(HttpHeader::new(name.trim(), value.trim()));
     }
 
+    if headers
+      .iter()
+      .any(|header| header.name.eq_ignore_ascii_case("Transfer-Encoding"))
+    {
+      return Err(HttpParseError::new(
+        "Transfer-Encoding request bodies are not supported",
+      ));
+    }
+
     let body = match headers
       .iter()
       .find(|header| header.name.eq_ignore_ascii_case("Content-Length"))
@@ -69,17 +78,7 @@ impl HttpRequest {
         }
         body_bytes.to_vec()
       }
-      None => {
-        if headers
-          .iter()
-          .any(|header| header.name.eq_ignore_ascii_case("Transfer-Encoding"))
-        {
-          return Err(HttpParseError::new(
-            "Transfer-Encoding request bodies are not supported",
-          ));
-        }
-        body_bytes.to_vec()
-      }
+      None => body_bytes.to_vec(),
     };
 
     Ok(Self {

--- a/rttp/tests/test_server_models.rs
+++ b/rttp/tests/test_server_models.rs
@@ -1,0 +1,78 @@
+use rttp::server::{HttpRequest, HttpResponse};
+
+#[test]
+fn parses_http_request_target_headers_and_body() {
+  let raw = concat!(
+    "POST /submit?name=Rttp&debug=true HTTP/1.1\r\n",
+    "Host: example.test\r\n",
+    "Content-Type: text/plain\r\n",
+    "X-Trace-Id: abc-123\r\n",
+    "\r\n",
+    "hello=world"
+  );
+
+  let request = HttpRequest::parse(raw.as_bytes()).expect("request should parse");
+
+  assert_eq!("POST", request.method());
+  assert_eq!("/submit", request.path());
+  assert_eq!(Some("name=Rttp&debug=true"), request.query());
+  assert_eq!("HTTP/1.1", request.version());
+  assert_eq!(Some("example.test"), request.header("host"));
+  assert_eq!(Some("text/plain"), request.header("Content-Type"));
+  assert_eq!(Some("abc-123"), request.header("x-trace-id"));
+  assert_eq!(b"hello=world", request.body());
+}
+
+#[test]
+fn parses_http_request_without_query_or_body() {
+  let raw = concat!(
+    "GET /health HTTP/1.0\r\n",
+    "Host: example.test\r\n",
+    "Connection: close\r\n",
+    "\r\n"
+  );
+
+  let request = HttpRequest::parse(raw.as_bytes()).expect("request should parse");
+
+  assert_eq!("GET", request.method());
+  assert_eq!("/health", request.path());
+  assert_eq!(None, request.query());
+  assert_eq!("HTTP/1.0", request.version());
+  assert_eq!(Some("close"), request.header("connection"));
+  assert!(request.body().is_empty());
+}
+
+#[test]
+fn serializes_http_response_status_headers_content_length_and_body() {
+  let response = HttpResponse::new(201, "Created")
+    .header("Content-Type", "application/json")
+    .header("Connection", "close")
+    .body(r#"{"ok":true}"#);
+
+  let serialized = response.to_bytes();
+
+  assert_eq!(
+    concat!(
+      "HTTP/1.1 201 Created\r\n",
+      "Content-Type: application/json\r\n",
+      "Connection: close\r\n",
+      "Content-Length: 11\r\n",
+      "\r\n",
+      r#"{"ok":true}"#
+    )
+    .as_bytes(),
+    serialized.as_slice()
+  );
+}
+
+#[test]
+fn serializes_empty_http_response_with_zero_content_length() {
+  let response = HttpResponse::new(204, "No Content");
+
+  let serialized = response.to_bytes();
+
+  assert_eq!(
+    b"HTTP/1.1 204 No Content\r\nContent-Length: 0\r\n\r\n",
+    serialized.as_slice()
+  );
+}

--- a/rttp/tests/test_server_models.rs
+++ b/rttp/tests/test_server_models.rs
@@ -75,6 +75,25 @@ fn rejects_request_body_longer_than_content_length() {
 }
 
 #[test]
+fn rejects_transfer_encoding_request_even_with_content_length() {
+  let raw = concat!(
+    "POST /submit HTTP/1.1\r\n",
+    "Host: example.test\r\n",
+    "Transfer-Encoding: chunked\r\n",
+    "Content-Length: 5\r\n",
+    "\r\n",
+    "hello"
+  );
+
+  let error = HttpRequest::parse(raw.as_bytes()).expect_err("request should be rejected");
+
+  assert_eq!(
+    "Transfer-Encoding request bodies are not supported",
+    error.to_string()
+  );
+}
+
+#[test]
 fn parses_http_request_without_query_or_body() {
   let raw = concat!(
     "GET /health HTTP/1.0\r\n",

--- a/rttp/tests/test_server_models.rs
+++ b/rttp/tests/test_server_models.rs
@@ -24,6 +24,57 @@ fn parses_http_request_target_headers_and_body() {
 }
 
 #[test]
+fn parses_body_only_when_content_length_matches() {
+  let raw = concat!(
+    "POST /submit HTTP/1.1\r\n",
+    "Host: example.test\r\n",
+    "Content-Length: 5\r\n",
+    "\r\n",
+    "hello"
+  );
+
+  let request = HttpRequest::parse(raw.as_bytes()).expect("request should parse");
+
+  assert_eq!(b"hello", request.body());
+}
+
+#[test]
+fn rejects_request_body_shorter_than_content_length() {
+  let raw = concat!(
+    "POST /submit HTTP/1.1\r\n",
+    "Host: example.test\r\n",
+    "Content-Length: 5\r\n",
+    "\r\n",
+    "hel"
+  );
+
+  let error = HttpRequest::parse(raw.as_bytes()).expect_err("request should be rejected");
+
+  assert_eq!(
+    "request body length does not match Content-Length",
+    error.to_string()
+  );
+}
+
+#[test]
+fn rejects_request_body_longer_than_content_length() {
+  let raw = concat!(
+    "POST /submit HTTP/1.1\r\n",
+    "Host: example.test\r\n",
+    "Content-Length: 5\r\n",
+    "\r\n",
+    "helloGET /next HTTP/1.1\r\n\r\n"
+  );
+
+  let error = HttpRequest::parse(raw.as_bytes()).expect_err("request should be rejected");
+
+  assert_eq!(
+    "request body length does not match Content-Length",
+    error.to_string()
+  );
+}
+
+#[test]
 fn parses_http_request_without_query_or_body() {
   let raw = concat!(
     "GET /health HTTP/1.0\r\n",
@@ -66,13 +117,31 @@ fn serializes_http_response_status_headers_content_length_and_body() {
 }
 
 #[test]
-fn serializes_empty_http_response_with_zero_content_length() {
+fn rejects_response_headers_with_crlf() {
+  let result = std::panic::catch_unwind(|| {
+    let _response = HttpResponse::new(302, "Found").header("Location", "/safe\r\nX-Evil: true");
+  });
+
+  assert!(result.is_err());
+}
+
+#[test]
+fn serializes_empty_http_response_without_content_length_for_204() {
   let response = HttpResponse::new(204, "No Content");
 
   let serialized = response.to_bytes();
 
+  assert_eq!(b"HTTP/1.1 204 No Content\r\n\r\n", serialized.as_slice());
+}
+
+#[test]
+fn serializes_empty_http_response_without_content_length_for_1xx() {
+  let response = HttpResponse::new(101, "Switching Protocols");
+
+  let serialized = response.to_bytes();
+
   assert_eq!(
-    b"HTTP/1.1 204 No Content\r\nContent-Length: 0\r\n\r\n",
+    b"HTTP/1.1 101 Switching Protocols\r\n\r\n",
     serialized.as_slice()
   );
 }


### PR DESCRIPTION
Added deterministic HTTP server request/response model coverage and a minimal server model in rttp. Request parsing now covers method, path, query, HTTP version, headers, and optional body; response serialization now emits the status line, headers, computed Content-Length, and body. Formatting and full workspace tests pass.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1241/
work_kind: code_work
branch: hbx-1241-rttp-add-http-server-request
base: main
commit: b49b2312b8214e4994b53c6e3c40494d80cd512f
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1241/
    url: https://plane.kahub.in/endless/browse/HBX-1241/
    close_policy: link_only
```