### PR TITLE
feat: [rttp] Strip sensitive request headers on cross-origin redirects

### DIFF
--- a/rttp_client/src/connection/async_connection.rs
+++ b/rttp_client/src/connection/async_connection.rs
@@ -56,7 +56,11 @@ impl<'a> AsyncConnection<'a> {
           }
 
           let redirect_url = self.conn.redirect_url(&url, location)?;
-          self.conn.request_mut().redirect_url_set(redirect_url)?;
+          let strip_sensitive_headers = !self.conn.is_same_origin_redirect(&url, location)?;
+          self
+            .conn
+            .request_mut()
+            .redirect_url_set(redirect_url, strip_sensitive_headers)?;
           self.conn.request_mut().origin_mut().count_set(count + 1);
           continue;
         }

--- a/rttp_client/src/connection/block_connection.rs
+++ b/rttp_client/src/connection/block_connection.rs
@@ -49,7 +49,11 @@ impl<'a> BlockConnection<'a> {
       }
 
       let redirect_url = self.conn.redirect_url(&url, location)?;
-      return HttpClient::with_request(self.conn.request().origin().clone())
+      let mut request = self.conn.request().origin().clone();
+      if !self.conn.is_same_origin_redirect(&url, location)? {
+        request.remove_sensitive_redirect_headers();
+      }
+      return HttpClient::with_request(request)
         .url(redirect_url)
         .count(count + 1)
         .emit();

--- a/rttp_client/src/connection/connection.rs
+++ b/rttp_client/src/connection/connection.rs
@@ -244,6 +244,13 @@ impl<'a> Connection<'a> {
       .map_err(|_| error::bad_url(url.clone(), "Bad redirect location"))
   }
 
+  pub fn is_same_origin_redirect(&self, url: &Url, redirect_url: &str) -> error::Result<bool> {
+    let redirect = url
+      .join(redirect_url)
+      .map_err(|_| error::bad_url(url.clone(), "Bad redirect location"))?;
+    Ok(is_same_origin(url, &redirect))
+  }
+
   pub fn expect_no_response_body(&self) -> bool {
     self.request.origin().method().eq_ignore_ascii_case("head")
   }
@@ -253,6 +260,12 @@ fn absolute_url(url: &Url) -> String {
   let mut absolute = url.clone();
   absolute.set_fragment(None);
   absolute.to_string()
+}
+
+fn is_same_origin(left: &Url, right: &Url) -> bool {
+  left.scheme() == right.scheme()
+    && left.host_str() == right.host_str()
+    && left.port_or_known_default() == right.port_or_known_default()
 }
 
 fn proxy_authorization_value(proxy: &Proxy) -> Option<String> {

--- a/rttp_client/src/request/raw_request.rs
+++ b/rttp_client/src/request/raw_request.rs
@@ -1,5 +1,6 @@
 use crate::error;
 use crate::request::builder::RawBuilder;
+#[cfg(feature = "async")]
 use crate::request::is_sensitive_redirect_header;
 use crate::request::{Request, RequestBody};
 #[cfg(feature = "async")]

--- a/rttp_client/src/request/raw_request.rs
+++ b/rttp_client/src/request/raw_request.rs
@@ -50,7 +50,11 @@ impl<'a> RawRequest<'a> {
   }
 
   #[cfg(feature = "async")]
-  pub(crate) fn redirect_url_set<S: ToRoUrl>(&mut self, rourl: S) -> error::Result<()> {
+  pub(crate) fn redirect_url_set<S: ToRoUrl>(
+    &mut self,
+    rourl: S,
+    strip_sensitive_headers: bool,
+  ) -> error::Result<()> {
     let rourl = rourl.to_rourl();
     let url = rourl.to_url()?;
     let host_header = Self::redirect_host_header(&url)?;
@@ -60,11 +64,19 @@ impl<'a> RawRequest<'a> {
     }
 
     self.origin.url_set(&rourl);
+    if strip_sensitive_headers {
+      self.origin.remove_sensitive_redirect_headers();
+    }
     self.redirect_host_set(host_header.clone());
     self.url = rourl;
 
     if let Some((_, rest)) = self.header.split_once("\r\n") {
       let rest = Self::redirect_header_host_set(rest, &host_header);
+      let rest = if strip_sensitive_headers {
+        Self::redirect_sensitive_headers_strip(&rest)
+      } else {
+        rest
+      };
       self.header = format!(
         "{} {} HTTP/1.1\r\n{}",
         self.origin.method().to_uppercase(),
@@ -123,5 +135,27 @@ impl<'a> RawRequest<'a> {
     } else {
       format!("{}: {}\r\n{}", header.name(), header.value(), rewritten)
     }
+  }
+
+  #[cfg(feature = "async")]
+  fn redirect_sensitive_headers_strip(rest: &str) -> String {
+    let mut rewritten = String::new();
+
+    for line in rest.split_inclusive("\r\n") {
+      let header_name = line
+        .trim_end_matches("\r\n")
+        .split_once(':')
+        .map(|(name, _)| name);
+
+      if header_name.is_some_and(|name| {
+        name.eq_ignore_ascii_case("authorization") || name.eq_ignore_ascii_case("cookie")
+      }) {
+        continue;
+      }
+
+      rewritten.push_str(line);
+    }
+
+    rewritten
   }
 }

--- a/rttp_client/src/request/raw_request.rs
+++ b/rttp_client/src/request/raw_request.rs
@@ -1,5 +1,6 @@
 use crate::error;
 use crate::request::builder::RawBuilder;
+use crate::request::is_sensitive_redirect_header;
 use crate::request::{Request, RequestBody};
 #[cfg(feature = "async")]
 use crate::types::Header;
@@ -147,9 +148,7 @@ impl<'a> RawRequest<'a> {
         .split_once(':')
         .map(|(name, _)| name);
 
-      if header_name.is_some_and(|name| {
-        name.eq_ignore_ascii_case("authorization") || name.eq_ignore_ascii_case("cookie")
-      }) {
+      if header_name.is_some_and(is_sensitive_redirect_header) {
         continue;
       }
 

--- a/rttp_client/src/request/request.rs
+++ b/rttp_client/src/request/request.rs
@@ -192,6 +192,13 @@ impl Request {
       .find(|h| h.name().eq_ignore_ascii_case(name.as_ref()))
       .map(|h| h.value().clone())
   }
+
+  pub(crate) fn remove_sensitive_redirect_headers(&mut self) {
+    self.headers.retain(|header| {
+      !header.name().eq_ignore_ascii_case("authorization")
+        && !header.name().eq_ignore_ascii_case("cookie")
+    });
+  }
 }
 
 #[derive(Clone)]

--- a/rttp_client/src/request/request.rs
+++ b/rttp_client/src/request/request.rs
@@ -3,6 +3,12 @@ use std::fmt;
 use crate::types::{FormData, Header, Para, Proxy, RoUrl, ToRoUrl};
 use crate::{error, Config};
 
+pub(crate) fn is_sensitive_redirect_header(name: &str) -> bool {
+  name.eq_ignore_ascii_case("authorization")
+    || name.eq_ignore_ascii_case("cookie")
+    || name.eq_ignore_ascii_case("proxy-authorization")
+}
+
 #[derive(Clone, Debug)]
 pub struct Request {
   closed: bool,
@@ -194,10 +200,9 @@ impl Request {
   }
 
   pub(crate) fn remove_sensitive_redirect_headers(&mut self) {
-    self.headers.retain(|header| {
-      !header.name().eq_ignore_ascii_case("authorization")
-        && !header.name().eq_ignore_ascii_case("cookie")
-    });
+    self
+      .headers
+      .retain(|header| !is_sensitive_redirect_header(header.name()));
   }
 }
 

--- a/rttp_client/tests/support/mod.rs
+++ b/rttp_client/tests/support/mod.rs
@@ -331,9 +331,10 @@ pub fn spawn_same_authority_redirect_header_echo_server() -> (SocketAddr, JoinHa
 
 fn echoed_redirect_headers(request: &[u8]) -> String {
   format!(
-    "authorization={}\ncookie={}\nx-trace={}",
+    "authorization={}\ncookie={}\nproxy-authorization={}\nx-trace={}",
     header_value(request, "Authorization").unwrap_or_default(),
     header_value(request, "Cookie").unwrap_or_default(),
+    header_value(request, "Proxy-Authorization").unwrap_or_default(),
     header_value(request, "X-Trace").unwrap_or_default()
   )
 }

--- a/rttp_client/tests/support/mod.rs
+++ b/rttp_client/tests/support/mod.rs
@@ -273,6 +273,71 @@ pub fn spawn_cross_authority_redirect_host_echo_server() -> (SocketAddr, SocketA
   (origin_addr, target_addr, handle)
 }
 
+pub fn spawn_cross_authority_redirect_header_echo_server(
+) -> (SocketAddr, SocketAddr, JoinHandle<()>) {
+  let (origin_listener, origin_addr) = bind_local_http_listener("cross authority redirect origin");
+  let (target_listener, target_addr) = bind_local_http_listener("cross authority redirect target");
+
+  let handle = thread::spawn(move || {
+    if let Ok((mut stream, _)) = origin_listener.accept() {
+      let _ = read_http_request(&mut stream);
+      let response = format!(
+        "HTTP/1.1 302 Found\r\nLocation: http://{}/final\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+        target_addr
+      );
+      let _ = stream.write_all(response.as_bytes());
+    }
+
+    if let Ok((mut stream, _)) = target_listener.accept() {
+      let request = read_http_request(&mut stream);
+      let body = echoed_redirect_headers(&request);
+      let response = format!(
+        "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+        body.len(),
+        body
+      );
+      let _ = stream.write_all(response.as_bytes());
+    }
+  });
+
+  (origin_addr, target_addr, handle)
+}
+
+pub fn spawn_same_authority_redirect_header_echo_server() -> (SocketAddr, JoinHandle<()>) {
+  let (listener, addr) = bind_local_http_listener("same authority redirect");
+
+  let handle = thread::spawn(move || {
+    if let Ok((mut stream, _)) = listener.accept() {
+      let _ = read_http_request(&mut stream);
+      let response =
+        "HTTP/1.1 302 Found\r\nLocation: /final\r\nContent-Length: 0\r\nConnection: close\r\n\r\n";
+      let _ = stream.write_all(response.as_bytes());
+    }
+
+    if let Ok((mut stream, _)) = listener.accept() {
+      let request = read_http_request(&mut stream);
+      let body = echoed_redirect_headers(&request);
+      let response = format!(
+        "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+        body.len(),
+        body
+      );
+      let _ = stream.write_all(response.as_bytes());
+    }
+  });
+
+  (addr, handle)
+}
+
+fn echoed_redirect_headers(request: &[u8]) -> String {
+  format!(
+    "authorization={}\ncookie={}\nx-trace={}",
+    header_value(request, "Authorization").unwrap_or_default(),
+    header_value(request, "Cookie").unwrap_or_default(),
+    header_value(request, "X-Trace").unwrap_or_default()
+  )
+}
+
 pub fn spawn_keep_alive_server() -> (SocketAddr, JoinHandle<()>) {
   let (listener, addr) = bind_local_http_listener("keep-alive server");
   let handle = thread::spawn(move || {

--- a/rttp_client/tests/test_http_async.rs
+++ b/rttp_client/tests/test_http_async.rs
@@ -345,6 +345,55 @@ fn test_async_auto_redirect_rebuilds_host_for_cross_authority_location() {
 }
 
 #[test]
+#[cfg(feature = "async")]
+fn test_async_auto_redirect_strips_sensitive_headers_for_cross_authority_location() {
+  let (origin_addr, _target_addr, _handle) =
+    support::spawn_cross_authority_redirect_header_echo_server();
+  block_on(async {
+    let response = client()
+      .config(Config::builder().auto_redirect(true))
+      .get()
+      .url(format!("http://{}/redirect", origin_addr))
+      .header(("Authorization", "Bearer secret"))
+      .header(("Cookie", "session=secret"))
+      .header(("X-Trace", "trace-123"))
+      .rasync()
+      .await;
+
+    assert!(response.is_ok());
+    let response = response.unwrap();
+    assert_eq!(
+      "authorization=\ncookie=\nx-trace=trace-123",
+      response.body().string().unwrap()
+    );
+  });
+}
+
+#[test]
+#[cfg(feature = "async")]
+fn test_async_auto_redirect_preserves_sensitive_headers_for_same_authority_location() {
+  let (addr, _handle) = support::spawn_same_authority_redirect_header_echo_server();
+  block_on(async {
+    let response = client()
+      .config(Config::builder().auto_redirect(true))
+      .get()
+      .url(format!("http://{}/redirect", addr))
+      .header(("Authorization", "Bearer secret"))
+      .header(("Cookie", "session=secret"))
+      .header(("X-Trace", "trace-123"))
+      .rasync()
+      .await;
+
+    assert!(response.is_ok());
+    let response = response.unwrap();
+    assert_eq!(
+      "authorization=Bearer secret\ncookie=session=secret\nx-trace=trace-123",
+      response.body().string().unwrap()
+    );
+  });
+}
+
+#[test]
 #[cfg(all(feature = "async", feature = "tls-rustls"))]
 fn test_async_https() {
   let (addr, _handle) = support::spawn_tls_server();

--- a/rttp_client/tests/test_http_async.rs
+++ b/rttp_client/tests/test_http_async.rs
@@ -356,6 +356,7 @@ fn test_async_auto_redirect_strips_sensitive_headers_for_cross_authority_locatio
       .url(format!("http://{}/redirect", origin_addr))
       .header(("Authorization", "Bearer secret"))
       .header(("Cookie", "session=secret"))
+      .header(("Proxy-Authorization", "Basic proxy-secret"))
       .header(("X-Trace", "trace-123"))
       .rasync()
       .await;
@@ -363,7 +364,7 @@ fn test_async_auto_redirect_strips_sensitive_headers_for_cross_authority_locatio
     assert!(response.is_ok());
     let response = response.unwrap();
     assert_eq!(
-      "authorization=\ncookie=\nx-trace=trace-123",
+      "authorization=\ncookie=\nproxy-authorization=\nx-trace=trace-123",
       response.body().string().unwrap()
     );
   });
@@ -380,6 +381,7 @@ fn test_async_auto_redirect_preserves_sensitive_headers_for_same_authority_locat
       .url(format!("http://{}/redirect", addr))
       .header(("Authorization", "Bearer secret"))
       .header(("Cookie", "session=secret"))
+      .header(("Proxy-Authorization", "Basic proxy-secret"))
       .header(("X-Trace", "trace-123"))
       .rasync()
       .await;
@@ -387,7 +389,7 @@ fn test_async_auto_redirect_preserves_sensitive_headers_for_same_authority_locat
     assert!(response.is_ok());
     let response = response.unwrap();
     assert_eq!(
-      "authorization=Bearer secret\ncookie=session=secret\nx-trace=trace-123",
+      "authorization=Bearer secret\ncookie=session=secret\nproxy-authorization=Basic proxy-secret\nx-trace=trace-123",
       response.body().string().unwrap()
     );
   });

--- a/rttp_client/tests/test_http_basic.rs
+++ b/rttp_client/tests/test_http_basic.rs
@@ -476,13 +476,14 @@ fn test_auto_redirect_strips_sensitive_headers_for_cross_authority_location() {
     .url(format!("http://{}/redirect", origin_addr))
     .header(("Authorization", "Bearer secret"))
     .header(("Cookie", "session=secret"))
+    .header(("Proxy-Authorization", "Basic proxy-secret"))
     .header(("X-Trace", "trace-123"))
     .emit();
 
   assert!(response.is_ok());
   let response = response.unwrap();
   assert_eq!(
-    "authorization=\ncookie=\nx-trace=trace-123",
+    "authorization=\ncookie=\nproxy-authorization=\nx-trace=trace-123",
     response.body().string().unwrap()
   );
 }
@@ -496,13 +497,14 @@ fn test_auto_redirect_preserves_sensitive_headers_for_same_authority_location() 
     .url(format!("http://{}/redirect", addr))
     .header(("Authorization", "Bearer secret"))
     .header(("Cookie", "session=secret"))
+    .header(("Proxy-Authorization", "Basic proxy-secret"))
     .header(("X-Trace", "trace-123"))
     .emit();
 
   assert!(response.is_ok());
   let response = response.unwrap();
   assert_eq!(
-    "authorization=Bearer secret\ncookie=session=secret\nx-trace=trace-123",
+    "authorization=Bearer secret\ncookie=session=secret\nproxy-authorization=Basic proxy-secret\nx-trace=trace-123",
     response.body().string().unwrap()
   );
 }

--- a/rttp_client/tests/test_http_basic.rs
+++ b/rttp_client/tests/test_http_basic.rs
@@ -467,6 +467,47 @@ fn test_auto_redirect_resolves_query_only_location() {
 }
 
 #[test]
+fn test_auto_redirect_strips_sensitive_headers_for_cross_authority_location() {
+  let (origin_addr, _target_addr, _handle) =
+    support::spawn_cross_authority_redirect_header_echo_server();
+  let response = client()
+    .config(Config::builder().auto_redirect(true))
+    .get()
+    .url(format!("http://{}/redirect", origin_addr))
+    .header(("Authorization", "Bearer secret"))
+    .header(("Cookie", "session=secret"))
+    .header(("X-Trace", "trace-123"))
+    .emit();
+
+  assert!(response.is_ok());
+  let response = response.unwrap();
+  assert_eq!(
+    "authorization=\ncookie=\nx-trace=trace-123",
+    response.body().string().unwrap()
+  );
+}
+
+#[test]
+fn test_auto_redirect_preserves_sensitive_headers_for_same_authority_location() {
+  let (addr, _handle) = support::spawn_same_authority_redirect_header_echo_server();
+  let response = client()
+    .config(Config::builder().auto_redirect(true))
+    .get()
+    .url(format!("http://{}/redirect", addr))
+    .header(("Authorization", "Bearer secret"))
+    .header(("Cookie", "session=secret"))
+    .header(("X-Trace", "trace-123"))
+    .emit();
+
+  assert!(response.is_ok());
+  let response = response.unwrap();
+  assert_eq!(
+    "authorization=Bearer secret\ncookie=session=secret\nx-trace=trace-123",
+    response.body().string().unwrap()
+  );
+}
+
+#[test]
 fn test_http_proxy_uses_absolute_form_for_http_requests() {
   let (addr, _handle) = support::spawn_http_proxy_server();
   let response = client()


### PR DESCRIPTION
Redirect handling now strips Authorization and Cookie on cross-origin follow-up requests while preserving same-origin sensitive headers and non-sensitive custom headers across sync and async clients. Focused redirect tests, formatting, full workspace tests, and async-feature workspace tests passed.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1297/
work_kind: code_work
branch: hbx-1297-rttp-strip-sensitive-request-headers
base: main
commit: c790721a70e262bbd8c9554b8eed2e69b86bddb6
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1297/
    url: https://plane.kahub.in/endless/browse/HBX-1297/
    close_policy: link_only
```