### PR TITLE
feat: [rttp] Resolve relative and query-only redirect Locations in sync and async clients

### DIFF
--- a/rttp_client/src/connection/async_connection.rs
+++ b/rttp_client/src/connection/async_connection.rs
@@ -16,7 +16,7 @@ use crate::connection::connection_reader::{
 use crate::error;
 use crate::request::RawRequest;
 use crate::response::Response;
-use crate::types::{Header, Proxy, ProxyType, RoUrl};
+use crate::types::{Header, Proxy, ProxyType};
 const CRLF: &[u8] = b"\r\n";
 
 pub struct AsyncConnection<'a> {
@@ -56,11 +56,7 @@ impl<'a> AsyncConnection<'a> {
           }
 
           let redirect_url = self.conn.redirect_url(&url, location)?;
-          self
-            .conn
-            .request_mut()
-            .origin_mut()
-            .url_set(RoUrl::with(redirect_url));
+          self.conn.request_mut().redirect_url_set(redirect_url)?;
           self.conn.request_mut().origin_mut().count_set(count + 1);
           continue;
         }

--- a/rttp_client/src/request/raw_request.rs
+++ b/rttp_client/src/request/raw_request.rs
@@ -2,6 +2,8 @@ use crate::error;
 use crate::request::builder::RawBuilder;
 use crate::request::{Request, RequestBody};
 use crate::types::RoUrl;
+#[cfg(feature = "async")]
+use crate::types::{ToRoUrl, ToUrl};
 
 #[derive(Debug)]
 pub struct RawRequest<'a> {
@@ -43,5 +45,29 @@ impl<'a> RawRequest<'a> {
 
   pub(crate) fn origin_mut(&mut self) -> &mut Request {
     self.origin
+  }
+
+  #[cfg(feature = "async")]
+  pub(crate) fn redirect_url_set<S: ToRoUrl>(&mut self, rourl: S) -> error::Result<()> {
+    let rourl = rourl.to_rourl();
+    let url = rourl.to_url()?;
+    let mut request_target = url.path().to_string();
+    if let Some(query) = url.query() {
+      request_target.push_str(&format!("?{}", query));
+    }
+
+    self.origin.url_set(&rourl);
+    self.url = rourl;
+
+    if let Some((_, rest)) = self.header.split_once("\r\n") {
+      self.header = format!(
+        "{} {} HTTP/1.1\r\n{}",
+        self.origin.method().to_uppercase(),
+        request_target,
+        rest
+      );
+    }
+
+    Ok(())
   }
 }

--- a/rttp_client/src/request/raw_request.rs
+++ b/rttp_client/src/request/raw_request.rs
@@ -1,6 +1,8 @@
 use crate::error;
 use crate::request::builder::RawBuilder;
 use crate::request::{Request, RequestBody};
+#[cfg(feature = "async")]
+use crate::types::Header;
 use crate::types::RoUrl;
 #[cfg(feature = "async")]
 use crate::types::{ToRoUrl, ToUrl};
@@ -51,15 +53,18 @@ impl<'a> RawRequest<'a> {
   pub(crate) fn redirect_url_set<S: ToRoUrl>(&mut self, rourl: S) -> error::Result<()> {
     let rourl = rourl.to_rourl();
     let url = rourl.to_url()?;
+    let host_header = Self::redirect_host_header(&url)?;
     let mut request_target = url.path().to_string();
     if let Some(query) = url.query() {
       request_target.push_str(&format!("?{}", query));
     }
 
     self.origin.url_set(&rourl);
+    self.redirect_host_set(host_header.clone());
     self.url = rourl;
 
     if let Some((_, rest)) = self.header.split_once("\r\n") {
+      let rest = Self::redirect_header_host_set(rest, &host_header);
       self.header = format!(
         "{} {} HTTP/1.1\r\n{}",
         self.origin.method().to_uppercase(),
@@ -69,5 +74,54 @@ impl<'a> RawRequest<'a> {
     }
 
     Ok(())
+  }
+
+  #[cfg(feature = "async")]
+  fn redirect_host_header(url: &url::Url) -> error::Result<Header> {
+    let host = url.host_str().ok_or(error::url_bad_host(url.clone()))?;
+    Ok(match url.port() {
+      Some(port) => Header::new("Host", format!("{}:{}", host, port)),
+      None => Header::new("Host", host),
+    })
+  }
+
+  #[cfg(feature = "async")]
+  fn redirect_host_set(&mut self, header: Header) {
+    if let Some(origin_header) = self
+      .origin
+      .headers_mut()
+      .iter_mut()
+      .find(|item| item.name().eq_ignore_ascii_case("host"))
+    {
+      origin_header.replace(header);
+    } else {
+      self.origin.headers_mut().push(header);
+    }
+  }
+
+  #[cfg(feature = "async")]
+  fn redirect_header_host_set(rest: &str, header: &Header) -> String {
+    let mut rewritten = String::new();
+    let mut replaced = false;
+
+    for line in rest.split_inclusive("\r\n") {
+      let header_name = line
+        .trim_end_matches("\r\n")
+        .split_once(':')
+        .map(|(name, _)| name);
+
+      if header_name.is_some_and(|name| name.eq_ignore_ascii_case("host")) {
+        rewritten.push_str(&format!("{}: {}\r\n", header.name(), header.value()));
+        replaced = true;
+      } else {
+        rewritten.push_str(line);
+      }
+    }
+
+    if replaced {
+      rewritten
+    } else {
+      format!("{}: {}\r\n{}", header.name(), header.value(), rewritten)
+    }
   }
 }

--- a/rttp_client/tests/support/mod.rs
+++ b/rttp_client/tests/support/mod.rs
@@ -208,6 +208,41 @@ pub fn spawn_redirect_server() -> (SocketAddr, JoinHandle<()>) {
   (addr, handle)
 }
 
+pub fn spawn_redirect_target_echo_server<F>(location: F) -> (SocketAddr, JoinHandle<()>)
+where
+  F: FnOnce(SocketAddr) -> String + Send + 'static,
+{
+  let (listener, addr) = bind_local_http_listener("redirect target echo server");
+  let handle = thread::spawn(move || {
+    let location = location(addr);
+    if let Ok((mut stream, _)) = listener.accept() {
+      let _ = read_http_request(&mut stream);
+      let response = format!(
+        "HTTP/1.1 302 Found\r\nLocation: {}\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+        location
+      );
+      let _ = stream.write_all(response.as_bytes());
+    }
+
+    if let Ok((mut stream, _)) = listener.accept() {
+      let request = read_http_request(&mut stream);
+      let target = String::from_utf8_lossy(&request)
+        .lines()
+        .next()
+        .and_then(|line| line.split_whitespace().nth(1))
+        .unwrap_or("")
+        .to_string();
+      let response = format!(
+        "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+        target.len(),
+        target
+      );
+      let _ = stream.write_all(response.as_bytes());
+    }
+  });
+  (addr, handle)
+}
+
 pub fn spawn_keep_alive_server() -> (SocketAddr, JoinHandle<()>) {
   let (listener, addr) = bind_local_http_listener("keep-alive server");
   let handle = thread::spawn(move || {

--- a/rttp_client/tests/support/mod.rs
+++ b/rttp_client/tests/support/mod.rs
@@ -243,6 +243,36 @@ where
   (addr, handle)
 }
 
+pub fn spawn_cross_authority_redirect_host_echo_server() -> (SocketAddr, SocketAddr, JoinHandle<()>)
+{
+  let (origin_listener, origin_addr) = bind_local_http_listener("cross authority redirect origin");
+  let (target_listener, target_addr) = bind_local_http_listener("cross authority redirect target");
+
+  let handle = thread::spawn(move || {
+    if let Ok((mut stream, _)) = origin_listener.accept() {
+      let _ = read_http_request(&mut stream);
+      let response = format!(
+        "HTTP/1.1 302 Found\r\nLocation: http://{}/final\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+        target_addr
+      );
+      let _ = stream.write_all(response.as_bytes());
+    }
+
+    if let Ok((mut stream, _)) = target_listener.accept() {
+      let request = read_http_request(&mut stream);
+      let host = header_value(&request, "Host").unwrap_or_default();
+      let response = format!(
+        "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+        host.len(),
+        host
+      );
+      let _ = stream.write_all(response.as_bytes());
+    }
+  });
+
+  (origin_addr, target_addr, handle)
+}
+
 pub fn spawn_keep_alive_server() -> (SocketAddr, JoinHandle<()>) {
   let (listener, addr) = bind_local_http_listener("keep-alive server");
   let handle = thread::spawn(move || {

--- a/rttp_client/tests/test_http_async.rs
+++ b/rttp_client/tests/test_http_async.rs
@@ -273,6 +273,58 @@ fn test_async_auto_redirect() {
   });
 }
 
+#[cfg(feature = "async")]
+async fn assert_async_redirect_resolves_to_target<F>(location: F, expected_target: &str)
+where
+  F: FnOnce(std::net::SocketAddr) -> String + Send + 'static,
+{
+  let (addr, _handle) = support::spawn_redirect_target_echo_server(location);
+  let response = client()
+    .config(Config::builder().auto_redirect(true))
+    .get()
+    .url(format!("http://{}/redirect/from?old=1", addr))
+    .rasync()
+    .await;
+
+  assert!(response.is_ok());
+  let response = response.unwrap();
+  assert_eq!(expected_target, response.body().string().unwrap());
+}
+
+#[test]
+#[cfg(feature = "async")]
+fn test_async_auto_redirect_resolves_absolute_location() {
+  block_on(async {
+    assert_async_redirect_resolves_to_target(|addr| format!("http://{}/final", addr), "/final")
+      .await;
+  });
+}
+
+#[test]
+#[cfg(feature = "async")]
+fn test_async_auto_redirect_resolves_absolute_path_location() {
+  block_on(async {
+    assert_async_redirect_resolves_to_target(|_| "/final?x=1".to_string(), "/final?x=1").await;
+  });
+}
+
+#[test]
+#[cfg(feature = "async")]
+fn test_async_auto_redirect_resolves_relative_path_location() {
+  block_on(async {
+    assert_async_redirect_resolves_to_target(|_| "../final".to_string(), "/final").await;
+  });
+}
+
+#[test]
+#[cfg(feature = "async")]
+fn test_async_auto_redirect_resolves_query_only_location() {
+  block_on(async {
+    assert_async_redirect_resolves_to_target(|_| "?page=2".to_string(), "/redirect/from?page=2")
+      .await;
+  });
+}
+
 #[test]
 #[cfg(all(feature = "async", feature = "tls-rustls"))]
 fn test_async_https() {

--- a/rttp_client/tests/test_http_async.rs
+++ b/rttp_client/tests/test_http_async.rs
@@ -326,6 +326,25 @@ fn test_async_auto_redirect_resolves_query_only_location() {
 }
 
 #[test]
+#[cfg(feature = "async")]
+fn test_async_auto_redirect_rebuilds_host_for_cross_authority_location() {
+  let (origin_addr, target_addr, _handle) =
+    support::spawn_cross_authority_redirect_host_echo_server();
+  block_on(async {
+    let response = client()
+      .config(Config::builder().auto_redirect(true))
+      .get()
+      .url(format!("http://{}/redirect", origin_addr))
+      .rasync()
+      .await;
+    assert!(response.is_ok());
+
+    let response = response.unwrap();
+    assert_eq!(target_addr.to_string(), response.body().string().unwrap());
+  });
+}
+
+#[test]
 #[cfg(all(feature = "async", feature = "tls-rustls"))]
 fn test_async_https() {
   let (addr, _handle) = support::spawn_tls_server();

--- a/rttp_client/tests/test_http_basic.rs
+++ b/rttp_client/tests/test_http_basic.rs
@@ -430,6 +430,42 @@ fn test_auto_redirect() {
   assert!(response.ok());
 }
 
+fn assert_redirect_resolves_to_target<F>(location: F, expected_target: &str)
+where
+  F: FnOnce(std::net::SocketAddr) -> String + Send + 'static,
+{
+  let (addr, _handle) = support::spawn_redirect_target_echo_server(location);
+  let response = client()
+    .config(Config::builder().auto_redirect(true))
+    .get()
+    .url(format!("http://{}/redirect/from?old=1", addr))
+    .emit();
+
+  assert!(response.is_ok());
+  let response = response.unwrap();
+  assert_eq!(expected_target, response.body().string().unwrap());
+}
+
+#[test]
+fn test_auto_redirect_resolves_absolute_location() {
+  assert_redirect_resolves_to_target(|addr| format!("http://{}/final", addr), "/final");
+}
+
+#[test]
+fn test_auto_redirect_resolves_absolute_path_location() {
+  assert_redirect_resolves_to_target(|_| "/final?x=1".to_string(), "/final?x=1");
+}
+
+#[test]
+fn test_auto_redirect_resolves_relative_path_location() {
+  assert_redirect_resolves_to_target(|_| "../final".to_string(), "/final");
+}
+
+#[test]
+fn test_auto_redirect_resolves_query_only_location() {
+  assert_redirect_resolves_to_target(|_| "?page=2".to_string(), "/redirect/from?page=2");
+}
+
 #[test]
 fn test_http_proxy_uses_absolute_form_for_http_requests() {
   let (addr, _handle) = support::spawn_http_proxy_server();


### PR DESCRIPTION
Redirect handling now has regression coverage for absolute, absolute-path, relative-path, and query-only Location values in both sync and async clients. Async redirects now refresh the raw request URL and request target before following the redirect, matching sync semantics. Verification passed: formatting, focused sync redirect tests, focused async redirect tests with async feature, and full workspace tests.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1295/
work_kind: code_work
branch: hbx-1295-rttp-resolve-relative-and-query
base: main
commit: 7c574ff6b5df7cc851662368a6e815c1416a96fb
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1295/
    url: https://plane.kahub.in/endless/browse/HBX-1295/
    close_policy: link_only
```