### PR TITLE
feat: [rttp] Align server Connection semantics for HTTP/1.0 and HTTP/1.1

### DIFF
--- a/rttp/src/server.rs
+++ b/rttp/src/server.rs
@@ -98,16 +98,21 @@ impl HttpServer {
         Err(err) => return Err(err),
       };
       let request_closes_connection = request.closes_connection();
-      let request_keeps_connection_alive = request.keeps_connection_alive();
+      let request_uses_http10_defaults = request.version() == "HTTP/1.0";
       let response = handler(request);
       let response_closes_connection = response.closes_connection();
       served += 1;
 
-      let close_after_response = request_closes_connection
-        || response_closes_connection
-        || !request_keeps_connection_alive
-        || served == request_limit;
-      response.write_to_with_default_connection(reader.get_mut(), close_after_response)?;
+      let close_after_response =
+        request_closes_connection || response_closes_connection || served == request_limit;
+      let default_connection = if close_after_response {
+        DefaultConnectionHeader::Close
+      } else if request_uses_http10_defaults {
+        DefaultConnectionHeader::KeepAlive
+      } else {
+        DefaultConnectionHeader::Omit
+      };
+      response.write_to_with_default_connection(reader.get_mut(), default_connection)?;
 
       if close_after_response {
         break;
@@ -169,11 +174,19 @@ impl Request {
   }
 
   pub fn closes_connection(&self) -> bool {
-    connection_header_has_token(self.header("Connection"), "close")
+    if self.connection_header_has_token("close") {
+      return true;
+    }
+
+    self.version == "HTTP/1.0" && !self.connection_header_has_token("keep-alive")
   }
 
-  fn keeps_connection_alive(&self) -> bool {
-    connection_header_has_token(self.header("Connection"), "keep-alive")
+  fn connection_header_has_token(&self, token: &str) -> bool {
+    self
+      .headers
+      .iter()
+      .filter(|(name, _)| name.eq_ignore_ascii_case("Connection"))
+      .any(|(_, value)| connection_header_has_token(Some(value), token))
   }
 
   fn read_from<R>(reader: &mut R) -> io::Result<Self>
@@ -442,6 +455,13 @@ pub struct HttpResponse {
   body: Vec<u8>,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum DefaultConnectionHeader {
+  Close,
+  KeepAlive,
+  Omit,
+}
+
 impl HttpResponse {
   pub fn new<S: AsRef<str>>(status_code: u16, reason: S) -> Self {
     Self {
@@ -474,7 +494,7 @@ impl HttpResponse {
   pub fn to_bytes(&self) -> Vec<u8> {
     let mut bytes = Vec::new();
     self
-      .write_head_to(&mut bytes, false)
+      .write_head_to(&mut bytes, DefaultConnectionHeader::Omit)
       .expect("write to Vec cannot fail");
     if self.allows_body() {
       bytes.extend_from_slice(&self.body);
@@ -486,25 +506,29 @@ impl HttpResponse {
   where
     W: Write,
   {
-    self.write_to_with_default_connection(writer, true)
+    self.write_to_with_default_connection(writer, DefaultConnectionHeader::Close)
   }
 
   fn write_to_with_default_connection<W>(
     &self,
     writer: &mut W,
-    close_by_default: bool,
+    default_connection: DefaultConnectionHeader,
   ) -> io::Result<()>
   where
     W: Write,
   {
-    self.write_head_to(writer, close_by_default)?;
+    self.write_head_to(writer, default_connection)?;
     if self.allows_body() {
       writer.write_all(&self.body)?;
     }
     writer.flush()
   }
 
-  fn write_head_to<W>(&self, writer: &mut W, include_default_connection: bool) -> io::Result<()>
+  fn write_head_to<W>(
+    &self,
+    writer: &mut W,
+    default_connection: DefaultConnectionHeader,
+  ) -> io::Result<()>
   where
     W: Write,
   {
@@ -514,8 +538,12 @@ impl HttpResponse {
       self.version, self.status_code, self.reason
     )?;
 
-    for header in &self.headers {
-      if !header.name.eq_ignore_ascii_case("Content-Length") {
+    let connection_header_index = self.connection_header_index();
+    for (index, header) in self.headers.iter().enumerate() {
+      if !header.name.eq_ignore_ascii_case("Content-Length")
+        && (!header.name.eq_ignore_ascii_case("Connection")
+          || Some(index) == connection_header_index)
+      {
         write!(writer, "{}: {}\r\n", header.name, header.value)?;
       }
     }
@@ -523,8 +551,12 @@ impl HttpResponse {
     if self.allows_body() {
       write!(writer, "Content-Length: {}\r\n", self.body.len())?;
     }
-    if include_default_connection && !self.has_header("Connection") {
-      writer.write_all(b"Connection: close\r\n")?;
+    if connection_header_index.is_none() {
+      match default_connection {
+        DefaultConnectionHeader::Close => writer.write_all(b"Connection: close\r\n")?,
+        DefaultConnectionHeader::KeepAlive => writer.write_all(b"Connection: keep-alive\r\n")?,
+        DefaultConnectionHeader::Omit => {}
+      }
     }
 
     writer.write_all(b"\r\n")
@@ -534,20 +566,19 @@ impl HttpResponse {
     response_status_allows_body(self.status_code)
   }
 
-  fn has_header(&self, name: &str) -> bool {
+  fn connection_header_index(&self) -> Option<usize> {
     self
       .headers
       .iter()
-      .any(|header| header.name.eq_ignore_ascii_case(name))
+      .rposition(|header| header.name.eq_ignore_ascii_case("Connection"))
   }
 
   fn closes_connection(&self) -> bool {
-    let connection = self
+    self
       .headers
       .iter()
-      .find(|header| header.name.eq_ignore_ascii_case("Connection"))
-      .map(|header| header.value.as_str());
-    connection_header_has_token(connection, "close")
+      .filter(|header| header.name.eq_ignore_ascii_case("Connection"))
+      .any(|header| connection_header_has_token(Some(header.value.as_str()), "close"))
   }
 }
 

--- a/rttp/tests/test_server.rs
+++ b/rttp/tests/test_server.rs
@@ -479,7 +479,7 @@ fn server_accepts_multiple_sequential_connections_on_one_listener() {
   let second = send_request(addr, b"GET /second HTTP/1.1\r\nHost: localhost\r\n\r\n");
 
   assert_eq!(
-    "HTTP/1.1 200 OK\r\nContent-Length: 13\r\nConnection: close\r\n\r\nserved /first",
+    "HTTP/1.1 200 OK\r\nContent-Length: 13\r\n\r\nserved /first",
     first
   );
   assert_eq!(
@@ -534,6 +534,162 @@ fn server_serves_multiple_requests_on_one_kept_alive_connection() {
   assert_eq!(
     concat!(
       "HTTP/1.1 200 OK\r\nContent-Length: 13\r\n\r\nserved /first",
+      "HTTP/1.1 200 OK\r\nContent-Length: 14\r\nConnection: close\r\n\r\nserved /second",
+    ),
+    response
+  );
+  assert_eq!("/first", rx.recv().expect("receive first target"));
+  assert_eq!("/second", rx.recv().expect("receive second target"));
+
+  handle.join().expect("server thread");
+}
+
+#[test]
+fn server_keeps_http11_connection_alive_by_default() {
+  let server = rttp::Http::server("127.0.0.1:0").expect("bind server");
+  let addr = server.local_addr().expect("server addr");
+  let (tx, rx) = mpsc::channel();
+
+  let handle = thread::spawn(move || {
+    server
+      .serve_requests(2, |request| {
+        let target = request.target().to_string();
+        tx.send(target.clone()).expect("send parsed target");
+        HttpResponse::ok(format!("served {target}"))
+      })
+      .expect("serve requests");
+  });
+
+  let mut stream = TcpStream::connect(addr).expect("connect server");
+  stream
+    .write_all(
+      concat!(
+        "GET /first HTTP/1.1\r\n",
+        "Host: localhost\r\n",
+        "\r\n",
+        "GET /second HTTP/1.1\r\n",
+        "Host: localhost\r\n",
+        "\r\n"
+      )
+      .as_bytes(),
+    )
+    .expect("write pipelined requests");
+  stream
+    .shutdown(std::net::Shutdown::Write)
+    .expect("shutdown write");
+
+  let mut response = String::new();
+  stream.read_to_string(&mut response).expect("read response");
+
+  assert_eq!(
+    concat!(
+      "HTTP/1.1 200 OK\r\nContent-Length: 13\r\n\r\nserved /first",
+      "HTTP/1.1 200 OK\r\nContent-Length: 14\r\nConnection: close\r\n\r\nserved /second",
+    ),
+    response
+  );
+  assert_eq!("/first", rx.recv().expect("receive first target"));
+  assert_eq!("/second", rx.recv().expect("receive second target"));
+
+  handle.join().expect("server thread");
+}
+
+#[test]
+fn server_closes_http10_connection_by_default() {
+  let server = rttp::Http::server("127.0.0.1:0").expect("bind server");
+  let addr = server.local_addr().expect("server addr");
+  let (tx, rx) = mpsc::channel();
+
+  let handle = thread::spawn(move || {
+    server
+      .serve_requests(2, |request| {
+        let target = request.target().to_string();
+        tx.send(target.clone()).expect("send parsed target");
+        HttpResponse::ok(format!("served {target}"))
+      })
+      .expect("serve requests");
+  });
+
+  let mut stream = TcpStream::connect(addr).expect("connect server");
+  stream
+    .write_all(
+      concat!(
+        "GET /first HTTP/1.0\r\n",
+        "Host: localhost\r\n",
+        "\r\n",
+        "GET /ignored HTTP/1.0\r\n",
+        "Host: localhost\r\n",
+        "\r\n"
+      )
+      .as_bytes(),
+    )
+    .expect("write pipelined requests");
+  stream
+    .shutdown(std::net::Shutdown::Write)
+    .expect("shutdown write");
+
+  let mut response = String::new();
+  stream.read_to_string(&mut response).expect("read response");
+
+  assert_eq!(
+    "HTTP/1.1 200 OK\r\nContent-Length: 13\r\nConnection: close\r\n\r\nserved /first",
+    response
+  );
+  assert_eq!("/first", rx.recv().expect("receive first target"));
+
+  let second = send_request(addr, b"GET /second HTTP/1.0\r\nHost: localhost\r\n\r\n");
+  assert_eq!(
+    "HTTP/1.1 200 OK\r\nContent-Length: 14\r\nConnection: close\r\n\r\nserved /second",
+    second
+  );
+  assert_eq!("/second", rx.recv().expect("receive second target"));
+  assert!(rx.try_recv().is_err());
+
+  handle.join().expect("server thread");
+}
+
+#[test]
+fn server_keeps_http10_connection_alive_when_requested() {
+  let server = rttp::Http::server("127.0.0.1:0").expect("bind server");
+  let addr = server.local_addr().expect("server addr");
+  let (tx, rx) = mpsc::channel();
+
+  let handle = thread::spawn(move || {
+    server
+      .serve_requests(2, |request| {
+        let target = request.target().to_string();
+        tx.send(target.clone()).expect("send parsed target");
+        HttpResponse::ok(format!("served {target}"))
+      })
+      .expect("serve requests");
+  });
+
+  let mut stream = TcpStream::connect(addr).expect("connect server");
+  stream
+    .write_all(
+      concat!(
+        "GET /first HTTP/1.0\r\n",
+        "Host: localhost\r\n",
+        "Connection: keep-alive\r\n",
+        "\r\n",
+        "GET /second HTTP/1.0\r\n",
+        "Host: localhost\r\n",
+        "Connection: keep-alive\r\n",
+        "\r\n"
+      )
+      .as_bytes(),
+    )
+    .expect("write pipelined requests");
+  stream
+    .shutdown(std::net::Shutdown::Write)
+    .expect("shutdown write");
+
+  let mut response = String::new();
+  stream.read_to_string(&mut response).expect("read response");
+
+  assert_eq!(
+    concat!(
+      "HTTP/1.1 200 OK\r\nContent-Length: 13\r\nConnection: keep-alive\r\n\r\nserved /first",
       "HTTP/1.1 200 OK\r\nContent-Length: 14\r\nConnection: close\r\n\r\nserved /second",
     ),
     response

--- a/rttp/tests/test_server_models.rs
+++ b/rttp/tests/test_server_models.rs
@@ -136,6 +136,24 @@ fn serializes_http_response_status_headers_content_length_and_body() {
 }
 
 #[test]
+fn serializes_at_most_one_connection_header() {
+  let response = HttpResponse::new(200, "OK")
+    .header("Connection", "keep-alive")
+    .header("Connection", "close")
+    .body("ok");
+
+  let serialized = String::from_utf8(response.to_bytes()).expect("response is UTF-8");
+  let connection_headers = serialized
+    .lines()
+    .filter(|line| line.to_ascii_lowercase().starts_with("connection:"))
+    .count();
+
+  assert_eq!(1, connection_headers);
+  assert!(serialized.contains("\r\nConnection: close\r\n"));
+  assert!(!serialized.contains("\r\nConnection: keep-alive\r\n"));
+}
+
+#[test]
 fn rejects_response_headers_with_crlf() {
   let result = std::panic::catch_unwind(|| {
     let _response = HttpResponse::new(302, "Found").header("Location", "/safe\r\nX-Evil: true");


### PR DESCRIPTION
Implemented server Connection semantics for HTTP/1.0 and HTTP/1.1, including default persistence for HTTP/1.1, default close for HTTP/1.0, HTTP/1.0 keep-alive responses, and deduped response Connection serialization. Verified with formatting, rttp test suite, and workspace tests.

## Source References
Closing GitHub issues:
- Fixes fewensa/rttp#10

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1250/
work_kind: code_work
branch: hbx-1250-rttp-align-server-connection-semantics
base: main
commit: 9a9cfbd0404603abc5e86308dbd8f153cd10bd26
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1250/
    url: https://plane.kahub.in/endless/browse/HBX-1250/
    close_policy: link_only
  - kind: github_issue
    canonical: fewensa/rttp#10
    url: https://github.com/fewensa/rttp/issues/10
    github_repository: fewensa/rttp
    number: 10
    close_policy: close_on_merge
    close_reason: The implementation fully covers the requested HTTP/1.0 and HTTP/1.1 server Connection semantics and response header deduplication behavior.
```