### PR TITLE
feat: [rttp] Bound async client chunked response framing and trailers

### DIFF
--- a/rttp_client/src/connection/async_connection.rs
+++ b/rttp_client/src/connection/async_connection.rs
@@ -2,14 +2,16 @@ use std::net::TcpStream;
 
 use futures::io::{AllowStdIo, AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use socks::{Socks4Stream, Socks5Stream};
-use std::io::Write;
+use std::io::{self, Write};
 use url::Url;
 
 #[cfg(feature = "tls-rustls")]
 use std::sync::Arc;
 
 use crate::connection::connection::{connect_tcp_stream, read_proxy_connect_response, Connection};
-use crate::connection::connection_reader::{response_body_kind, ResponseBodyKind, ResponseParts};
+use crate::connection::connection_reader::{
+  response_body_kind, ResponseBodyKind, ResponseParts, MAX_CHUNKED_RESPONSE_LINE_BYTES,
+};
 use crate::error;
 use crate::request::RawRequest;
 use crate::response::Response;
@@ -173,7 +175,7 @@ where
   let mut body = Vec::new();
 
   loop {
-    let line = async_read_crlf_line(stream).await?;
+    let line = async_read_bounded_crlf_line(stream, MAX_CHUNKED_RESPONSE_LINE_BYTES).await?;
     let chunk_size = parse_chunk_size(&line)?;
 
     if chunk_size == 0 {
@@ -191,7 +193,7 @@ where
   }
 }
 
-async fn async_read_crlf_line<S>(stream: &mut S) -> error::Result<Vec<u8>>
+async fn async_read_bounded_crlf_line<S>(stream: &mut S, max_len: usize) -> error::Result<Vec<u8>>
 where
   S: AsyncRead + Unpin,
 {
@@ -202,6 +204,10 @@ where
     let read = stream.read(&mut byte).await.map_err(error::request)?;
     if read == 0 {
       return Err(error::bad_response("Unexpected end of chunked body"));
+    }
+
+    if line.len() == max_len {
+      return Err(error::bad_response("chunked response line is too large"));
     }
 
     line.push(byte[0]);
@@ -229,10 +235,13 @@ where
   S: AsyncRead + Unpin,
 {
   let mut suffix = [0u8; 2];
-  stream
-    .read_exact(&mut suffix)
-    .await
-    .map_err(error::request)?;
+  stream.read_exact(&mut suffix).await.map_err(|err| {
+    if err.kind() == io::ErrorKind::UnexpectedEof {
+      error::bad_response("Unexpected end of chunked body")
+    } else {
+      error::request(err)
+    }
+  })?;
   if suffix == *CRLF {
     Ok(())
   } else {
@@ -246,7 +255,7 @@ where
 {
   let mut trailers = Vec::new();
   loop {
-    let line = async_read_crlf_line(stream).await?;
+    let line = async_read_bounded_crlf_line(stream, MAX_CHUNKED_RESPONSE_LINE_BYTES).await?;
     if line == CRLF {
       return Ok(trailers);
     }

--- a/rttp_client/src/connection/connection_reader.rs
+++ b/rttp_client/src/connection/connection_reader.rs
@@ -9,7 +9,7 @@ use crate::types::{Header, RoUrl};
 
 const HEADER_END: &[u8] = b"\r\n\r\n";
 const CRLF: &[u8] = b"\r\n";
-const MAX_CHUNKED_RESPONSE_LINE_BYTES: usize = 8 * 1024;
+pub(crate) const MAX_CHUNKED_RESPONSE_LINE_BYTES: usize = 8 * 1024;
 
 #[derive(Debug, Eq, PartialEq)]
 pub(crate) enum ResponseBodyKind {

--- a/rttp_client/tests/test_http_async.rs
+++ b/rttp_client/tests/test_http_async.rs
@@ -58,6 +58,73 @@ fn test_async_chunked() {
 
 #[test]
 #[cfg(feature = "async")]
+fn test_async_chunked_oversized_extension_is_rejected() {
+  let extension = "a".repeat(16 * 1024);
+  let response = format!(
+    "HTTP/1.1 200 OK\r\n\
+     Transfer-Encoding: chunked\r\n\
+     Connection: close\r\n\
+     \r\n\
+     7;foo={extension}\r\n\
+     chunked\r\n\
+     0\r\n\
+     \r\n"
+  );
+  let (addr, _handle) = support::spawn_chunked_response_server(response);
+
+  block_on(async {
+    let error = client()
+      .get()
+      .url(format!("http://{}/chunked", addr))
+      .rasync()
+      .await
+      .expect_err("oversized chunk extension should be rejected");
+
+    assert!(
+      error
+        .to_string()
+        .contains("chunked response line is too large"),
+      "unexpected error: {error}"
+    );
+  });
+}
+
+#[test]
+#[cfg(feature = "async")]
+fn test_async_chunked_oversized_trailer_is_rejected() {
+  let trailer = "a".repeat(16 * 1024);
+  let response = format!(
+    "HTTP/1.1 200 OK\r\n\
+     Transfer-Encoding: chunked\r\n\
+     Connection: close\r\n\
+     \r\n\
+     7\r\n\
+     chunked\r\n\
+     0\r\n\
+     X-Trace: {trailer}\r\n\
+     \r\n"
+  );
+  let (addr, _handle) = support::spawn_chunked_response_server(response);
+
+  block_on(async {
+    let error = client()
+      .get()
+      .url(format!("http://{}/chunked", addr))
+      .rasync()
+      .await
+      .expect_err("oversized chunk trailer should be rejected");
+
+    assert!(
+      error
+        .to_string()
+        .contains("chunked response line is too large"),
+      "unexpected error: {error}"
+    );
+  });
+}
+
+#[test]
+#[cfg(feature = "async")]
 fn test_async_duplicate_set_cookie_headers_are_preserved() {
   let (addr, _handle) = support::spawn_duplicate_set_cookie_server();
   block_on(async {


### PR DESCRIPTION
Implemented bounded async chunked response framing for rttp_client, aligning async chunk-size/extension and trailer line handling with the blocking client path while preserving normal chunked trailer decoding.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1260/
work_kind: code_work
branch: hbx-1260-rttp-bound-async-client-chunked
base: main
commit: 75c989c889cb5cf06904bfe2ac76694189b58224
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1260/
    url: https://plane.kahub.in/endless/browse/HBX-1260/
    close_policy: link_only
```