### PR TITLE
feat: [rttp] Preserve duplicate response headers without losing Set-Cookie values

### DIFF
--- a/rttp_client/src/types/cookie.rs
+++ b/rttp_client/src/types/cookie.rs
@@ -89,7 +89,7 @@ impl Cookie {
   pub fn parse<S: AsRef<str>>(text: S) -> error::Result<Self> {
     let mut builder = Cookie::builder();
     let parts: Vec<&str> = text.as_ref().split(";").collect();
-    for item in parts {
+    for (index, item) in parts.iter().enumerate() {
       let nvs: Vec<&str> = item.split("=").collect();
       let name = nvs
         .first()
@@ -103,6 +103,11 @@ impl Cookie {
         .collect::<Vec<&str>>()
         .join("=");
       let value = value.trim();
+      if index == 0 {
+        builder.name(name);
+        builder.value(value);
+        continue;
+      }
       match name.to_ascii_lowercase().as_str() {
         "expires" => {
           let value = value.replace("-", " ");

--- a/rttp_client/src/types/cookie.rs
+++ b/rttp_client/src/types/cookie.rs
@@ -103,7 +103,7 @@ impl Cookie {
         .collect::<Vec<&str>>()
         .join("=");
       let value = value.trim();
-      match name {
+      match name.to_ascii_lowercase().as_str() {
         "expires" => {
           let value = value.replace("-", " ");
           match httpdate::parse_http_date(&value[..]) {
@@ -130,7 +130,7 @@ impl Cookie {
             );
           }
         }
-        "http_only" | "httponly" | "httpOnly" => {
+        "http_only" | "httponly" => {
           if value.is_empty() {
             builder.http_only(true);
           } else {
@@ -141,7 +141,7 @@ impl Cookie {
             );
           }
         }
-        "host_only" | "hostonly" | "hostOnly" => {
+        "host_only" | "hostonly" => {
           if value.is_empty() {
             builder.host_only(true);
           } else {
@@ -152,7 +152,7 @@ impl Cookie {
             );
           }
         }
-        "same_site" | "SameSite" | "samSite" => {
+        "same_site" | "samesite" => {
           builder.same_site(value);
         }
         _ => {

--- a/rttp_client/tests/support/mod.rs
+++ b/rttp_client/tests/support/mod.rs
@@ -134,6 +134,27 @@ pub fn spawn_chunked_server() -> (SocketAddr, JoinHandle<()>) {
   (addr, handle)
 }
 
+pub fn spawn_duplicate_set_cookie_server() -> (SocketAddr, JoinHandle<()>) {
+  let (listener, addr) = bind_local_http_listener("duplicate set-cookie server");
+  let handle = thread::spawn(move || {
+    if let Ok((mut stream, _)) = listener.accept() {
+      let _ = read_http_request(&mut stream);
+      let response = concat!(
+        "HTTP/1.1 200 OK\r\n",
+        "Content-Type: text/plain\r\n",
+        "Set-Cookie: session=abc; Path=/; HttpOnly\r\n",
+        "Set-Cookie: theme=dark; Path=/; SameSite=Lax\r\n",
+        "Content-Length: 2\r\n",
+        "Connection: close\r\n",
+        "\r\n",
+        "OK"
+      );
+      let _ = stream.write_all(response.as_bytes());
+    }
+  });
+  (addr, handle)
+}
+
 pub fn spawn_redirect_server() -> (SocketAddr, JoinHandle<()>) {
   let (listener, addr) = bind_local_http_listener("redirect server");
   let handle = thread::spawn(move || {

--- a/rttp_client/tests/test_http_async.rs
+++ b/rttp_client/tests/test_http_async.rs
@@ -45,6 +45,40 @@ fn test_async_chunked() {
 
 #[test]
 #[cfg(feature = "async")]
+fn test_async_duplicate_set_cookie_headers_are_preserved() {
+  let (addr, _handle) = support::spawn_duplicate_set_cookie_server();
+  block_on(async {
+    let response = client()
+      .get()
+      .url(format!("http://{}/cookies", addr))
+      .rasync()
+      .await;
+    assert!(response.is_ok());
+
+    let response = response.unwrap();
+    assert_eq!(
+      vec![
+        &"session=abc; Path=/; HttpOnly".to_string(),
+        &"theme=dark; Path=/; SameSite=Lax".to_string()
+      ],
+      response.header_values("set-cookie")
+    );
+    assert_eq!(
+      Some(&"session=abc; Path=/; HttpOnly".to_string()),
+      response.header_value("set-cookie")
+    );
+    assert_eq!(2, response.cookies().len());
+    assert!(response.cookie("session").is_some());
+    assert!(response.cookie("theme").is_some());
+    assert_eq!(
+      Some(&"text/plain".to_string()),
+      response.header_value("content-type")
+    );
+  });
+}
+
+#[test]
+#[cfg(feature = "async")]
 fn test_async_content_length_response_does_not_wait_for_eof() {
   let (addr, _handle) = support::spawn_keep_alive_server();
   block_on(async {

--- a/rttp_client/tests/test_http_basic.rs
+++ b/rttp_client/tests/test_http_basic.rs
@@ -85,6 +85,36 @@ fn test_chunked() {
 }
 
 #[test]
+fn test_duplicate_set_cookie_headers_are_preserved() {
+  let (addr, _handle) = support::spawn_duplicate_set_cookie_server();
+  let response = client()
+    .get()
+    .url(format!("http://{}/cookies", addr))
+    .emit();
+  assert!(response.is_ok());
+
+  let response = response.unwrap();
+  assert_eq!(
+    vec![
+      &"session=abc; Path=/; HttpOnly".to_string(),
+      &"theme=dark; Path=/; SameSite=Lax".to_string()
+    ],
+    response.header_values("set-cookie")
+  );
+  assert_eq!(
+    Some(&"session=abc; Path=/; HttpOnly".to_string()),
+    response.header_value("set-cookie")
+  );
+  assert_eq!(2, response.cookies().len());
+  assert!(response.cookie("session").is_some());
+  assert!(response.cookie("theme").is_some());
+  assert_eq!(
+    Some(&"text/plain".to_string()),
+    response.header_value("content-type")
+  );
+}
+
+#[test]
 fn test_content_length_response_does_not_wait_for_eof() {
   let (addr, _handle) = support::spawn_keep_alive_server();
   let response = client()

--- a/rttp_client/tests/test_response.rs
+++ b/rttp_client/tests/test_response.rs
@@ -1,5 +1,18 @@
 use rttp_client::response::Response;
-use rttp_client::types::RoUrl;
+use rttp_client::types::{Cookie, RoUrl};
+
+#[test]
+fn test_parse_cookie_name_can_match_attribute_name() {
+  let same_site = Cookie::parse("SameSite=choice; Path=/").unwrap();
+  assert_eq!("SameSite", same_site.name());
+  assert_eq!("choice", same_site.value());
+  assert_eq!(Some(&"/".to_string()), same_site.path().as_ref());
+
+  let path = Cookie::parse("Path=value; HttpOnly").unwrap();
+  assert_eq!("Path", path.name());
+  assert_eq!("value", path.value());
+  assert!(path.http_only());
+}
 
 #[test]
 fn test_parse_response() {


### PR DESCRIPTION
Adds blocking and async regression coverage proving duplicate Set-Cookie response headers remain independently accessible through header_values while common single-header lookup remains stable. Also fixes case-insensitive Set-Cookie attribute parsing so parsed cookie lookup does not lose cookie names when attributes use standard casing.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1263/
work_kind: code_work
branch: hbx-1263-rttp-preserve-duplicate-response-headers
base: main
commit: 16f65d13d96f5454fdcbd645cfe31d8582fa1c72
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1263/
    url: https://plane.kahub.in/endless/browse/HBX-1263/
    close_policy: link_only
```