### PR TITLE
feat: [rttp] Add bounded server write and idle timeout controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,8 @@ fn main() -> std::io::Result<()> {
 Use `HttpServer::bind` directly when you already want the server type,
 `HttpServer::local_addr` to read the bound address, `accept_one` for one
 connection, and `serve_requests` for a fixed number of sequential connections.
-The listener path uses `socket2`.
+Use `with_read_timeout` and `with_write_timeout` to apply socket-level
+timeouts to each accepted connection. The listener path uses `socket2`.
 
 The server is intentionally small: it handles blocking HTTP/1.x request parsing
 for local tests and simple embedded use. It accepts fixed `Content-Length` and

--- a/rttp/README.md
+++ b/rttp/README.md
@@ -26,7 +26,9 @@ fn main() -> std::io::Result<()> {
 `HttpServer::local_addr` returns the bound address, which is useful when binding
 to port `0` in tests. `HttpServer::accept_one` serves one connection.
 `HttpServer::serve_requests` serves a fixed number of sequential connections on
-the same listener.
+the same listener. `HttpServer::with_read_timeout` and
+`HttpServer::with_write_timeout` apply socket-level timeouts to each accepted
+connection.
 
 The server currently parses blocking HTTP/1.x requests for local tests and
 simple embedded use. It supports fixed `Content-Length` and chunked request

--- a/rttp/src/server.rs
+++ b/rttp/src/server.rs
@@ -2,6 +2,7 @@ use std::error::Error;
 use std::fmt;
 use std::io::{self, BufRead, BufReader, Read, Write};
 use std::net::{SocketAddr, TcpListener, TcpStream, ToSocketAddrs};
+use std::time::Duration;
 
 use socket2::{Domain, Protocol, Socket, Type};
 
@@ -10,6 +11,8 @@ const MAX_REQUEST_BODY_BYTES: usize = 1024 * 1024;
 
 pub struct HttpServer {
   listener: TcpListener,
+  read_timeout: Option<Duration>,
+  write_timeout: Option<Duration>,
 }
 
 impl HttpServer {
@@ -43,6 +46,8 @@ impl HttpServer {
 
       return Ok(Self {
         listener: TcpListener::from(socket),
+        read_timeout: None,
+        write_timeout: None,
       });
     }
 
@@ -54,6 +59,18 @@ impl HttpServer {
 
   pub fn local_addr(&self) -> io::Result<SocketAddr> {
     self.listener.local_addr()
+  }
+
+  /// Sets the read timeout applied to each accepted connection before parsing requests.
+  pub fn with_read_timeout(mut self, timeout: Option<Duration>) -> Self {
+    self.read_timeout = timeout;
+    self
+  }
+
+  /// Sets the write timeout applied to each accepted connection before writing responses.
+  pub fn with_write_timeout(mut self, timeout: Option<Duration>) -> Self {
+    self.write_timeout = timeout;
+    self
   }
 
   pub fn accept_one<F>(&self, handler: F) -> io::Result<()>
@@ -71,6 +88,7 @@ impl HttpServer {
 
     while served < request_count {
       let (stream, _) = self.listener.accept()?;
+      self.configure_stream(&stream)?;
       let handled = self.handle_connection(stream, request_count - served, &mut handler)?;
       served += handled.max(1);
     }
@@ -91,15 +109,16 @@ impl HttpServer {
     let mut served = 0;
 
     while served < request_limit {
-      let request = match Request::read_next_from_with_continue(&mut reader) {
-        Ok(Some(request)) => request,
-        Ok(None) => break,
-        Err(err) if is_bad_request_error(&err) => {
-          bad_request_response().write_to(reader.get_mut())?;
-          break;
-        }
-        Err(err) => return Err(err),
-      };
+      let request =
+        match self.normalize_connection_error(Request::read_next_from_with_continue(&mut reader)) {
+          Ok(Some(request)) => request,
+          Ok(None) => break,
+          Err(err) if is_bad_request_error(&err) => {
+            self.normalize_connection_error(bad_request_response().write_to(reader.get_mut()))?;
+            break;
+          }
+          Err(err) => return Err(err),
+        };
       let request_closes_connection = request.closes_connection();
       let request_uses_http10_defaults = request.version() == "HTTP/1.0";
       let request_is_head = request.method() == "HEAD";
@@ -116,11 +135,11 @@ impl HttpServer {
       } else {
         DefaultConnectionHeader::Omit
       };
-      response.write_to_with_default_connection_and_body(
+      self.normalize_connection_error(response.write_to_with_default_connection_and_body(
         reader.get_mut(),
         default_connection,
         !request_is_head,
-      )?;
+      ))?;
 
       if close_after_response {
         break;
@@ -135,23 +154,43 @@ impl HttpServer {
     F: FnOnce(Request) -> HttpResponse,
   {
     let (stream, _) = self.listener.accept()?;
+    self.configure_stream(&stream)?;
     let mut reader = BufReader::new(stream);
-    let request = match Request::read_next_from_with_continue(&mut reader).and_then(|request| {
-      request.ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "incomplete HTTP request"))
-    }) {
+    let request = match self.normalize_connection_error(
+      Request::read_next_from_with_continue(&mut reader).and_then(|request| {
+        request.ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "incomplete HTTP request"))
+      }),
+    ) {
       Ok(request) => request,
       Err(err) if is_bad_request_error(&err) => {
-        return bad_request_response().write_to(reader.get_mut());
+        return self.normalize_connection_error(bad_request_response().write_to(reader.get_mut()));
       }
       Err(err) => return Err(err),
     };
     let request_is_head = request.method() == "HEAD";
     let response = handler(request);
-    response.write_to_with_default_connection_and_body(
+    self.normalize_connection_error(response.write_to_with_default_connection_and_body(
       reader.get_mut(),
       DefaultConnectionHeader::Close,
       !request_is_head,
-    )
+    ))
+  }
+
+  fn configure_stream(&self, stream: &TcpStream) -> io::Result<()> {
+    stream.set_read_timeout(self.read_timeout)?;
+    stream.set_write_timeout(self.write_timeout)
+  }
+
+  fn normalize_connection_error<T>(&self, result: io::Result<T>) -> io::Result<T> {
+    result.map_err(|err| {
+      if err.kind() == io::ErrorKind::WouldBlock
+        && (self.read_timeout.is_some() || self.write_timeout.is_some())
+      {
+        io::Error::new(io::ErrorKind::TimedOut, err)
+      } else {
+        err
+      }
+    })
   }
 }
 

--- a/rttp/src/server.rs
+++ b/rttp/src/server.rs
@@ -1131,12 +1131,7 @@ where
 
     let copied = {
       let mut chunk_reader = reader.take(chunk_size as u64);
-      io::copy(&mut chunk_reader, &mut body).map_err(|_| {
-        io::Error::new(
-          io::ErrorKind::UnexpectedEof,
-          "incomplete chunked request body",
-        )
-      })?
+      io::copy(&mut chunk_reader, &mut body)?
     };
 
     if copied != chunk_size as u64 {
@@ -1206,11 +1201,15 @@ where
 {
   add_request_body_bytes(body_bytes_read, 2)?;
   let mut suffix = [0u8; 2];
-  reader.read_exact(&mut suffix).map_err(|_| {
-    io::Error::new(
-      io::ErrorKind::UnexpectedEof,
-      "incomplete chunked request body",
-    )
+  reader.read_exact(&mut suffix).map_err(|err| {
+    if err.kind() == io::ErrorKind::UnexpectedEof {
+      io::Error::new(
+        io::ErrorKind::UnexpectedEof,
+        "incomplete chunked request body",
+      )
+    } else {
+      err
+    }
   })?;
   if suffix == *b"\r\n" {
     Ok(())

--- a/rttp/tests/test_server.rs
+++ b/rttp/tests/test_server.rs
@@ -84,6 +84,73 @@ fn server_accepts_get_request_and_writes_response() {
 }
 
 #[test]
+fn server_accepts_get_request_with_default_timeout_configuration() {
+  let server = rttp::Http::server("127.0.0.1:0").expect("bind server");
+  let addr = server.local_addr().expect("server addr");
+
+  let handle = thread::spawn(move || {
+    server
+      .accept_one(|_request| HttpResponse::ok("default"))
+      .expect("serve one request");
+  });
+
+  let response = send_request(addr, b"GET /default HTTP/1.1\r\nHost: localhost\r\n\r\n");
+
+  assert_eq!(
+    "HTTP/1.1 200 OK\r\nContent-Length: 7\r\nConnection: close\r\n\r\ndefault",
+    response
+  );
+
+  handle.join().expect("server thread");
+}
+
+#[test]
+fn configured_read_timeout_bounds_idle_accepted_connection() {
+  let server = rttp::Http::server("127.0.0.1:0")
+    .expect("bind server")
+    .with_read_timeout(Some(Duration::from_millis(100)));
+  let addr = server.local_addr().expect("server addr");
+  let (result_tx, result_rx) = mpsc::channel();
+
+  let handle = thread::spawn(move || {
+    let result = server.accept_one(|_request| HttpResponse::ok("unexpected"));
+    result_tx.send(result).expect("send server result");
+  });
+
+  let _stream = TcpStream::connect(addr).expect("connect server");
+  let result = result_rx
+    .recv_timeout(Duration::from_secs(1))
+    .expect("server returned after read timeout");
+  let err = result.expect_err("idle accepted connection should time out");
+  assert_eq!(std::io::ErrorKind::TimedOut, err.kind());
+
+  handle.join().expect("server thread");
+}
+
+#[test]
+fn configured_write_timeout_preserves_normal_response_behavior() {
+  let server = rttp::Http::server("127.0.0.1:0")
+    .expect("bind server")
+    .with_write_timeout(Some(Duration::from_secs(1)));
+  let addr = server.local_addr().expect("server addr");
+
+  let handle = thread::spawn(move || {
+    server
+      .accept_one(|_request| HttpResponse::ok("write bounded"))
+      .expect("serve one request");
+  });
+
+  let response = send_request(addr, b"GET /write HTTP/1.1\r\nHost: localhost\r\n\r\n");
+
+  assert_eq!(
+    "HTTP/1.1 200 OK\r\nContent-Length: 13\r\nConnection: close\r\n\r\nwrite bounded",
+    response
+  );
+
+  handle.join().expect("server thread");
+}
+
+#[test]
 fn server_writes_chunked_response_framing() {
   let server = rttp::Http::server("127.0.0.1:0").expect("bind server");
   let addr = server.local_addr().expect("server addr");

--- a/rttp/tests/test_server.rs
+++ b/rttp/tests/test_server.rs
@@ -870,6 +870,41 @@ fn server_returns_bad_request_for_truncated_chunked_request_body() {
 }
 
 #[test]
+fn configured_read_timeout_is_preserved_for_stalled_chunked_request_body() {
+  let server = rttp::Http::server("127.0.0.1:0")
+    .expect("bind server")
+    .with_read_timeout(Some(Duration::from_millis(100)));
+  let addr = server.local_addr().expect("server addr");
+  let (result_tx, result_rx) = mpsc::channel();
+
+  let handle = thread::spawn(move || {
+    let result = server.accept_one(|_request| HttpResponse::ok("unexpected"));
+    result_tx.send(result).expect("send server result");
+  });
+
+  let mut stream = TcpStream::connect(addr).expect("connect server");
+  stream
+    .write_all(
+      concat!(
+        "POST /upload HTTP/1.1\r\n",
+        "Transfer-Encoding: chunked\r\n",
+        "\r\n",
+        "5\r\nhel"
+      )
+      .as_bytes(),
+    )
+    .expect("write partial chunked request body");
+
+  let result = result_rx
+    .recv_timeout(Duration::from_secs(1))
+    .expect("server returned after chunked request body timeout");
+  let err = result.expect_err("stalled chunked request body should time out");
+  assert_eq!(std::io::ErrorKind::TimedOut, err.kind());
+
+  handle.join().expect("server thread");
+}
+
+#[test]
 fn server_returns_bad_request_for_huge_truncated_chunked_request_body() {
   let (response, handler_called) = send_raw_request(
     concat!(


### PR DESCRIPTION
Implemented builder-style read/write timeout controls for accepted blocking server connections, preserving default behavior while bounding idle or stalled sockets. Timeout-caused WouldBlock errors are normalized to TimedOut for deterministic server IO behavior. Added server integration coverage and README documentation; formatting, rttp server tests, and workspace tests pass.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1266/
work_kind: code_work
branch: hbx-1266-rttp-add-bounded-server-write
base: main
commit: 98f294e5db7d62f4a97823cef9157523bdbede7d
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1266/
    url: https://plane.kahub.in/endless/browse/HBX-1266/
    close_policy: link_only
```