### PR TITLE
feat: [rttp] Bound sync client chunked response framing and trailers

### DIFF
--- a/rttp_client/src/connection/connection_reader.rs
+++ b/rttp_client/src/connection/connection_reader.rs
@@ -233,9 +233,13 @@ where
   R: Read + ?Sized,
 {
   let mut suffix = [0u8; 2];
-  reader
-    .read_exact(&mut suffix)
-    .map_err(|_| error::bad_response("Unexpected end of chunked body"))?;
+  reader.read_exact(&mut suffix).map_err(|err| {
+    if err.kind() == io::ErrorKind::UnexpectedEof {
+      error::bad_response("Unexpected end of chunked body")
+    } else {
+      error::request(err)
+    }
+  })?;
   if suffix == *CRLF {
     Ok(())
   } else {
@@ -257,7 +261,8 @@ where
 
 #[cfg(test)]
 mod tests {
-  use std::io::Cursor;
+  use std::error::Error as StdError;
+  use std::io::{self, Cursor, Read};
 
   use super::{ConnectionReader, ResponseBodyKind};
 
@@ -303,6 +308,45 @@ mod tests {
     assert_eq!(
       Some(&"gzip, chunked".to_string()),
       response.header_value("Transfer-Encoding")
+    );
+  }
+
+  #[test]
+  fn test_chunked_terminator_read_error_is_preserved() {
+    struct FailingTerminator {
+      bytes: Cursor<&'static [u8]>,
+    }
+
+    impl Read for FailingTerminator {
+      fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        let read = self.bytes.read(buf)?;
+        if read == 0 {
+          Err(io::Error::new(
+            io::ErrorKind::TimedOut,
+            "terminator read timed out",
+          ))
+        } else {
+          Ok(read)
+        }
+      }
+    }
+
+    let mut reader = FailingTerminator {
+      bytes: Cursor::new(b"4\r\nWiki"),
+    };
+
+    let err = super::read_chunked_body(&mut reader).unwrap_err();
+
+    assert!(
+      err.to_string().contains("terminator read timed out"),
+      "unexpected error: {err}"
+    );
+    assert!(
+      err
+        .source()
+        .and_then(|source| source.downcast_ref::<io::Error>())
+        .is_some_and(|io_error| io_error.kind() == io::ErrorKind::TimedOut),
+      "expected timed out io source: {err:?}"
     );
   }
 

--- a/rttp_client/src/connection/connection_reader.rs
+++ b/rttp_client/src/connection/connection_reader.rs
@@ -9,6 +9,7 @@ use crate::types::RoUrl;
 
 const HEADER_END: &[u8] = b"\r\n\r\n";
 const CRLF: &[u8] = b"\r\n";
+const MAX_CHUNKED_RESPONSE_LINE_BYTES: usize = 8 * 1024;
 
 #[derive(Debug, Eq, PartialEq)]
 pub(crate) enum ResponseBodyKind {
@@ -173,7 +174,7 @@ where
   let mut body = Vec::new();
 
   loop {
-    let line = read_crlf_line(reader)?;
+    let line = read_bounded_crlf_line(reader, MAX_CHUNKED_RESPONSE_LINE_BYTES)?;
     let chunk_size = parse_chunk_size(&line)?;
 
     if chunk_size == 0 {
@@ -190,7 +191,7 @@ where
   }
 }
 
-fn read_crlf_line<R>(reader: &mut R) -> error::Result<Vec<u8>>
+fn read_bounded_crlf_line<R>(reader: &mut R, max_len: usize) -> error::Result<Vec<u8>>
 where
   R: Read + ?Sized,
 {
@@ -201,6 +202,10 @@ where
     let read = reader.read(&mut byte).map_err(error::request)?;
     if read == 0 {
       return Err(error::bad_response("Unexpected end of chunked body"));
+    }
+
+    if line.len() == max_len {
+      return Err(error::bad_response("chunked response line is too large"));
     }
 
     line.push(byte[0]);
@@ -228,7 +233,9 @@ where
   R: Read + ?Sized,
 {
   let mut suffix = [0u8; 2];
-  reader.read_exact(&mut suffix).map_err(error::request)?;
+  reader
+    .read_exact(&mut suffix)
+    .map_err(|_| error::bad_response("Unexpected end of chunked body"))?;
   if suffix == *CRLF {
     Ok(())
   } else {
@@ -241,7 +248,7 @@ where
   R: Read + ?Sized,
 {
   loop {
-    let line = read_crlf_line(reader)?;
+    let line = read_bounded_crlf_line(reader, MAX_CHUNKED_RESPONSE_LINE_BYTES)?;
     if line == CRLF {
       return Ok(());
     }

--- a/rttp_client/tests/support/mod.rs
+++ b/rttp_client/tests/support/mod.rs
@@ -113,22 +113,26 @@ pub fn spawn_http_server_count(count: usize) -> (SocketAddr, JoinHandle<()>) {
 }
 
 pub fn spawn_chunked_server() -> (SocketAddr, JoinHandle<()>) {
+  spawn_chunked_response_server(concat!(
+    "HTTP/1.1 200 OK\r\n",
+    "Transfer-Encoding: chunked\r\n",
+    "Connection: close\r\n",
+    "\r\n",
+    "7;foo=bar\r\nchunked\r\n",
+    "6\r\n body!\r\n",
+    "0\r\n",
+    "X-Trailer: ignored\r\n",
+    "\r\n"
+  ))
+}
+
+pub fn spawn_chunked_response_server(response: impl Into<Vec<u8>>) -> (SocketAddr, JoinHandle<()>) {
   let (listener, addr) = bind_local_http_listener("chunked server");
+  let response = response.into();
   let handle = thread::spawn(move || {
     if let Ok((mut stream, _)) = listener.accept() {
       let _ = read_http_request(&mut stream);
-      let response = concat!(
-        "HTTP/1.1 200 OK\r\n",
-        "Transfer-Encoding: chunked\r\n",
-        "Connection: close\r\n",
-        "\r\n",
-        "7;foo=bar\r\nchunked\r\n",
-        "6\r\n body!\r\n",
-        "0\r\n",
-        "X-Trailer: ignored\r\n",
-        "\r\n"
-      );
-      let _ = stream.write_all(response.as_bytes());
+      let _ = stream.write_all(&response);
     }
   });
   (addr, handle)

--- a/rttp_client/tests/test_http_basic.rs
+++ b/rttp_client/tests/test_http_basic.rs
@@ -85,6 +85,89 @@ fn test_chunked() {
 }
 
 #[test]
+fn test_chunked_with_trailers_decodes_body() {
+  let (addr, _handle) = support::spawn_chunked_response_server(concat!(
+    "HTTP/1.1 200 OK\r\n",
+    "Transfer-Encoding: chunked\r\n",
+    "Connection: close\r\n",
+    "\r\n",
+    "7;foo=bar\r\nchunked\r\n",
+    "6\r\n body!\r\n",
+    "0\r\n",
+    "X-Trace: abc\r\n",
+    "X-Signature: signed\r\n",
+    "\r\n"
+  ));
+
+  let response = client()
+    .get()
+    .url(format!("http://{}/chunked", addr))
+    .emit()
+    .unwrap();
+
+  assert_eq!("chunked body!", response.body().string().unwrap());
+}
+
+#[test]
+fn test_chunked_oversized_extension_is_rejected() {
+  let extension = "a".repeat(16 * 1024);
+  let response = format!(
+    "HTTP/1.1 200 OK\r\n\
+     Transfer-Encoding: chunked\r\n\
+     Connection: close\r\n\
+     \r\n\
+     7;foo={extension}\r\n\
+     chunked\r\n\
+     0\r\n\
+     \r\n"
+  );
+  let (addr, _handle) = support::spawn_chunked_response_server(response);
+
+  let error = client()
+    .get()
+    .url(format!("http://{}/chunked", addr))
+    .emit()
+    .expect_err("oversized chunk extension should be rejected");
+
+  assert!(
+    error
+      .to_string()
+      .contains("chunked response line is too large"),
+    "unexpected error: {error}"
+  );
+}
+
+#[test]
+fn test_chunked_oversized_trailer_is_rejected() {
+  let trailer = "a".repeat(16 * 1024);
+  let response = format!(
+    "HTTP/1.1 200 OK\r\n\
+     Transfer-Encoding: chunked\r\n\
+     Connection: close\r\n\
+     \r\n\
+     7\r\n\
+     chunked\r\n\
+     0\r\n\
+     X-Trace: {trailer}\r\n\
+     \r\n"
+  );
+  let (addr, _handle) = support::spawn_chunked_response_server(response);
+
+  let error = client()
+    .get()
+    .url(format!("http://{}/chunked", addr))
+    .emit()
+    .expect_err("oversized chunk trailer should be rejected");
+
+  assert!(
+    error
+      .to_string()
+      .contains("chunked response line is too large"),
+    "unexpected error: {error}"
+  );
+}
+
+#[test]
 fn test_content_length_response_does_not_wait_for_eof() {
   let (addr, _handle) = support::spawn_keep_alive_server();
   let response = client()


### PR DESCRIPTION
The blocking rttp_client chunked response path now bounds chunk-size/extension and trailer line reads, returning a deterministic bad_response for oversized framing while preserving normal chunked body decoding. Added integration coverage for normal trailers and oversized extension/trailer rejection.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1259/
work_kind: code_work
branch: hbx-1259-rttp-bound-sync-client-chunked
base: main
commit: d425193b882976a53bfdbb53798fc08a72a359bf
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1259/
    url: https://plane.kahub.in/endless/browse/HBX-1259/
    close_policy: link_only
```