### PR TITLE
feat: [rttp] Tighten HTTP request syntax validation in the server parser

### DIFF
--- a/rttp/src/server.rs
+++ b/rttp/src/server.rs
@@ -710,7 +710,7 @@ fn parse_request_head(raw: &[u8]) -> io::Result<RequestHead> {
   let request_line = lines
     .next()
     .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "missing request line"))?;
-  let mut parts = request_line.split_whitespace();
+  let mut parts = request_line.split(' ');
   let method = parts
     .next()
     .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "missing request method"))?;
@@ -727,6 +727,7 @@ fn parse_request_head(raw: &[u8]) -> io::Result<RequestHead> {
       "invalid request line",
     ));
   }
+  validate_request_line(method, target, version)?;
 
   Ok(RequestHead {
     method: method.to_string(),
@@ -734,6 +735,29 @@ fn parse_request_head(raw: &[u8]) -> io::Result<RequestHead> {
     version: version.to_string(),
     headers: parse_header_lines(lines)?,
   })
+}
+
+fn validate_request_line(method: &str, target: &str, version: &str) -> io::Result<()> {
+  if !is_http_token(method) {
+    return Err(io::Error::new(
+      io::ErrorKind::InvalidData,
+      "invalid request method",
+    ));
+  }
+  if target.is_empty() || !target.bytes().all(is_request_target_byte) {
+    return Err(io::Error::new(
+      io::ErrorKind::InvalidData,
+      "invalid request target",
+    ));
+  }
+  if !matches!(version, "HTTP/1.0" | "HTTP/1.1") {
+    return Err(io::Error::new(
+      io::ErrorKind::InvalidData,
+      "invalid request version",
+    ));
+  }
+
+  Ok(())
 }
 
 fn parse_header_lines<'a>(
@@ -745,13 +769,59 @@ fn parse_header_lines<'a>(
     if line.is_empty() {
       continue;
     }
+    if line.starts_with(' ') || line.starts_with('\t') {
+      return Err(io::Error::new(
+        io::ErrorKind::InvalidData,
+        "invalid request header",
+      ));
+    }
     let (name, value) = line
       .split_once(':')
       .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "invalid request header"))?;
+    if !is_http_token(name) || !value.bytes().all(is_header_value_byte) {
+      return Err(io::Error::new(
+        io::ErrorKind::InvalidData,
+        "invalid request header",
+      ));
+    }
     headers.push((name.trim().to_string(), value.trim().to_string()));
   }
 
   Ok(headers)
+}
+
+fn is_http_token(value: &str) -> bool {
+  !value.is_empty() && value.bytes().all(is_token_byte)
+}
+
+fn is_token_byte(byte: u8) -> bool {
+  byte.is_ascii_alphanumeric()
+    || matches!(
+      byte,
+      b'!'
+        | b'#'
+        | b'$'
+        | b'%'
+        | b'&'
+        | b'\''
+        | b'*'
+        | b'+'
+        | b'-'
+        | b'.'
+        | b'^'
+        | b'_'
+        | b'`'
+        | b'|'
+        | b'~'
+    )
+}
+
+fn is_request_target_byte(byte: u8) -> bool {
+  byte > 0x20 && byte != 0x7f
+}
+
+fn is_header_value_byte(byte: u8) -> bool {
+  byte == b'\t' || byte == b' ' || (0x21..=0x7e).contains(&byte) || byte >= 0x80
 }
 
 fn optional_header_content_length(headers: &[(String, String)]) -> io::Result<Option<usize>> {

--- a/rttp/tests/test_server.rs
+++ b/rttp/tests/test_server.rs
@@ -33,6 +33,16 @@ fn send_raw_request(raw: &[u8]) -> (String, bool) {
   (response, rx.try_recv().is_ok())
 }
 
+fn assert_bad_request_without_handler(raw: &[u8]) {
+  let (response, handler_called) = send_raw_request(raw);
+
+  assert!(!handler_called);
+  assert_eq!(
+    "HTTP/1.1 400 Bad Request\r\nContent-Length: 11\r\nConnection: close\r\n\r\nBad Request",
+    response
+  );
+}
+
 #[test]
 fn server_accepts_get_request_and_writes_response() {
   let server = rttp::Http::server("127.0.0.1:0").expect("bind server");
@@ -151,13 +161,68 @@ fn server_accept_one_sends_head_headers_without_body() {
 
 #[test]
 fn server_returns_bad_request_for_malformed_request_line() {
-  let (response, handler_called) = send_raw_request(b"GET /too many parts HTTP/1.1\r\n\r\n");
+  assert_bad_request_without_handler(b"GET /too many parts HTTP/1.1\r\n\r\n");
+}
 
-  assert!(!handler_called);
+#[test]
+fn server_returns_bad_request_for_invalid_http_version() {
+  assert_bad_request_without_handler(b"GET / HTTP/2.0\r\nHost: localhost\r\n\r\n");
+}
+
+#[test]
+fn server_returns_bad_request_for_invalid_method_token() {
+  assert_bad_request_without_handler(b"GE(T / HTTP/1.1\r\nHost: localhost\r\n\r\n");
+}
+
+#[test]
+fn server_returns_bad_request_for_header_name_with_whitespace() {
+  assert_bad_request_without_handler(b"GET / HTTP/1.1\r\nBad Name: value\r\n\r\n");
+}
+
+#[test]
+fn server_returns_bad_request_for_obsolete_folded_header() {
+  assert_bad_request_without_handler(
+    b"GET / HTTP/1.1\r\nHost: localhost\r\n folded: value\r\n\r\n",
+  );
+}
+
+#[test]
+fn server_accepts_mixed_case_header_names() {
+  let server = rttp::Http::server("127.0.0.1:0").expect("bind server");
+  let addr = server.local_addr().expect("server addr");
+  let (tx, rx) = mpsc::channel();
+
+  let handle = thread::spawn(move || {
+    server
+      .accept_one(|request| {
+        tx.send(request.header("x-custom-header").map(str::to_string))
+          .expect("send parsed header");
+        HttpResponse::ok("accepted")
+      })
+      .expect("serve one request");
+  });
+
+  let mut stream = TcpStream::connect(addr).expect("connect server");
+  stream
+    .write_all(b"GET / HTTP/1.1\r\nX-Custom-Header: Mixed\r\n\r\n")
+    .expect("write request");
+  stream
+    .shutdown(std::net::Shutdown::Write)
+    .expect("shutdown write");
+
+  let mut response = String::new();
+  stream.read_to_string(&mut response).expect("read response");
+
   assert_eq!(
-    "HTTP/1.1 400 Bad Request\r\nContent-Length: 11\r\nConnection: close\r\n\r\nBad Request",
+    Some("Mixed".to_string()),
+    rx.recv().expect("receive header")
+  );
+  assert_eq!(
+    "HTTP/1.1 200 OK\r\nContent-Length: 8\r\nConnection: close\r\n\r\naccepted",
     response
   );
+
+  handle.join().expect("server thread");
 }
 
 #[test]
@@ -202,13 +267,7 @@ fn server_rejects_malformed_request_line_before_reading_declared_body() {
 
 #[test]
 fn server_returns_bad_request_for_invalid_header_syntax() {
-  let (response, handler_called) = send_raw_request(b"GET / HTTP/1.1\r\nHost localhost\r\n\r\n");
-
-  assert!(!handler_called);
-  assert_eq!(
-    "HTTP/1.1 400 Bad Request\r\nContent-Length: 11\r\nConnection: close\r\n\r\nBad Request",
-    response
-  );
+  assert_bad_request_without_handler(b"GET / HTTP/1.1\r\nHost localhost\r\n\r\n");
 }
 
 #[test]


### PR DESCRIPTION
The rttp server parser now performs conservative HTTP request syntax validation before invoking handlers. Invalid methods, unsupported HTTP versions, malformed header names, invalid header values, and obsolete folded headers return deterministic 400 responses, while valid HTTP/1.0, HTTP/1.1, and mixed-case headers continue to work.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1256/
work_kind: code_work
branch: hbx-1256-rttp-tighten-http-request-syntax
base: main
commit: ef9bed64506f081e6affb773e149510c13a0286d
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1256/
    url: https://plane.kahub.in/endless/browse/HBX-1256/
    close_policy: link_only
```