### PR TITLE
feat: [rttp] Return deterministic HTTP error responses for bad requests

### DIFF
--- a/rttp/src/server.rs
+++ b/rttp/src/server.rs
@@ -123,9 +123,9 @@ impl Request {
 
       if content_length.is_none() {
         if let Some(header_end) = header_end {
-          let headers = parse_headers(&raw[..header_end])?;
-          reject_transfer_encoding(&headers)?;
-          content_length = Some(header_content_length(&headers)?);
+          let head = parse_request_head(&raw[..header_end])?;
+          reject_transfer_encoding(&head.headers)?;
+          content_length = Some(header_content_length(&head.headers)?);
         }
       }
 
@@ -469,12 +469,6 @@ fn parse_request_head(raw: &[u8]) -> io::Result<RequestHead> {
     version: version.to_string(),
     headers: parse_header_lines(lines)?,
   })
-}
-
-fn parse_headers(raw: &[u8]) -> io::Result<Vec<(String, String)>> {
-  let text = std::str::from_utf8(raw)
-    .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "request head is not UTF-8"))?;
-  parse_header_lines(text.split("\r\n").skip(1))
 }
 
 fn parse_header_lines<'a>(

--- a/rttp/src/server.rs
+++ b/rttp/src/server.rs
@@ -58,7 +58,13 @@ impl HttpServer {
     F: FnOnce(Request) -> HttpResponse,
   {
     let (mut stream, _) = self.listener.accept()?;
-    let request = Request::read_from(&mut stream)?;
+    let request = match Request::read_from(&mut stream) {
+      Ok(request) => request,
+      Err(err) if is_bad_request_error(&err) => {
+        return bad_request_response().write_to(&mut stream);
+      }
+      Err(err) => return Err(err),
+    };
     let response = handler(request);
     response.write_to(&mut stream)
   }
@@ -536,4 +542,15 @@ fn assert_valid_header_component(component: &str) {
 
 fn response_status_allows_body(status_code: u16) -> bool {
   !(status_code / 100 == 1 || status_code == 204 || status_code == 304)
+}
+
+fn is_bad_request_error(err: &io::Error) -> bool {
+  matches!(
+    err.kind(),
+    io::ErrorKind::InvalidData | io::ErrorKind::UnexpectedEof
+  )
+}
+
+fn bad_request_response() -> HttpResponse {
+  HttpResponse::new(400, "Bad Request").body("Bad Request")
 }

--- a/rttp/tests/test_server.rs
+++ b/rttp/tests/test_server.rs
@@ -2,6 +2,7 @@ use std::io::{Read, Write};
 use std::net::TcpStream;
 use std::sync::mpsc;
 use std::thread;
+use std::time::Duration;
 
 use rttp::server::{HttpResponse, Request};
 
@@ -117,6 +118,46 @@ fn server_returns_bad_request_for_malformed_request_line() {
   let (response, handler_called) = send_raw_request(b"GET /too many parts HTTP/1.1\r\n\r\n");
 
   assert!(!handler_called);
+  assert_eq!(
+    "HTTP/1.1 400 Bad Request\r\nContent-Length: 11\r\nConnection: close\r\n\r\nBad Request",
+    response
+  );
+}
+
+#[test]
+fn server_rejects_malformed_request_line_before_reading_declared_body() {
+  let server = rttp::Http::server("127.0.0.1:0").expect("bind server");
+  let addr = server.local_addr().expect("server addr");
+  let (tx, rx) = mpsc::channel();
+
+  let handle = thread::spawn(move || {
+    let result = server.accept_one(|request| {
+      tx.send(request).expect("send parsed request");
+      HttpResponse::ok("unexpected")
+    });
+    assert!(result.is_ok(), "serve one request: {result:?}");
+  });
+
+  let mut stream = TcpStream::connect(addr).expect("connect server");
+  stream
+    .set_read_timeout(Some(Duration::from_millis(250)))
+    .expect("set read timeout");
+  stream
+    .write_all(b"GET /too many parts HTTP/1.1\r\nContent-Length: 1000000\r\n\r\n")
+    .expect("write request head");
+
+  let mut response = String::new();
+  let read_result = stream.read_to_string(&mut response);
+  if read_result.is_err() {
+    stream
+      .shutdown(std::net::Shutdown::Write)
+      .expect("shutdown write");
+    let _ = stream.read_to_string(&mut response);
+  }
+
+  handle.join().expect("server thread");
+  assert!(read_result.is_ok(), "server waited for the declared body");
+  assert!(rx.try_recv().is_err());
   assert_eq!(
     "HTTP/1.1 400 Bad Request\r\nContent-Length: 11\r\nConnection: close\r\n\r\nBad Request",
     response

--- a/rttp/tests/test_server.rs
+++ b/rttp/tests/test_server.rs
@@ -5,6 +5,33 @@ use std::thread;
 
 use rttp::server::{HttpResponse, Request};
 
+fn send_raw_request(raw: &[u8]) -> (String, bool) {
+  let server = rttp::Http::server("127.0.0.1:0").expect("bind server");
+  let addr = server.local_addr().expect("server addr");
+  let (tx, rx) = mpsc::channel();
+
+  let handle = thread::spawn(move || {
+    server
+      .accept_one(|request| {
+        tx.send(request).expect("send parsed request");
+        HttpResponse::ok("unexpected")
+      })
+      .expect("serve one request");
+  });
+
+  let mut stream = TcpStream::connect(addr).expect("connect server");
+  stream.write_all(raw).expect("write request");
+  stream
+    .shutdown(std::net::Shutdown::Write)
+    .expect("shutdown write");
+
+  let mut response = String::new();
+  stream.read_to_string(&mut response).expect("read response");
+
+  handle.join().expect("server thread");
+  (response, rx.try_recv().is_ok())
+}
+
 #[test]
 fn server_accepts_get_request_and_writes_response() {
   let server = rttp::Http::server("127.0.0.1:0").expect("bind server");
@@ -83,6 +110,52 @@ fn server_request_body_stops_at_declared_content_length() {
   );
 
   handle.join().expect("server thread");
+}
+
+#[test]
+fn server_returns_bad_request_for_malformed_request_line() {
+  let (response, handler_called) = send_raw_request(b"GET /too many parts HTTP/1.1\r\n\r\n");
+
+  assert!(!handler_called);
+  assert_eq!(
+    "HTTP/1.1 400 Bad Request\r\nContent-Length: 11\r\nConnection: close\r\n\r\nBad Request",
+    response
+  );
+}
+
+#[test]
+fn server_returns_bad_request_for_invalid_header_syntax() {
+  let (response, handler_called) = send_raw_request(b"GET / HTTP/1.1\r\nHost localhost\r\n\r\n");
+
+  assert!(!handler_called);
+  assert_eq!(
+    "HTTP/1.1 400 Bad Request\r\nContent-Length: 11\r\nConnection: close\r\n\r\nBad Request",
+    response
+  );
+}
+
+#[test]
+fn server_returns_bad_request_for_unsupported_transfer_encoding() {
+  let (response, handler_called) =
+    send_raw_request(b"POST /upload HTTP/1.1\r\nTransfer-Encoding: chunked\r\n\r\n0\r\n\r\n");
+
+  assert!(!handler_called);
+  assert_eq!(
+    "HTTP/1.1 400 Bad Request\r\nContent-Length: 11\r\nConnection: close\r\n\r\nBad Request",
+    response
+  );
+}
+
+#[test]
+fn server_returns_bad_request_for_short_request_body() {
+  let (response, handler_called) =
+    send_raw_request(b"POST /upload HTTP/1.1\r\nContent-Length: 5\r\n\r\nhel");
+
+  assert!(!handler_called);
+  assert_eq!(
+    "HTTP/1.1 400 Bad Request\r\nContent-Length: 11\r\nConnection: close\r\n\r\nBad Request",
+    response
+  );
 }
 
 #[test]


### PR DESCRIPTION
Server-side request parsing failures now return deterministic HTTP 400 responses for malformed request lines, invalid header syntax, unsupported transfer encoding, and short request bodies. Successful request handling is preserved, and focused integration coverage verifies response status, connection closure, and that handlers are skipped for bad input. Formatting and workspace tests pass.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1245/
work_kind: code_work
branch: hbx-1245-rttp-return-deterministic-http-error
base: main
commit: facb3ae3e13607a03128633161caff4613a0b201
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1245/
    url: https://plane.kahub.in/endless/browse/HBX-1245/
    close_policy: link_only
```