### PR TITLE
feat: [rttp] Validate HTTP/1.x request-target forms in the socket2 server

### DIFF
--- a/rttp/src/server.rs
+++ b/rttp/src/server.rs
@@ -909,6 +909,12 @@ fn validate_request_line(method: &str, target: &str, version: &str) -> io::Resul
       "invalid request target",
     ));
   }
+  if !is_valid_request_target_for_method(method, target) {
+    return Err(io::Error::new(
+      io::ErrorKind::InvalidData,
+      "invalid request target",
+    ));
+  }
   if !matches!(version, "HTTP/1.0" | "HTTP/1.1") {
     return Err(io::Error::new(
       io::ErrorKind::InvalidData,
@@ -917,6 +923,75 @@ fn validate_request_line(method: &str, target: &str, version: &str) -> io::Resul
   }
 
   Ok(())
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+enum RequestTargetForm {
+  Origin,
+  Absolute,
+  Asterisk,
+  Authority,
+}
+
+fn is_valid_request_target_for_method(method: &str, target: &str) -> bool {
+  let Some(form) = request_target_form(target) else {
+    return false;
+  };
+
+  match form {
+    RequestTargetForm::Origin | RequestTargetForm::Absolute => method != "CONNECT",
+    RequestTargetForm::Asterisk => method == "OPTIONS",
+    RequestTargetForm::Authority => method == "CONNECT",
+  }
+}
+
+fn request_target_form(target: &str) -> Option<RequestTargetForm> {
+  if target == "*" {
+    Some(RequestTargetForm::Asterisk)
+  } else if target.starts_with('/') {
+    Some(RequestTargetForm::Origin)
+  } else if is_absolute_form_target(target) {
+    Some(RequestTargetForm::Absolute)
+  } else if is_authority_form_target(target) {
+    Some(RequestTargetForm::Authority)
+  } else {
+    None
+  }
+}
+
+fn is_absolute_form_target(target: &str) -> bool {
+  let Some((scheme, rest)) = target.split_once("://") else {
+    return false;
+  };
+  if !is_uri_scheme(scheme) {
+    return false;
+  }
+
+  let authority_end = rest.find(['/', '?', '#']).unwrap_or(rest.len());
+  authority_end > 0
+}
+
+fn is_uri_scheme(scheme: &str) -> bool {
+  let mut bytes = scheme.bytes();
+  let Some(first) = bytes.next() else {
+    return false;
+  };
+  first.is_ascii_alphabetic()
+    && bytes.all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'+' | b'-' | b'.'))
+}
+
+fn is_authority_form_target(target: &str) -> bool {
+  if target
+    .bytes()
+    .any(|byte| matches!(byte, b'/' | b'?' | b'#'))
+  {
+    return false;
+  }
+
+  let Some((host, port)) = target.rsplit_once(':') else {
+    return false;
+  };
+  !host.is_empty() && !port.is_empty() && port.bytes().all(|byte| byte.is_ascii_digit())
 }
 
 fn parse_header_lines<'a>(

--- a/rttp/src/server.rs
+++ b/rttp/src/server.rs
@@ -966,8 +966,11 @@ fn is_absolute_form_target(target: &str) -> bool {
   if !is_uri_scheme(scheme) {
     return false;
   }
+  if rest.contains('#') {
+    return false;
+  }
 
-  let authority_end = rest.find(['/', '?', '#']).unwrap_or(rest.len());
+  let authority_end = rest.find(['/', '?']).unwrap_or(rest.len());
   authority_end > 0
 }
 

--- a/rttp/tests/test_server.rs
+++ b/rttp/tests/test_server.rs
@@ -415,6 +415,58 @@ fn server_returns_bad_request_for_invalid_method_token() {
 }
 
 #[test]
+fn server_accepts_absolute_form_request_target() {
+  let (response, handler_called) =
+    send_raw_request(b"GET http://example.test/path?query=1 HTTP/1.1\r\nHost: localhost\r\n\r\n");
+
+  assert!(handler_called);
+  assert_eq!(
+    "HTTP/1.1 200 OK\r\nContent-Length: 10\r\nConnection: close\r\n\r\nunexpected",
+    response
+  );
+}
+
+#[test]
+fn server_accepts_options_asterisk_request_target() {
+  let (response, handler_called) =
+    send_raw_request(b"OPTIONS * HTTP/1.1\r\nHost: localhost\r\n\r\n");
+
+  assert!(handler_called);
+  assert_eq!(
+    "HTTP/1.1 200 OK\r\nContent-Length: 10\r\nConnection: close\r\n\r\nunexpected",
+    response
+  );
+}
+
+#[test]
+fn server_accepts_connect_authority_request_target() {
+  let (response, handler_called) =
+    send_raw_request(b"CONNECT example.test:443 HTTP/1.1\r\nHost: example.test\r\n\r\n");
+
+  assert!(handler_called);
+  assert_eq!(
+    "HTTP/1.1 200 OK\r\nContent-Length: 10\r\nConnection: close\r\n\r\nunexpected",
+    response
+  );
+}
+
+#[test]
+fn server_rejects_request_target_forms_for_wrong_methods() {
+  for raw in [
+    b"GET * HTTP/1.1\r\nHost: localhost\r\n\r\n".as_slice(),
+    b"GET example.test:443 HTTP/1.1\r\nHost: example.test\r\n\r\n",
+    b"CONNECT /tunnel HTTP/1.1\r\nHost: example.test\r\n\r\n",
+  ] {
+    assert_bad_request_without_handler(raw);
+  }
+}
+
+#[test]
+fn server_returns_bad_request_for_invalid_absolute_form_target() {
+  assert_bad_request_without_handler(b"GET http:///path HTTP/1.1\r\nHost: localhost\r\n\r\n");
+}
+
+#[test]
 fn server_returns_bad_request_for_header_name_with_whitespace() {
   assert_bad_request_without_handler(b"GET / HTTP/1.1\r\nBad Name: value\r\n\r\n");
 }

--- a/rttp/tests/test_server.rs
+++ b/rttp/tests/test_server.rs
@@ -464,6 +464,9 @@ fn server_rejects_request_target_forms_for_wrong_methods() {
 #[test]
 fn server_returns_bad_request_for_invalid_absolute_form_target() {
   assert_bad_request_without_handler(b"GET http:///path HTTP/1.1\r\nHost: localhost\r\n\r\n");
+  assert_bad_request_without_handler(
+    b"GET http://example.test/path#frag HTTP/1.1\r\nHost: localhost\r\n\r\n",
+  );
 }
 
 #[test]


### PR DESCRIPTION
Adds method-aware HTTP/1.x request-target validation to the rttp socket2 server. Common origin-form and minimally valid absolute-form targets remain accepted for ordinary requests, `OPTIONS *` and `CONNECT host:port` are handled explicitly, and clearly invalid method/form combinations now return 400 before reaching handlers. Verified with formatting and full workspace tests.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1270/
work_kind: code_work
branch: hbx-1270-rttp-validate-http-1-x
base: main
commit: a0ba09ae4948d18cf75d9958a23afa92bbfeb0cf
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1270/
    url: https://plane.kahub.in/endless/browse/HBX-1270/
    close_policy: link_only
  - kind: other_url
    canonical: http://example.test/path
    url: http://example.test/path
    close_policy: link_only
```