### PR TITLE
feat: [rttp] Harden response framing headers for no-body statuses

### DIFF
--- a/rttp/README.md
+++ b/rttp/README.md
@@ -36,7 +36,7 @@ connection; pass `None` to leave the corresponding socket timeout unset.
 
 Add `Transfer-Encoding: chunked` to an `HttpResponse` to write the complete
 response body with chunked transfer framing instead of an automatic
-`Content-Length`.
+`Content-Length` when the response status permits a message body.
 
 The server currently parses blocking HTTP/1.x requests for local tests and
 simple embedded use. It supports fixed `Content-Length` and chunked request

--- a/rttp/src/server.rs
+++ b/rttp/src/server.rs
@@ -699,6 +699,7 @@ impl HttpResponse {
     let connection_header_index = self.connection_header_index();
     for (index, header) in self.headers.iter().enumerate() {
       if !header.name.eq_ignore_ascii_case("Content-Length")
+        && (self.allows_body() || !header.name.eq_ignore_ascii_case("Transfer-Encoding"))
         && (!header.name.eq_ignore_ascii_case("Connection")
           || Some(index) == connection_header_index)
       {

--- a/rttp/tests/test_server.rs
+++ b/rttp/tests/test_server.rs
@@ -1507,6 +1507,61 @@ fn response_write_to_omits_content_length_and_body_for_1xx() {
   );
 }
 
+#[test]
+fn response_write_to_omits_transfer_encoding_and_chunk_framing_for_no_body_statuses() {
+  for (status_code, reason) in [
+    (101, "Switching Protocols"),
+    (204, "No Content"),
+    (304, "Not Modified"),
+  ] {
+    let response = HttpResponse::new(status_code, reason)
+      .header("Transfer-Encoding", "chunked")
+      .body("ignored");
+    let mut serialized = Vec::new();
+
+    response
+      .write_to(&mut serialized)
+      .expect("serialize response");
+
+    assert_eq!(
+      format!("HTTP/1.1 {status_code} {reason}\r\nConnection: close\r\n\r\n").as_bytes(),
+      serialized.as_slice()
+    );
+  }
+}
+
+#[test]
+fn server_omits_transfer_encoding_and_chunk_framing_for_no_body_statuses() {
+  for (status_code, reason) in [
+    (101, "Switching Protocols"),
+    (204, "No Content"),
+    (304, "Not Modified"),
+  ] {
+    let server = rttp::Http::server("127.0.0.1:0").expect("bind server");
+    let addr = server.local_addr().expect("server addr");
+    let response_reason = reason.to_string();
+
+    let handle = thread::spawn(move || {
+      server
+        .accept_one(|_request| {
+          HttpResponse::new(status_code, response_reason)
+            .header("Transfer-Encoding", "chunked")
+            .body("ignored")
+        })
+        .expect("serve one request");
+    });
+
+    let response = send_request(addr, b"GET /empty HTTP/1.1\r\nHost: localhost\r\n\r\n");
+
+    assert_eq!(
+      format!("HTTP/1.1 {status_code} {reason}\r\nConnection: close\r\n\r\n"),
+      response
+    );
+
+    handle.join().expect("server thread");
+  }
+}
+
 fn send_request(addr: std::net::SocketAddr, request: &[u8]) -> String {
   let mut stream = TcpStream::connect(addr).expect("connect server");
   stream.write_all(request).expect("write request");


### PR DESCRIPTION
Implemented response framing hardening for no-body statuses in rttp. 1xx, 204, and 304 responses now suppress handler-provided Transfer-Encoding as well as Content-Length while continuing to omit body bytes. Normal body-capable responses, including explicit chunked 2xx responses and automatic Content-Length, remain unchanged. Added write_to and server-path regression coverage and clarified the rttp README chunked-response wording.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1271/
work_kind: code_work
branch: hbx-1271-rttp-harden-response-framing-headers
base: main
commit: 4fc012e181bfa075c496da495849291c035617ea
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1271/
    url: https://plane.kahub.in/endless/browse/HBX-1271/
    close_policy: link_only
```