### PR TITLE
feat: [rttp] Enforce bounded HTTP request head and body reads

### DIFF
--- a/rttp/src/server.rs
+++ b/rttp/src/server.rs
@@ -798,21 +798,18 @@ where
   R: BufRead,
 {
   let mut body = Vec::new();
+  let mut body_bytes_read = 0;
 
   loop {
-    let line = read_crlf_line(reader)?;
+    let line = read_bounded_crlf_line(reader, &mut body_bytes_read)?;
     let chunk_size = parse_chunk_size(&line)?;
 
     if chunk_size == 0 {
-      consume_trailers(reader)?;
+      consume_trailers(reader, &mut body_bytes_read)?;
       return Ok(body);
     }
 
-    let body_len = body
-      .len()
-      .checked_add(chunk_size)
-      .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "request body is too large"))?;
-    reject_oversized_request_body(body_len)?;
+    add_request_body_bytes(&mut body_bytes_read, chunk_size)?;
 
     let copied = {
       let mut chunk_reader = reader.take(chunk_size as u64);
@@ -830,22 +827,36 @@ where
         "incomplete chunked request body",
       ));
     };
-    consume_crlf(reader)?;
+    consume_crlf(reader, &mut body_bytes_read)?;
   }
 }
 
-fn read_crlf_line<R>(reader: &mut R) -> io::Result<Vec<u8>>
+fn add_request_body_bytes(total: &mut usize, length: usize) -> io::Result<()> {
+  *total = total
+    .checked_add(length)
+    .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "request body is too large"))?;
+  reject_oversized_request_body(*total)
+}
+
+fn read_bounded_crlf_line<R>(reader: &mut R, body_bytes_read: &mut usize) -> io::Result<Vec<u8>>
 where
   R: BufRead,
 {
   let mut line = Vec::new();
-  let read = reader.read_until(b'\n', &mut line)?;
+  let remaining = MAX_REQUEST_BODY_BYTES
+    .checked_sub(*body_bytes_read)
+    .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "request body is too large"))?;
+  let read = {
+    let mut limited_reader = reader.take(remaining.saturating_add(1) as u64);
+    limited_reader.read_until(b'\n', &mut line)?
+  };
   if read == 0 {
     return Err(io::Error::new(
       io::ErrorKind::UnexpectedEof,
       "incomplete chunked request body",
     ));
   }
+  add_request_body_bytes(body_bytes_read, read)?;
   if line.ends_with(b"\r\n") {
     Ok(line)
   } else {
@@ -871,10 +882,11 @@ fn parse_chunk_size(line: &[u8]) -> io::Result<usize> {
     .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "invalid chunk size"))
 }
 
-fn consume_crlf<R>(reader: &mut R) -> io::Result<()>
+fn consume_crlf<R>(reader: &mut R, body_bytes_read: &mut usize) -> io::Result<()>
 where
   R: BufRead,
 {
+  add_request_body_bytes(body_bytes_read, 2)?;
   let mut suffix = [0u8; 2];
   reader.read_exact(&mut suffix).map_err(|_| {
     io::Error::new(
@@ -892,12 +904,12 @@ where
   }
 }
 
-fn consume_trailers<R>(reader: &mut R) -> io::Result<()>
+fn consume_trailers<R>(reader: &mut R, body_bytes_read: &mut usize) -> io::Result<()>
 where
   R: BufRead,
 {
   loop {
-    let line = read_crlf_line(reader)?;
+    let line = read_bounded_crlf_line(reader, body_bytes_read)?;
     if line == b"\r\n" {
       return Ok(());
     }
@@ -1053,6 +1065,51 @@ mod tests {
     assert_eq!("/first", first.target());
     assert_eq!(io::ErrorKind::UnexpectedEof, error.kind());
     assert_eq!("incomplete HTTP request body", error.to_string());
+  }
+
+  #[test]
+  fn chunk_extension_bytes_count_toward_request_body_limit() {
+    let chunk_extension = "a".repeat(MAX_REQUEST_BODY_BYTES);
+    let raw = format!(
+      concat!(
+        "POST /chunked HTTP/1.1\r\n",
+        "Host: example.test\r\n",
+        "Transfer-Encoding: chunked\r\n",
+        "\r\n",
+        "0;{}\r\n",
+        "\r\n"
+      ),
+      chunk_extension
+    );
+    let mut reader = BufReader::new(Cursor::new(raw.as_bytes()));
+
+    let error = Request::read_next_from(&mut reader).expect_err("chunk extension should be capped");
+
+    assert_eq!(io::ErrorKind::InvalidData, error.kind());
+    assert_eq!("request body is too large", error.to_string());
+  }
+
+  #[test]
+  fn chunk_trailer_bytes_count_toward_request_body_limit() {
+    let trailer_value = "a".repeat(MAX_REQUEST_BODY_BYTES);
+    let raw = format!(
+      concat!(
+        "POST /chunked HTTP/1.1\r\n",
+        "Host: example.test\r\n",
+        "Transfer-Encoding: chunked\r\n",
+        "\r\n",
+        "0\r\n",
+        "X-Trace: {}\r\n",
+        "\r\n"
+      ),
+      trailer_value
+    );
+    let mut reader = BufReader::new(Cursor::new(raw.as_bytes()));
+
+    let error = Request::read_next_from(&mut reader).expect_err("chunk trailer should be capped");
+
+    assert_eq!(io::ErrorKind::InvalidData, error.kind());
+    assert_eq!("request body is too large", error.to_string());
   }
 
   #[test]

--- a/rttp/src/server.rs
+++ b/rttp/src/server.rs
@@ -5,6 +5,9 @@ use std::net::{SocketAddr, TcpListener, TcpStream, ToSocketAddrs};
 
 use socket2::{Domain, Protocol, Socket, Type};
 
+const MAX_REQUEST_HEAD_BYTES: usize = 64 * 1024;
+const MAX_REQUEST_BODY_BYTES: usize = 1024 * 1024;
+
 pub struct HttpServer {
   listener: TcpListener,
 }
@@ -209,7 +212,7 @@ impl Request {
       if let (Some(header_end), Some(RequestBodyKind::ContentLength(content_length))) =
         (find_header_end(&raw), body_kind)
       {
-        let message_len = header_end + 4 + content_length;
+        let message_len = checked_request_message_len(header_end, content_length)?;
         if raw.len() == message_len {
           return Ok(Some(Self::from_raw_frame(&raw)?));
         }
@@ -224,7 +227,8 @@ impl Request {
           (find_header_end(&raw), body_kind)
         {
           let body_start = header_end + 4;
-          if raw.len() < body_start + content_length {
+          let body_end = checked_request_message_len(header_end, content_length)?;
+          if raw.len() < body_end || body_end < body_start {
             return Err(io::Error::new(
               io::ErrorKind::UnexpectedEof,
               "incomplete HTTP request body",
@@ -240,7 +244,7 @@ impl Request {
       if let (Some(header_end), Some(RequestBodyKind::ContentLength(content_length))) =
         (find_header_end(&raw), body_kind)
       {
-        let message_len = header_end + 4 + content_length;
+        let message_len = checked_request_message_len(header_end, content_length)?;
         let take = (message_len - raw.len()).min(available.len());
         raw.extend_from_slice(&available[..take]);
         reader.consume(take);
@@ -252,6 +256,7 @@ impl Request {
       match find_header_end(&combined) {
         Some(header_end) => {
           let take = header_end + 4 - raw.len();
+          reject_oversized_request_head(header_end + 4)?;
           raw.extend_from_slice(&available[..take]);
           reader.consume(take);
           let head = parse_request_head(&raw[..header_end])?;
@@ -260,6 +265,7 @@ impl Request {
               return Ok(Some(Self::from_head_and_body(head, Vec::new())));
             }
             RequestBodyKind::ContentLength(content_length) => {
+              reject_oversized_request_body(content_length)?;
               body_kind = Some(RequestBodyKind::ContentLength(content_length));
             }
             RequestBodyKind::Chunked => {
@@ -270,6 +276,7 @@ impl Request {
         }
         None => {
           let take = available.len();
+          reject_oversized_request_head(raw.len().saturating_add(take))?;
           raw.extend_from_slice(available);
           reader.consume(take);
         }
@@ -280,11 +287,13 @@ impl Request {
   fn from_raw_frame(raw: &[u8]) -> io::Result<Self> {
     let header_end = find_header_end(raw)
       .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "incomplete HTTP request"))?;
+    reject_oversized_request_head(header_end + 4)?;
     let head = parse_request_head(&raw[..header_end])?;
     let body_start = header_end + 4;
     let body = match request_body_kind(&head.headers)? {
       RequestBodyKind::ContentLength(content_length) => {
-        let body_end = body_start + content_length;
+        reject_oversized_request_body(content_length)?;
+        let body_end = checked_request_message_len(header_end, content_length)?;
 
         if raw.len() < body_end {
           return Err(io::Error::new(
@@ -630,6 +639,35 @@ fn find_header_end(raw: &[u8]) -> Option<usize> {
   raw.windows(4).position(|window| window == b"\r\n\r\n")
 }
 
+fn reject_oversized_request_head(length: usize) -> io::Result<()> {
+  if length > MAX_REQUEST_HEAD_BYTES {
+    Err(io::Error::new(
+      io::ErrorKind::InvalidData,
+      "request head is too large",
+    ))
+  } else {
+    Ok(())
+  }
+}
+
+fn reject_oversized_request_body(length: usize) -> io::Result<()> {
+  if length > MAX_REQUEST_BODY_BYTES {
+    Err(io::Error::new(
+      io::ErrorKind::InvalidData,
+      "request body is too large",
+    ))
+  } else {
+    Ok(())
+  }
+}
+
+fn checked_request_message_len(header_end: usize, content_length: usize) -> io::Result<usize> {
+  header_end
+    .checked_add(4)
+    .and_then(|body_start| body_start.checked_add(content_length))
+    .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "request body is too large"))
+}
+
 struct RequestHead {
   method: String,
   target: String,
@@ -769,6 +807,12 @@ where
       consume_trailers(reader)?;
       return Ok(body);
     }
+
+    let body_len = body
+      .len()
+      .checked_add(chunk_size)
+      .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "request body is too large"))?;
+    reject_oversized_request_body(body_len)?;
 
     let copied = {
       let mut chunk_reader = reader.take(chunk_size as u64);

--- a/rttp/tests/test_server.rs
+++ b/rttp/tests/test_server.rs
@@ -176,6 +176,53 @@ fn server_returns_bad_request_for_invalid_header_syntax() {
 }
 
 #[test]
+fn server_returns_bad_request_for_oversized_request_head() {
+  let header_value = "x".repeat(70 * 1024);
+  let raw = format!("GET / HTTP/1.1\r\nX-Large: {header_value}\r\n\r\n");
+  let (response, handler_called) = send_raw_request(raw.as_bytes());
+
+  assert!(!handler_called);
+  assert_eq!(
+    "HTTP/1.1 400 Bad Request\r\nContent-Length: 11\r\nConnection: close\r\n\r\nBad Request",
+    response
+  );
+}
+
+#[test]
+fn server_returns_bad_request_for_oversized_content_length_body() {
+  let server = rttp::Http::server("127.0.0.1:0").expect("bind server");
+  let addr = server.local_addr().expect("server addr");
+  let (tx, rx) = mpsc::channel();
+
+  let handle = thread::spawn(move || {
+    server
+      .accept_one(|request| {
+        tx.send(request).expect("send parsed request");
+        HttpResponse::ok("unexpected")
+      })
+      .expect("serve one request");
+  });
+
+  let mut stream = TcpStream::connect(addr).expect("connect server");
+  stream
+    .set_read_timeout(Some(Duration::from_millis(250)))
+    .expect("set read timeout");
+  stream
+    .write_all(b"POST /upload HTTP/1.1\r\nContent-Length: 1048577\r\n\r\n")
+    .expect("write request head");
+
+  let mut response = String::new();
+  stream.read_to_string(&mut response).expect("read response");
+
+  handle.join().expect("server thread");
+  assert!(rx.try_recv().is_err());
+  assert_eq!(
+    "HTTP/1.1 400 Bad Request\r\nContent-Length: 11\r\nConnection: close\r\n\r\nBad Request",
+    response
+  );
+}
+
+#[test]
 fn server_decodes_chunked_request_body() {
   let server = rttp::Http::server("127.0.0.1:0").expect("bind server");
   let addr = server.local_addr().expect("server addr");
@@ -222,6 +269,80 @@ fn server_decodes_chunked_request_body() {
   );
 
   handle.join().expect("server thread");
+}
+
+#[test]
+fn server_accepts_small_content_length_request_body() {
+  let (response, handler_called) =
+    send_raw_request(b"POST /upload HTTP/1.1\r\nContent-Length: 4\r\n\r\nbody");
+
+  assert!(handler_called);
+  assert_eq!(
+    "HTTP/1.1 200 OK\r\nContent-Length: 10\r\nConnection: close\r\n\r\nunexpected",
+    response
+  );
+}
+
+#[test]
+fn server_accepts_small_chunked_request_body() {
+  let (response, handler_called) = send_raw_request(
+    concat!(
+      "POST /upload HTTP/1.1\r\n",
+      "Transfer-Encoding: chunked\r\n",
+      "\r\n",
+      "4\r\nbody\r\n",
+      "0\r\n\r\n"
+    )
+    .as_bytes(),
+  );
+
+  assert!(handler_called);
+  assert_eq!(
+    "HTTP/1.1 200 OK\r\nContent-Length: 10\r\nConnection: close\r\n\r\nunexpected",
+    response
+  );
+}
+
+#[test]
+fn server_returns_bad_request_for_oversized_chunked_request_body() {
+  let server = rttp::Http::server("127.0.0.1:0").expect("bind server");
+  let addr = server.local_addr().expect("server addr");
+  let (tx, rx) = mpsc::channel();
+
+  let handle = thread::spawn(move || {
+    server
+      .accept_one(|request| {
+        tx.send(request).expect("send parsed request");
+        HttpResponse::ok("unexpected")
+      })
+      .expect("serve one request");
+  });
+
+  let mut stream = TcpStream::connect(addr).expect("connect server");
+  stream
+    .set_read_timeout(Some(Duration::from_millis(250)))
+    .expect("set read timeout");
+  stream
+    .write_all(
+      concat!(
+        "POST /upload HTTP/1.1\r\n",
+        "Transfer-Encoding: chunked\r\n",
+        "\r\n",
+        "100001\r\n"
+      )
+      .as_bytes(),
+    )
+    .expect("write oversized chunk header");
+
+  let mut response = String::new();
+  stream.read_to_string(&mut response).expect("read response");
+
+  handle.join().expect("server thread");
+  assert!(rx.try_recv().is_err());
+  assert_eq!(
+    "HTTP/1.1 400 Bad Request\r\nContent-Length: 11\r\nConnection: close\r\n\r\nBad Request",
+    response
+  );
 }
 
 #[test]


### PR DESCRIPTION
Implemented conservative request parser limits for the rttp socket2 server: 64 KiB request heads and 1 MiB decoded bodies for Content-Length and chunked requests. Oversized inputs now return deterministic 400 responses before handler invocation, while normal small request bodies continue to work. Verified with formatting, rttp tests, and the full workspace test suite.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1253/
work_kind: code_work
branch: hbx-1253-rttp-enforce-bounded-http-request
base: main
commit: f297769a6afe249583e1e4a3b2c138d3cea6032e
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1253/
    url: https://plane.kahub.in/endless/browse/HBX-1253/
    close_policy: link_only
```