### PR TITLE
feat: [rttp] Pin RoUrl question-mark and fragment parsing edge cases

### DIFF
--- a/rttp_client/src/types/url.rs
+++ b/rttp_client/src/types/url.rs
@@ -52,42 +52,19 @@ impl RoUrl {
   /// ```
   pub fn with(url: impl AsRef<str>) -> RoUrl {
     let url = url.as_ref();
-    let netloc_and_para: Vec<&str> = url.split("?").collect::<Vec<&str>>();
-    let url = netloc_and_para
-      .first()
-      .map_or("".to_string(), |v| v.to_string());
-    let mut para_string = String::new();
-    let mut fragment = None;
-    for (i, nap) in netloc_and_para.iter().enumerate() {
-      if i == 0 {
-        continue;
-      }
-      let para_and_fragment: Vec<&str> = nap.split("#").collect::<Vec<&str>>();
-      if para_and_fragment.is_empty() {
-        para_string.push_str(nap);
-      } else {
-        if let Some(last_para) = para_and_fragment.first() {
-          para_string.push_str(last_para);
-        }
-
-        let fragment_string = para_and_fragment
-          .iter()
-          .enumerate()
-          .filter(|(ix, _)| *ix > 0)
-          .map(|(_, v)| *v)
-          .collect::<Vec<&str>>()
-          .join("#");
-        if !fragment_string.is_empty() {
-          fragment = Some(fragment_string);
-        }
-      }
-    }
+    let (url_without_fragment, fragment) =
+      url.split_once("#").map_or((url, None), |(url, fragment)| {
+        (url, Some(fragment.to_string()))
+      });
+    let (url, para_string) = url_without_fragment
+      .split_once("?")
+      .map_or((url_without_fragment, ""), |(url, para)| (url, para));
     let mut paras = para_string.into_paras();
     for para in &mut paras {
       *para.type_mut() = ParaType::URL;
     }
     Self {
-      url,
+      url: url.to_string(),
       paths: Default::default(),
       username: Default::default(),
       password: None,

--- a/rttp_client/tests/test_url.rs
+++ b/rttp_client/tests/test_url.rs
@@ -104,6 +104,66 @@ fn rourl_preserves_equals_signs_in_initial_url_query_values() {
 }
 
 #[test]
+fn rourl_preserves_query_values_and_fragment_from_initial_url() {
+  let url = RoUrl::with("https://example.test/a?token=a=b#frag")
+    .to_url()
+    .expect("BAD URL");
+
+  let query_pairs: Vec<_> = url.query_pairs().into_owned().collect();
+
+  assert_eq!(query_pairs, vec![("token".to_string(), "a=b".to_string())]);
+  assert_eq!(url.fragment(), Some("frag"));
+}
+
+#[test]
+fn rourl_keeps_empty_initial_query_values_before_fragment() {
+  let url = RoUrl::with("https://example.test/get?empty=&present=value#section")
+    .to_url()
+    .expect("BAD URL");
+
+  let query_pairs: Vec<_> = url.query_pairs().into_owned().collect();
+
+  assert_eq!(
+    query_pairs,
+    vec![
+      ("empty".to_string(), "".to_string()),
+      ("present".to_string(), "value".to_string()),
+    ]
+  );
+  assert_eq!(url.fragment(), Some("section"));
+}
+
+#[test]
+fn rourl_preserves_raw_question_marks_in_initial_query_values() {
+  let url = RoUrl::with("https://example.test/search?redirect=/next?token=a=b&mode=raw#done")
+    .to_url()
+    .expect("BAD URL");
+
+  let query_pairs: Vec<_> = url.query_pairs().into_owned().collect();
+
+  assert_eq!(
+    query_pairs,
+    vec![
+      ("redirect".to_string(), "/next?token=a=b".to_string()),
+      ("mode".to_string(), "raw".to_string()),
+    ]
+  );
+  assert_eq!(url.fragment(), Some("done"));
+}
+
+#[test]
+fn rourl_preserves_hashes_inside_initial_url_fragment() {
+  let url = RoUrl::with("https://example.test/get?token=a=b#outer#inner")
+    .to_url()
+    .expect("BAD URL");
+
+  let query_pairs: Vec<_> = url.query_pairs().into_owned().collect();
+
+  assert_eq!(query_pairs, vec![("token".to_string(), "a=b".to_string())]);
+  assert_eq!(url.fragment(), Some("outer#inner"));
+}
+
+#[test]
 fn string_form_parameters_preserve_equals_signs_in_values() {
   let paras = "token=a=b&empty=&key-only&signed=part1=part2".into_paras();
   let parsed: Vec<_> = paras


### PR DESCRIPTION
Implemented bounded RoUrl query and fragment parsing so initial URLs preserve query values containing reserved characters, query-plus-fragment boundaries, empty query values, raw question marks in query input, and hashes inside fragments. Added focused regression coverage and verified rttp_client URL tests, formatting, and the rttp_client test suite.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1279/
work_kind: code_work
branch: hbx-1279-rttp-pin-rourl-question-mark
base: main
commit: 61d24d3a0d3048e274b5ae8ab65eaad38da57b5f
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1279/
    url: https://plane.kahub.in/endless/browse/HBX-1279/
    close_policy: link_only
```