### PR TITLE
feat: [rttp] Implement Expect: 100-continue handling in the server

### DIFF
--- a/rttp/src/server.rs
+++ b/rttp/src/server.rs
@@ -862,11 +862,10 @@ fn request_needs_continue(
 
   Ok(
     has_expect
-      && matches!(
+      && (matches!(
         body_kind,
         RequestBodyKind::ContentLength(content_length) if content_length > 0
-      )
-      || has_expect && body_kind == RequestBodyKind::Chunked,
+      ) || body_kind == RequestBodyKind::Chunked),
   )
 }
 

--- a/rttp/src/server.rs
+++ b/rttp/src/server.rs
@@ -88,7 +88,7 @@ impl HttpServer {
     let mut served = 0;
 
     while served < request_limit {
-      let request = match Request::read_next_from(&mut reader) {
+      let request = match Request::read_next_from_with_continue(&mut reader) {
         Ok(Some(request)) => request,
         Ok(None) => break,
         Err(err) if is_bad_request_error(&err) => {
@@ -126,16 +126,19 @@ impl HttpServer {
   where
     F: FnOnce(Request) -> HttpResponse,
   {
-    let (mut stream, _) = self.listener.accept()?;
-    let request = match Request::read_from(&mut stream) {
+    let (stream, _) = self.listener.accept()?;
+    let mut reader = BufReader::new(stream);
+    let request = match Request::read_next_from_with_continue(&mut reader).and_then(|request| {
+      request.ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "incomplete HTTP request"))
+    }) {
       Ok(request) => request,
       Err(err) if is_bad_request_error(&err) => {
-        return bad_request_response().write_to(&mut stream);
+        return bad_request_response().write_to(reader.get_mut());
       }
       Err(err) => return Err(err),
     };
     let response = handler(request);
-    response.write_to(&mut stream)
+    response.write_to(reader.get_mut())
   }
 }
 
@@ -189,16 +192,99 @@ impl Request {
       .any(|(_, value)| connection_header_has_token(Some(value), token))
   }
 
-  fn read_from<R>(reader: &mut R) -> io::Result<Self>
+  #[cfg(test)]
+  fn read_next_from<R>(reader: &mut R) -> io::Result<Option<Self>>
   where
-    R: Read,
+    R: BufRead,
   {
-    let mut reader = BufReader::new(reader);
-    Self::read_next_from(&mut reader)?
-      .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "incomplete HTTP request"))
+    Self::read_next_from_without_continue(reader)
   }
 
-  fn read_next_from<R>(reader: &mut R) -> io::Result<Option<Self>>
+  fn read_next_from_with_continue<S>(reader: &mut BufReader<S>) -> io::Result<Option<Self>>
+  where
+    S: Read + Write,
+  {
+    let mut raw = Vec::new();
+    let mut body_kind: Option<RequestBodyKind> = None;
+
+    loop {
+      if let (Some(header_end), Some(RequestBodyKind::ContentLength(content_length))) =
+        (find_header_end(&raw), body_kind)
+      {
+        let message_len = header_end + 4 + content_length;
+        if raw.len() == message_len {
+          return Ok(Some(Self::from_raw_frame(&raw)?));
+        }
+      }
+
+      let available = reader.fill_buf()?;
+      if available.is_empty() {
+        if raw.is_empty() {
+          return Ok(None);
+        }
+        if let (Some(header_end), Some(RequestBodyKind::ContentLength(content_length))) =
+          (find_header_end(&raw), body_kind)
+        {
+          let body_start = header_end + 4;
+          if raw.len() < body_start + content_length {
+            return Err(io::Error::new(
+              io::ErrorKind::UnexpectedEof,
+              "incomplete HTTP request body",
+            ));
+          }
+        }
+        return Err(io::Error::new(
+          io::ErrorKind::InvalidData,
+          "incomplete HTTP request",
+        ));
+      }
+
+      if let (Some(header_end), Some(RequestBodyKind::ContentLength(content_length))) =
+        (find_header_end(&raw), body_kind)
+      {
+        let message_len = header_end + 4 + content_length;
+        let take = (message_len - raw.len()).min(available.len());
+        raw.extend_from_slice(&available[..take]);
+        reader.consume(take);
+        continue;
+      }
+
+      let mut combined = raw.clone();
+      combined.extend_from_slice(available);
+      match find_header_end(&combined) {
+        Some(header_end) => {
+          let take = header_end + 4 - raw.len();
+          raw.extend_from_slice(&available[..take]);
+          reader.consume(take);
+          let head = parse_request_head(&raw[..header_end])?;
+          let parsed_body_kind = request_body_kind(&head.headers)?;
+          if request_needs_continue(&head.headers, parsed_body_kind)? {
+            write_continue_response(reader.get_mut())?;
+          }
+          match parsed_body_kind {
+            RequestBodyKind::ContentLength(0) => {
+              return Ok(Some(Self::from_head_and_body(head, Vec::new())));
+            }
+            RequestBodyKind::ContentLength(content_length) => {
+              body_kind = Some(RequestBodyKind::ContentLength(content_length));
+            }
+            RequestBodyKind::Chunked => {
+              let body = read_chunked_request_body(reader)?;
+              return Ok(Some(Self::from_head_and_body(head, body)));
+            }
+          }
+        }
+        None => {
+          let take = available.len();
+          raw.extend_from_slice(available);
+          reader.consume(take);
+        }
+      }
+    }
+  }
+
+  #[cfg(test)]
+  fn read_next_from_without_continue<R>(reader: &mut R) -> io::Result<Option<Self>>
   where
     R: BufRead,
   {
@@ -753,6 +839,43 @@ fn request_body_kind(headers: &[(String, String)]) -> io::Result<RequestBodyKind
       "unsupported Transfer-Encoding request body",
     ))
   }
+}
+
+fn request_needs_continue(
+  headers: &[(String, String)],
+  body_kind: RequestBodyKind,
+) -> io::Result<bool> {
+  let mut has_expect = false;
+
+  for (_, value) in headers
+    .iter()
+    .filter(|(name, _)| name.eq_ignore_ascii_case("Expect"))
+  {
+    has_expect = true;
+    if !value.eq_ignore_ascii_case("100-continue") {
+      return Err(io::Error::new(
+        io::ErrorKind::InvalidData,
+        "unsupported Expect header",
+      ));
+    }
+  }
+
+  Ok(
+    has_expect
+      && matches!(
+        body_kind,
+        RequestBodyKind::ContentLength(content_length) if content_length > 0
+      )
+      || has_expect && body_kind == RequestBodyKind::Chunked,
+  )
+}
+
+fn write_continue_response<W>(writer: &mut W) -> io::Result<()>
+where
+  W: Write,
+{
+  writer.write_all(b"HTTP/1.1 100 Continue\r\n\r\n")?;
+  writer.flush()
 }
 
 fn read_chunked_request_body<R>(reader: &mut R) -> io::Result<Vec<u8>>

--- a/rttp/tests/test_server.rs
+++ b/rttp/tests/test_server.rs
@@ -114,6 +114,140 @@ fn server_request_body_stops_at_declared_content_length() {
 }
 
 #[test]
+fn server_sends_continue_before_reading_expected_content_length_body() {
+  let server = rttp::Http::server("127.0.0.1:0").expect("bind server");
+  let addr = server.local_addr().expect("server addr");
+  let (tx, rx) = mpsc::channel();
+
+  let handle = thread::spawn(move || {
+    server
+      .accept_one(|request| {
+        tx.send(request).expect("send parsed request");
+        HttpResponse::ok("accepted")
+      })
+      .expect("serve one request");
+  });
+
+  let mut stream = TcpStream::connect(addr).expect("connect server");
+  stream
+    .set_read_timeout(Some(Duration::from_millis(250)))
+    .expect("set read timeout");
+  stream
+    .write_all(
+      concat!(
+        "POST /submit HTTP/1.1\r\n",
+        "Host: localhost\r\n",
+        "Expect: 100-continue\r\n",
+        "Content-Length: 5\r\n",
+        "\r\n"
+      )
+      .as_bytes(),
+    )
+    .expect("write request head");
+
+  let mut interim = [0u8; 25];
+  stream
+    .read_exact(&mut interim)
+    .expect("read interim response");
+  assert_eq!(b"HTTP/1.1 100 Continue\r\n\r\n", &interim);
+
+  stream.write_all(b"hello").expect("write request body");
+  stream
+    .shutdown(std::net::Shutdown::Write)
+    .expect("shutdown write");
+
+  let mut response = String::new();
+  stream.read_to_string(&mut response).expect("read response");
+
+  let request: Request = rx.recv().expect("receive parsed request");
+  assert_eq!(b"hello", request.body());
+  assert_eq!(
+    "HTTP/1.1 200 OK\r\nContent-Length: 8\r\nConnection: close\r\n\r\naccepted",
+    response
+  );
+
+  handle.join().expect("server thread");
+}
+
+#[test]
+fn server_sends_continue_before_reading_expected_chunked_body() {
+  let server = rttp::Http::server("127.0.0.1:0").expect("bind server");
+  let addr = server.local_addr().expect("server addr");
+  let (tx, rx) = mpsc::channel();
+
+  let handle = thread::spawn(move || {
+    server
+      .accept_one(|request| {
+        tx.send(request).expect("send parsed request");
+        HttpResponse::ok("accepted")
+      })
+      .expect("serve one request");
+  });
+
+  let mut stream = TcpStream::connect(addr).expect("connect server");
+  stream
+    .set_read_timeout(Some(Duration::from_millis(250)))
+    .expect("set read timeout");
+  stream
+    .write_all(
+      concat!(
+        "POST /upload HTTP/1.1\r\n",
+        "Host: localhost\r\n",
+        "Expect: 100-continue\r\n",
+        "Transfer-Encoding: chunked\r\n",
+        "\r\n"
+      )
+      .as_bytes(),
+    )
+    .expect("write request head");
+
+  let mut interim = [0u8; 25];
+  stream
+    .read_exact(&mut interim)
+    .expect("read interim response");
+  assert_eq!(b"HTTP/1.1 100 Continue\r\n\r\n", &interim);
+
+  stream
+    .write_all(b"4\r\nWiki\r\n5\r\npedia\r\n0\r\n\r\n")
+    .expect("write chunked body");
+  stream
+    .shutdown(std::net::Shutdown::Write)
+    .expect("shutdown write");
+
+  let mut response = String::new();
+  stream.read_to_string(&mut response).expect("read response");
+
+  let request: Request = rx.recv().expect("receive parsed request");
+  assert_eq!(b"Wikipedia", request.body());
+  assert_eq!(
+    "HTTP/1.1 200 OK\r\nContent-Length: 8\r\nConnection: close\r\n\r\naccepted",
+    response
+  );
+
+  handle.join().expect("server thread");
+}
+
+#[test]
+fn server_returns_bad_request_for_unsupported_expectation_without_calling_handler() {
+  let (response, handler_called) = send_raw_request(
+    concat!(
+      "POST /submit HTTP/1.1\r\n",
+      "Expect: magic\r\n",
+      "Content-Length: 5\r\n",
+      "\r\n",
+      "hello"
+    )
+    .as_bytes(),
+  );
+
+  assert!(!handler_called);
+  assert_eq!(
+    "HTTP/1.1 400 Bad Request\r\nContent-Length: 11\r\nConnection: close\r\n\r\nBad Request",
+    response
+  );
+}
+
+#[test]
 fn server_returns_bad_request_for_malformed_request_line() {
   let (response, handler_called) = send_raw_request(b"GET /too many parts HTTP/1.1\r\n\r\n");
 


### PR DESCRIPTION
Implemented server-side Expect: 100-continue handling for supported Content-Length and chunked request bodies, with deterministic rejection for unsupported expectations and regression coverage for interim response timing and handler suppression.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1254/
work_kind: code_work
branch: hbx-1254-rttp-implement-expect-100-continue
base: main
commit: a6547efed951dedf165d4be02467d1d3f09c115f
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1254/
    url: https://plane.kahub.in/endless/browse/HBX-1254/
    close_policy: link_only
```