### PR TITLE
feat: [rttp] Expose chunked response trailers on client responses

### DIFF
--- a/rttp_client/src/connection/async_connection.rs
+++ b/rttp_client/src/connection/async_connection.rs
@@ -9,11 +9,11 @@ use url::Url;
 use std::sync::Arc;
 
 use crate::connection::connection::{connect_tcp_stream, read_proxy_connect_response, Connection};
-use crate::connection::connection_reader::{response_body_kind, ResponseBodyKind};
+use crate::connection::connection_reader::{response_body_kind, ResponseBodyKind, ResponseParts};
 use crate::error;
 use crate::request::RawRequest;
 use crate::response::Response;
-use crate::types::{Proxy, ProxyType, RoUrl};
+use crate::types::{Header, Proxy, ProxyType, RoUrl};
 const CRLF: &[u8] = b"\r\n";
 
 pub struct AsyncConnection<'a> {
@@ -31,13 +31,14 @@ impl<'a> AsyncConnection<'a> {
     loop {
       let url = self.conn.url().map_err(error::builder)?;
       let proxy = self.conn.proxy().clone();
-      let binary = if let Some(proxy) = proxy.as_ref() {
+      let parts = if let Some(proxy) = proxy.as_ref() {
         self.call_with_proxy(&url, proxy).await?
       } else {
-        self.async_send(&url).await?
+        self.async_send_parts(&url).await?
       };
 
-      let response = Response::new(self.conn.rourl().clone(), binary)?;
+      let response =
+        Response::with_trailers(self.conn.rourl().clone(), parts.binary, parts.trailers)?;
       let config = self.conn.config().clone();
 
       if let Some(location) = response.location() {
@@ -101,15 +102,22 @@ impl<'a> AsyncConnection<'a> {
     Ok(())
   }
 
-  async fn async_read_stream<S>(&self, _url: &Url, stream: &mut S) -> error::Result<Vec<u8>>
+  async fn async_read_stream_parts<S>(
+    &self,
+    _url: &Url,
+    stream: &mut S,
+  ) -> error::Result<ResponseParts>
   where
     S: AsyncRead + Unpin,
   {
     let mut binary = async_read_response_header(stream).await?;
+    let mut trailers = Vec::new();
     match response_body_kind(&binary, self.conn.expect_no_response_body())? {
       ResponseBodyKind::NoBody => {}
       ResponseBodyKind::Chunked => {
-        binary.extend_from_slice(&async_read_chunked_body(stream).await?);
+        let chunked = async_read_chunked_response_body(stream).await?;
+        binary.extend_from_slice(&chunked.body);
+        trailers = chunked.trailers;
       }
       ResponseBodyKind::ContentLength(content_length) => {
         let current_len = binary.len();
@@ -126,7 +134,7 @@ impl<'a> AsyncConnection<'a> {
           .map_err(error::request)?;
       }
     }
-    Ok(binary)
+    Ok(ResponseParts { binary, trailers })
   }
 }
 
@@ -153,7 +161,12 @@ where
   }
 }
 
-async fn async_read_chunked_body<S>(stream: &mut S) -> error::Result<Vec<u8>>
+struct ChunkedResponseBody {
+  body: Vec<u8>,
+  trailers: Vec<Header>,
+}
+
+async fn async_read_chunked_response_body<S>(stream: &mut S) -> error::Result<ChunkedResponseBody>
 where
   S: AsyncRead + Unpin,
 {
@@ -164,8 +177,8 @@ where
     let chunk_size = parse_chunk_size(&line)?;
 
     if chunk_size == 0 {
-      async_consume_trailers(stream).await?;
-      return Ok(body);
+      let trailers = async_read_trailers(stream).await?;
+      return Ok(ChunkedResponseBody { body, trailers });
     }
 
     let current_len = body.len();
@@ -227,56 +240,81 @@ where
   }
 }
 
-async fn async_consume_trailers<S>(stream: &mut S) -> error::Result<()>
+async fn async_read_trailers<S>(stream: &mut S) -> error::Result<Vec<Header>>
 where
   S: AsyncRead + Unpin,
 {
+  let mut trailers = Vec::new();
   loop {
     let line = async_read_crlf_line(stream).await?;
     if line == CRLF {
-      return Ok(());
+      return Ok(trailers);
     }
+
+    trailers.push(parse_trailer_line(&line)?);
   }
+}
+
+fn parse_trailer_line(line: &[u8]) -> error::Result<Header> {
+  let line = std::str::from_utf8(line).map_err(error::response)?;
+  let line = line.trim_end_matches("\r\n");
+  let (name, value) = line
+    .split_once(':')
+    .ok_or_else(|| error::bad_response("Invalid trailer header"))?;
+
+  Ok(Header::new(name, value))
 }
 
 // connection send
 impl<'a> AsyncConnection<'a> {
-  async fn async_send(&self, url: &Url) -> error::Result<Vec<u8>> {
+  async fn async_send_parts(&self, url: &Url) -> error::Result<ResponseParts> {
     let addr = self.conn.addr(url)?;
     let stream = self.async_tcp_stream(&addr).await?;
 
-    self.async_send_with_stream(url, stream).await
+    self.async_send_with_stream_parts(url, stream).await
   }
 
-  async fn async_send_with_stream(&self, url: &Url, stream: TcpStream) -> error::Result<Vec<u8>> {
+  async fn async_send_with_stream_parts(
+    &self,
+    url: &Url,
+    stream: TcpStream,
+  ) -> error::Result<ResponseParts> {
     match url.scheme() {
       "http" => {
         let mut stream = AllowStdIo::new(stream);
-        self.async_send_http(url, &mut stream).await
+        self.async_send_http_parts(url, &mut stream).await
       }
-      "https" => self.async_send_https(url, stream).await,
+      "https" => self.async_send_https_parts(url, stream).await,
       _ => Err(error::url_bad_scheme(url.clone())),
     }
   }
 
-  async fn async_send_http<S>(&self, url: &Url, stream: &mut S) -> error::Result<Vec<u8>>
+  async fn async_send_http_parts<S>(
+    &self,
+    url: &Url,
+    stream: &mut S,
+  ) -> error::Result<ResponseParts>
   where
     S: AsyncRead + AsyncWrite + Unpin,
   {
     self.async_write_stream(stream).await?;
-    self.async_read_stream(url, stream).await
+    self.async_read_stream_parts(url, stream).await
   }
 
-  async fn async_send_https(&self, url: &Url, stream: TcpStream) -> error::Result<Vec<u8>> {
+  async fn async_send_https_parts(
+    &self,
+    url: &Url,
+    stream: TcpStream,
+  ) -> error::Result<ResponseParts> {
     #[cfg(feature = "tls-rustls")]
     {
-      return self.async_send_https_rustls(url, stream).await;
+      return self.async_send_https_rustls_parts(url, stream).await;
     }
 
     #[cfg(all(feature = "tls-native", not(feature = "tls-rustls")))]
     {
       let mut stream = stream;
-      return self.conn.block_send_https(url, &mut stream);
+      return self.conn.block_send_https_parts(url, &mut stream);
     }
 
     #[cfg(not(any(feature = "tls-native", feature = "tls-rustls")))]
@@ -290,7 +328,11 @@ impl<'a> AsyncConnection<'a> {
   }
 
   #[cfg(feature = "tls-rustls")]
-  async fn async_send_https_rustls(&self, url: &Url, stream: TcpStream) -> error::Result<Vec<u8>> {
+  async fn async_send_https_rustls_parts(
+    &self,
+    url: &Url,
+    stream: TcpStream,
+  ) -> error::Result<ResponseParts> {
     use futures_rustls::TlsConnector;
     use rustls::pki_types::ServerName;
     use rustls::{ClientConfig, RootCertStore};
@@ -339,13 +381,13 @@ impl<'a> AsyncConnection<'a> {
       .map_err(|e| error::bad_ssl(e.to_string()))?;
 
     self.async_write_stream(&mut tls_stream).await?;
-    self.async_read_stream(url, &mut tls_stream).await
+    self.async_read_stream_parts(url, &mut tls_stream).await
   }
 }
 
 // proxy connection
 impl<'a> AsyncConnection<'a> {
-  async fn call_with_proxy(&self, url: &Url, proxy: &Proxy) -> error::Result<Vec<u8>> {
+  async fn call_with_proxy(&self, url: &Url, proxy: &Proxy) -> error::Result<ResponseParts> {
     match proxy.type_() {
       ProxyType::HTTP => {
         if url.scheme() == "http" {
@@ -360,17 +402,17 @@ impl<'a> AsyncConnection<'a> {
     }
   }
 
-  async fn call_with_proxy_http(&self, url: &Url, proxy: &Proxy) -> error::Result<Vec<u8>> {
+  async fn call_with_proxy_http(&self, url: &Url, proxy: &Proxy) -> error::Result<ResponseParts> {
     let addr = format!("{}:{}", proxy.host(), proxy.port());
     let stream = self.async_tcp_stream(&addr).await?;
     let mut stream = AllowStdIo::new(stream);
     let header = self.conn.proxy_http_header(url, proxy);
 
     self.async_write_request(&mut stream, &header).await?;
-    self.async_read_stream(url, &mut stream).await
+    self.async_read_stream_parts(url, &mut stream).await
   }
 
-  async fn call_with_proxy_https(&self, url: &Url, proxy: &Proxy) -> error::Result<Vec<u8>> {
+  async fn call_with_proxy_https(&self, url: &Url, proxy: &Proxy) -> error::Result<ResponseParts> {
     let connect_header = self.conn.proxy_header(url, proxy)?;
 
     let addr = format!("{}:{}", proxy.host(), proxy.port());
@@ -382,10 +424,10 @@ impl<'a> AsyncConnection<'a> {
     stream.flush().map_err(error::request)?;
     read_proxy_connect_response(&mut stream)?;
 
-    self.async_send_with_stream(url, stream).await
+    self.async_send_with_stream_parts(url, stream).await
   }
 
-  async fn call_with_proxy_socks4(&self, url: &Url, proxy: &Proxy) -> error::Result<Vec<u8>> {
+  async fn call_with_proxy_socks4(&self, url: &Url, proxy: &Proxy) -> error::Result<ResponseParts> {
     // The SOCKS crate is sync-only, but its established stream still plugs into the existing
     // response path. Keeping it avoids duplicating the handshake state machine here.
     let addr_proxy = format!("{}:{}", proxy.host(), proxy.port());
@@ -397,10 +439,10 @@ impl<'a> AsyncConnection<'a> {
     };
     let mut stream = Socks4Stream::connect(&addr_proxy[..], &addr_target[..], &user[..])
       .map_err(error::request)?;
-    self.conn.block_send_with_stream(url, &mut stream)
+    self.conn.block_send_with_stream_parts(url, &mut stream)
   }
 
-  async fn call_with_proxy_socks5(&self, url: &Url, proxy: &Proxy) -> error::Result<Vec<u8>> {
+  async fn call_with_proxy_socks5(&self, url: &Url, proxy: &Proxy) -> error::Result<ResponseParts> {
     // socket2 already covers the direct TCP path; the SOCKS exception stays isolated to the
     // proxy handshake and keeps the async API surface unchanged.
     let addr_proxy = format!("{}:{}", proxy.host(), proxy.port());
@@ -415,6 +457,6 @@ impl<'a> AsyncConnection<'a> {
       Socks5Stream::connect(&addr_proxy[..], &addr_target[..])
     }
     .map_err(error::request)?;
-    self.conn.block_send_with_stream(url, &mut stream)
+    self.conn.block_send_with_stream_parts(url, &mut stream)
   }
 }

--- a/rttp_client/src/connection/block_connection.rs
+++ b/rttp_client/src/connection/block_connection.rs
@@ -4,6 +4,7 @@ use socks::{Socks4Stream, Socks5Stream};
 use url::Url;
 
 use crate::connection::connection::Connection;
+use crate::connection::connection_reader::ResponseParts;
 use crate::request::RawRequest;
 use crate::response::Response;
 use crate::types::{Proxy, ProxyType};
@@ -23,14 +24,15 @@ impl<'a> BlockConnection<'a> {
   pub fn call(mut self) -> error::Result<Response> {
     let url = self.conn.url().map_err(error::builder)?;
     let proxy = self.conn.proxy().clone();
-    let binary = if let Some(proxy) = proxy.as_ref() {
+    let parts = if let Some(proxy) = proxy.as_ref() {
       self.call_with_proxy(&url, proxy)?
     } else {
-      self.conn.block_send(&url)?
+      self.conn.block_send_parts(&url)?
     };
 
     let config = self.conn.config();
-    let response = Response::new(self.conn.rourl().clone(), binary)?;
+    let response =
+      Response::with_trailers(self.conn.rourl().clone(), parts.binary, parts.trailers)?;
 
     if let Some(location) = response.location() {
       let req_url = url.as_str();
@@ -60,7 +62,7 @@ impl<'a> BlockConnection<'a> {
 
 // proxy connection
 impl<'a> BlockConnection<'a> {
-  fn call_with_proxy(&self, url: &Url, proxy: &Proxy) -> error::Result<Vec<u8>> {
+  fn call_with_proxy(&self, url: &Url, proxy: &Proxy) -> error::Result<ResponseParts> {
     match proxy.type_() {
       ProxyType::HTTP => {
         if url.scheme() == "http" {
@@ -75,7 +77,7 @@ impl<'a> BlockConnection<'a> {
     }
   }
 
-  fn call_with_proxy_http(&self, url: &Url, proxy: &Proxy) -> error::Result<Vec<u8>> {
+  fn call_with_proxy_http(&self, url: &Url, proxy: &Proxy) -> error::Result<ResponseParts> {
     let addr = format!("{}:{}", proxy.host(), proxy.port());
     let mut stream = self.conn.block_tcp_stream(&addr)?;
     let header = self.conn.proxy_http_header(url, proxy);
@@ -88,10 +90,10 @@ impl<'a> BlockConnection<'a> {
     }
     stream.flush().map_err(error::request)?;
 
-    self.conn.block_read_stream(url, &mut stream)
+    self.conn.block_read_stream_parts(url, &mut stream)
   }
 
-  fn call_with_proxy_https(&self, url: &Url, proxy: &Proxy) -> error::Result<Vec<u8>> {
+  fn call_with_proxy_https(&self, url: &Url, proxy: &Proxy) -> error::Result<ResponseParts> {
     //CONNECT proxy.google.com:443 HTTP/1.1
     //Host: www.google.com:443
     //Proxy-Connection: keep-alive
@@ -106,10 +108,10 @@ impl<'a> BlockConnection<'a> {
     stream.flush().map_err(error::request)?;
     crate::connection::connection::read_proxy_connect_response(&mut stream)?;
 
-    self.conn.block_send_with_stream(url, &mut stream)
+    self.conn.block_send_with_stream_parts(url, &mut stream)
   }
 
-  fn call_with_proxy_socks4(&self, url: &Url, proxy: &Proxy) -> error::Result<Vec<u8>> {
+  fn call_with_proxy_socks4(&self, url: &Url, proxy: &Proxy) -> error::Result<ResponseParts> {
     // Keep the `socks` crate for SOCKS handshakes: it owns the proxy connection setup and
     // returns a stream that already satisfies the shared `Read + Write` send path.
     let addr_proxy = format!("{}:{}", proxy.host(), proxy.port());
@@ -121,10 +123,10 @@ impl<'a> BlockConnection<'a> {
     };
     let mut stream = Socks4Stream::connect(&addr_proxy[..], &addr_target[..], &user[..])
       .map_err(error::request)?;
-    self.conn.block_send_with_stream(url, &mut stream)
+    self.conn.block_send_with_stream_parts(url, &mut stream)
   }
 
-  fn call_with_proxy_socks5(&self, url: &Url, proxy: &Proxy) -> error::Result<Vec<u8>> {
+  fn call_with_proxy_socks5(&self, url: &Url, proxy: &Proxy) -> error::Result<ResponseParts> {
     // Reimplementing SOCKS on top of socket2 would duplicate protocol logic without changing
     // how the rest of the client reads and writes the established stream.
     let addr_proxy = format!("{}:{}", proxy.host(), proxy.port());
@@ -139,6 +141,6 @@ impl<'a> BlockConnection<'a> {
       Socks5Stream::connect(&addr_proxy[..], &addr_target[..])
     }
     .map_err(error::request)?;
-    self.conn.block_send_with_stream(url, &mut stream)
+    self.conn.block_send_with_stream_parts(url, &mut stream)
   }
 }

--- a/rttp_client/src/connection/connection.rs
+++ b/rttp_client/src/connection/connection.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 
 use url::Url;
 
-use crate::connection::connection_reader::ConnectionReader;
+use crate::connection::connection_reader::{ConnectionReader, ResponseParts};
 use crate::request::{RawRequest, RequestBody};
 use crate::types::{Proxy, RoUrl, ToUrl};
 use crate::{error, Config};
@@ -400,41 +400,57 @@ impl<'a> Connection<'a> {
     write_http_request(stream, self.header(), self.body().as_ref())
   }
 
-  pub fn block_read_stream<S>(&self, url: &Url, stream: &mut S) -> error::Result<Vec<u8>>
+  pub(crate) fn block_read_stream_parts<S>(
+    &self,
+    url: &Url,
+    stream: &mut S,
+  ) -> error::Result<ResponseParts>
   where
     S: io::Read,
   {
     let mut reader = ConnectionReader::new(url, stream, self.expect_no_response_body());
-    reader.binary()
+    reader.response_parts()
   }
 
-  pub fn block_send(&self, url: &Url) -> error::Result<Vec<u8>> {
+  pub(crate) fn block_send_parts(&self, url: &Url) -> error::Result<ResponseParts> {
     let addr = self.addr(url)?;
     let mut stream = self.block_tcp_stream(&addr)?;
-    self.block_send_with_stream(url, &mut stream)
+    self.block_send_with_stream_parts(url, &mut stream)
   }
 
-  pub fn block_send_with_stream<S>(&self, url: &Url, stream: &mut S) -> error::Result<Vec<u8>>
+  pub(crate) fn block_send_with_stream_parts<S>(
+    &self,
+    url: &Url,
+    stream: &mut S,
+  ) -> error::Result<ResponseParts>
   where
     S: io::Read + io::Write,
   {
     match url.scheme() {
-      "http" => self.block_send_http(url, stream),
-      "https" => self.block_send_https(url, stream),
+      "http" => self.block_send_http_parts(url, stream),
+      "https" => self.block_send_https_parts(url, stream),
       _ => Err(error::url_bad_scheme(url.clone())),
     }
   }
 
-  pub fn block_send_http<S>(&self, url: &Url, stream: &mut S) -> error::Result<Vec<u8>>
+  pub(crate) fn block_send_http_parts<S>(
+    &self,
+    url: &Url,
+    stream: &mut S,
+  ) -> error::Result<ResponseParts>
   where
     S: io::Read + io::Write,
   {
     self.block_write_stream(stream)?;
-    self.block_read_stream(url, stream)
+    self.block_read_stream_parts(url, stream)
   }
 
   #[cfg(not(any(feature = "tls-native", feature = "tls-rustls")))]
-  pub fn block_send_https<S>(&self, _url: &Url, _stream: &mut S) -> error::Result<Vec<u8>>
+  pub(crate) fn block_send_https_parts<S>(
+    &self,
+    _url: &Url,
+    _stream: &mut S,
+  ) -> error::Result<ResponseParts>
   where
     S: io::Read + io::Write,
   {
@@ -444,26 +460,34 @@ impl<'a> Connection<'a> {
   }
 
   #[cfg(any(feature = "tls-native", feature = "tls-rustls"))]
-  pub fn block_send_https<S>(&self, url: &Url, stream: &mut S) -> error::Result<Vec<u8>>
+  pub(crate) fn block_send_https_parts<S>(
+    &self,
+    url: &Url,
+    stream: &mut S,
+  ) -> error::Result<ResponseParts>
   where
     S: io::Read + io::Write,
   {
     #[cfg(all(feature = "tls-native", feature = "tls-rustls"))]
     {
-      return self.block_send_https_rustls(url, stream);
+      return self.block_send_https_rustls_parts(url, stream);
     }
     #[cfg(all(feature = "tls-native", not(feature = "tls-rustls")))]
     {
-      return self.block_send_https_native(url, stream);
+      return self.block_send_https_native_parts(url, stream);
     }
     #[cfg(all(feature = "tls-rustls", not(feature = "tls-native")))]
     {
-      return self.block_send_https_rustls(url, stream);
+      return self.block_send_https_rustls_parts(url, stream);
     }
   }
 
   #[cfg(all(feature = "tls-native", not(feature = "tls-rustls")))]
-  fn block_send_https_native<S>(&self, url: &Url, stream: &mut S) -> error::Result<Vec<u8>>
+  fn block_send_https_native_parts<S>(
+    &self,
+    url: &Url,
+    stream: &mut S,
+  ) -> error::Result<ResponseParts>
   where
     S: io::Read + io::Write,
   {
@@ -478,11 +502,15 @@ impl<'a> Connection<'a> {
       .map_err(|_| error::bad_ssl("Native tls handshake error"))?;
 
     self.block_write_stream(&mut ssl_stream)?;
-    self.block_read_stream(url, &mut ssl_stream)
+    self.block_read_stream_parts(url, &mut ssl_stream)
   }
 
   #[cfg(feature = "tls-rustls")]
-  fn block_send_https_rustls<S>(&self, url: &Url, stream: &mut S) -> error::Result<Vec<u8>>
+  fn block_send_https_rustls_parts<S>(
+    &self,
+    url: &Url,
+    stream: &mut S,
+  ) -> error::Result<ResponseParts>
   where
     S: io::Read + io::Write,
   {
@@ -524,7 +552,7 @@ impl<'a> Connection<'a> {
     let mut tls = StreamOwned::new(client, stream);
 
     self.block_write_stream(&mut tls)?;
-    self.block_read_stream(url, &mut tls)
+    self.block_read_stream_parts(url, &mut tls)
   }
 }
 

--- a/rttp_client/src/connection/connection_reader.rs
+++ b/rttp_client/src/connection/connection_reader.rs
@@ -5,7 +5,7 @@ use url::Url;
 
 use crate::error;
 use crate::response::Response;
-use crate::types::RoUrl;
+use crate::types::{Header, RoUrl};
 
 const HEADER_END: &[u8] = b"\r\n\r\n";
 const CRLF: &[u8] = b"\r\n";
@@ -16,6 +16,11 @@ pub(crate) enum ResponseBodyKind {
   Chunked,
   ContentLength(usize),
   UntilEof,
+}
+
+pub(crate) struct ResponseParts {
+  pub(crate) binary: Vec<u8>,
+  pub(crate) trailers: Vec<Header>,
 }
 
 #[allow(dead_code)]
@@ -38,27 +43,39 @@ impl<'a> ConnectionReader<'a> {
     }
   }
 
+  #[allow(dead_code)]
   pub fn binary(&mut self) -> error::Result<Vec<u8>> {
-    read_response_binary(self.reader, self.expect_no_body)
+    Ok(read_response_parts(self.reader, self.expect_no_body)?.binary)
+  }
+
+  pub(crate) fn response_parts(&mut self) -> error::Result<ResponseParts> {
+    read_response_parts(self.reader, self.expect_no_body)
   }
 
   #[allow(dead_code)]
   pub fn response(&mut self) -> error::Result<Response> {
-    Response::new(RoUrl::from(self.url.clone()), self.binary()?)
+    let parts = self.response_parts()?;
+    Response::with_trailers(RoUrl::from(self.url.clone()), parts.binary, parts.trailers)
   }
 
   // todo Connection reader will read more type from io::Reader, like Chunk data, and Stream data.
 }
 
-fn read_response_binary<R>(reader: &mut R, expect_no_body: bool) -> error::Result<Vec<u8>>
+pub(crate) fn read_response_parts<R>(
+  reader: &mut R,
+  expect_no_body: bool,
+) -> error::Result<ResponseParts>
 where
   R: Read + ?Sized,
 {
   let mut binary = read_response_header(reader)?;
+  let mut trailers = Vec::new();
   match response_body_kind(&binary, expect_no_body)? {
     ResponseBodyKind::NoBody => {}
     ResponseBodyKind::Chunked => {
-      binary.extend_from_slice(&read_chunked_body(reader)?);
+      let chunked = read_chunked_response_body(reader)?;
+      binary.extend_from_slice(&chunked.body);
+      trailers = chunked.trailers;
     }
     ResponseBodyKind::ContentLength(content_length) => {
       let current_len = binary.len();
@@ -71,7 +88,7 @@ where
       reader.read_to_end(&mut binary).map_err(error::request)?;
     }
   }
-  Ok(binary)
+  Ok(ResponseParts { binary, trailers })
 }
 
 fn read_response_header<R>(reader: &mut R) -> error::Result<Vec<u8>>
@@ -166,7 +183,12 @@ pub(crate) fn response_body_kind(
   }
 }
 
-fn read_chunked_body<R>(reader: &mut R) -> error::Result<Vec<u8>>
+struct ChunkedResponseBody {
+  body: Vec<u8>,
+  trailers: Vec<Header>,
+}
+
+fn read_chunked_response_body<R>(reader: &mut R) -> error::Result<ChunkedResponseBody>
 where
   R: Read + ?Sized,
 {
@@ -177,8 +199,8 @@ where
     let chunk_size = parse_chunk_size(&line)?;
 
     if chunk_size == 0 {
-      consume_trailers(reader)?;
-      return Ok(body);
+      let trailers = read_trailers(reader)?;
+      return Ok(ChunkedResponseBody { body, trailers });
     }
 
     let current_len = body.len();
@@ -236,16 +258,29 @@ where
   }
 }
 
-fn consume_trailers<R>(reader: &mut R) -> error::Result<()>
+fn read_trailers<R>(reader: &mut R) -> error::Result<Vec<Header>>
 where
   R: Read + ?Sized,
 {
+  let mut trailers = Vec::new();
   loop {
     let line = read_crlf_line(reader)?;
     if line == CRLF {
-      return Ok(());
+      return Ok(trailers);
     }
+
+    trailers.push(parse_trailer_line(&line)?);
   }
+}
+
+fn parse_trailer_line(line: &[u8]) -> error::Result<Header> {
+  let line = std::str::from_utf8(line).map_err(error::response)?;
+  let line = line.trim_end_matches("\r\n");
+  let (name, value) = line
+    .split_once(':')
+    .ok_or_else(|| error::bad_response("Invalid trailer header"))?;
+
+  Ok(Header::new(name, value))
 }
 
 #[cfg(test)]
@@ -276,7 +311,7 @@ mod tests {
   }
 
   #[test]
-  fn test_chunked_extensions_and_trailers_are_ignored() {
+  fn test_chunked_extensions_and_trailers_are_preserved() {
     let raw = concat!(
       "HTTP/1.1 200 OK\r\n",
       "Transfer-Encoding: gzip, chunked\r\n",
@@ -296,6 +331,10 @@ mod tests {
     assert_eq!(
       Some(&"gzip, chunked".to_string()),
       response.header_value("Transfer-Encoding")
+    );
+    assert_eq!(
+      Some("abc"),
+      response.trailer_value("x-trace").map(String::as_str)
     );
   }
 

--- a/rttp_client/src/response/raw_response.rs
+++ b/rttp_client/src/response/raw_response.rs
@@ -18,12 +18,21 @@ pub struct RawResponse {
   version: String,
   reason: String,
   headers: Vec<Header>,
+  trailers: Vec<Header>,
   cookies: Vec<Cookie>,
   body: ResponseBody,
 }
 
 impl RawResponse {
   pub fn new(url: RoUrl, binary: Vec<u8>) -> error::Result<Self> {
+    Self::with_trailers(url, binary, Vec::new())
+  }
+
+  pub(crate) fn with_trailers(
+    url: RoUrl,
+    binary: Vec<u8>,
+    trailers: Vec<Header>,
+  ) -> error::Result<Self> {
     let _url = url.to_url().map_err(error::builder)?;
     let mut response = RawResponse {
       _url,
@@ -32,6 +41,7 @@ impl RawResponse {
       version: "".to_string(),
       reason: "".to_string(),
       headers: vec![],
+      trailers,
       cookies: vec![],
       body: ResponseBody::new(vec![]),
     };
@@ -86,6 +96,9 @@ impl RawResponse {
   }
   pub fn headers_get(&self) -> &Vec<Header> {
     &self.headers
+  }
+  pub fn trailers_get(&self) -> &Vec<Header> {
+    &self.trailers
   }
   pub fn body_get(&self) -> &ResponseBody {
     &self.body

--- a/rttp_client/src/response/response.rs
+++ b/rttp_client/src/response/response.rs
@@ -17,6 +17,16 @@ impl Response {
       raw: RawResponse::new(url, binary)?,
     })
   }
+
+  pub(crate) fn with_trailers(
+    url: RoUrl,
+    binary: Vec<u8>,
+    trailers: Vec<Header>,
+  ) -> error::Result<Self> {
+    Ok(Self {
+      raw: RawResponse::with_trailers(url, binary, trailers)?,
+    })
+  }
 }
 
 impl Response {
@@ -68,6 +78,10 @@ impl Response {
     self.raw.headers_get()
   }
 
+  pub fn trailers(&self) -> &Vec<Header> {
+    self.raw.trailers_get()
+  }
+
   pub fn headers_of_name<S: AsRef<str>>(&self, name: S) -> Vec<&Header> {
     self
       .headers()
@@ -94,6 +108,17 @@ impl Response {
 
   pub fn header_value<S: AsRef<str>>(&self, name: S) -> Option<&String> {
     self.header(name).map(|header| header.value())
+  }
+
+  pub fn trailer<S: AsRef<str>>(&self, name: S) -> Option<&Header> {
+    self
+      .trailers()
+      .iter()
+      .find(|header| header.name().eq_ignore_ascii_case(name.as_ref()))
+  }
+
+  pub fn trailer_value<S: AsRef<str>>(&self, name: S) -> Option<&String> {
+    self.trailer(name).map(|header| header.value())
   }
 
   pub fn cookies(&self) -> &Vec<Cookie> {

--- a/rttp_client/tests/support/mod.rs
+++ b/rttp_client/tests/support/mod.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 use std::io::{self, Read, Write};
 use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr, TcpListener, TcpStream};
 use std::thread::{self, JoinHandle};
@@ -125,7 +127,28 @@ pub fn spawn_chunked_server() -> (SocketAddr, JoinHandle<()>) {
         "7;foo=bar\r\nchunked\r\n",
         "6\r\n body!\r\n",
         "0\r\n",
-        "X-Trailer: ignored\r\n",
+        "X-Trace: abc\r\n",
+        "X-Signature: signed\r\n",
+        "\r\n"
+      );
+      let _ = stream.write_all(response.as_bytes());
+    }
+  });
+  (addr, handle)
+}
+
+pub fn spawn_chunked_server_without_trailers() -> (SocketAddr, JoinHandle<()>) {
+  let (listener, addr) = bind_local_http_listener("chunked server without trailers");
+  let handle = thread::spawn(move || {
+    if let Ok((mut stream, _)) = listener.accept() {
+      let _ = read_http_request(&mut stream);
+      let response = concat!(
+        "HTTP/1.1 200 OK\r\n",
+        "Transfer-Encoding: chunked\r\n",
+        "Connection: close\r\n",
+        "\r\n",
+        "2\r\nOK\r\n",
+        "0\r\n",
         "\r\n"
       );
       let _ = stream.write_all(response.as_bytes());

--- a/rttp_client/tests/test_http_async.rs
+++ b/rttp_client/tests/test_http_async.rs
@@ -1,9 +1,13 @@
 mod support;
 
+#[cfg(feature = "async")]
 use futures::executor::block_on;
+#[cfg(feature = "async")]
 use rttp_client::types::Proxy;
+#[cfg(feature = "async")]
 use rttp_client::{Config, HttpClient};
 
+#[cfg(feature = "async")]
 fn client() -> HttpClient {
   HttpClient::new()
 }
@@ -40,6 +44,15 @@ fn test_async_chunked() {
 
     let response = response.unwrap();
     assert_eq!("chunked body!", response.body().string().unwrap());
+    assert_eq!(2, response.trailers().len());
+    assert_eq!(
+      Some("abc"),
+      response.trailer("X-TRACE").map(|h| h.value().as_str())
+    );
+    assert_eq!(
+      Some("signed"),
+      response.trailer("x-signature").map(|h| h.value().as_str())
+    );
   });
 }
 

--- a/rttp_client/tests/test_http_basic.rs
+++ b/rttp_client/tests/test_http_basic.rs
@@ -82,6 +82,30 @@ fn test_chunked() {
     Some(&"chunked".to_string()),
     response.header_value("Transfer-Encoding")
   );
+  assert_eq!(2, response.trailers().len());
+  assert_eq!(
+    Some("abc"),
+    response.trailer("x-trace").map(|h| h.value().as_str())
+  );
+  assert_eq!(
+    Some("signed"),
+    response.trailer("X-SIGNATURE").map(|h| h.value().as_str())
+  );
+}
+
+#[test]
+fn test_chunked_without_trailers_exposes_empty_trailers() {
+  let (addr, _handle) = support::spawn_chunked_server_without_trailers();
+  let response = client()
+    .get()
+    .url(format!("http://{}/chunked", addr))
+    .emit();
+  assert!(response.is_ok());
+
+  let response = response.unwrap();
+  assert_eq!("OK", response.body().string().unwrap());
+  assert!(response.trailers().is_empty());
+  assert!(response.trailer("x-trace").is_none());
 }
 
 #[test]

--- a/rttp_client/tests/test_response.rs
+++ b/rttp_client/tests/test_response.rs
@@ -77,3 +77,17 @@ fn test_parse_response_1() {
   let response = response.unwrap();
   println!("{}", response);
 }
+
+#[test]
+fn test_non_chunked_response_exposes_empty_trailers() {
+  let s = "HTTP/1.1 200 OK\r\n\
+        Content-Length: 2\r\n\
+        \r\n\
+        OK";
+  let response = Response::new(RoUrl::with("https://example.test"), s.as_bytes().to_vec());
+
+  assert!(response.is_ok());
+  let response = response.unwrap();
+  assert!(response.trailers().is_empty());
+  assert!(response.trailer("x-trace").is_none());
+}


### PR DESCRIPTION
rttp_client now preserves chunked response trailers across blocking and async response paths and exposes trailer inspection APIs with case-insensitive lookup. Existing response headers and body behavior is unchanged, and responses without trailers expose an empty trailer collection.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1261/
work_kind: code_work
branch: hbx-1261-rttp-expose-chunked-response-trailers
base: main
commit: 284ff93a96b0613958552d2f94deed6ccd441992
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1261/
    url: https://plane.kahub.in/endless/browse/HBX-1261/
    close_policy: link_only
```