### PR TITLE
feat: [rttp] Apply status-specific redirect method and body semantics

### DIFF
--- a/rttp_client/src/connection/async_connection.rs
+++ b/rttp_client/src/connection/async_connection.rs
@@ -56,6 +56,7 @@ impl<'a> AsyncConnection<'a> {
           }
 
           let redirect_url = self.conn.redirect_url(&url, location)?;
+          self.conn.request_mut().redirect_status_set(response.code());
           self.conn.request_mut().redirect_url_set(redirect_url)?;
           self.conn.request_mut().origin_mut().count_set(count + 1);
           continue;

--- a/rttp_client/src/connection/block_connection.rs
+++ b/rttp_client/src/connection/block_connection.rs
@@ -49,7 +49,9 @@ impl<'a> BlockConnection<'a> {
       }
 
       let redirect_url = self.conn.redirect_url(&url, location)?;
-      return HttpClient::with_request(self.conn.request().origin().clone())
+      let mut request = self.conn.request().origin().clone();
+      request.redirect_status_set(response.code());
+      return HttpClient::with_request(request)
         .url(redirect_url)
         .count(count + 1)
         .emit();

--- a/rttp_client/src/request/raw_request.rs
+++ b/rttp_client/src/request/raw_request.rs
@@ -52,7 +52,7 @@ impl<'a> RawRequest<'a> {
   #[cfg(feature = "async")]
   pub(crate) fn redirect_status_set(&mut self, status_code: u32) {
     self.origin.redirect_status_set(status_code);
-    if status_code == 303 {
+    if status_code == 303 && !self.origin.method().eq_ignore_ascii_case("head") {
       self.body = None;
       self.header = Self::redirect_body_headers_remove(&self.header);
     }

--- a/rttp_client/src/request/raw_request.rs
+++ b/rttp_client/src/request/raw_request.rs
@@ -50,6 +50,15 @@ impl<'a> RawRequest<'a> {
   }
 
   #[cfg(feature = "async")]
+  pub(crate) fn redirect_status_set(&mut self, status_code: u32) {
+    self.origin.redirect_status_set(status_code);
+    if status_code == 303 {
+      self.body = None;
+      self.header = Self::redirect_body_headers_remove(&self.header);
+    }
+  }
+
+  #[cfg(feature = "async")]
   pub(crate) fn redirect_url_set<S: ToRoUrl>(&mut self, rourl: S) -> error::Result<()> {
     let rourl = rourl.to_rourl();
     let url = rourl.to_url()?;
@@ -123,5 +132,32 @@ impl<'a> RawRequest<'a> {
     } else {
       format!("{}: {}\r\n{}", header.name(), header.value(), rewritten)
     }
+  }
+
+  #[cfg(feature = "async")]
+  fn redirect_body_headers_remove(header: &str) -> String {
+    let Some((request_line, rest)) = header.split_once("\r\n") else {
+      return header.to_string();
+    };
+    let mut rewritten = format!("{}\r\n", request_line);
+
+    for line in rest.split_inclusive("\r\n") {
+      let header_name = line
+        .trim_end_matches("\r\n")
+        .split_once(':')
+        .map(|(name, _)| name);
+
+      if header_name.is_some_and(|name| {
+        name.eq_ignore_ascii_case("content-length")
+          || name.eq_ignore_ascii_case("content-type")
+          || name.eq_ignore_ascii_case("transfer-encoding")
+      }) {
+        continue;
+      }
+
+      rewritten.push_str(line);
+    }
+
+    rewritten
   }
 }

--- a/rttp_client/src/request/request.rs
+++ b/rttp_client/src/request/request.rs
@@ -192,6 +192,22 @@ impl Request {
       .find(|h| h.name().eq_ignore_ascii_case(name.as_ref()))
       .map(|h| h.value().clone())
   }
+
+  pub(crate) fn redirect_status_set(&mut self, status_code: u32) -> &mut Self {
+    if status_code == 303 {
+      self.method_set("GET");
+      self.paras.clear();
+      self.formdatas.clear();
+      self.raw = None;
+      self.binary.clear();
+      self.headers.retain(|header| {
+        !header.name().eq_ignore_ascii_case("content-length")
+          && !header.name().eq_ignore_ascii_case("content-type")
+          && !header.name().eq_ignore_ascii_case("transfer-encoding")
+      });
+    }
+    self
+  }
 }
 
 #[derive(Clone)]

--- a/rttp_client/src/request/request.rs
+++ b/rttp_client/src/request/request.rs
@@ -194,7 +194,7 @@ impl Request {
   }
 
   pub(crate) fn redirect_status_set(&mut self, status_code: u32) -> &mut Self {
-    if status_code == 303 {
+    if status_code == 303 && !self.method.eq_ignore_ascii_case("head") {
       self.method_set("GET");
       self.paras.clear();
       self.formdatas.clear();

--- a/rttp_client/tests/support/mod.rs
+++ b/rttp_client/tests/support/mod.rs
@@ -243,6 +243,32 @@ where
   (addr, handle)
 }
 
+pub fn spawn_status_redirect_request_capture_server(
+  status_code: u16,
+  reason: &'static str,
+) -> (SocketAddr, JoinHandle<Vec<u8>>) {
+  let (listener, addr) = bind_local_http_listener("status redirect request capture server");
+  let handle = thread::spawn(move || {
+    if let Ok((mut stream, _)) = listener.accept() {
+      let _ = read_http_request(&mut stream);
+      let response = format!(
+        "HTTP/1.1 {} {}\r\nLocation: http://{}/final?via=redirect\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+        status_code, reason, addr
+      );
+      let _ = stream.write_all(response.as_bytes());
+    }
+
+    if let Ok((mut stream, _)) = listener.accept() {
+      let request = read_http_request(&mut stream);
+      let _ = stream.write_all(HTTP_OK_RESPONSE);
+      return request;
+    }
+
+    Vec::new()
+  });
+  (addr, handle)
+}
+
 pub fn spawn_cross_authority_redirect_host_echo_server() -> (SocketAddr, SocketAddr, JoinHandle<()>)
 {
   let (origin_listener, origin_addr) = bind_local_http_listener("cross authority redirect origin");

--- a/rttp_client/tests/test_http_async.rs
+++ b/rttp_client/tests/test_http_async.rs
@@ -1,6 +1,9 @@
 mod support;
 
 #[cfg(feature = "async")]
+use std::collections::HashMap;
+
+#[cfg(feature = "async")]
 use futures::executor::block_on;
 #[cfg(feature = "async")]
 use rttp_client::types::Proxy;
@@ -289,6 +292,118 @@ where
   assert!(response.is_ok());
   let response = response.unwrap();
   assert_eq!(expected_target, response.body().string().unwrap());
+}
+
+#[cfg(feature = "async")]
+struct CapturedRequest {
+  method: String,
+  target: String,
+  headers: HashMap<String, String>,
+  body: Vec<u8>,
+}
+
+#[cfg(feature = "async")]
+fn captured_request(request: Vec<u8>) -> CapturedRequest {
+  let header_end = request
+    .windows(4)
+    .position(|window| window == b"\r\n\r\n")
+    .expect("captured request headers");
+  let header = String::from_utf8_lossy(&request[..header_end]);
+  let mut lines = header.lines();
+  let request_line = lines.next().expect("captured request line");
+  let mut request_line_parts = request_line.split_whitespace();
+  let method = request_line_parts
+    .next()
+    .expect("captured request method")
+    .to_string();
+  let target = request_line_parts
+    .next()
+    .expect("captured request target")
+    .to_string();
+  let headers = lines
+    .filter_map(|line| {
+      let (name, value) = line.split_once(':')?;
+      Some((name.to_ascii_lowercase(), value.trim().to_string()))
+    })
+    .collect();
+  let body = request[header_end + 4..].to_vec();
+
+  CapturedRequest {
+    method,
+    target,
+    headers,
+    body,
+  }
+}
+
+#[cfg(feature = "async")]
+async fn captured_async_redirected_post(status_code: u16, reason: &'static str) -> CapturedRequest {
+  let (addr, handle) = support::spawn_status_redirect_request_capture_server(status_code, reason);
+  let response = client()
+    .config(Config::builder().auto_redirect(true))
+    .post()
+    .url(format!("http://{}/redirect", addr))
+    .raw("redirect-body")
+    .rasync()
+    .await;
+
+  assert!(response.is_ok());
+  captured_request(handle.join().expect("redirect capture thread"))
+}
+
+#[test]
+#[cfg(feature = "async")]
+fn test_async_auto_redirect_303_post_becomes_get_without_body_or_body_framing() {
+  block_on(async {
+    let request = captured_async_redirected_post(303, "See Other").await;
+
+    assert_eq!("GET", request.method);
+    assert_eq!("/final?via=redirect", request.target);
+    assert_eq!(b"", request.body.as_slice());
+    assert!(!request.headers.contains_key("content-length"));
+    assert!(!request.headers.contains_key("content-type"));
+    assert!(!request.headers.contains_key("transfer-encoding"));
+  });
+}
+
+#[test]
+#[cfg(feature = "async")]
+fn test_async_auto_redirect_307_post_preserves_method_body_and_body_framing() {
+  block_on(async {
+    let request = captured_async_redirected_post(307, "Temporary Redirect").await;
+
+    assert_eq!("POST", request.method);
+    assert_eq!("/final?via=redirect", request.target);
+    assert_eq!(b"redirect-body", request.body.as_slice());
+    assert_eq!(
+      Some("13"),
+      request.headers.get("content-length").map(String::as_str)
+    );
+    assert_eq!(
+      Some("text/plain"),
+      request.headers.get("content-type").map(String::as_str)
+    );
+  });
+}
+
+#[test]
+#[cfg(feature = "async")]
+fn test_async_auto_redirect_308_post_preserves_method_body_and_body_framing() {
+  block_on(async {
+    let request = captured_async_redirected_post(308, "Permanent Redirect").await;
+
+    assert_eq!("POST", request.method);
+    assert_eq!("/final?via=redirect", request.target);
+    assert_eq!(b"redirect-body", request.body.as_slice());
+    assert_eq!(
+      Some("13"),
+      request.headers.get("content-length").map(String::as_str)
+    );
+    assert_eq!(
+      Some("text/plain"),
+      request.headers.get("content-type").map(String::as_str)
+    );
+  });
 }
 
 #[test]

--- a/rttp_client/tests/test_http_async.rs
+++ b/rttp_client/tests/test_http_async.rs
@@ -351,6 +351,20 @@ async fn captured_async_redirected_post(status_code: u16, reason: &'static str) 
   captured_request(handle.join().expect("redirect capture thread"))
 }
 
+#[cfg(feature = "async")]
+async fn captured_async_redirected_head(status_code: u16, reason: &'static str) -> CapturedRequest {
+  let (addr, handle) = support::spawn_status_redirect_request_capture_server(status_code, reason);
+  let response = client()
+    .config(Config::builder().auto_redirect(true))
+    .head()
+    .url(format!("http://{}/redirect", addr))
+    .rasync()
+    .await;
+
+  assert!(response.is_ok());
+  captured_request(handle.join().expect("redirect capture thread"))
+}
+
 #[test]
 #[cfg(feature = "async")]
 fn test_async_auto_redirect_303_post_becomes_get_without_body_or_body_framing() {
@@ -363,6 +377,17 @@ fn test_async_auto_redirect_303_post_becomes_get_without_body_or_body_framing() 
     assert!(!request.headers.contains_key("content-length"));
     assert!(!request.headers.contains_key("content-type"));
     assert!(!request.headers.contains_key("transfer-encoding"));
+  });
+}
+
+#[test]
+#[cfg(feature = "async")]
+fn test_async_auto_redirect_303_head_preserves_method() {
+  block_on(async {
+    let request = captured_async_redirected_head(303, "See Other").await;
+
+    assert_eq!("HEAD", request.method);
+    assert_eq!("/final?via=redirect", request.target);
   });
 }
 

--- a/rttp_client/tests/test_http_basic.rs
+++ b/rttp_client/tests/test_http_basic.rs
@@ -499,6 +499,18 @@ fn captured_redirected_post(status_code: u16, reason: &'static str) -> CapturedR
   captured_request(handle.join().expect("redirect capture thread"))
 }
 
+fn captured_redirected_head(status_code: u16, reason: &'static str) -> CapturedRequest {
+  let (addr, handle) = support::spawn_status_redirect_request_capture_server(status_code, reason);
+  let response = client()
+    .config(Config::builder().auto_redirect(true))
+    .head()
+    .url(format!("http://{}/redirect", addr))
+    .emit();
+
+  assert!(response.is_ok());
+  captured_request(handle.join().expect("redirect capture thread"))
+}
+
 #[test]
 fn test_auto_redirect_303_post_becomes_get_without_body_or_body_framing() {
   let request = captured_redirected_post(303, "See Other");
@@ -509,6 +521,14 @@ fn test_auto_redirect_303_post_becomes_get_without_body_or_body_framing() {
   assert!(!request.headers.contains_key("content-length"));
   assert!(!request.headers.contains_key("content-type"));
   assert!(!request.headers.contains_key("transfer-encoding"));
+}
+
+#[test]
+fn test_auto_redirect_303_head_preserves_method() {
+  let request = captured_redirected_head(303, "See Other");
+
+  assert_eq!("HEAD", request.method);
+  assert_eq!("/final?via=redirect", request.target);
 }
 
 #[test]

--- a/rttp_client/tests/test_http_basic.rs
+++ b/rttp_client/tests/test_http_basic.rs
@@ -446,6 +446,105 @@ where
   assert_eq!(expected_target, response.body().string().unwrap());
 }
 
+struct CapturedRequest {
+  method: String,
+  target: String,
+  headers: HashMap<String, String>,
+  body: Vec<u8>,
+}
+
+fn captured_request(request: Vec<u8>) -> CapturedRequest {
+  let header_end = request
+    .windows(4)
+    .position(|window| window == b"\r\n\r\n")
+    .expect("captured request headers");
+  let header = String::from_utf8_lossy(&request[..header_end]);
+  let mut lines = header.lines();
+  let request_line = lines.next().expect("captured request line");
+  let mut request_line_parts = request_line.split_whitespace();
+  let method = request_line_parts
+    .next()
+    .expect("captured request method")
+    .to_string();
+  let target = request_line_parts
+    .nth(0)
+    .expect("captured request target")
+    .to_string();
+  let headers = lines
+    .filter_map(|line| {
+      let (name, value) = line.split_once(':')?;
+      Some((name.to_ascii_lowercase(), value.trim().to_string()))
+    })
+    .collect();
+  let body = request[header_end + 4..].to_vec();
+
+  CapturedRequest {
+    method,
+    target,
+    headers,
+    body,
+  }
+}
+
+fn captured_redirected_post(status_code: u16, reason: &'static str) -> CapturedRequest {
+  let (addr, handle) = support::spawn_status_redirect_request_capture_server(status_code, reason);
+  let response = client()
+    .config(Config::builder().auto_redirect(true))
+    .post()
+    .url(format!("http://{}/redirect", addr))
+    .raw("redirect-body")
+    .emit();
+
+  assert!(response.is_ok());
+  captured_request(handle.join().expect("redirect capture thread"))
+}
+
+#[test]
+fn test_auto_redirect_303_post_becomes_get_without_body_or_body_framing() {
+  let request = captured_redirected_post(303, "See Other");
+
+  assert_eq!("GET", request.method);
+  assert_eq!("/final?via=redirect", request.target);
+  assert_eq!(b"", request.body.as_slice());
+  assert!(!request.headers.contains_key("content-length"));
+  assert!(!request.headers.contains_key("content-type"));
+  assert!(!request.headers.contains_key("transfer-encoding"));
+}
+
+#[test]
+fn test_auto_redirect_307_post_preserves_method_body_and_body_framing() {
+  let request = captured_redirected_post(307, "Temporary Redirect");
+
+  assert_eq!("POST", request.method);
+  assert_eq!("/final?via=redirect", request.target);
+  assert_eq!(b"redirect-body", request.body.as_slice());
+  assert_eq!(
+    Some("13"),
+    request.headers.get("content-length").map(String::as_str)
+  );
+  assert_eq!(
+    Some("text/plain"),
+    request.headers.get("content-type").map(String::as_str)
+  );
+}
+
+#[test]
+fn test_auto_redirect_308_post_preserves_method_body_and_body_framing() {
+  let request = captured_redirected_post(308, "Permanent Redirect");
+
+  assert_eq!("POST", request.method);
+  assert_eq!("/final?via=redirect", request.target);
+  assert_eq!(b"redirect-body", request.body.as_slice());
+  assert_eq!(
+    Some("13"),
+    request.headers.get("content-length").map(String::as_str)
+  );
+  assert_eq!(
+    Some("text/plain"),
+    request.headers.get("content-type").map(String::as_str)
+  );
+}
+
 #[test]
 fn test_auto_redirect_resolves_absolute_location() {
   assert_redirect_resolves_to_target(|addr| format!("http://{}/final", addr), "/final");


### PR DESCRIPTION
Implemented status-specific redirect semantics for rttp_client: 303 redirects now switch follow-up requests to GET without a body or body framing headers, while 307 and 308 preserve method, body, and framing in sync and async clients. Added local capture-based tests for redirected request shape and verified formatting, focused redirect coverage, and the full workspace test suite.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1296/
work_kind: code_work
branch: hbx-1296-rttp-apply-status-specific-redirect
base: main
commit: b0a2d22c030e96014d02ad17ea065e6bd5eccb15
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1296/
    url: https://plane.kahub.in/endless/browse/HBX-1296/
    close_policy: link_only
```