### PR TITLE
feat: [rttp] Keep async client informational response handling in parity with sync client

### DIFF
--- a/rttp_client/src/connection/async_connection.rs
+++ b/rttp_client/src/connection/async_connection.rs
@@ -115,7 +115,8 @@ impl<'a> AsyncConnection<'a> {
   {
     let mut binary = loop {
       let header = async_read_response_header(stream).await?;
-      if response_status_code(&header)? == 100 {
+      let status_code = response_status_code(&header)?;
+      if status_code == 100 || (102..200).contains(&status_code) {
         continue;
       }
       break header;

--- a/rttp_client/src/connection/async_connection.rs
+++ b/rttp_client/src/connection/async_connection.rs
@@ -10,7 +10,8 @@ use std::sync::Arc;
 
 use crate::connection::connection::{connect_tcp_stream, read_proxy_connect_response, Connection};
 use crate::connection::connection_reader::{
-  response_body_kind, ResponseBodyKind, ResponseParts, MAX_CHUNKED_RESPONSE_LINE_BYTES,
+  response_body_kind, response_status_code, ResponseBodyKind, ResponseParts,
+  MAX_CHUNKED_RESPONSE_LINE_BYTES,
 };
 use crate::error;
 use crate::request::RawRequest;
@@ -112,7 +113,13 @@ impl<'a> AsyncConnection<'a> {
   where
     S: AsyncRead + Unpin,
   {
-    let mut binary = async_read_response_header(stream).await?;
+    let mut binary = loop {
+      let header = async_read_response_header(stream).await?;
+      if response_status_code(&header)? == 100 {
+        continue;
+      }
+      break header;
+    };
     let mut trailers = Vec::new();
     match response_body_kind(&binary, self.conn.expect_no_response_body())? {
       ResponseBodyKind::NoBody => {}

--- a/rttp_client/src/connection/connection_reader.rs
+++ b/rttp_client/src/connection/connection_reader.rs
@@ -71,7 +71,8 @@ where
 {
   let mut binary = loop {
     let header = read_response_header(reader)?;
-    if response_status_code(&header)? == 100 {
+    let status_code = response_status_code(&header)?;
+    if status_code == 100 || (102..200).contains(&status_code) {
       continue;
     }
     break header;

--- a/rttp_client/src/connection/connection_reader.rs
+++ b/rttp_client/src/connection/connection_reader.rs
@@ -121,7 +121,7 @@ where
   }
 }
 
-fn response_status_code(header: &[u8]) -> error::Result<u16> {
+pub(crate) fn response_status_code(header: &[u8]) -> error::Result<u16> {
   let header = String::from_utf8_lossy(header);
   let status_line = header
     .lines()

--- a/rttp_client/tests/support/mod.rs
+++ b/rttp_client/tests/support/mod.rs
@@ -222,6 +222,10 @@ pub fn spawn_keep_alive_server() -> (SocketAddr, JoinHandle<()>) {
 }
 
 pub fn spawn_continue_then_ok_server() -> (SocketAddr, JoinHandle<()>) {
+  spawn_informational_then_ok_server("100 Continue")
+}
+
+pub fn spawn_informational_then_ok_server(status: &'static str) -> (SocketAddr, JoinHandle<()>) {
   let socket = Socket::new(Domain::IPV4, Type::STREAM, Some(Protocol::TCP))
     .expect("create continue server socket");
   socket
@@ -234,17 +238,20 @@ pub fn spawn_continue_then_ok_server() -> (SocketAddr, JoinHandle<()>) {
   let handle = thread::spawn(move || {
     if let Ok((mut stream, _)) = listener.accept() {
       let _ = read_http_request(&mut stream);
-      let response = concat!(
-        "HTTP/1.1 100 Continue\r\n",
-        "X-Interim: ignored\r\n",
-        "\r\n",
-        "HTTP/1.1 200 OK\r\n",
-        "Content-Type: text/plain\r\n",
-        "X-Final: yes\r\n",
-        "Content-Length: 10\r\n",
-        "Connection: close\r\n",
-        "\r\n",
-        "final body"
+      let response = format!(
+        concat!(
+          "HTTP/1.1 {}\r\n",
+          "X-Interim: ignored\r\n",
+          "\r\n",
+          "HTTP/1.1 200 OK\r\n",
+          "Content-Type: text/plain\r\n",
+          "X-Final: yes\r\n",
+          "Content-Length: 10\r\n",
+          "Connection: close\r\n",
+          "\r\n",
+          "final body"
+        ),
+        status
       );
       let _ = stream.write_all(response.as_bytes());
     }

--- a/rttp_client/tests/test_http_async.rs
+++ b/rttp_client/tests/test_http_async.rs
@@ -203,6 +203,30 @@ fn test_async_client_skips_100_continue_before_final_response() {
 
 #[test]
 #[cfg(feature = "async")]
+fn test_async_client_skips_103_early_hints_before_final_response() {
+  let (addr, _handle) = support::spawn_informational_then_ok_server("103 Early Hints");
+  block_on(async {
+    let response = client()
+      .get()
+      .url(format!("http://{}/early-hints", addr))
+      .rasync()
+      .await
+      .unwrap();
+
+    assert_eq!(200, response.code());
+    assert_eq!("OK", response.reason());
+    assert_eq!(
+      Some(&"text/plain".to_string()),
+      response.header_value("Content-Type")
+    );
+    assert_eq!(Some(&"yes".to_string()), response.header_value("X-Final"));
+    assert!(response.header_value("X-Interim").is_none());
+    assert_eq!("final body", response.body().string().unwrap());
+  });
+}
+
+#[test]
+#[cfg(feature = "async")]
 fn test_async_auto_redirect() {
   let (addr, _handle) = support::spawn_redirect_server();
   block_on(async {

--- a/rttp_client/tests/test_http_async.rs
+++ b/rttp_client/tests/test_http_async.rs
@@ -177,6 +177,32 @@ fn test_async_content_length_response_does_not_wait_for_eof() {
 
 #[test]
 #[cfg(feature = "async")]
+fn test_async_client_skips_100_continue_before_final_response() {
+  let (addr, _handle) = support::spawn_continue_then_ok_server();
+  block_on(async {
+    let response = client()
+      .post()
+      .url(format!("http://{}/continue", addr))
+      .header(("Expect", "100-continue"))
+      .raw("request body")
+      .rasync()
+      .await
+      .unwrap();
+
+    assert_eq!(200, response.code());
+    assert_eq!("OK", response.reason());
+    assert_eq!(
+      Some(&"text/plain".to_string()),
+      response.header_value("Content-Type")
+    );
+    assert_eq!(Some(&"yes".to_string()), response.header_value("X-Final"));
+    assert!(response.header_value("X-Interim").is_none());
+    assert_eq!("final body", response.body().string().unwrap());
+  });
+}
+
+#[test]
+#[cfg(feature = "async")]
 fn test_async_auto_redirect() {
   let (addr, _handle) = support::spawn_redirect_server();
   block_on(async {

--- a/rttp_client/tests/test_http_basic.rs
+++ b/rttp_client/tests/test_http_basic.rs
@@ -258,6 +258,26 @@ fn test_sync_client_skips_100_continue_before_final_response() {
 }
 
 #[test]
+fn test_sync_client_skips_103_early_hints_before_final_response() {
+  let (addr, _handle) = support::spawn_informational_then_ok_server("103 Early Hints");
+  let response = client()
+    .get()
+    .url(format!("http://{}/early-hints", addr))
+    .emit()
+    .unwrap();
+
+  assert_eq!(200, response.code());
+  assert_eq!("OK", response.reason());
+  assert_eq!(
+    Some(&"text/plain".to_string()),
+    response.header_value("Content-Type")
+  );
+  assert_eq!(Some(&"yes".to_string()), response.header_value("X-Final"));
+  assert!(response.header_value("X-Interim").is_none());
+  assert_eq!("final body", response.body().string().unwrap());
+}
+
+#[test]
 fn test_upload() {
   let (addr, _handle) = support::spawn_http_server();
   let response = client()


### PR DESCRIPTION
Implemented async client parity for informational responses. The async response reader now skips interim 100 Continue responses before parsing the final response, reusing the sync status-code parser and preserving the existing async API and body-framing behavior. Added async coverage for a local server that sends 100 Continue followed by a normal final response.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1291/
work_kind: code_work
branch: hbx-1291-rttp-keep-async-client-informational
base: main
commit: 6dc499febfeee03ca0a07872d10d5a0586767056
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1291/
    url: https://plane.kahub.in/endless/browse/HBX-1291/
    close_policy: link_only
```