### PR TITLE
feat: [rttp] Refresh README server capability matrix after protocol hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ rttp_client = "0.2"
 
 Direct TCP client connections are opened with `socket2`. SOCKS proxy handshakes
 are still delegated to the `socks` crate.
+Chunked responses are decoded by the client, and response trailers are available
+through the response trailer accessors.
 
 ```rust,no_run
 use rttp_client::HttpClient;
@@ -63,6 +65,11 @@ connection, and `serve_requests` for a fixed number of sequential connections.
 The listener path uses `socket2`.
 
 The server is intentionally small: it handles blocking HTTP/1.x request parsing
-for local tests and simple embedded use, closes each connection after one
-response, and does not implement chunked request bodies, keep-alive serving, TLS,
-or async accept loops.
+for local tests and simple embedded use. It accepts fixed `Content-Length` and
+chunked request bodies, exposes chunked request trailers, applies bounded
+request head/body validation, handles `HEAD` without writing a response body,
+honors `Connection` close/keep-alive semantics across a bounded
+`serve_requests` loop, and accepts `Expect: 100-continue`.
+
+It is not a full RFC-covering web server and still does not implement server
+TLS or async accept loops.

--- a/rttp/README.md
+++ b/rttp/README.md
@@ -28,10 +28,15 @@ to port `0` in tests. `HttpServer::accept_one` serves one connection.
 `HttpServer::serve_requests` serves a fixed number of sequential connections on
 the same listener.
 
-The server currently parses blocking HTTP/1.x requests, supports fixed
-`Content-Length` request bodies, writes one response, and closes the connection.
-It does not implement chunked request bodies, keep-alive serving, TLS, or async
-accept loops.
+The server currently parses blocking HTTP/1.x requests for local tests and
+simple embedded use. It supports fixed `Content-Length` and chunked request
+bodies, preserves chunked request trailers on `Request`, bounds request
+head/body parsing, handles `HEAD` without writing a response body, honors
+`Connection` close/keep-alive semantics across a bounded `serve_requests` loop,
+and accepts `Expect: 100-continue`.
+
+The server is intentionally not a full RFC-covering web server and still does
+not implement server TLS or async accept loops.
 
 ## Client feature
 

--- a/rttp_client/README.md
+++ b/rttp_client/README.md
@@ -22,6 +22,8 @@ rttp_client = { version = "0.2", features = ["async", "tls-rustls"] }
 
 Direct TCP connections use `socket2`. SOCKS proxy handshakes remain delegated to
 the `socks` crate.
+Chunked responses are decoded, and response trailers are exposed through
+`Response::trailers` and `Response::trailer`.
 
 ## Examples
 


### PR DESCRIPTION
README capability documentation now matches the hardened rttp server behavior and client response trailer support, while preserving clear limits around server TLS and async accept loops.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1262/
work_kind: code_work
branch: hbx-1262-rttp-refresh-readme-server-capability
base: main
commit: 793a0f439e6b1534b47dc58910fb564a52d31dc3
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1262/
    url: https://plane.kahub.in/endless/browse/HBX-1262/
    close_policy: link_only
```