### PR TITLE
feat: [rttp] Add HEAD response semantics for the socket2 server

### DIFF
--- a/rttp/src/server.rs
+++ b/rttp/src/server.rs
@@ -99,6 +99,7 @@ impl HttpServer {
       };
       let request_closes_connection = request.closes_connection();
       let request_uses_http10_defaults = request.version() == "HTTP/1.0";
+      let request_is_head = request.method() == "HEAD";
       let response = handler(request);
       let response_closes_connection = response.closes_connection();
       served += 1;
@@ -112,7 +113,11 @@ impl HttpServer {
       } else {
         DefaultConnectionHeader::Omit
       };
-      response.write_to_with_default_connection(reader.get_mut(), default_connection)?;
+      response.write_to_with_default_connection_and_body(
+        reader.get_mut(),
+        default_connection,
+        !request_is_head,
+      )?;
 
       if close_after_response {
         break;
@@ -134,8 +139,13 @@ impl HttpServer {
       }
       Err(err) => return Err(err),
     };
+    let request_is_head = request.method() == "HEAD";
     let response = handler(request);
-    response.write_to(&mut stream)
+    response.write_to_with_default_connection_and_body(
+      &mut stream,
+      DefaultConnectionHeader::Close,
+      !request_is_head,
+    )
   }
 }
 
@@ -517,8 +527,20 @@ impl HttpResponse {
   where
     W: Write,
   {
+    self.write_to_with_default_connection_and_body(writer, default_connection, true)
+  }
+
+  fn write_to_with_default_connection_and_body<W>(
+    &self,
+    writer: &mut W,
+    default_connection: DefaultConnectionHeader,
+    write_body: bool,
+  ) -> io::Result<()>
+  where
+    W: Write,
+  {
     self.write_head_to(writer, default_connection)?;
-    if self.allows_body() {
+    if write_body && self.allows_body() {
       writer.write_all(&self.body)?;
     }
     writer.flush()

--- a/rttp/tests/test_server.rs
+++ b/rttp/tests/test_server.rs
@@ -114,6 +114,42 @@ fn server_request_body_stops_at_declared_content_length() {
 }
 
 #[test]
+fn server_accept_one_sends_head_headers_without_body() {
+  let server = rttp::Http::server("127.0.0.1:0").expect("bind server");
+  let addr = server.local_addr().expect("server addr");
+  let (tx, rx) = mpsc::channel();
+
+  let handle = thread::spawn(move || {
+    server
+      .accept_one(|request| {
+        tx.send(request.method().to_string())
+          .expect("send parsed method");
+        HttpResponse::ok("head body")
+      })
+      .expect("serve one request");
+  });
+
+  let mut stream = TcpStream::connect(addr).expect("connect server");
+  stream
+    .write_all(b"HEAD /resource HTTP/1.1\r\nHost: localhost\r\n\r\n")
+    .expect("write request");
+  stream
+    .shutdown(std::net::Shutdown::Write)
+    .expect("shutdown write");
+
+  let mut response = String::new();
+  stream.read_to_string(&mut response).expect("read response");
+
+  assert_eq!("HEAD", rx.recv().expect("receive parsed method"));
+  assert_eq!(
+    "HTTP/1.1 200 OK\r\nContent-Length: 9\r\nConnection: close\r\n\r\n",
+    response
+  );
+
+  handle.join().expect("server thread");
+}
+
+#[test]
 fn server_returns_bad_request_for_malformed_request_line() {
   let (response, handler_called) = send_raw_request(b"GET /too many parts HTTP/1.1\r\n\r\n");
 
@@ -545,6 +581,65 @@ fn server_serves_multiple_requests_on_one_kept_alive_connection() {
 }
 
 #[test]
+fn server_keeps_head_connection_framed_for_following_request() {
+  let server = rttp::Http::server("127.0.0.1:0").expect("bind server");
+  let addr = server.local_addr().expect("server addr");
+  let (tx, rx) = mpsc::channel();
+
+  let handle = thread::spawn(move || {
+    server
+      .serve_requests(2, |request| {
+        let method = request.method().to_string();
+        let target = request.target().to_string();
+        tx.send((method.clone(), target.clone()))
+          .expect("send parsed request");
+        HttpResponse::ok(format!("{method} {target} body"))
+      })
+      .expect("serve requests");
+  });
+
+  let mut stream = TcpStream::connect(addr).expect("connect server");
+  stream
+    .write_all(
+      concat!(
+        "HEAD /first HTTP/1.1\r\n",
+        "Host: localhost\r\n",
+        "Connection: keep-alive\r\n",
+        "\r\n",
+        "GET /second HTTP/1.1\r\n",
+        "Host: localhost\r\n",
+        "\r\n"
+      )
+      .as_bytes(),
+    )
+    .expect("write pipelined requests");
+  stream
+    .shutdown(std::net::Shutdown::Write)
+    .expect("shutdown write");
+
+  let mut response = String::new();
+  stream.read_to_string(&mut response).expect("read response");
+
+  assert_eq!(
+    concat!(
+      "HTTP/1.1 200 OK\r\nContent-Length: 16\r\n\r\n",
+      "HTTP/1.1 200 OK\r\nContent-Length: 16\r\nConnection: close\r\n\r\nGET /second body",
+    ),
+    response
+  );
+  assert_eq!(
+    ("HEAD".to_string(), "/first".to_string()),
+    rx.recv().expect("receive first request")
+  );
+  assert_eq!(
+    ("GET".to_string(), "/second".to_string()),
+    rx.recv().expect("receive second request")
+  );
+
+  handle.join().expect("server thread");
+}
+
+#[test]
 fn server_keeps_http11_connection_alive_by_default() {
   let server = rttp::Http::server("127.0.0.1:0").expect("bind server");
   let addr = server.local_addr().expect("server addr");
@@ -767,6 +862,21 @@ fn response_write_to_omits_content_length_and_body_for_204() {
 
   assert_eq!(
     b"HTTP/1.1 204 No Content\r\nConnection: close\r\n\r\n",
+    serialized.as_slice()
+  );
+}
+
+#[test]
+fn response_write_to_omits_content_length_and_body_for_304() {
+  let response = HttpResponse::new(304, "Not Modified").body("ignored");
+  let mut serialized = Vec::new();
+
+  response
+    .write_to(&mut serialized)
+    .expect("serialize response");
+
+  assert_eq!(
+    b"HTTP/1.1 304 Not Modified\r\nConnection: close\r\n\r\n",
     serialized.as_slice()
   );
 }


### PR DESCRIPTION
Implemented HEAD response semantics for the rttp socket2 server. Server responses to HEAD now preserve GET-equivalent headers and Content-Length without sending body bytes, including keep-alive framing for a following request. GET behavior and existing no-body status handling remain unchanged.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1255/
work_kind: code_work
branch: hbx-1255-rttp-add-head-response-semantics
base: main
commit: 00df95a3a18f16c39ffb4d8e8b097a616453683f
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1255/
    url: https://plane.kahub.in/endless/browse/HBX-1255/
    close_policy: link_only
```