### PR TITLE
feat: [rttp] Preserve query parameter values containing equals signs

### DIFF
--- a/rttp_client/src/types/para.rs
+++ b/rttp_client/src/types/para.rs
@@ -101,11 +101,8 @@ impl IntoPara for &str {
       .collect::<Vec<&str>>()
       .iter()
       .map(|part: &&str| {
-        let pvs: Vec<&str> = part.split("=").collect::<Vec<&str>>();
-        Para::with_form(
-          pvs.first().map_or("".to_string(), |v| v.to_string()).trim(),
-          pvs.get(1).map_or("".to_string(), |v| v.to_string()).trim(),
-        )
+        let (name, value) = part.split_once("=").unwrap_or((part, ""));
+        Para::with_form(name.trim(), value.trim())
       })
       .filter(|para: &Para| !para.name.is_empty())
       .collect::<Vec<Para>>()

--- a/rttp_client/tests/test_url.rs
+++ b/rttp_client/tests/test_url.rs
@@ -1,4 +1,4 @@
-use rttp_client::types::{RoUrl, ToUrl};
+use rttp_client::types::{IntoPara, RoUrl, ToUrl};
 use url::Url;
 
 #[test]
@@ -61,5 +61,68 @@ fn rourl_round_trips_generated_urls_without_dropping_query_parameters() {
   assert_eq!(
     round_tripped.as_str(),
     "https://example.test/get/child?name=a&name=b&name=c#section-1"
+  );
+}
+
+#[test]
+fn rourl_preserves_equals_signs_in_query_parameter_values() {
+  let url = RoUrl::with("https://example.test/get")
+    .para("token=a=b&signed=part1=part2")
+    .to_url()
+    .expect("BAD URL");
+
+  let query_pairs: Vec<_> = url.query_pairs().into_owned().collect();
+
+  assert_eq!(
+    query_pairs,
+    vec![
+      ("token".to_string(), "a=b".to_string()),
+      ("signed".to_string(), "part1=part2".to_string()),
+    ]
+  );
+  assert!(url.as_str().contains("token=a=b"));
+  assert!(url.as_str().contains("signed=part1=part2"));
+}
+
+#[test]
+fn rourl_preserves_equals_signs_in_initial_url_query_values() {
+  let url = RoUrl::with("https://example.test/get?token=a=b&signed=part1=part2")
+    .to_url()
+    .expect("BAD URL");
+
+  let query_pairs: Vec<_> = url.query_pairs().into_owned().collect();
+
+  assert_eq!(
+    query_pairs,
+    vec![
+      ("token".to_string(), "a=b".to_string()),
+      ("signed".to_string(), "part1=part2".to_string()),
+    ]
+  );
+  assert!(url.as_str().contains("token=a=b"));
+  assert!(url.as_str().contains("signed=part1=part2"));
+}
+
+#[test]
+fn string_form_parameters_preserve_equals_signs_in_values() {
+  let paras = "token=a=b&empty=&key-only&signed=part1=part2".into_paras();
+  let parsed: Vec<_> = paras
+    .iter()
+    .map(|para| {
+      (
+        para.name().to_string(),
+        para.value().clone().unwrap_or_default(),
+      )
+    })
+    .collect();
+
+  assert_eq!(
+    parsed,
+    vec![
+      ("token".to_string(), "a=b".to_string()),
+      ("empty".to_string(), "".to_string()),
+      ("key-only".to_string(), "".to_string()),
+      ("signed".to_string(), "part1=part2".to_string()),
+    ]
   );
 }


### PR DESCRIPTION
Updated rttp_client string parameter parsing to split only on the first equals sign, preserving opaque query and form-style values that contain additional equals signs. Added regression coverage for RoUrl query construction, initial URL query parsing, and direct form-style IntoPara parsing.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1278/
work_kind: code_work
branch: hbx-1278-rttp-preserve-query-parameter-values
base: main
commit: c238095a5001d873b2348c44104c9949e157972c
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1278/
    url: https://plane.kahub.in/endless/browse/HBX-1278/
    close_policy: link_only
```