### PR TITLE
feat: [rttp] Avoid default Content-Type on bodyless client requests

### DIFF
--- a/rttp_client/src/request/builder/build_body_block.rs
+++ b/rttp_client/src/request/builder/build_body_block.rs
@@ -30,8 +30,6 @@ impl<'a> RawBuilder<'a> {
         rourl.para(para);
       }
     }
-    self.content_type = Some(mime::APPLICATION_WWW_FORM_URLENCODED);
-
     // paras
     if !paras.is_empty() && raw.is_none() && binary.is_empty() && formdatas.is_empty() && !is_get {
       return self.build_body_with_form_urlencoded();
@@ -211,6 +209,8 @@ impl<'a> RawBuilder<'a> {
 // build body common
 impl<'a> RawBuilder<'a> {
   fn build_body_with_form_urlencoded(&mut self) -> error::Result<Option<RequestBody>> {
+    self.content_type = Some(mime::APPLICATION_WWW_FORM_URLENCODED);
+
     let encode = self.request.encode();
     let traditional = self.request.traditional();
     let paras = self.request.paras();

--- a/rttp_client/src/request/builder/build_header.rs
+++ b/rttp_client/src/request/builder/build_header.rs
@@ -17,7 +17,7 @@ impl<'a> RawBuilder<'a> {
     self.auto_add_connection()?;
     self.auto_add_ua()?;
     self.auto_add_accept()?;
-    self.auto_add_content_type()?;
+    self.auto_add_content_type(body)?;
     self.auto_add_content_length(body)?;
 
     let mut builder = String::new();
@@ -114,19 +114,27 @@ impl<'a> RawBuilder<'a> {
     Ok(())
   }
 
-  fn auto_add_content_type(&mut self) -> error::Result<()> {
-    // not form-data request
-    if self.request.formdatas().is_empty() && !self.found_header("content-type") {
-      let header = match &self.content_type {
-        Some(ct) => Header::new("Content-Type", ct),
-        None => Header::new("Content-Type", &mime::APPLICATION_WWW_FORM_URLENCODED),
-      };
+  fn auto_add_content_type(&mut self, body: &Option<RequestBody>) -> error::Result<()> {
+    let is_form_data = !self.request.formdatas().is_empty();
+    let has_content_type = self.found_header("content-type");
 
-      self.request.headers_mut().push(header);
+    if !is_form_data {
+      if has_content_type || body.is_none() {
+        return Ok(());
+      }
+
+      let content_type = self
+        .content_type
+        .clone()
+        .unwrap_or(mime::APPLICATION_WWW_FORM_URLENCODED);
+      self
+        .request
+        .headers_mut()
+        .push(Header::new("Content-Type", content_type));
       return Ok(());
     }
 
-    // if it's form data request, replace header use generate header
+    // if it's form data request, replace header with generated multipart header
     let mut headers = self.request.headers().clone();
     let origin = headers
       .iter()

--- a/rttp_client/tests/test_raw_request_capture.rs
+++ b/rttp_client/tests/test_raw_request_capture.rs
@@ -51,6 +51,65 @@ fn get_with_query_parameters_sends_request_target_without_body() {
   let text = request_text(&request);
 
   assert!(text.starts_with("GET /search?name=Julia&debug=true HTTP/1.1\r\n"));
+  assert_eq!(None, header_value(&text, "Content-Type"));
+  assert_eq!(None, header_value(&text, "Content-Length"));
+  assert_eq!(b"", request_body(&request));
+}
+
+#[test]
+fn head_without_body_omits_content_type_and_content_length() {
+  let request = capture_request(|base_url| {
+    client()
+      .head()
+      .url(format!("{}/metadata", base_url))
+      .emit()
+      .expect("request should succeed");
+  });
+
+  let text = request_text(&request);
+
+  assert!(text.starts_with("HEAD /metadata HTTP/1.1\r\n"));
+  assert_eq!(None, header_value(&text, "Content-Type"));
+  assert_eq!(None, header_value(&text, "Content-Length"));
+  assert_eq!(b"", request_body(&request));
+}
+
+#[test]
+fn delete_without_body_omits_content_type_and_content_length() {
+  let request = capture_request(|base_url| {
+    client()
+      .delete()
+      .url(format!("{}/resource", base_url))
+      .emit()
+      .expect("request should succeed");
+  });
+
+  let text = request_text(&request);
+
+  assert!(text.starts_with("DELETE /resource HTTP/1.1\r\n"));
+  assert_eq!(None, header_value(&text, "Content-Type"));
+  assert_eq!(None, header_value(&text, "Content-Length"));
+  assert_eq!(b"", request_body(&request));
+}
+
+#[test]
+fn bodyless_request_preserves_explicit_content_type_without_content_length() {
+  let request = capture_request(|base_url| {
+    client()
+      .head()
+      .url(format!("{}/metadata", base_url))
+      .content_type("application/json")
+      .emit()
+      .expect("request should succeed");
+  });
+
+  let text = request_text(&request);
+
+  assert!(text.starts_with("HEAD /metadata HTTP/1.1\r\n"));
+  assert_eq!(
+    Some("application/json"),
+    header_value(&text, "Content-Type")
+  );
   assert_eq!(None, header_value(&text, "Content-Length"));
   assert_eq!(b"", request_body(&request));
 }
@@ -83,6 +142,30 @@ fn post_para_sends_form_urlencoded_body_and_matching_content_length() {
 }
 
 #[test]
+fn raw_body_without_explicit_content_type_sends_text_plain() {
+  let raw_body = "plain body";
+  let request = capture_request(|base_url| {
+    client()
+      .post()
+      .url(format!("{}/raw", base_url))
+      .raw(raw_body)
+      .emit()
+      .expect("request should succeed");
+  });
+
+  let text = request_text(&request);
+  let body = request_body(&request);
+
+  assert!(text.starts_with("POST /raw HTTP/1.1\r\n"));
+  assert_eq!(Some("text/plain"), header_value(&text, "Content-Type"));
+  assert_eq!(
+    Some(raw_body.len().to_string().as_str()),
+    header_value(&text, "Content-Length")
+  );
+  assert_eq!(raw_body.as_bytes(), body);
+}
+
+#[test]
 fn raw_json_preserves_explicit_content_type_and_content_length() {
   let raw_body = r#"{"from":"rttp"}"#;
   let request = capture_request(|base_url| {
@@ -108,6 +191,58 @@ fn raw_json_preserves_explicit_content_type_and_content_length() {
     header_value(&text, "Content-Length")
   );
   assert_eq!(raw_body.as_bytes(), body);
+}
+
+#[test]
+fn binary_body_without_explicit_content_type_sends_octet_stream() {
+  let binary_body = vec![0, 1, 2, 3];
+  let request = capture_request(|base_url| {
+    client()
+      .post()
+      .url(format!("{}/binary", base_url))
+      .binary(binary_body.clone())
+      .emit()
+      .expect("request should succeed");
+  });
+
+  let text = request_text(&request);
+  let body = request_body(&request);
+
+  assert!(text.starts_with("POST /binary HTTP/1.1\r\n"));
+  assert_eq!(
+    Some("application/octet-stream"),
+    header_value(&text, "Content-Type")
+  );
+  assert_eq!(
+    Some(binary_body.len().to_string().as_str()),
+    header_value(&text, "Content-Length")
+  );
+  assert_eq!(binary_body.as_slice(), body);
+}
+
+#[test]
+fn multipart_form_body_sends_generated_content_type_and_content_length() {
+  let request = capture_request(|base_url| {
+    client()
+      .post()
+      .url(format!("{}/form", base_url))
+      .form("name=Julia")
+      .emit()
+      .expect("request should succeed");
+  });
+
+  let text = request_text(&request);
+  let body = request_body(&request);
+  let content_type = header_value(&text, "Content-Type").expect("content type header");
+
+  assert!(text.starts_with("POST /form HTTP/1.1\r\n"));
+  assert!(content_type.starts_with("multipart/form-data; boundary="));
+  assert_eq!(
+    Some(body.len().to_string().as_str()),
+    header_value(&text, "Content-Length")
+  );
+  assert!(body.starts_with(b"-----------------------------"));
+  assert!(body.ends_with(b"--\r\n"));
 }
 
 #[test]


### PR DESCRIPTION
Implemented request header framing so bodyless client requests no longer receive an implicit default Content-Type, while explicit Content-Type and body-bearing request Content-Type behavior remain covered by raw capture tests.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1282/
work_kind: code_work
branch: hbx-1282-rttp-avoid-default-content-type
base: main
commit: f614875fb217d807ec4ec030c2cac67549ff54f1
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1282/
    url: https://plane.kahub.in/endless/browse/HBX-1282/
    close_policy: link_only
```