### PR TITLE
feat: [rttp] Preserve and expose chunked request trailers

### DIFF
--- a/rttp/src/server.rs
+++ b/rttp/src/server.rs
@@ -155,6 +155,7 @@ pub struct Request {
   target: String,
   version: String,
   headers: Vec<(String, String)>,
+  trailers: Vec<(String, String)>,
   body: Vec<u8>,
 }
 
@@ -174,6 +175,18 @@ impl Request {
   pub fn header(&self, name: &str) -> Option<&str> {
     self
       .headers
+      .iter()
+      .find(|(key, _)| key.eq_ignore_ascii_case(name))
+      .map(|(_, value)| value.as_str())
+  }
+
+  pub fn trailers(&self) -> &[(String, String)] {
+    &self.trailers
+  }
+
+  pub fn trailer(&self, name: &str) -> Option<&str> {
+    self
+      .trailers
       .iter()
       .find(|(key, _)| key.eq_ignore_ascii_case(name))
       .map(|(_, value)| value.as_str())
@@ -273,8 +286,12 @@ impl Request {
               body_kind = Some(RequestBodyKind::ContentLength(content_length));
             }
             RequestBodyKind::Chunked => {
-              let body = read_chunked_request_body(reader)?;
-              return Ok(Some(Self::from_head_and_body(head, body)));
+              let chunked = read_chunked_request_body(reader)?;
+              return Ok(Some(Self::from_head_body_and_trailers(
+                head,
+                chunked.body,
+                chunked.trailers,
+              )));
             }
           }
         }
@@ -318,16 +335,26 @@ impl Request {
       target: head.target,
       version: head.version,
       headers: head.headers,
+      trailers: Vec::new(),
       body,
     })
   }
 
   fn from_head_and_body(head: RequestHead, body: Vec<u8>) -> Self {
+    Self::from_head_body_and_trailers(head, body, Vec::new())
+  }
+
+  fn from_head_body_and_trailers(
+    head: RequestHead,
+    body: Vec<u8>,
+    trailers: Vec<(String, String)>,
+  ) -> Self {
     Self {
       method: head.method,
       target: head.target,
       version: head.version,
       headers: head.headers,
+      trailers,
       body,
     }
   }
@@ -665,6 +692,11 @@ enum RequestBodyKind {
   Chunked,
 }
 
+struct ChunkedRequestBody {
+  body: Vec<u8>,
+  trailers: Vec<(String, String)>,
+}
+
 fn parse_request_head(raw: &[u8]) -> io::Result<RequestHead> {
   let text = std::str::from_utf8(raw)
     .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "request head is not UTF-8"))?;
@@ -777,7 +809,7 @@ fn request_body_kind(headers: &[(String, String)]) -> io::Result<RequestBodyKind
   }
 }
 
-fn read_chunked_request_body<R>(reader: &mut R) -> io::Result<Vec<u8>>
+fn read_chunked_request_body<R>(reader: &mut R) -> io::Result<ChunkedRequestBody>
 where
   R: BufRead,
 {
@@ -788,8 +820,8 @@ where
     let chunk_size = parse_chunk_size(&line)?;
 
     if chunk_size == 0 {
-      consume_trailers(reader)?;
-      return Ok(body);
+      let trailers = read_trailers(reader)?;
+      return Ok(ChunkedRequestBody { body, trailers });
     }
 
     let copied = {
@@ -870,15 +902,21 @@ where
   }
 }
 
-fn consume_trailers<R>(reader: &mut R) -> io::Result<()>
+fn read_trailers<R>(reader: &mut R) -> io::Result<Vec<(String, String)>>
 where
   R: BufRead,
 {
+  let mut lines = Vec::new();
+
   loop {
     let line = read_crlf_line(reader)?;
     if line == b"\r\n" {
-      return Ok(());
+      return parse_header_lines(lines.iter().map(String::as_str));
     }
+    let line = line.strip_suffix(b"\r\n").unwrap_or(&line);
+    let line = std::str::from_utf8(line)
+      .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "trailer line is not UTF-8"))?;
+    lines.push(line.to_string());
   }
 }
 

--- a/rttp/tests/test_server.rs
+++ b/rttp/tests/test_server.rs
@@ -261,7 +261,7 @@ fn server_decodes_chunked_request_body() {
 }
 
 #[test]
-fn server_ignores_chunk_extensions_and_trailers() {
+fn server_preserves_chunked_request_trailers() {
   let server = rttp::Http::server("127.0.0.1:0").expect("bind server");
   let addr = server.local_addr().expect("server addr");
   let (tx, rx) = mpsc::channel();
@@ -287,6 +287,7 @@ fn server_ignores_chunk_extensions_and_trailers() {
         "6\r\n body!\r\n",
         "0\r\n",
         "X-Trace: abc\r\n",
+        "X-Signature: signed\r\n",
         "\r\n"
       )
       .as_bytes(),
@@ -301,12 +302,92 @@ fn server_ignores_chunk_extensions_and_trailers() {
 
   let request: Request = rx.recv().expect("receive parsed request");
   assert_eq!(b"chunked body!", request.body());
+  assert_eq!(Some("abc"), request.trailer("x-trace"));
+  assert_eq!(Some("signed"), request.trailer("X-SIGNATURE"));
+  assert_eq!(
+    &[
+      ("X-Trace".to_string(), "abc".to_string()),
+      ("X-Signature".to_string(), "signed".to_string())
+    ],
+    request.trailers()
+  );
   assert_eq!(
     "HTTP/1.1 200 OK\r\nContent-Length: 8\r\nConnection: close\r\n\r\naccepted",
     response
   );
 
   handle.join().expect("server thread");
+}
+
+#[test]
+fn server_exposes_empty_trailers_for_chunked_request_without_trailers() {
+  let server = rttp::Http::server("127.0.0.1:0").expect("bind server");
+  let addr = server.local_addr().expect("server addr");
+  let (tx, rx) = mpsc::channel();
+
+  let handle = thread::spawn(move || {
+    server
+      .accept_one(|request| {
+        tx.send(request).expect("send parsed request");
+        HttpResponse::ok("accepted")
+      })
+      .expect("serve one request");
+  });
+
+  let mut stream = TcpStream::connect(addr).expect("connect server");
+  stream
+    .write_all(
+      concat!(
+        "POST /upload HTTP/1.1\r\n",
+        "Host: localhost\r\n",
+        "Transfer-Encoding: chunked\r\n",
+        "\r\n",
+        "4\r\nbody\r\n",
+        "0\r\n",
+        "\r\n"
+      )
+      .as_bytes(),
+    )
+    .expect("write request");
+  stream
+    .shutdown(std::net::Shutdown::Write)
+    .expect("shutdown write");
+
+  let mut response = String::new();
+  stream.read_to_string(&mut response).expect("read response");
+
+  let request: Request = rx.recv().expect("receive parsed request");
+  assert_eq!(b"body", request.body());
+  assert!(request.trailers().is_empty());
+  assert_eq!(None, request.trailer("x-trace"));
+  assert_eq!(
+    "HTTP/1.1 200 OK\r\nContent-Length: 8\r\nConnection: close\r\n\r\naccepted",
+    response
+  );
+
+  handle.join().expect("server thread");
+}
+
+#[test]
+fn server_returns_bad_request_for_malformed_chunked_request_trailer() {
+  let (response, handler_called) = send_raw_request(
+    concat!(
+      "POST /upload HTTP/1.1\r\n",
+      "Transfer-Encoding: chunked\r\n",
+      "\r\n",
+      "5\r\nhello\r\n",
+      "0\r\n",
+      "X-Trace abc\r\n",
+      "\r\n"
+    )
+    .as_bytes(),
+  );
+
+  assert!(!handler_called);
+  assert_eq!(
+    "HTTP/1.1 400 Bad Request\r\nContent-Length: 11\r\nConnection: close\r\n\r\nBad Request",
+    response
+  );
 }
 
 #[test]


### PR DESCRIPTION
Implemented chunked request trailer preservation for the rttp server Request API. Handlers can inspect trailers through `trailers()` and case-insensitive `trailer(name)`, malformed trailer lines are rejected with 400 before handler invocation, and no-trailer chunked requests expose an empty trailer set. Verification passed with formatting, rttp tests, workspace tests, and diff whitespace checks.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1257/
work_kind: code_work
branch: hbx-1257-rttp-preserve-and-expose-chunked
base: main
commit: e647a106acae1857d4ff495480710155a8c6135e
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1257/
    url: https://plane.kahub.in/endless/browse/HBX-1257/
    close_policy: link_only
```