### PR TITLE
feat: [rttp] Teach sync client to skip interim 100 Continue before final response

### DIFF
--- a/rttp_client/src/connection/connection_reader.rs
+++ b/rttp_client/src/connection/connection_reader.rs
@@ -69,7 +69,13 @@ pub(crate) fn read_response_parts<R>(
 where
   R: Read + ?Sized,
 {
-  let mut binary = read_response_header(reader)?;
+  let mut binary = loop {
+    let header = read_response_header(reader)?;
+    if response_status_code(&header)? == 100 {
+      continue;
+    }
+    break header;
+  };
   let mut trailers = Vec::new();
   match response_body_kind(&binary, expect_no_body)? {
     ResponseBodyKind::NoBody => {}
@@ -115,6 +121,20 @@ where
   }
 }
 
+fn response_status_code(header: &[u8]) -> error::Result<u16> {
+  let header = String::from_utf8_lossy(header);
+  let status_line = header
+    .lines()
+    .next()
+    .ok_or_else(|| error::bad_response("Response not have status line"))?;
+  status_line
+    .split_whitespace()
+    .nth(1)
+    .ok_or_else(|| error::bad_response("Response status not have code"))?
+    .parse::<u16>()
+    .map_err(|_| error::bad_response("Response status code is not a number"))
+}
+
 pub(crate) fn response_body_kind(
   header: &[u8],
   expect_no_body: bool,
@@ -123,22 +143,14 @@ pub(crate) fn response_body_kind(
     return Ok(ResponseBodyKind::NoBody);
   }
 
-  let header = String::from_utf8_lossy(header);
-  let mut lines = header.lines();
-  let status_line = lines
-    .next()
-    .ok_or_else(|| error::bad_response("Response not have status line"))?;
-  let status_code = status_line
-    .split_whitespace()
-    .nth(1)
-    .ok_or_else(|| error::bad_response("Response status not have code"))?
-    .parse::<u16>()
-    .map_err(|_| error::bad_response("Response status code is not a number"))?;
+  let status_code = response_status_code(header)?;
 
   if (100..200).contains(&status_code) || status_code == 204 || status_code == 304 {
     return Ok(ResponseBodyKind::NoBody);
   }
 
+  let header = String::from_utf8_lossy(header);
+  let lines = header.lines().skip(1);
   let mut content_length = None;
   let mut invalid_content_length = false;
   let mut conflicting_content_length = false;
@@ -431,7 +443,6 @@ mod tests {
   #[test]
   fn test_no_body_status_codes_ignore_framing_headers() {
     for status_line in [
-      "HTTP/1.1 100 Continue",
       "HTTP/1.1 101 Switching Protocols",
       "HTTP/1.1 204 No Content",
       "HTTP/1.1 304 Not Modified",

--- a/rttp_client/tests/support/mod.rs
+++ b/rttp_client/tests/support/mod.rs
@@ -5,6 +5,8 @@ use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr, TcpListener, TcpStream};
 use std::thread::{self, JoinHandle};
 use std::time::Duration;
 
+use socket2::{Domain, Protocol, Socket, Type};
+
 #[path = "local_http.rs"]
 mod local_http;
 
@@ -216,6 +218,38 @@ pub fn spawn_keep_alive_server() -> (SocketAddr, JoinHandle<()>) {
       thread::sleep(Duration::from_millis(300));
     }
   });
+  (addr, handle)
+}
+
+pub fn spawn_continue_then_ok_server() -> (SocketAddr, JoinHandle<()>) {
+  let socket = Socket::new(Domain::IPV4, Type::STREAM, Some(Protocol::TCP))
+    .expect("create continue server socket");
+  socket
+    .bind(&SocketAddr::from((Ipv4Addr::LOCALHOST, 0)).into())
+    .expect("bind continue server");
+  socket.listen(1).expect("listen continue server");
+  let listener = TcpListener::from(socket);
+  let addr = listener.local_addr().expect("continue server addr");
+
+  let handle = thread::spawn(move || {
+    if let Ok((mut stream, _)) = listener.accept() {
+      let _ = read_http_request(&mut stream);
+      let response = concat!(
+        "HTTP/1.1 100 Continue\r\n",
+        "X-Interim: ignored\r\n",
+        "\r\n",
+        "HTTP/1.1 200 OK\r\n",
+        "Content-Type: text/plain\r\n",
+        "X-Final: yes\r\n",
+        "Content-Length: 10\r\n",
+        "Connection: close\r\n",
+        "\r\n",
+        "final body"
+      );
+      let _ = stream.write_all(response.as_bytes());
+    }
+  });
+
   (addr, handle)
 }
 

--- a/rttp_client/tests/test_http_basic.rs
+++ b/rttp_client/tests/test_http_basic.rs
@@ -236,6 +236,28 @@ fn test_content_length_response_does_not_wait_for_eof() {
 }
 
 #[test]
+fn test_sync_client_skips_100_continue_before_final_response() {
+  let (addr, _handle) = support::spawn_continue_then_ok_server();
+  let response = client()
+    .post()
+    .url(format!("http://{}/continue", addr))
+    .header(("Expect", "100-continue"))
+    .raw("request body")
+    .emit()
+    .unwrap();
+
+  assert_eq!(200, response.code());
+  assert_eq!("OK", response.reason());
+  assert_eq!(
+    Some(&"text/plain".to_string()),
+    response.header_value("Content-Type")
+  );
+  assert_eq!(Some(&"yes".to_string()), response.header_value("X-Final"));
+  assert!(response.header_value("X-Interim").is_none());
+  assert_eq!("final body", response.body().string().unwrap());
+}
+
+#[test]
 fn test_upload() {
   let (addr, _handle) = support::spawn_http_server();
   let response = client()


### PR DESCRIPTION
The sync HTTP client now skips interim 100 Continue responses on a connection and returns the final response status, headers, and body. A local socket2/TcpListener integration test covers the public sync client behavior, and terminal no-body response handling remains intact.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1290/
work_kind: code_work
branch: hbx-1290-rttp-teach-sync-client-to
base: main
commit: afade2b49348ae3e20513bcda922ae27532b82be
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1290/
    url: https://plane.kahub.in/endless/browse/HBX-1290/
    close_policy: link_only
```