### PR TITLE
feat: [rttp] Pin 101 Switching Protocols as terminal client response instead of skipped interim

### DIFF
--- a/rttp_client/src/connection/async_connection.rs
+++ b/rttp_client/src/connection/async_connection.rs
@@ -10,8 +10,8 @@ use std::sync::Arc;
 
 use crate::connection::connection::{connect_tcp_stream, read_proxy_connect_response, Connection};
 use crate::connection::connection_reader::{
-  response_body_kind, response_status_code, ResponseBodyKind, ResponseParts,
-  MAX_CHUNKED_RESPONSE_LINE_BYTES,
+  is_skippable_informational_status, response_body_kind, response_status_code, ResponseBodyKind,
+  ResponseParts, MAX_CHUNKED_RESPONSE_LINE_BYTES,
 };
 use crate::error;
 use crate::request::RawRequest;
@@ -116,7 +116,7 @@ impl<'a> AsyncConnection<'a> {
     let mut binary = loop {
       let header = async_read_response_header(stream).await?;
       let status_code = response_status_code(&header)?;
-      if status_code == 100 || (102..200).contains(&status_code) {
+      if is_skippable_informational_status(status_code) {
         continue;
       }
       break header;

--- a/rttp_client/src/connection/connection_reader.rs
+++ b/rttp_client/src/connection/connection_reader.rs
@@ -72,7 +72,7 @@ where
   let mut binary = loop {
     let header = read_response_header(reader)?;
     let status_code = response_status_code(&header)?;
-    if status_code == 100 || (102..200).contains(&status_code) {
+    if is_skippable_informational_status(status_code) {
       continue;
     }
     break header;
@@ -120,6 +120,10 @@ where
       return Ok(header);
     }
   }
+}
+
+pub(crate) fn is_skippable_informational_status(status_code: u16) -> bool {
+  status_code == 100 || (102..200).contains(&status_code)
 }
 
 pub(crate) fn response_status_code(header: &[u8]) -> error::Result<u16> {

--- a/rttp_client/tests/support/mod.rs
+++ b/rttp_client/tests/support/mod.rs
@@ -260,6 +260,29 @@ pub fn spawn_informational_then_ok_server(status: &'static str) -> (SocketAddr, 
   (addr, handle)
 }
 
+pub fn spawn_switching_protocols_server() -> (SocketAddr, JoinHandle<()>) {
+  let (listener, addr) = bind_local_http_listener("switching protocols server");
+  let handle = thread::spawn(move || {
+    if let Ok((mut stream, _)) = listener.accept() {
+      let _ = read_http_request(&mut stream);
+      let response = concat!(
+        "HTTP/1.1 101 Switching Protocols\r\n",
+        "Connection: Upgrade\r\n",
+        "Upgrade: websocket\r\n",
+        "Sec-WebSocket-Accept: test-accept\r\n",
+        "\r\n",
+        "HTTP/1.1 200 OK\r\n",
+        "Content-Length: 18\r\n",
+        "\r\n",
+        "must not be read\r\n"
+      );
+      let _ = stream.write_all(response.as_bytes());
+    }
+  });
+
+  (addr, handle)
+}
+
 pub fn spawn_http_proxy_server() -> (SocketAddr, JoinHandle<()>) {
   let (listener, addr) = bind_local_http_listener("http proxy server");
   let handle = thread::spawn(move || {

--- a/rttp_client/tests/test_http_async.rs
+++ b/rttp_client/tests/test_http_async.rs
@@ -227,6 +227,36 @@ fn test_async_client_skips_103_early_hints_before_final_response() {
 
 #[test]
 #[cfg(feature = "async")]
+fn test_async_client_returns_101_switching_protocols_as_terminal_response() {
+  let (addr, _handle) = support::spawn_switching_protocols_server();
+  block_on(async {
+    let response = client()
+      .get()
+      .url(format!("http://{}/upgrade", addr))
+      .rasync()
+      .await
+      .unwrap();
+
+    assert_eq!(101, response.code());
+    assert_eq!("Switching Protocols", response.reason());
+    assert_eq!(
+      Some(&"Upgrade".to_string()),
+      response.header_value("Connection")
+    );
+    assert_eq!(
+      Some(&"websocket".to_string()),
+      response.header_value("Upgrade")
+    );
+    assert_eq!(
+      Some(&"test-accept".to_string()),
+      response.header_value("Sec-WebSocket-Accept")
+    );
+    assert_eq!("", response.body().string().unwrap());
+  });
+}
+
+#[test]
+#[cfg(feature = "async")]
 fn test_async_auto_redirect() {
   let (addr, _handle) = support::spawn_redirect_server();
   block_on(async {

--- a/rttp_client/tests/test_http_basic.rs
+++ b/rttp_client/tests/test_http_basic.rs
@@ -278,6 +278,32 @@ fn test_sync_client_skips_103_early_hints_before_final_response() {
 }
 
 #[test]
+fn test_sync_client_returns_101_switching_protocols_as_terminal_response() {
+  let (addr, _handle) = support::spawn_switching_protocols_server();
+  let response = client()
+    .get()
+    .url(format!("http://{}/upgrade", addr))
+    .emit()
+    .unwrap();
+
+  assert_eq!(101, response.code());
+  assert_eq!("Switching Protocols", response.reason());
+  assert_eq!(
+    Some(&"Upgrade".to_string()),
+    response.header_value("Connection")
+  );
+  assert_eq!(
+    Some(&"websocket".to_string()),
+    response.header_value("Upgrade")
+  );
+  assert_eq!(
+    Some(&"test-accept".to_string()),
+    response.header_value("Sec-WebSocket-Accept")
+  );
+  assert_eq!("", response.body().string().unwrap());
+}
+
+#[test]
 fn test_upload() {
   let (addr, _handle) = support::spawn_http_server();
   let response = client()


### PR DESCRIPTION
Implemented deterministic sync and async client handling for HTTP 101 Switching Protocols as the terminal response while preserving skip behavior for other informational responses. Added focused coverage and verified formatting, focused client tests, and the workspace test suite.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1292/
work_kind: code_work
branch: hbx-1292-rttp-pin-101-switching-protocols
base: main
commit: bf1f98131395bef438163b8fa3b8419dba546052
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1292/
    url: https://plane.kahub.in/endless/browse/HBX-1292/
    close_policy: link_only
```