### PR TITLE
feat: Recover retained claimed work for default:ed49867b-42ad-4840-a426-692f05017e92

### DIFF
--- a/rttp/src/server.rs
+++ b/rttp/src/server.rs
@@ -637,7 +637,9 @@ impl HttpResponse {
       .write_head_to(&mut bytes, DefaultConnectionHeader::Omit)
       .expect("write to Vec cannot fail");
     if self.allows_body() {
-      bytes.extend_from_slice(&self.body);
+      self
+        .write_body_to(&mut bytes)
+        .expect("write to Vec cannot fail");
     }
     bytes
   }
@@ -671,7 +673,7 @@ impl HttpResponse {
   {
     self.write_head_to(writer, default_connection)?;
     if write_body && self.allows_body() {
-      writer.write_all(&self.body)?;
+      self.write_body_to(writer)?;
     }
     writer.flush()
   }
@@ -700,7 +702,7 @@ impl HttpResponse {
       }
     }
 
-    if self.allows_body() {
+    if self.allows_body() && !self.uses_chunked_transfer_encoding() {
       write!(writer, "Content-Length: {}\r\n", self.body.len())?;
     }
     if connection_header_index.is_none() {
@@ -714,8 +716,31 @@ impl HttpResponse {
     writer.write_all(b"\r\n")
   }
 
+  fn write_body_to<W>(&self, writer: &mut W) -> io::Result<()>
+  where
+    W: Write,
+  {
+    if self.uses_chunked_transfer_encoding() {
+      write!(writer, "{:x}\r\n", self.body.len())?;
+      writer.write_all(&self.body)?;
+      writer.write_all(b"\r\n0\r\n\r\n")
+    } else {
+      writer.write_all(&self.body)
+    }
+  }
+
   fn allows_body(&self) -> bool {
     response_status_allows_body(self.status_code)
+  }
+
+  fn uses_chunked_transfer_encoding(&self) -> bool {
+    self.headers.iter().any(|header| {
+      header.name.eq_ignore_ascii_case("Transfer-Encoding")
+        && header
+          .value
+          .split(',')
+          .any(|token| token.trim().eq_ignore_ascii_case("chunked"))
+    })
   }
 
   fn connection_header_index(&self) -> Option<usize> {

--- a/rttp/tests/test_server.rs
+++ b/rttp/tests/test_server.rs
@@ -84,6 +84,45 @@ fn server_accepts_get_request_and_writes_response() {
 }
 
 #[test]
+fn server_writes_chunked_response_framing() {
+  let server = rttp::Http::server("127.0.0.1:0").expect("bind server");
+  let addr = server.local_addr().expect("server addr");
+
+  let handle = thread::spawn(move || {
+    server
+      .accept_one(|_request| HttpResponse::ok("hello").header("Transfer-Encoding", "chunked"))
+      .expect("serve one request");
+  });
+
+  let mut stream = TcpStream::connect(addr).expect("connect server");
+  stream
+    .write_all(b"GET /hello HTTP/1.1\r\nHost: localhost\r\n\r\n")
+    .expect("write request");
+  stream
+    .shutdown(std::net::Shutdown::Write)
+    .expect("shutdown write");
+
+  let mut response = String::new();
+  stream.read_to_string(&mut response).expect("read response");
+
+  assert_eq!(
+    concat!(
+      "HTTP/1.1 200 OK\r\n",
+      "Transfer-Encoding: chunked\r\n",
+      "Connection: close\r\n",
+      "\r\n",
+      "5\r\n",
+      "hello\r\n",
+      "0\r\n",
+      "\r\n"
+    ),
+    response
+  );
+
+  handle.join().expect("server thread");
+}
+
+#[test]
 fn server_request_body_stops_at_declared_content_length() {
   let server = rttp::Http::server("127.0.0.1:0").expect("bind server");
   let addr = server.local_addr().expect("server addr");

--- a/rttp/tests/test_server_models.rs
+++ b/rttp/tests/test_server_models.rs
@@ -154,6 +154,29 @@ fn serializes_at_most_one_connection_header() {
 }
 
 #[test]
+fn serializes_chunked_response_body_when_transfer_encoding_is_chunked() {
+  let response = HttpResponse::new(200, "OK")
+    .header("Transfer-Encoding", "chunked")
+    .body("hello");
+
+  let serialized = response.to_bytes();
+
+  assert_eq!(
+    concat!(
+      "HTTP/1.1 200 OK\r\n",
+      "Transfer-Encoding: chunked\r\n",
+      "\r\n",
+      "5\r\n",
+      "hello\r\n",
+      "0\r\n",
+      "\r\n"
+    )
+    .as_bytes(),
+    serialized.as_slice()
+  );
+}
+
+#[test]
 fn rejects_response_headers_with_crlf() {
   let result = std::panic::catch_unwind(|| {
     let _response = HttpResponse::new(302, "Found").header("Location", "/safe\r\nX-Evil: true");


### PR DESCRIPTION
Implemented chunked response framing for explicit `Transfer-Encoding: chunked` server responses. The server now omits automatic `Content-Length` for chunked responses, writes the body using chunk framing with a terminating chunk, and preserves existing fixed-length and no-body response behavior.

## Metadata
```yaml
version: 1
issue: default:ed49867b-42ad-4840-a426-692f05017e92
work_kind: code_work
branch: hbx-1265-rttp-add-chunked-response-framing
base: main
commit: 8ba5a2f1e047354752863a000740b9ad58f276be
```