### PR TITLE
feat: [rttp] Parse chunked request bodies in the socket2 server

### DIFF
--- a/rttp/src/server.rs
+++ b/rttp/src/server.rs
@@ -673,14 +673,22 @@ where
       return Ok(body);
     }
 
-    let current_len = body.len();
-    body.resize(current_len + chunk_size, 0);
-    reader.read_exact(&mut body[current_len..]).map_err(|_| {
-      io::Error::new(
+    let copied = {
+      let mut chunk_reader = reader.take(chunk_size as u64);
+      io::copy(&mut chunk_reader, &mut body).map_err(|_| {
+        io::Error::new(
+          io::ErrorKind::UnexpectedEof,
+          "incomplete chunked request body",
+        )
+      })?
+    };
+
+    if copied != chunk_size as u64 {
+      return Err(io::Error::new(
         io::ErrorKind::UnexpectedEof,
         "incomplete chunked request body",
-      )
-    })?;
+      ));
+    };
     consume_crlf(reader)?;
   }
 }

--- a/rttp/src/server.rs
+++ b/rttp/src/server.rs
@@ -144,10 +144,12 @@ impl Request {
     R: BufRead,
   {
     let mut raw = Vec::new();
-    let mut content_length: Option<usize> = None;
+    let mut body_kind: Option<RequestBodyKind> = None;
 
     loop {
-      if let (Some(header_end), Some(content_length)) = (find_header_end(&raw), content_length) {
+      if let (Some(header_end), Some(RequestBodyKind::ContentLength(content_length))) =
+        (find_header_end(&raw), body_kind)
+      {
         let message_len = header_end + 4 + content_length;
         if raw.len() == message_len {
           return Ok(Some(Self::from_raw_frame(&raw)?));
@@ -159,7 +161,9 @@ impl Request {
         if raw.is_empty() {
           return Ok(None);
         }
-        if let (Some(header_end), Some(content_length)) = (find_header_end(&raw), content_length) {
+        if let (Some(header_end), Some(RequestBodyKind::ContentLength(content_length))) =
+          (find_header_end(&raw), body_kind)
+        {
           let body_start = header_end + 4;
           if raw.len() < body_start + content_length {
             return Err(io::Error::new(
@@ -174,7 +178,9 @@ impl Request {
         ));
       }
 
-      if let (Some(header_end), Some(content_length)) = (find_header_end(&raw), content_length) {
+      if let (Some(header_end), Some(RequestBodyKind::ContentLength(content_length))) =
+        (find_header_end(&raw), body_kind)
+      {
         let message_len = header_end + 4 + content_length;
         let take = (message_len - raw.len()).min(available.len());
         raw.extend_from_slice(&available[..take]);
@@ -190,8 +196,18 @@ impl Request {
           raw.extend_from_slice(&available[..take]);
           reader.consume(take);
           let head = parse_request_head(&raw[..header_end])?;
-          reject_transfer_encoding(&head.headers)?;
-          content_length = Some(header_content_length(&head.headers)?);
+          match request_body_kind(&head.headers)? {
+            RequestBodyKind::ContentLength(0) => {
+              return Ok(Some(Self::from_head_and_body(head, Vec::new())));
+            }
+            RequestBodyKind::ContentLength(content_length) => {
+              body_kind = Some(RequestBodyKind::ContentLength(content_length));
+            }
+            RequestBodyKind::Chunked => {
+              let body = read_chunked_request_body(reader)?;
+              return Ok(Some(Self::from_head_and_body(head, body)));
+            }
+          }
         }
         None => {
           let take = available.len();
@@ -206,25 +222,45 @@ impl Request {
     let header_end = find_header_end(raw)
       .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "incomplete HTTP request"))?;
     let head = parse_request_head(&raw[..header_end])?;
-    reject_transfer_encoding(&head.headers)?;
     let body_start = header_end + 4;
-    let content_length = header_content_length(&head.headers)?;
-    let body_end = body_start + content_length;
+    let body = match request_body_kind(&head.headers)? {
+      RequestBodyKind::ContentLength(content_length) => {
+        let body_end = body_start + content_length;
 
-    if raw.len() < body_end {
-      return Err(io::Error::new(
-        io::ErrorKind::UnexpectedEof,
-        "incomplete HTTP request body",
-      ));
-    }
+        if raw.len() < body_end {
+          return Err(io::Error::new(
+            io::ErrorKind::UnexpectedEof,
+            "incomplete HTTP request body",
+          ));
+        }
+
+        raw[body_start..body_end].to_vec()
+      }
+      RequestBodyKind::Chunked => {
+        return Err(io::Error::new(
+          io::ErrorKind::InvalidData,
+          "chunked request body requires streaming reader",
+        ));
+      }
+    };
 
     Ok(Self {
       method: head.method,
       target: head.target,
       version: head.version,
       headers: head.headers,
-      body: raw[body_start..body_end].to_vec(),
+      body,
     })
+  }
+
+  fn from_head_and_body(head: RequestHead, body: Vec<u8>) -> Self {
+    Self {
+      method: head.method,
+      target: head.target,
+      version: head.version,
+      headers: head.headers,
+      body,
+    }
   }
 }
 
@@ -504,6 +540,12 @@ struct RequestHead {
   headers: Vec<(String, String)>,
 }
 
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+enum RequestBodyKind {
+  ContentLength(usize),
+  Chunked,
+}
+
 fn parse_request_head(raw: &[u8]) -> io::Result<RequestHead> {
   let text = std::str::from_utf8(raw)
     .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "request head is not UTF-8"))?;
@@ -555,7 +597,7 @@ fn parse_header_lines<'a>(
   Ok(headers)
 }
 
-fn header_content_length(headers: &[(String, String)]) -> io::Result<usize> {
+fn optional_header_content_length(headers: &[(String, String)]) -> io::Result<Option<usize>> {
   let mut length = None;
 
   for (_, value) in headers
@@ -576,21 +618,141 @@ fn header_content_length(headers: &[(String, String)]) -> io::Result<usize> {
     }
   }
 
-  Ok(length.unwrap_or(0))
+  Ok(length)
 }
 
-fn reject_transfer_encoding(headers: &[(String, String)]) -> io::Result<()> {
-  if headers
+fn request_body_kind(headers: &[(String, String)]) -> io::Result<RequestBodyKind> {
+  let content_length = optional_header_content_length(headers)?;
+  let mut transfer_codings = Vec::new();
+
+  for (_, value) in headers
     .iter()
-    .any(|(name, _)| name.eq_ignore_ascii_case("Transfer-Encoding"))
+    .filter(|(name, _)| name.eq_ignore_ascii_case("Transfer-Encoding"))
   {
+    transfer_codings.extend(
+      value
+        .split(',')
+        .map(str::trim)
+        .filter(|token| !token.is_empty()),
+    );
+  }
+
+  if transfer_codings.is_empty() {
+    return Ok(RequestBodyKind::ContentLength(content_length.unwrap_or(0)));
+  }
+
+  if content_length.is_some() {
     return Err(io::Error::new(
       io::ErrorKind::InvalidData,
-      "Transfer-Encoding request bodies are not supported",
+      "Transfer-Encoding conflicts with Content-Length",
     ));
   }
 
-  Ok(())
+  if transfer_codings.len() == 1 && transfer_codings[0].eq_ignore_ascii_case("chunked") {
+    Ok(RequestBodyKind::Chunked)
+  } else {
+    Err(io::Error::new(
+      io::ErrorKind::InvalidData,
+      "unsupported Transfer-Encoding request body",
+    ))
+  }
+}
+
+fn read_chunked_request_body<R>(reader: &mut R) -> io::Result<Vec<u8>>
+where
+  R: BufRead,
+{
+  let mut body = Vec::new();
+
+  loop {
+    let line = read_crlf_line(reader)?;
+    let chunk_size = parse_chunk_size(&line)?;
+
+    if chunk_size == 0 {
+      consume_trailers(reader)?;
+      return Ok(body);
+    }
+
+    let current_len = body.len();
+    body.resize(current_len + chunk_size, 0);
+    reader.read_exact(&mut body[current_len..]).map_err(|_| {
+      io::Error::new(
+        io::ErrorKind::UnexpectedEof,
+        "incomplete chunked request body",
+      )
+    })?;
+    consume_crlf(reader)?;
+  }
+}
+
+fn read_crlf_line<R>(reader: &mut R) -> io::Result<Vec<u8>>
+where
+  R: BufRead,
+{
+  let mut line = Vec::new();
+  let read = reader.read_until(b'\n', &mut line)?;
+  if read == 0 {
+    return Err(io::Error::new(
+      io::ErrorKind::UnexpectedEof,
+      "incomplete chunked request body",
+    ));
+  }
+  if line.ends_with(b"\r\n") {
+    Ok(line)
+  } else {
+    Err(io::Error::new(
+      io::ErrorKind::InvalidData,
+      "invalid chunked request line terminator",
+    ))
+  }
+}
+
+fn parse_chunk_size(line: &[u8]) -> io::Result<usize> {
+  let line = std::str::from_utf8(line)
+    .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "chunk size is not UTF-8"))?;
+  let size = line
+    .trim_end_matches("\r\n")
+    .split(';')
+    .next()
+    .map(str::trim)
+    .filter(|value| !value.is_empty())
+    .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "empty chunk size"))?;
+
+  usize::from_str_radix(size, 16)
+    .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "invalid chunk size"))
+}
+
+fn consume_crlf<R>(reader: &mut R) -> io::Result<()>
+where
+  R: BufRead,
+{
+  let mut suffix = [0u8; 2];
+  reader.read_exact(&mut suffix).map_err(|_| {
+    io::Error::new(
+      io::ErrorKind::UnexpectedEof,
+      "incomplete chunked request body",
+    )
+  })?;
+  if suffix == *b"\r\n" {
+    Ok(())
+  } else {
+    Err(io::Error::new(
+      io::ErrorKind::InvalidData,
+      "invalid chunk terminator",
+    ))
+  }
+}
+
+fn consume_trailers<R>(reader: &mut R) -> io::Result<()>
+where
+  R: BufRead,
+{
+  loop {
+    let line = read_crlf_line(reader)?;
+    if line == b"\r\n" {
+      return Ok(());
+    }
+  }
 }
 
 fn assert_valid_header_component(component: &str) {
@@ -649,6 +811,38 @@ mod tests {
     assert_eq!("POST", second.method());
     assert_eq!("/second", second.target());
     assert_eq!(b"world", second.body());
+    assert!(reader.fill_buf().expect("remaining bytes").is_empty());
+  }
+
+  #[test]
+  fn read_next_from_consumes_one_chunked_request_at_a_time() {
+    let raw = concat!(
+      "POST /first HTTP/1.1\r\n",
+      "Host: example.test\r\n",
+      "Transfer-Encoding: chunked\r\n",
+      "\r\n",
+      "5\r\nhello\r\n",
+      "0\r\n",
+      "X-Trace: abc\r\n",
+      "\r\n",
+      "GET /second HTTP/1.1\r\n",
+      "Host: example.test\r\n",
+      "\r\n"
+    );
+    let mut reader = BufReader::new(Cursor::new(raw.as_bytes()));
+
+    let first = Request::read_next_from(&mut reader)
+      .expect("first frame should parse")
+      .expect("first request should be present");
+    let second = Request::read_next_from(&mut reader)
+      .expect("second frame should parse")
+      .expect("second request should be present");
+
+    assert_eq!("POST", first.method());
+    assert_eq!("/first", first.target());
+    assert_eq!(b"hello", first.body());
+    assert_eq!("GET", second.method());
+    assert_eq!("/second", second.target());
     assert!(reader.fill_buf().expect("remaining bytes").is_empty());
   }
 

--- a/rttp/tests/test_server.rs
+++ b/rttp/tests/test_server.rs
@@ -313,6 +313,25 @@ fn server_returns_bad_request_for_truncated_chunked_request_body() {
 }
 
 #[test]
+fn server_returns_bad_request_for_huge_truncated_chunked_request_body() {
+  let (response, handler_called) = send_raw_request(
+    concat!(
+      "POST /upload HTTP/1.1\r\n",
+      "Transfer-Encoding: chunked\r\n",
+      "\r\n",
+      "4000000000000000\r\nhel"
+    )
+    .as_bytes(),
+  );
+
+  assert!(!handler_called);
+  assert_eq!(
+    "HTTP/1.1 400 Bad Request\r\nContent-Length: 11\r\nConnection: close\r\n\r\nBad Request",
+    response
+  );
+}
+
+#[test]
 fn server_returns_bad_request_for_invalid_chunk_terminator() {
   let (response, handler_called) = send_raw_request(
     concat!(

--- a/rttp/tests/test_server.rs
+++ b/rttp/tests/test_server.rs
@@ -176,9 +176,186 @@ fn server_returns_bad_request_for_invalid_header_syntax() {
 }
 
 #[test]
+fn server_decodes_chunked_request_body() {
+  let server = rttp::Http::server("127.0.0.1:0").expect("bind server");
+  let addr = server.local_addr().expect("server addr");
+  let (tx, rx) = mpsc::channel();
+
+  let handle = thread::spawn(move || {
+    server
+      .accept_one(|request| {
+        tx.send(request).expect("send parsed request");
+        HttpResponse::ok("accepted")
+      })
+      .expect("serve one request");
+  });
+
+  let mut stream = TcpStream::connect(addr).expect("connect server");
+  stream
+    .write_all(
+      concat!(
+        "POST /upload HTTP/1.1\r\n",
+        "Host: localhost\r\n",
+        "Transfer-Encoding: chunked\r\n",
+        "\r\n",
+        "4\r\nWiki\r\n",
+        "5\r\npedia\r\n",
+        "0\r\n\r\n"
+      )
+      .as_bytes(),
+    )
+    .expect("write request");
+  stream
+    .shutdown(std::net::Shutdown::Write)
+    .expect("shutdown write");
+
+  let mut response = String::new();
+  stream.read_to_string(&mut response).expect("read response");
+
+  let request: Request = rx.recv().expect("receive parsed request");
+  assert_eq!("POST", request.method());
+  assert_eq!("/upload", request.target());
+  assert_eq!(b"Wikipedia", request.body());
+  assert_eq!(
+    "HTTP/1.1 200 OK\r\nContent-Length: 8\r\nConnection: close\r\n\r\naccepted",
+    response
+  );
+
+  handle.join().expect("server thread");
+}
+
+#[test]
+fn server_ignores_chunk_extensions_and_trailers() {
+  let server = rttp::Http::server("127.0.0.1:0").expect("bind server");
+  let addr = server.local_addr().expect("server addr");
+  let (tx, rx) = mpsc::channel();
+
+  let handle = thread::spawn(move || {
+    server
+      .accept_one(|request| {
+        tx.send(request).expect("send parsed request");
+        HttpResponse::ok("accepted")
+      })
+      .expect("serve one request");
+  });
+
+  let mut stream = TcpStream::connect(addr).expect("connect server");
+  stream
+    .write_all(
+      concat!(
+        "POST /upload HTTP/1.1\r\n",
+        "Host: localhost\r\n",
+        "Transfer-Encoding: chunked\r\n",
+        "\r\n",
+        "7;foo=bar\r\nchunked\r\n",
+        "6\r\n body!\r\n",
+        "0\r\n",
+        "X-Trace: abc\r\n",
+        "\r\n"
+      )
+      .as_bytes(),
+    )
+    .expect("write request");
+  stream
+    .shutdown(std::net::Shutdown::Write)
+    .expect("shutdown write");
+
+  let mut response = String::new();
+  stream.read_to_string(&mut response).expect("read response");
+
+  let request: Request = rx.recv().expect("receive parsed request");
+  assert_eq!(b"chunked body!", request.body());
+  assert_eq!(
+    "HTTP/1.1 200 OK\r\nContent-Length: 8\r\nConnection: close\r\n\r\naccepted",
+    response
+  );
+
+  handle.join().expect("server thread");
+}
+
+#[test]
+fn server_returns_bad_request_for_malformed_chunk_size() {
+  let (response, handler_called) = send_raw_request(
+    concat!(
+      "POST /upload HTTP/1.1\r\n",
+      "Transfer-Encoding: chunked\r\n",
+      "\r\n",
+      "not-hex\r\nhello\r\n",
+      "0\r\n\r\n"
+    )
+    .as_bytes(),
+  );
+
+  assert!(!handler_called);
+  assert_eq!(
+    "HTTP/1.1 400 Bad Request\r\nContent-Length: 11\r\nConnection: close\r\n\r\nBad Request",
+    response
+  );
+}
+
+#[test]
+fn server_returns_bad_request_for_truncated_chunked_request_body() {
+  let (response, handler_called) = send_raw_request(
+    concat!(
+      "POST /upload HTTP/1.1\r\n",
+      "Transfer-Encoding: chunked\r\n",
+      "\r\n",
+      "5\r\nhel"
+    )
+    .as_bytes(),
+  );
+
+  assert!(!handler_called);
+  assert_eq!(
+    "HTTP/1.1 400 Bad Request\r\nContent-Length: 11\r\nConnection: close\r\n\r\nBad Request",
+    response
+  );
+}
+
+#[test]
+fn server_returns_bad_request_for_invalid_chunk_terminator() {
+  let (response, handler_called) = send_raw_request(
+    concat!(
+      "POST /upload HTTP/1.1\r\n",
+      "Transfer-Encoding: chunked\r\n",
+      "\r\n",
+      "5\r\nhelloXX",
+      "0\r\n\r\n"
+    )
+    .as_bytes(),
+  );
+
+  assert!(!handler_called);
+  assert_eq!(
+    "HTTP/1.1 400 Bad Request\r\nContent-Length: 11\r\nConnection: close\r\n\r\nBad Request",
+    response
+  );
+}
+
+#[test]
 fn server_returns_bad_request_for_unsupported_transfer_encoding() {
   let (response, handler_called) =
-    send_raw_request(b"POST /upload HTTP/1.1\r\nTransfer-Encoding: chunked\r\n\r\n0\r\n\r\n");
+    send_raw_request(b"POST /upload HTTP/1.1\r\nTransfer-Encoding: gzip, chunked\r\n\r\n0\r\n\r\n");
+
+  assert!(!handler_called);
+  assert_eq!(
+    "HTTP/1.1 400 Bad Request\r\nContent-Length: 11\r\nConnection: close\r\n\r\nBad Request",
+    response
+  );
+}
+
+#[test]
+fn server_returns_bad_request_for_transfer_encoding_with_content_length() {
+  let (response, handler_called) = send_raw_request(
+    concat!(
+      "POST /upload HTTP/1.1\r\n",
+      "Transfer-Encoding: chunked\r\n",
+      "Content-Length: 0\r\n",
+      "\r\n",
+      "0\r\n\r\n"
+    )
+    .as_bytes(),
+  );
 
   assert!(!handler_called);
   assert_eq!(


### PR DESCRIPTION
Implemented server-side HTTP/1.1 chunked request body decoding for the rttp socket2 server, including safe handling for chunk extensions/trailers and deterministic 400 responses for malformed or conflicting framing. Verification passed with formatting, rttp tests, and workspace tests.

## Source References
Closing GitHub issues:
- Fixes fewensa/rttp#10

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1249/
work_kind: code_work
branch: hbx-1249-rttp-parse-chunked-request-bodies
base: main
commit: 455d33e729f6b879d4ff1a68463c61406713a30b
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1249/
    url: https://plane.kahub.in/endless/browse/HBX-1249/
    close_policy: link_only
  - kind: github_issue
    canonical: fewensa/rttp#10
    url: https://github.com/fewensa/rttp/issues/10
    github_repository: fewensa/rttp
    number: 10
    close_policy: close_on_merge
    close_reason: The implementation fully satisfies the requested server-side chunked request body support, malformed chunk rejection, extension/trailer handling, and tests.
```