### PR TITLE
feat: [rttp] Package and document socket2 server/client coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,219 +1,68 @@
 rttp
-===
+====
 
-# rttp
-A simple to use http lib for rust.
+A small Rust HTTP workspace with a client crate (`rttp_client`) and a wrapper
+crate (`rttp`) that also provides a minimal blocking HTTP server.
 
-# rttp_client
+## Client
 
-## Additional features
-rttp_client is a minimal http client, the default features only support
-http request, but you can add features to support https request, and async support
+`rttp_client` supports plain HTTP by default. Optional features add async
+request APIs and TLS implementations:
 
 | name | comment |
 |------|---------|
-| async | Async request features |
-| tls-native | support https request use `native-tls` crate |
-| tls-rustls | support https request use `rustls` crate |
-
-The default use
+| async | Async request APIs |
+| tls-native | HTTPS with `native-tls` |
+| tls-rustls | HTTPS with `rustls` |
 
 ```toml
 [dependencies]
-rttp_client = "0.1"
+rttp_client = "0.2"
 ```
 
-With tls-native
+Direct TCP client connections are opened with `socket2`. SOCKS proxy handshakes
+are still delegated to the `socks` crate.
 
-```toml
-[dependencies]
-rttp_client = { version = "0.1", features = ["tls-native"] }
-```
+```rust,no_run
+use rttp_client::HttpClient;
 
-With tls-rustls
-
-```toml
-[dependencies]
-rttp_client = { version = "0.1", features = ["tls-rustls"] }
-```
-
-Async support
-
-
-```toml
-[dependencies]
-rttp_client = { version = "0.1", features = ["async"] }
-```
-
-Full support
-
-```toml
-[dependencies]
-rttp_client = { version = "0.1", features = ["async", "tls-native"] }
-```
-
-*Important*
-`tls-native` and `tls-rustls` only support choose on features, do not same to use.
-
-## Examples
-
-### GET
-
-```rust
-# use rttp_client::HttpClient;
-HttpClient::new().get()
-  .url("http://httpbin.org/get")
-  .emit();
-```
-
-### POST
-
-```rust
-# use rttp_client::HttpClient;
-HttpClient::new().post()
-  .url("http://httpbin.org/post")
-  .emit();
-```
-
-### Header
-
-```rust
-# use rttp_client::HttpClient;
-# use rttp_client::types::Header;
-# use std::collections::HashMap;
-let mut multi_headers = HashMap::new();
-multi_headers.insert("name", "value");
-HttpClient::new().get()
- .url("http://httpbin.org/get")
- .header("name: value\nname: value")
- .header(("name", "value", "name: value\nname: value"))
- .header(Header::new("name", "value"))
- .header(multi_headers)
- .emit();
-```
-
-### Para
-
-```rust
-# use rttp_client::HttpClient;
-# use rttp_client::types::Para;
-# use std::collections::HashMap;
-let mut multi_para = HashMap::new();
-multi_para.insert("name", "value");
-HttpClient::new().post()
-  .url("http://httpbin.org/post")
-  .para("name=value&name=value")
-  .para(("name", "value", "name=value&name=value"))
-  .para(Para::new("name", "value"))
-  .para(multi_para)
-  .emit();
-```
-
-### Url
-
-```rust
-# use rttp_client::HttpClient;
-# use rttp_client::types::RoUrl;
-HttpClient::new().get()
-  .url(RoUrl::with("http://httpbin.org").path("get").para("name=value").para(("from", "rttp")))
-  .emit();
-```
-
-### POST JSON
-
-```rust
-# use rttp_client::HttpClient;
-HttpClient::new().post()
-  .url("http://httpbin.org/post")
-  .content_type("application/json")
-  .raw(r#" {"id": 1, "from": "rttp"} "#)
-  .emit();
-```
-
-### Form && Upload file
-
-```rust
-# use rttp_client::HttpClient;
-# use rttp_client::types::FormData;
-# use std::collections::HashMap;
-let mut multi_form = HashMap::new();
-multi_form.insert("name", "value");
-HttpClient::new().post()
-  .url("http://httpbin.org/post")
-  .para("name=value")
-  .form("name=value")
-  .form("name=value&name=value")
-  .form(("name", "value", "name=value&name=value"))
-  .form("file=@filename#/path/to/file")
-  .form("file=@/path/to/file")
-  .form(multi_form)
-  .form(FormData::with_text("name", "value"))
-  .form(FormData::with_file("name", "/path/to/file"))
-  .form(FormData::with_file_and_name("name", "/path/to/file", "filename"))
-  .form(FormData::with_binary("name", vec![]))  // Vec<u8>
-  .emit();
-```
-Para and form can be mixed, para does not support file parsing
-
-### Proxy
-
-*BASIC*
-
-```rust
-# use rttp_client::HttpClient;
-# use rttp_client::types::Proxy;
-HttpClient::new().post()
-  .url("http://httpbin.org/post")
-  .content_type("application/json")
-  .raw(r#" {"id": 1, "from": "rttp"} "#)
-  .proxy(Proxy::http("127.0.0.1", 1081))
-  .emit();
-```
-
-*BASIC WITH AUTHORIZATION*
-
-```rust
-# use rttp_client::HttpClient;
-# use rttp_client::types::Proxy;
-HttpClient::new().post()
-  .url("http://httpbin.org/post")
-  .content_type("application/json")
-  .raw(r#" {"id": 1, "from": "rttp"} "#)
-  .proxy(Proxy::socks5_with_authorization("127.0.0.1", 1081, "username", "password"))
-  .emit();
-```
-
-### Auto redirect
-
-```rust
-# use rttp_client::HttpClient;
-# use rttp_client::Config;
-let response = HttpClient::new().post()
-  .config(Config::builder().auto_redirect(true))
+let response = HttpClient::new()
   .get()
-  .url("http://bing.com")
-  .emit();
-assert!(response.is_ok());
-let response = response.unwrap();
-assert_ne!("bing.com", response.host());
+  .url("http://127.0.0.1:8080/health")
+  .emit()?;
+# Ok::<(), Box<dyn std::error::Error>>(())
 ```
 
-### Async
+## Server
 
-```rust
-# use rttp_client::HttpClient;
-# #[cfg(feature = "async")]
-let response = HttpClient::new().post()
-  .url("http://httpbin.org/post")
-  .rasync()
-  .await;
+The `rttp` crate exposes `rttp::Http::server`, which creates a blocking
+`HttpServer` listener.
+
+```toml
+[dependencies]
+rttp = "0.2"
 ```
 
+```rust,no_run
+use rttp::server::HttpResponse;
 
+fn main() -> std::io::Result<()> {
+  let server = rttp::Http::server("127.0.0.1:0")?;
+  println!("listening on {}", server.local_addr()?);
 
+  server.accept_one(|request| {
+    println!("{} {}", request.method(), request.target());
+    HttpResponse::ok("hello")
+  })
+}
+```
 
+Use `HttpServer::bind` directly when you already want the server type,
+`HttpServer::local_addr` to read the bound address, `accept_one` for one
+connection, and `serve_requests` for a fixed number of sequential connections.
+The listener path uses `socket2`.
 
-
-
-
-
+The server is intentionally small: it handles blocking HTTP/1.x request parsing
+for local tests and simple embedded use, closes each connection after one
+response, and does not implement chunked request bodies, keep-alive serving, TLS,
+or async accept loops.

--- a/rttp/README.md
+++ b/rttp/README.md
@@ -1,19 +1,21 @@
 rttp
-===
+====
 
-# rttp
+`rttp` wraps `rttp_client` behind optional client features and provides a small
+blocking HTTP server for local tests and simple embedded use.
 
-Wrapper of rttp_client
+## Server
 
-[rttp_client](https://github.com/fewensa/rttp)
+Create a listener with `rttp::Http::server` or call `HttpServer::bind` directly.
+The server listener is built with `socket2`.
 
-## Minimal server
-
-```rust
+```rust,no_run
 use rttp::server::HttpResponse;
 
 fn main() -> std::io::Result<()> {
-  let server = rttp::Http::server("127.0.0.1:8080")?;
+  let server = rttp::Http::server("127.0.0.1:0")?;
+  println!("listening on {}", server.local_addr()?);
+
   server.accept_one(|request| {
     println!("{} {}", request.method(), request.target());
     HttpResponse::ok("hello")
@@ -21,8 +23,21 @@ fn main() -> std::io::Result<()> {
 }
 ```
 
+`HttpServer::local_addr` returns the bound address, which is useful when binding
+to port `0` in tests. `HttpServer::accept_one` serves one connection.
+`HttpServer::serve_requests` serves a fixed number of sequential connections on
+the same listener.
 
+The server currently parses blocking HTTP/1.x requests, supports fixed
+`Content-Length` request bodies, writes one response, and closes the connection.
+It does not implement chunked request bodies, keep-alive serving, TLS, or async
+accept loops.
 
+## Client feature
 
+Enable the `client` feature to access `rttp::Http::client`, or enable `async`,
+`tls-native`, `tls-rustls`, or `all` for the corresponding `rttp_client`
+capabilities.
 
-
+Direct TCP client connections use `socket2`. SOCKS proxy handshakes remain
+delegated to the `socks` crate.

--- a/rttp/tests/package_list.rs
+++ b/rttp/tests/package_list.rs
@@ -1,0 +1,34 @@
+use std::process::Command;
+
+#[test]
+fn package_includes_server_tests_and_support_files() {
+  let output = Command::new(env!("CARGO"))
+    .arg("package")
+    .arg("--list")
+    .arg("--allow-dirty")
+    .arg("-p")
+    .arg("rttp")
+    .current_dir(concat!(env!("CARGO_MANIFEST_DIR"), "/.."))
+    .output()
+    .expect("run cargo package --list -p rttp");
+
+  assert!(
+    output.status.success(),
+    "cargo package --list failed: {}",
+    String::from_utf8_lossy(&output.stderr)
+  );
+
+  let package_files = String::from_utf8(output.stdout).expect("package list is utf-8");
+  for expected in [
+    "tests/test_server.rs",
+    "tests/test_server_models.rs",
+    "tests/test_client.rs",
+    "tests/support/mod.rs",
+    "tests/support/local_http.rs",
+  ] {
+    assert!(
+      package_files.lines().any(|line| line == expected),
+      "missing {expected} from package list:\n{package_files}"
+    );
+  }
+}

--- a/rttp/tests/package_list.rs
+++ b/rttp/tests/package_list.rs
@@ -6,11 +6,9 @@ fn package_includes_server_tests_and_support_files() {
     .arg("package")
     .arg("--list")
     .arg("--allow-dirty")
-    .arg("-p")
-    .arg("rttp")
-    .current_dir(concat!(env!("CARGO_MANIFEST_DIR"), "/.."))
+    .current_dir(env!("CARGO_MANIFEST_DIR"))
     .output()
-    .expect("run cargo package --list -p rttp");
+    .expect("run cargo package --list");
 
   assert!(
     output.status.success(),

--- a/rttp_client/README.md
+++ b/rttp_client/README.md
@@ -1,216 +1,64 @@
 rttp_client
-===
+===========
 
-# rttp_client
-
-## Additional features
-rttp_client is a minimal http client, the default features only support
-http request, but you can add features to support https request, and async support
+`rttp_client` is a small HTTP client crate. Plain HTTP is available by default;
+optional features add async request APIs and TLS implementations.
 
 | name | comment |
 |------|---------|
-| async | Async request features |
-| tls-native | support https request use `native-tls` crate |
-| tls-rustls | support https request use `rustls` crate |
-
-The default use
+| async | Async request APIs |
+| tls-native | HTTPS with `native-tls` |
+| tls-rustls | HTTPS with `rustls` |
 
 ```toml
 [dependencies]
-rttp_client = "0.1"
+rttp_client = "0.2"
 ```
-
-With tls-native
 
 ```toml
 [dependencies]
-rttp_client = { version = "0.1", features = ["tls-native"] }
+rttp_client = { version = "0.2", features = ["async", "tls-rustls"] }
 ```
 
-With tls-rustls
-
-```toml
-[dependencies]
-rttp_client = { version = "0.1", features = ["tls-rustls"] }
-```
-
-Async support
-
-
-```toml
-[dependencies]
-rttp_client = { version = "0.1", features = ["async"] }
-```
-
-Full support
-
-```toml
-[dependencies]
-rttp_client = { version = "0.1", features = ["async", "tls-native"] }
-```
-
-*Important*
-`tls-native` and `tls-rustls` only support choose on features, do not same to use.
+Direct TCP connections use `socket2`. SOCKS proxy handshakes remain delegated to
+the `socks` crate.
 
 ## Examples
 
-### GET
+```rust,no_run
+use rttp_client::HttpClient;
 
-```rust
-# use rttp_client::HttpClient;
-HttpClient::new().get()
-  .url("http://httpbin.org/get")
-  .emit();
-```
-
-### POST
-
-```rust
-# use rttp_client::HttpClient;
-HttpClient::new().post()
-  .url("http://httpbin.org/post")
-  .emit();
-```
-
-### Header
-
-```rust
-# use rttp_client::HttpClient;
-# use rttp_client::types::Header;
-# use std::collections::HashMap;
-let mut multi_headers = HashMap::new();
-multi_headers.insert("name", "value");
-HttpClient::new().get()
- .url("http://httpbin.org/get")
- .header("name=value&name=value")
- .header(("name", "value", "name=value&name=value"))
- .header(Header::new("name", "value"))
- .header(multi_headers)
- .emit();
-```
-
-### Para
-
-```rust
-# use rttp_client::HttpClient;
-# use rttp_client::types::Para;
-# use std::collections::HashMap;
-let mut multi_para = HashMap::new();
-multi_para.insert("name", "value");
-HttpClient::new().post()
-  .url("http://httpbin.org/post")
-  .para("name=value&name=value")
-  .para(("name", "value", "name=value&name=value"))
-  .para(Para::new("name", "value"))
-  .para(multi_para)
-  .emit();
-```
-
-### Url
-
-```rust
-# use rttp_client::HttpClient;
-# use rttp_client::types::RoUrl;
-HttpClient::new().get()
-  .url(RoUrl::with("http://httpbin.org").path("get").para("name=value").para(("from", "rttp")))
-  .emit();
-```
-
-### POST JSON
-
-```rust
-# use rttp_client::HttpClient;
-HttpClient::new().post()
-  .url("http://httpbin.org/post")
-  .content_type("application/json")
-  .raw(r#" {"id": 1, "from": "rttp"} "#)
-  .emit();
-```
-
-### Form && Upload file
-
-```rust
-# use rttp_client::HttpClient;
-# use rttp_client::types::FormData;
-# use std::collections::HashMap;
-let mut multi_form = HashMap::new();
-multi_form.insert("name", "value");
-HttpClient::new().post()
-  .url("http://httpbin.org/post")
-  .para("name=value")
-  .form("name=value")
-  .form("name=value&name=value")
-  .form(("name", "value", "name=value&name=value"))
-  .form("file=@filename#/path/to/file")
-  .form("file=@/path/to/file")
-  .form(multi_form)
-  .form(FormData::with_text("name", "value"))
-  .form(FormData::with_file("name", "/path/to/file"))
-  .form(FormData::with_file_and_name("name", "/path/to/file", "filename"))
-  .form(FormData::with_binary("name", vec![]))  // Vec<u8>
-  .emit();
-```
-Para and form can be mixed, para does not support file parsing
-
-### Proxy
-
-*BASIC*
-
-```rust
-# use rttp_client::HttpClient;
-# use rttp_client::types::Proxy;
-HttpClient::new().post()
-  .url("http://httpbin.org/post")
-  .content_type("application/json")
-  .raw(r#" {"id": 1, "from": "rttp"} "#)
-  .proxy(Proxy::http("127.0.0.1", 1081))
-  .emit();
-```
-
-*BASIC WITH AUTHORIZATION*
-
-```rust
-# use rttp_client::HttpClient;
-# use rttp_client::types::Proxy;
-HttpClient::new().post()
-  .url("http://httpbin.org/post")
-  .content_type("application/json")
-  .raw(r#" {"id": 1, "from": "rttp"} "#)
-  .proxy(Proxy::socks5_with_authorization("127.0.0.1", 1081, "username", "password"))
-  .emit();
-```
-
-### Auto redirect
-
-```rust
-# use rttp_client::HttpClient;
-# use rttp_client::Config;
-let response = HttpClient::new().post()
-  .config(Config::builder().auto_redirect(true))
+let response = HttpClient::new()
   .get()
-  .url("http://bing.com")
-  .emit();
-assert!(response.is_ok());
-let response = response.unwrap();
-assert_ne!("bing.com", response.host());
+  .url("http://127.0.0.1:8080/health")
+  .emit()?;
+# Ok::<(), Box<dyn std::error::Error>>(())
 ```
 
-### Async
+```rust,no_run
+use rttp_client::HttpClient;
+use rttp_client::types::Proxy;
 
-```rust
-# use rttp_client::HttpClient;
+let response = HttpClient::new()
+  .post()
+  .url("http://127.0.0.1:8080/messages")
+  .content_type("application/json")
+  .raw(r#"{"from":"rttp"}"#)
+  .proxy(Proxy::http("127.0.0.1", 1081))
+  .emit()?;
+# Ok::<(), Box<dyn std::error::Error>>(())
+```
+
+```rust,no_run
 # #[cfg(feature = "async")]
-let response = HttpClient::new().post()
-  .url("http://httpbin.org/post")
+# async fn example() -> Result<(), Box<dyn std::error::Error>> {
+use rttp_client::HttpClient;
+
+let response = HttpClient::new()
+  .get()
+  .url("http://127.0.0.1:8080/health")
   .rasync()
-  .await;
+  .await?;
+# Ok(())
+# }
 ```
-
-
-
-
-
-
-
-
-

--- a/rttp_client/src/lib.rs
+++ b/rttp_client/src/lib.rs
@@ -1,217 +1,52 @@
-//! # rttp
-//! A simple to use http lib for rust.
-//!
-//! # rttp_client
-//!
-//! ## Additional features
-//! rttp_client is a minimal http client, the default features only support
-//! http request, but you can add features to support https request, and async support
+//! `rttp_client` is a small HTTP client crate. Plain HTTP is available by
+//! default; optional features add async request APIs and TLS implementations.
 //!
 //! | name | comment |
 //! |------|---------|
-//! | async | Async request features |
-//! | tls-native | support https request use `native-tls` crate |
-//! | tls-rustls | support https request use `rustls` crate |
+//! | async | Async request APIs |
+//! | tls-native | HTTPS with `native-tls` |
+//! | tls-rustls | HTTPS with `rustls` |
 //!
-//! The default use
+//! Direct TCP connections use `socket2`. SOCKS proxy handshakes remain delegated
+//! to the `socks` crate.
 //!
-//! ```toml
-//! [dependencies]
-//! rttp_client = "*"
-//! ```
+//! ```rust,no_run
+//! use rttp_client::HttpClient;
 //!
-//! With tls-native
-//!
-//! ```toml
-//! [dependencies]
-//! rttp_client = { version = "*", features = ["tls-native"] }
-//! ```
-//!
-//! With tls-rustls
-//!
-//! ```toml
-//! [dependencies]
-//! rttp_client = { version = "*", features = ["tls-rustls"] }
-//! ```
-//!
-//! Async support
-//!
-//!
-//! ```toml
-//! [dependencies]
-//! rttp_client = { version = "*", features = ["async"] }
-//! ```
-//!
-//! Full support
-//!
-//! ```toml
-//! [dependencies]
-//! rttp_client = { version = "*", features = ["async", "tls-native"] }
-//! ```
-//!
-//! *Important*
-//! `tls-native` and `tls-rustls` can be enabled together; when both are enabled,
-//! the client prefers the rustls implementation for HTTPS requests.
-//!
-//! ## Examples
-//!
-//! ### GET
-//!
-//! ```rust
-//! # use rttp_client::HttpClient;
-//! HttpClient::new().get()
-//!   .url("http://httpbin.org/get")
-//!   .emit();
-//! ```
-//!
-//! ### POST
-//!
-//! ```rust
-//! # use rttp_client::HttpClient;
-//! HttpClient::new().post()
-//!   .url("http://httpbin.org/post")
-//!   .emit();
-//! ```
-//!
-//! ### Header
-//!
-//! ```rust
-//! # use rttp_client::HttpClient;
-//! # use rttp_client::types::Header;
-//! # use std::collections::HashMap;
-//! let mut multi_headers = HashMap::new();
-//! multi_headers.insert("name", "value");
-//! HttpClient::new().get()
-//!  .url("http://httpbin.org/get")
-//!  .header("name: value\nname: value")
-//!  .header(("name", "value", "name: value\nname: value"))
-//!  .header(Header::new("name", "value"))
-//!  .header(multi_headers)
-//!  .emit();
-//! ```
-//!
-//! ### Para
-//!
-//! ```rust
-//! # use rttp_client::HttpClient;
-//! # use rttp_client::types::Para;
-//! # use std::collections::HashMap;
-//! let mut multi_para = HashMap::new();
-//! multi_para.insert("name", "value");
-//! HttpClient::new().post()
-//!   .url("http://httpbin.org/post")
-//!   .para("name=value&name=value")
-//!   .para(("name", "value", "name=value&name=value"))
-//!   .para(Para::with_form("name", "value"))
-//!   .para(multi_para)
-//!   .emit();
-//! ```
-//!
-//! ### Url
-//!
-//! ```rust
-//! # use rttp_client::HttpClient;
-//! # use rttp_client::types::RoUrl;
-//! HttpClient::new().get()
-//!   .url(RoUrl::with("http://httpbin.org").path("get").para("name=value").para(("from", "rttp")))
-//!   .emit();
-//! ```
-//!
-//! ### POST JSON
-//!
-//! ```rust
-//! # use rttp_client::HttpClient;
-//! HttpClient::new().post()
-//!   .url("http://httpbin.org/post")
-//!   .content_type("application/json")
-//!   .raw(r#" {"id": 1, "from": "rttp"} "#)
-//!   .emit();
-//! ```
-//!
-//! ### Form && Upload file
-//!
-//! ```rust
-//! # use rttp_client::HttpClient;
-//! # use rttp_client::types::FormData;
-//! # use std::collections::HashMap;
-//! let mut multi_form = HashMap::new();
-//! multi_form.insert("name", "value");
-//! HttpClient::new().post()
-//!   .url("http://httpbin.org/post")
-//!   .para("name=value")
-//!   .form("name=value")
-//!   .form("name=value&name=value")
-//!   .form(("name", "value", "name=value&name=value"))
-//!   .form("file=@filename#/path/to/file")
-//!   .form("file=@/path/to/file")
-//!   .form(multi_form)
-//!   .form(FormData::with_text("name", "value"))
-//!   .form(FormData::with_file("name", "/path/to/file"))
-//!   .form(FormData::with_file_and_name("name", "/path/to/file", "filename"))
-//!   .form(FormData::with_binary("name", vec![]))  // Vec<u8>
-//!   .emit();
-//! ```
-//! Para and form can be mixed, para does not support file parsing
-//!
-//! ### Proxy
-//!
-//! *BASIC*
-//!
-//! ```rust
-//! # use rttp_client::HttpClient;
-//! # use rttp_client::types::Proxy;
-//! HttpClient::new().post()
-//!   .url("http://httpbin.org/post")
-//!   .content_type("application/json")
-//!   .raw(r#" {"id": 1, "from": "rttp"} "#)
-//!   .proxy(Proxy::http("127.0.0.1", 1081))
-//!   .emit();
-//! ```
-//!
-//! *BASIC WITH AUTHORIZATION*
-//!
-//! ```rust
-//! # use rttp_client::HttpClient;
-//! # use rttp_client::types::Proxy;
-//! HttpClient::new().post()
-//!   .url("http://httpbin.org/post")
-//!   .content_type("application/json")
-//!   .raw(r#" {"id": 1, "from": "rttp"} "#)
-//!   .proxy(Proxy::socks5_with_authorization("127.0.0.1", 1081, "username", "password"))
-//!   .emit();
-//! ```
-//!
-//! ### Auto redirect
-//!
-//! ```rust
-//! # use rttp_client::HttpClient;
-//! # use rttp_client::Config;
-//! let response = HttpClient::new().post()
-//!   .config(Config::builder().auto_redirect(true))
+//! let response = HttpClient::new()
 //!   .get()
-//!   .url("http://bing.com")
-//!   .emit();
-//! assert!(response.is_ok());
-//! let response = response.unwrap();
-//! assert_ne!("bing.com", response.host());
+//!   .url("http://127.0.0.1:8080/health")
+//!   .emit()?;
+//! # Ok::<(), Box<dyn std::error::Error>>(())
 //! ```
 //!
-//! ### Async
+//! ```rust,no_run
+//! use rttp_client::HttpClient;
+//! use rttp_client::types::Proxy;
 //!
-//! ```rust
-//! # use rttp_client::HttpClient;
+//! let response = HttpClient::new()
+//!   .post()
+//!   .url("http://127.0.0.1:8080/messages")
+//!   .content_type("application/json")
+//!   .raw(r#"{"from":"rttp"}"#)
+//!   .proxy(Proxy::http("127.0.0.1", 1081))
+//!   .emit()?;
+//! # Ok::<(), Box<dyn std::error::Error>>(())
+//! ```
+//!
+//! ```rust,no_run
 //! # #[cfg(feature = "async")]
-//! # async fn test_async() {
-//! let response = HttpClient::new().post()
-//!   .url("http://httpbin.org/post")
+//! # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+//! use rttp_client::HttpClient;
+//!
+//! let response = HttpClient::new()
+//!   .get()
+//!   .url("http://127.0.0.1:8080/health")
 //!   .rasync()
-//!   .await;
+//!   .await?;
+//! # Ok(())
 //! # }
 //! ```
-//!
-//!
-//!
-//!
 
 pub use self::client::*;
 pub use self::config::*;

--- a/rttp_client/tests/package_list.rs
+++ b/rttp_client/tests/package_list.rs
@@ -1,0 +1,34 @@
+use std::process::Command;
+
+#[test]
+fn package_includes_client_tests_and_support_files() {
+  let output = Command::new(env!("CARGO"))
+    .arg("package")
+    .arg("--list")
+    .arg("--allow-dirty")
+    .arg("-p")
+    .arg("rttp_client")
+    .current_dir(concat!(env!("CARGO_MANIFEST_DIR"), "/.."))
+    .output()
+    .expect("run cargo package --list -p rttp_client");
+
+  assert!(
+    output.status.success(),
+    "cargo package --list failed: {}",
+    String::from_utf8_lossy(&output.stderr)
+  );
+
+  let package_files = String::from_utf8(output.stdout).expect("package list is utf-8");
+  for expected in [
+    "tests/test_http_basic.rs",
+    "tests/test_http_async.rs",
+    "tests/test_rustls.rs",
+    "tests/support/mod.rs",
+    "tests/support/local_http.rs",
+  ] {
+    assert!(
+      package_files.lines().any(|line| line == expected),
+      "missing {expected} from package list:\n{package_files}"
+    );
+  }
+}

--- a/rttp_client/tests/package_list.rs
+++ b/rttp_client/tests/package_list.rs
@@ -6,11 +6,9 @@ fn package_includes_client_tests_and_support_files() {
     .arg("package")
     .arg("--list")
     .arg("--allow-dirty")
-    .arg("-p")
-    .arg("rttp_client")
-    .current_dir(concat!(env!("CARGO_MANIFEST_DIR"), "/.."))
+    .current_dir(env!("CARGO_MANIFEST_DIR"))
     .output()
-    .expect("run cargo package --list -p rttp_client");
+    .expect("run cargo package --list");
 
   assert!(
     output.status.success(),


### PR DESCRIPTION
Documented socket2-backed client/server coverage and current server limitations, removed external-service README examples, and added package-list regression tests to keep packaged test fixtures included. Verification passed with formatting, package listing, and workspace tests.

## Source References
Related GitHub issues:
- [fewensa/rttp#10](https://github.com/fewensa/rttp/issues/10)

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1251/
work_kind: code_work
branch: hbx-1251-rttp-package-and-document-socket2
base: main
commit: c9fd1766e84a9985cdd0a6c77755506022442a62
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1251/
    url: https://plane.kahub.in/endless/browse/HBX-1251/
    close_policy: link_only
  - kind: github_issue
    canonical: fewensa/rttp#10
    url: https://github.com/fewensa/rttp/issues/10
    github_repository: fewensa/rttp
    number: 10
    close_policy: link_only
```