### PR TITLE
feat: [rttp] Align HttpRequest::parse with streaming server request semantics

### DIFF
--- a/rttp/src/server.rs
+++ b/rttp/src/server.rs
@@ -514,64 +514,20 @@ pub struct HttpRequest {
 
 impl HttpRequest {
   pub fn parse(raw: &[u8]) -> Result<Self, HttpParseError> {
-    let header_end = raw
-      .windows(4)
-      .position(|window| window == b"\r\n\r\n")
+    let header_end = find_header_end(raw)
       .ok_or_else(|| HttpParseError::new("request is missing header terminator"))?;
-    let head = std::str::from_utf8(&raw[..header_end])
-      .map_err(|_| HttpParseError::new("request headers are not valid UTF-8"))?;
+    reject_oversized_request_head(header_end + 4).map_err(HttpParseError::from_io_error)?;
+    let head = parse_request_head(&raw[..header_end]).map_err(HttpParseError::from_io_error)?;
     let body_bytes = &raw[(header_end + 4)..];
 
-    let mut lines = head.split("\r\n");
-    let request_line = lines
-      .next()
-      .ok_or_else(|| HttpParseError::new("request line is missing"))?;
-    let mut request_parts = request_line.split_whitespace();
-    let method = request_parts
-      .next()
-      .ok_or_else(|| HttpParseError::new("request method is missing"))?;
-    let target = request_parts
-      .next()
-      .ok_or_else(|| HttpParseError::new("request target is missing"))?;
-    let version = request_parts
-      .next()
-      .ok_or_else(|| HttpParseError::new("request version is missing"))?;
-
-    if request_parts.next().is_some() {
-      return Err(HttpParseError::new("request line has too many parts"));
-    }
-
-    let (path, query) = match target.split_once('?') {
+    let (path, query) = match head.target.split_once('?') {
       Some((path, query)) => (path.to_string(), Some(query.to_string())),
-      None => (target.to_string(), None),
+      None => (head.target.clone(), None),
     };
 
-    let mut headers = Vec::new();
-    for line in lines {
-      let (name, value) = line
-        .split_once(':')
-        .ok_or_else(|| HttpParseError::new("header line is missing ':'"))?;
-      headers.push(HttpHeader::new(name.trim(), value.trim()));
-    }
-
-    if headers
-      .iter()
-      .any(|header| header.name.eq_ignore_ascii_case("Transfer-Encoding"))
-    {
-      return Err(HttpParseError::new(
-        "Transfer-Encoding request bodies are not supported",
-      ));
-    }
-
-    let body = match headers
-      .iter()
-      .find(|header| header.name.eq_ignore_ascii_case("Content-Length"))
-    {
-      Some(header) => {
-        let content_length = header
-          .value
-          .parse::<usize>()
-          .map_err(|_| HttpParseError::new("Content-Length is not a valid length"))?;
+    let body = match request_body_kind(&head.headers).map_err(HttpParseError::from_io_error)? {
+      RequestBodyKind::ContentLength(content_length) => {
+        reject_oversized_request_body(content_length).map_err(HttpParseError::from_io_error)?;
         if body_bytes.len() != content_length {
           return Err(HttpParseError::new(
             "request body length does not match Content-Length",
@@ -579,14 +535,23 @@ impl HttpRequest {
         }
         body_bytes.to_vec()
       }
-      None => body_bytes.to_vec(),
+      RequestBodyKind::Chunked => {
+        return Err(HttpParseError::new(
+          "chunked request body requires streaming reader",
+        ));
+      }
     };
+    let headers = head
+      .headers
+      .into_iter()
+      .map(|(name, value)| HttpHeader::new(name, value))
+      .collect();
 
     Ok(Self {
-      method: method.to_string(),
+      method: head.method,
       path,
       query,
-      version: version.to_string(),
+      version: head.version,
       headers,
       body,
     })
@@ -831,6 +796,10 @@ impl HttpParseError {
     Self {
       message: message.as_ref().to_string(),
     }
+  }
+
+  fn from_io_error(error: io::Error) -> Self {
+    Self::new(error.to_string())
   }
 }
 

--- a/rttp/tests/test_server_models.rs
+++ b/rttp/tests/test_server_models.rs
@@ -7,6 +7,7 @@ fn parses_http_request_target_headers_and_body() {
     "Host: example.test\r\n",
     "Content-Type: text/plain\r\n",
     "X-Trace-Id: abc-123\r\n",
+    "Content-Length: 11\r\n",
     "\r\n",
     "hello=world"
   );
@@ -28,6 +29,22 @@ fn parses_body_only_when_content_length_matches() {
   let raw = concat!(
     "POST /submit HTTP/1.1\r\n",
     "Host: example.test\r\n",
+    "Content-Length: 5\r\n",
+    "\r\n",
+    "hello"
+  );
+
+  let request = HttpRequest::parse(raw.as_bytes()).expect("request should parse");
+
+  assert_eq!(b"hello", request.body());
+}
+
+#[test]
+fn parses_fixed_length_request_with_duplicate_matching_content_length() {
+  let raw = concat!(
+    "POST /submit HTTP/1.1\r\n",
+    "Host: example.test\r\n",
+    "Content-Length: 5\r\n",
     "Content-Length: 5\r\n",
     "\r\n",
     "hello"
@@ -75,6 +92,45 @@ fn rejects_request_body_longer_than_content_length() {
 }
 
 #[test]
+fn rejects_malformed_request_line_and_request_metadata() {
+  for raw in [
+    b"GET  HTTP/1.1\r\nHost: example.test\r\n\r\n".as_slice(),
+    b"GET / HTTP/2.0\r\nHost: example.test\r\n\r\n",
+    b"GE(T / HTTP/1.1\r\nHost: example.test\r\n\r\n",
+    b"GET /bad path HTTP/1.1\r\nHost: example.test\r\n\r\n",
+  ] {
+    let _error = HttpRequest::parse(raw).expect_err("request should be rejected");
+  }
+}
+
+#[test]
+fn rejects_invalid_and_folded_request_headers() {
+  for raw in [
+    b"GET / HTTP/1.1\r\nBad Header: value\r\n\r\n".as_slice(),
+    b"GET / HTTP/1.1\r\nHost: bad\rvalue\r\n\r\n",
+    b"GET / HTTP/1.1\r\nHost: example.test\r\n folded: value\r\n\r\n",
+  ] {
+    let _error = HttpRequest::parse(raw).expect_err("request should be rejected");
+  }
+}
+
+#[test]
+fn rejects_conflicting_duplicate_content_length() {
+  let raw = concat!(
+    "POST /submit HTTP/1.1\r\n",
+    "Host: example.test\r\n",
+    "Content-Length: 5\r\n",
+    "Content-Length: 6\r\n",
+    "\r\n",
+    "hello"
+  );
+
+  let error = HttpRequest::parse(raw.as_bytes()).expect_err("request should be rejected");
+
+  assert_eq!("conflicting Content-Length headers", error.to_string());
+}
+
+#[test]
 fn rejects_transfer_encoding_request_even_with_content_length() {
   let raw = concat!(
     "POST /submit HTTP/1.1\r\n",
@@ -88,7 +144,7 @@ fn rejects_transfer_encoding_request_even_with_content_length() {
   let error = HttpRequest::parse(raw.as_bytes()).expect_err("request should be rejected");
 
   assert_eq!(
-    "Transfer-Encoding request bodies are not supported",
+    "Transfer-Encoding conflicts with Content-Length",
     error.to_string()
   );
 }


### PR DESCRIPTION
HttpRequest::parse now reuses the streaming parser's request head, header, Content-Length, Transfer-Encoding conflict, and size validation semantics while preserving the public request model. Focused model tests cover accepted fixed-length requests and rejected malformed or conflicting requests.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1269/
work_kind: code_work
branch: hbx-1269-rttp-align-httprequest-parse-with
base: main
commit: 9868ecdc9fac9a25b9863b8794e4bf5df07f9bf5
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1269/
    url: https://plane.kahub.in/endless/browse/HBX-1269/
    close_policy: link_only
```