### PR TITLE
feat: [rttp] Serve multiple HTTP requests on one socket2 listener

### DIFF
--- a/rttp/src/server.rs
+++ b/rttp/src/server.rs
@@ -57,6 +57,24 @@ impl HttpServer {
   where
     F: FnOnce(Request) -> HttpResponse,
   {
+    self.handle_next_connection(handler)
+  }
+
+  pub fn serve_requests<F>(&self, request_count: usize, mut handler: F) -> io::Result<()>
+  where
+    F: FnMut(Request) -> HttpResponse,
+  {
+    for _ in 0..request_count {
+      self.handle_next_connection(&mut handler)?;
+    }
+
+    Ok(())
+  }
+
+  fn handle_next_connection<F>(&self, handler: F) -> io::Result<()>
+  where
+    F: FnOnce(Request) -> HttpResponse,
+  {
     let (mut stream, _) = self.listener.accept()?;
     let request = Request::read_from(&mut stream)?;
     let response = handler(request);

--- a/rttp/tests/test_server.rs
+++ b/rttp/tests/test_server.rs
@@ -86,6 +86,39 @@ fn server_request_body_stops_at_declared_content_length() {
 }
 
 #[test]
+fn server_accepts_multiple_sequential_connections_on_one_listener() {
+  let server = rttp::Http::server("127.0.0.1:0").expect("bind server");
+  let addr = server.local_addr().expect("server addr");
+  let (tx, rx) = mpsc::channel();
+
+  let handle = thread::spawn(move || {
+    server
+      .serve_requests(2, |request| {
+        let target = request.target().to_string();
+        tx.send(target.clone()).expect("send parsed target");
+        HttpResponse::ok(format!("served {target}"))
+      })
+      .expect("serve sequential requests");
+  });
+
+  let first = send_request(addr, b"GET /first HTTP/1.1\r\nHost: localhost\r\n\r\n");
+  let second = send_request(addr, b"GET /second HTTP/1.1\r\nHost: localhost\r\n\r\n");
+
+  assert_eq!(
+    "HTTP/1.1 200 OK\r\nContent-Length: 13\r\nConnection: close\r\n\r\nserved /first",
+    first
+  );
+  assert_eq!(
+    "HTTP/1.1 200 OK\r\nContent-Length: 14\r\nConnection: close\r\n\r\nserved /second",
+    second
+  );
+  assert_eq!("/first", rx.recv().expect("receive first target"));
+  assert_eq!("/second", rx.recv().expect("receive second target"));
+
+  handle.join().expect("server thread");
+}
+
+#[test]
 fn response_write_to_omits_content_length_and_body_for_204() {
   let response = HttpResponse::new(204, "No Content").body("ignored");
   let mut serialized = Vec::new();
@@ -113,4 +146,16 @@ fn response_write_to_omits_content_length_and_body_for_1xx() {
     b"HTTP/1.1 101 Switching Protocols\r\nConnection: close\r\n\r\n",
     serialized.as_slice()
   );
+}
+
+fn send_request(addr: std::net::SocketAddr, request: &[u8]) -> String {
+  let mut stream = TcpStream::connect(addr).expect("connect server");
+  stream.write_all(request).expect("write request");
+  stream
+    .shutdown(std::net::Shutdown::Write)
+    .expect("shutdown write");
+
+  let mut response = String::new();
+  stream.read_to_string(&mut response).expect("read response");
+  response
 }


### PR DESCRIPTION
Implemented a small sequential server loop for the rttp socket2-backed listener. The server can now serve multiple sequential TCP connections from one listener instance, parsing one HTTP/1.1 request per connection and returning handler-produced responses. Formatting and full workspace tests passed.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1243/
work_kind: code_work
branch: hbx-1243-rttp-serve-multiple-http-requests
base: main
commit: 410b6e9174d4302fda5c0717493a9edbd82d7241
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1243/
    url: https://plane.kahub.in/endless/browse/HBX-1243/
    close_policy: link_only
```