### PR TITLE
feat: [rttp] Serve multiple HTTP/1.1 requests on one accepted connection

### DIFF
--- a/rttp/src/server.rs
+++ b/rttp/src/server.rs
@@ -68,7 +68,8 @@ impl HttpServer {
 
     while served < request_count {
       let (stream, _) = self.listener.accept()?;
-      served += self.handle_connection(stream, request_count - served, &mut handler)?;
+      let handled = self.handle_connection(stream, request_count - served, &mut handler)?;
+      served += handled.max(1);
     }
 
     Ok(())

--- a/rttp/src/server.rs
+++ b/rttp/src/server.rs
@@ -1,7 +1,7 @@
 use std::error::Error;
 use std::fmt;
 use std::io::{self, BufRead, BufReader, Read, Write};
-use std::net::{SocketAddr, TcpListener, ToSocketAddrs};
+use std::net::{SocketAddr, TcpListener, TcpStream, ToSocketAddrs};
 
 use socket2::{Domain, Protocol, Socket, Type};
 
@@ -64,11 +64,56 @@ impl HttpServer {
   where
     F: FnMut(Request) -> HttpResponse,
   {
-    for _ in 0..request_count {
-      self.handle_next_connection(&mut handler)?;
+    let mut served = 0;
+
+    while served < request_count {
+      let (stream, _) = self.listener.accept()?;
+      served += self.handle_connection(stream, request_count - served, &mut handler)?;
     }
 
     Ok(())
+  }
+
+  fn handle_connection<F>(
+    &self,
+    stream: TcpStream,
+    request_limit: usize,
+    handler: &mut F,
+  ) -> io::Result<usize>
+  where
+    F: FnMut(Request) -> HttpResponse,
+  {
+    let mut reader = BufReader::new(stream);
+    let mut served = 0;
+
+    while served < request_limit {
+      let request = match Request::read_next_from(&mut reader) {
+        Ok(Some(request)) => request,
+        Ok(None) => break,
+        Err(err) if is_bad_request_error(&err) => {
+          bad_request_response().write_to(reader.get_mut())?;
+          break;
+        }
+        Err(err) => return Err(err),
+      };
+      let request_closes_connection = request.closes_connection();
+      let request_keeps_connection_alive = request.keeps_connection_alive();
+      let response = handler(request);
+      let response_closes_connection = response.closes_connection();
+      served += 1;
+
+      let close_after_response = request_closes_connection
+        || response_closes_connection
+        || !request_keeps_connection_alive
+        || served == request_limit;
+      response.write_to_with_default_connection(reader.get_mut(), close_after_response)?;
+
+      if close_after_response {
+        break;
+      }
+    }
+
+    Ok(served)
   }
 
   fn handle_next_connection<F>(&self, handler: F) -> io::Result<()>
@@ -123,11 +168,11 @@ impl Request {
   }
 
   pub fn closes_connection(&self) -> bool {
-    self.header("Connection").is_some_and(|value| {
-      value
-        .split(',')
-        .any(|token| token.trim().eq_ignore_ascii_case("close"))
-    })
+    connection_header_has_token(self.header("Connection"), "close")
+  }
+
+  fn keeps_connection_alive(&self) -> bool {
+    connection_header_has_token(self.header("Connection"), "keep-alive")
   }
 
   fn read_from<R>(reader: &mut R) -> io::Result<Self>
@@ -404,7 +449,18 @@ impl HttpResponse {
   where
     W: Write,
   {
-    self.write_head_to(writer, true)?;
+    self.write_to_with_default_connection(writer, true)
+  }
+
+  fn write_to_with_default_connection<W>(
+    &self,
+    writer: &mut W,
+    close_by_default: bool,
+  ) -> io::Result<()>
+  where
+    W: Write,
+  {
+    self.write_head_to(writer, close_by_default)?;
     if self.allows_body() {
       writer.write_all(&self.body)?;
     }
@@ -446,6 +502,15 @@ impl HttpResponse {
       .headers
       .iter()
       .any(|header| header.name.eq_ignore_ascii_case(name))
+  }
+
+  fn closes_connection(&self) -> bool {
+    let connection = self
+      .headers
+      .iter()
+      .find(|header| header.name.eq_ignore_ascii_case("Connection"))
+      .map(|header| header.value.as_str());
+    connection_header_has_token(connection, "close")
   }
 }
 
@@ -591,6 +656,14 @@ fn reject_transfer_encoding(headers: &[(String, String)]) -> io::Result<()> {
   }
 
   Ok(())
+}
+
+fn connection_header_has_token(value: Option<&str>, expected: &str) -> bool {
+  value.is_some_and(|value| {
+    value
+      .split(',')
+      .any(|token| token.trim().eq_ignore_ascii_case(expected))
+  })
 }
 
 fn assert_valid_header_component(component: &str) {

--- a/rttp/tests/test_server.rs
+++ b/rttp/tests/test_server.rs
@@ -200,6 +200,70 @@ fn server_returns_bad_request_for_short_request_body() {
 }
 
 #[test]
+fn serve_requests_counts_malformed_connection_toward_limit() {
+  let server = rttp::Http::server("127.0.0.1:0").expect("bind server");
+  let addr = server.local_addr().expect("server addr");
+  let (handler_tx, handler_rx) = mpsc::channel();
+  let (done_tx, done_rx) = mpsc::channel();
+
+  thread::spawn(move || {
+    let result = server.serve_requests(1, |request| {
+      handler_tx.send(request).expect("send parsed request");
+      HttpResponse::ok("unexpected")
+    });
+    done_tx.send(result).expect("send server result");
+  });
+
+  let mut stream = TcpStream::connect(addr).expect("connect server");
+  stream
+    .write_all(b"GET /too many parts HTTP/1.1\r\n\r\n")
+    .expect("write malformed request");
+  stream
+    .shutdown(std::net::Shutdown::Write)
+    .expect("shutdown write");
+
+  let mut response = String::new();
+  stream.read_to_string(&mut response).expect("read response");
+
+  assert!(handler_rx.try_recv().is_err());
+  assert_eq!(
+    "HTTP/1.1 400 Bad Request\r\nContent-Length: 11\r\nConnection: close\r\n\r\nBad Request",
+    response
+  );
+  let result = done_rx
+    .recv_timeout(Duration::from_millis(250))
+    .expect("serve_requests returned after rejected connection");
+  assert!(result.is_ok(), "serve_requests failed: {result:?}");
+}
+
+#[test]
+fn serve_requests_counts_empty_connection_toward_limit() {
+  let server = rttp::Http::server("127.0.0.1:0").expect("bind server");
+  let addr = server.local_addr().expect("server addr");
+  let (handler_tx, handler_rx) = mpsc::channel();
+  let (done_tx, done_rx) = mpsc::channel();
+
+  thread::spawn(move || {
+    let result = server.serve_requests(1, |request| {
+      handler_tx.send(request).expect("send parsed request");
+      HttpResponse::ok("unexpected")
+    });
+    done_tx.send(result).expect("send server result");
+  });
+
+  let stream = TcpStream::connect(addr).expect("connect server");
+  stream
+    .shutdown(std::net::Shutdown::Both)
+    .expect("close connection");
+
+  assert!(handler_rx.try_recv().is_err());
+  let result = done_rx
+    .recv_timeout(Duration::from_millis(250))
+    .expect("serve_requests returned after empty connection");
+  assert!(result.is_ok(), "serve_requests failed: {result:?}");
+}
+
+#[test]
 fn server_accepts_multiple_sequential_connections_on_one_listener() {
   let server = rttp::Http::server("127.0.0.1:0").expect("bind server");
   let addr = server.local_addr().expect("server addr");

--- a/rttp/tests/test_server.rs
+++ b/rttp/tests/test_server.rs
@@ -233,6 +233,114 @@ fn server_accepts_multiple_sequential_connections_on_one_listener() {
 }
 
 #[test]
+fn server_serves_multiple_requests_on_one_kept_alive_connection() {
+  let server = rttp::Http::server("127.0.0.1:0").expect("bind server");
+  let addr = server.local_addr().expect("server addr");
+  let (tx, rx) = mpsc::channel();
+
+  let handle = thread::spawn(move || {
+    server
+      .serve_requests(2, |request| {
+        let target = request.target().to_string();
+        tx.send(target.clone()).expect("send parsed target");
+        HttpResponse::ok(format!("served {target}"))
+      })
+      .expect("serve requests");
+  });
+
+  let mut stream = TcpStream::connect(addr).expect("connect server");
+  stream
+    .write_all(
+      concat!(
+        "GET /first HTTP/1.1\r\n",
+        "Host: localhost\r\n",
+        "Connection: keep-alive\r\n",
+        "\r\n",
+        "GET /second HTTP/1.1\r\n",
+        "Host: localhost\r\n",
+        "Connection: keep-alive\r\n",
+        "\r\n"
+      )
+      .as_bytes(),
+    )
+    .expect("write pipelined requests");
+  stream
+    .shutdown(std::net::Shutdown::Write)
+    .expect("shutdown write");
+
+  let mut response = String::new();
+  stream.read_to_string(&mut response).expect("read response");
+
+  assert_eq!(
+    concat!(
+      "HTTP/1.1 200 OK\r\nContent-Length: 13\r\n\r\nserved /first",
+      "HTTP/1.1 200 OK\r\nContent-Length: 14\r\nConnection: close\r\n\r\nserved /second",
+    ),
+    response
+  );
+  assert_eq!("/first", rx.recv().expect("receive first target"));
+  assert_eq!("/second", rx.recv().expect("receive second target"));
+
+  handle.join().expect("server thread");
+}
+
+#[test]
+fn server_stops_one_connection_after_connection_close_request() {
+  let server = rttp::Http::server("127.0.0.1:0").expect("bind server");
+  let addr = server.local_addr().expect("server addr");
+  let (tx, rx) = mpsc::channel();
+
+  let handle = thread::spawn(move || {
+    server
+      .serve_requests(2, |request| {
+        let target = request.target().to_string();
+        tx.send(target.clone()).expect("send parsed target");
+        HttpResponse::ok(format!("served {target}"))
+      })
+      .expect("serve requests");
+  });
+
+  let mut stream = TcpStream::connect(addr).expect("connect server");
+  stream
+    .write_all(
+      concat!(
+        "GET /final HTTP/1.1\r\n",
+        "Host: localhost\r\n",
+        "Connection: close\r\n",
+        "\r\n",
+        "GET /ignored HTTP/1.1\r\n",
+        "Host: localhost\r\n",
+        "Connection: keep-alive\r\n",
+        "\r\n"
+      )
+      .as_bytes(),
+    )
+    .expect("write pipelined requests");
+  stream
+    .shutdown(std::net::Shutdown::Write)
+    .expect("shutdown write");
+
+  let mut response = String::new();
+  stream.read_to_string(&mut response).expect("read response");
+
+  assert_eq!(
+    "HTTP/1.1 200 OK\r\nContent-Length: 13\r\nConnection: close\r\n\r\nserved /final",
+    response
+  );
+  assert_eq!("/final", rx.recv().expect("receive final target"));
+
+  let second = send_request(addr, b"GET /next HTTP/1.1\r\nHost: localhost\r\n\r\n");
+  assert_eq!(
+    "HTTP/1.1 200 OK\r\nContent-Length: 12\r\nConnection: close\r\n\r\nserved /next",
+    second
+  );
+  assert_eq!("/next", rx.recv().expect("receive next target"));
+  assert!(rx.try_recv().is_err());
+
+  handle.join().expect("server thread");
+}
+
+#[test]
 fn response_write_to_omits_content_length_and_body_for_204() {
   let response = HttpResponse::new(204, "No Content").body("ignored");
   let mut serialized = Vec::new();


### PR DESCRIPTION
HttpServer now supports serving multiple keep-alive HTTP/1.1 requests on a single accepted TCP connection while preserving accept_one and default close behavior. Added regression coverage for multi-request keep-alive handling and Connection: close termination.

## Source References
Closing GitHub issues:
- Fixes fewensa/rttp#10

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1248/
work_kind: code_work
branch: hbx-1248-rttp-serve-multiple-http-1
base: main
commit: b949e6457b9910b8da85421cb98ac9d370960e8c
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1248/
    url: https://plane.kahub.in/endless/browse/HBX-1248/
    close_policy: link_only
  - kind: github_issue
    canonical: fewensa/rttp#10
    url: https://github.com/fewensa/rttp/issues/10
    github_repository: fewensa/rttp
    number: 10
    close_policy: close_on_merge
    close_reason: The implementation adds per-connection request looping for kept-alive HTTP/1.1 requests and covers the requested close termination behavior with regression tests.
```