### PR TITLE
feat: [rttp] Add asserted RoUrl query/path/fragment regression coverage

### DIFF
--- a/rttp_client/tests/test_url.rs
+++ b/rttp_client/tests/test_url.rs
@@ -2,15 +2,18 @@ use rttp_client::types::{RoUrl, ToUrl};
 use url::Url;
 
 #[test]
-fn test_url_gen() {
-  let result = Url::parse("https://example.test/get?name=文山");
-  let url = result.expect("INVALID URL");
-  println!("{}  ", url.as_str());
+fn url_parse_percent_encodes_unicode_query_values() {
+  let url = Url::parse("https://example.test/get?name=文山").expect("INVALID URL");
+
+  assert_eq!(
+    url.as_str(),
+    "https://example.test/get?name=%E6%96%87%E5%B1%B1"
+  );
 }
 
 #[test]
-fn test_rourl_gen() {
-  let url = RoUrl::with("https://example.test/get/?name=a&name=b")
+fn rourl_joins_paths_and_preserves_credentials_query_order_and_fragment() {
+  let url = RoUrl::with("https://example.test/get/?name=a&name=b#section-1")
     .path("//test/")
     .path("/a")
     .para("name[]=文")
@@ -21,9 +24,42 @@ fn test_rourl_gen() {
     .traditional(true)
     .to_url()
     .expect("BAD URL");
-  println!("{}", url);
+
+  assert_eq!(
+    url.as_str(),
+    "https://Tom:1123@example.test/get/test/a?name=a&name=b&name[]=%E6%96%87&name=I&name=Z&name=K&name=O&name=P#section-1"
+  );
+}
+
+#[test]
+fn rourl_uses_array_style_for_duplicate_query_parameters_when_not_traditional() {
+  let url = RoUrl::with("https://example.test/get?tag=one")
+    .para(("tag", "two"))
+    .para("name[]=文")
+    .para(("single", "value"))
+    .traditional(false)
+    .to_url()
+    .expect("BAD URL");
+
+  assert_eq!(
+    url.as_str(),
+    "https://example.test/get?tag[]=one&tag[]=two&name[]=%E6%96%87&single=value"
+  );
+}
+
+#[test]
+fn rourl_round_trips_generated_urls_without_dropping_query_parameters() {
+  let url = RoUrl::with("https://example.test/get?name=a&name=b#section-1")
+    .path("child")
+    .para(("name", "c"))
+    .to_url()
+    .expect("BAD URL");
 
   let rourl: RoUrl = url.into();
-  println!("{:?}", rourl);
-  println!("{}", rourl.to_url().expect("BAD URL"));
+  let round_tripped = rourl.to_url().expect("BAD URL");
+
+  assert_eq!(
+    round_tripped.as_str(),
+    "https://example.test/get/child?name=a&name=b&name=c#section-1"
+  );
 }


### PR DESCRIPTION
Added regression assertions for RoUrl URL construction behavior covering path normalization, credentials, query merging, duplicate parameter ordering, traditional versus array-style query output, Unicode query encoding, and fragment preservation. Verified with rustfmt, focused rttp_client URL tests, full rttp_client tests, and full workspace tests.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1277/
work_kind: code_work
branch: hbx-1277-rttp-add-asserted-rourl-query
base: main
commit: af7683213c51d4d448ce7d2c0f7c2d092e36c75c
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1277/
    url: https://plane.kahub.in/endless/browse/HBX-1277/
    close_policy: link_only
```