### PR TITLE
feat: [rttp] Bound redirect chains and normalized loop detection across sync and async clients

### DIFF
--- a/rttp_client/src/connection/async_connection.rs
+++ b/rttp_client/src/connection/async_connection.rs
@@ -55,13 +55,16 @@ impl<'a> AsyncConnection<'a> {
             return Err(error::too_many_redirects(url));
           }
 
-          let redirect_url = self.conn.redirect_url(&url, location)?;
-          let strip_sensitive_headers = !self.conn.is_same_origin_redirect(&url, location)?;
+          let redirect_url = self.conn.resolve_redirect_url(&url, location)?;
+          if url == redirect_url {
+            return Err(error::loop_detected(url));
+          }
+          let strip_sensitive_headers = !self.conn.is_same_origin_url(&url, &redirect_url);
           self.conn.request_mut().redirect_status_set(response.code());
           self
             .conn
             .request_mut()
-            .redirect_url_set(redirect_url, strip_sensitive_headers)?;
+            .redirect_url_set(redirect_url.to_string(), strip_sensitive_headers)?;
           self.conn.request_mut().origin_mut().count_set(count + 1);
           continue;
         }

--- a/rttp_client/src/connection/block_connection.rs
+++ b/rttp_client/src/connection/block_connection.rs
@@ -48,14 +48,17 @@ impl<'a> BlockConnection<'a> {
         return Err(error::too_many_redirects(url));
       }
 
-      let redirect_url = self.conn.redirect_url(&url, location)?;
+      let redirect_url = self.conn.resolve_redirect_url(&url, location)?;
+      if url == redirect_url {
+        return Err(error::loop_detected(url));
+      }
       let mut request = self.conn.request().origin().clone();
       request.redirect_status_set(response.code());
-      if !self.conn.is_same_origin_redirect(&url, location)? {
+      if !self.conn.is_same_origin_url(&url, &redirect_url) {
         request.remove_sensitive_redirect_headers();
       }
       return HttpClient::with_request(request)
-        .url(redirect_url)
+        .url(redirect_url.to_string())
         .count(count + 1)
         .emit();
     }

--- a/rttp_client/src/connection/connection.rs
+++ b/rttp_client/src/connection/connection.rs
@@ -237,18 +237,14 @@ impl<'a> Connection<'a> {
     proxy_header
   }
 
-  pub fn redirect_url(&self, url: &Url, location: &str) -> error::Result<String> {
+  pub fn resolve_redirect_url(&self, url: &Url, location: &str) -> error::Result<Url> {
     url
       .join(location)
-      .map(|redirect| redirect.to_string())
       .map_err(|_| error::bad_url(url.clone(), "Bad redirect location"))
   }
 
-  pub fn is_same_origin_redirect(&self, url: &Url, redirect_url: &str) -> error::Result<bool> {
-    let redirect = url
-      .join(redirect_url)
-      .map_err(|_| error::bad_url(url.clone(), "Bad redirect location"))?;
-    Ok(is_same_origin(url, &redirect))
+  pub fn is_same_origin_url(&self, url: &Url, redirect: &Url) -> bool {
+    is_same_origin(url, redirect)
   }
 
   pub fn expect_no_response_body(&self) -> bool {

--- a/rttp_client/tests/support/mod.rs
+++ b/rttp_client/tests/support/mod.rs
@@ -1,5 +1,6 @@
 #![allow(dead_code)]
 
+use std::collections::HashMap;
 use std::io::{self, Read, Write};
 use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr, TcpListener, TcpStream};
 use std::thread::{self, JoinHandle};
@@ -238,6 +239,44 @@ where
         target
       );
       let _ = stream.write_all(response.as_bytes());
+    }
+  });
+  (addr, handle)
+}
+
+pub fn spawn_redirect_chain_server(
+  redirects: Vec<(&'static str, &'static str)>,
+  max_requests: usize,
+) -> (SocketAddr, JoinHandle<()>) {
+  let (listener, addr) = bind_local_http_listener("redirect chain server");
+  let handle = thread::spawn(move || {
+    let redirects: HashMap<&'static str, &'static str> = redirects.into_iter().collect();
+
+    for _ in 0..max_requests {
+      if let Ok((mut stream, _)) = listener.accept() {
+        let request = read_http_request(&mut stream);
+        let target = String::from_utf8_lossy(&request)
+          .lines()
+          .next()
+          .and_then(|line| line.split_whitespace().nth(1))
+          .unwrap_or("")
+          .to_string();
+
+        if let Some(location) = redirects.get(target.as_str()) {
+          let response = format!(
+            "HTTP/1.1 302 Found\r\nLocation: {}\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+            location
+          );
+          let _ = stream.write_all(response.as_bytes());
+        } else {
+          let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+            target.len(),
+            target
+          );
+          let _ = stream.write_all(response.as_bytes());
+        }
+      }
     }
   });
   (addr, handle)

--- a/rttp_client/tests/test_http_async.rs
+++ b/rttp_client/tests/test_http_async.rs
@@ -467,6 +467,94 @@ fn test_async_auto_redirect_resolves_query_only_location() {
 
 #[test]
 #[cfg(feature = "async")]
+fn test_async_auto_redirect_preserves_chain_that_finishes_within_max_redirect() {
+  let (addr, _handle) = support::spawn_redirect_chain_server(
+    vec![("/start", "/hop-one"), ("/hop-one", "/final?done=1")],
+    3,
+  );
+  block_on(async {
+    let response = client()
+      .config(Config::builder().auto_redirect(true).max_redirect(2))
+      .get()
+      .url(format!("http://{}/start", addr))
+      .rasync()
+      .await;
+
+    assert!(response.is_ok());
+    let response = response.unwrap();
+    assert_eq!("/final?done=1", response.body().string().unwrap());
+  });
+}
+
+#[test]
+#[cfg(feature = "async")]
+fn test_async_auto_redirect_enforces_max_redirect_bound() {
+  let (addr, _handle) = support::spawn_redirect_chain_server(
+    vec![
+      ("/start", "/hop-one"),
+      ("/hop-one", "/hop-two"),
+      ("/hop-two", "/final"),
+    ],
+    3,
+  );
+  block_on(async {
+    let error = client()
+      .config(Config::builder().auto_redirect(true).max_redirect(2))
+      .get()
+      .url(format!("http://{}/start", addr))
+      .rasync()
+      .await
+      .expect_err("redirect chain should exceed max_redirect");
+
+    assert!(error.is_redirect());
+    assert!(error.to_string().contains("too many redirects"));
+  });
+}
+
+#[test]
+#[cfg(feature = "async")]
+fn test_async_auto_redirect_detects_loop_after_relative_location_is_normalized() {
+  let (addr, _handle) =
+    support::spawn_redirect_chain_server(vec![("/redirect/from?old=1", "?old=1")], 8);
+  block_on(async {
+    let error = client()
+      .config(Config::builder().auto_redirect(true))
+      .get()
+      .url(format!("http://{}/redirect/from?old=1", addr))
+      .rasync()
+      .await
+      .expect_err("redirect should resolve back to current URL");
+
+    assert!(error.is_redirect());
+    assert!(error
+      .to_string()
+      .contains("infinite redirect loop detected"));
+  });
+}
+
+#[test]
+#[cfg(feature = "async")]
+fn test_async_auto_redirect_detects_loop_after_dot_segments_are_normalized() {
+  let (addr, _handle) =
+    support::spawn_redirect_chain_server(vec![("/a/current", "../a/current")], 8);
+  block_on(async {
+    let error = client()
+      .config(Config::builder().auto_redirect(true))
+      .get()
+      .url(format!("http://{}/a/current", addr))
+      .rasync()
+      .await
+      .expect_err("redirect should normalize back to current URL");
+
+    assert!(error.is_redirect());
+    assert!(error
+      .to_string()
+      .contains("infinite redirect loop detected"));
+  });
+}
+
+#[test]
+#[cfg(feature = "async")]
 fn test_async_auto_redirect_rebuilds_host_for_cross_authority_location() {
   let (origin_addr, target_addr, _handle) =
     support::spawn_cross_authority_redirect_host_echo_server();

--- a/rttp_client/tests/test_http_basic.rs
+++ b/rttp_client/tests/test_http_basic.rs
@@ -586,6 +586,78 @@ fn test_auto_redirect_resolves_query_only_location() {
 }
 
 #[test]
+fn test_auto_redirect_preserves_chain_that_finishes_within_max_redirect() {
+  let (addr, _handle) = support::spawn_redirect_chain_server(
+    vec![("/start", "/hop-one"), ("/hop-one", "/final?done=1")],
+    3,
+  );
+  let response = client()
+    .config(Config::builder().auto_redirect(true).max_redirect(2))
+    .get()
+    .url(format!("http://{}/start", addr))
+    .emit();
+
+  assert!(response.is_ok());
+  let response = response.unwrap();
+  assert_eq!("/final?done=1", response.body().string().unwrap());
+}
+
+#[test]
+fn test_auto_redirect_enforces_max_redirect_bound() {
+  let (addr, _handle) = support::spawn_redirect_chain_server(
+    vec![
+      ("/start", "/hop-one"),
+      ("/hop-one", "/hop-two"),
+      ("/hop-two", "/final"),
+    ],
+    3,
+  );
+  let error = client()
+    .config(Config::builder().auto_redirect(true).max_redirect(2))
+    .get()
+    .url(format!("http://{}/start", addr))
+    .emit()
+    .expect_err("redirect chain should exceed max_redirect");
+
+  assert!(error.is_redirect());
+  assert!(error.to_string().contains("too many redirects"));
+}
+
+#[test]
+fn test_auto_redirect_detects_loop_after_relative_location_is_normalized() {
+  let (addr, _handle) =
+    support::spawn_redirect_chain_server(vec![("/redirect/from?old=1", "?old=1")], 8);
+  let error = client()
+    .config(Config::builder().auto_redirect(true))
+    .get()
+    .url(format!("http://{}/redirect/from?old=1", addr))
+    .emit()
+    .expect_err("redirect should resolve back to current URL");
+
+  assert!(error.is_redirect());
+  assert!(error
+    .to_string()
+    .contains("infinite redirect loop detected"));
+}
+
+#[test]
+fn test_auto_redirect_detects_loop_after_dot_segments_are_normalized() {
+  let (addr, _handle) =
+    support::spawn_redirect_chain_server(vec![("/a/current", "../a/current")], 8);
+  let error = client()
+    .config(Config::builder().auto_redirect(true))
+    .get()
+    .url(format!("http://{}/a/current", addr))
+    .emit()
+    .expect_err("redirect should normalize back to current URL");
+
+  assert!(error.is_redirect());
+  assert!(error
+    .to_string()
+    .contains("infinite redirect loop detected"));
+}
+
+#[test]
 fn test_auto_redirect_strips_sensitive_headers_for_cross_authority_location() {
   let (origin_addr, _target_addr, _handle) =
     support::spawn_cross_authority_redirect_header_echo_server();


### PR DESCRIPTION
Implemented normalized redirect target resolution before following redirects so sync and async clients consistently detect equivalent self-redirect loops and enforce max_redirect bounds. Added local multi-hop redirect test support plus sync and async coverage for bounded success, too-many-redirect failures, and normalized loop detection. Verification passed with formatting, focused redirect tests, and full workspace tests.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1298/
work_kind: code_work
branch: hbx-1298-rttp-bound-redirect-chains-and
base: main
commit: c07d4ced70480b254b47841149a1f8bc70ef7bd0
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1298/
    url: https://plane.kahub.in/endless/browse/HBX-1298/
    close_policy: link_only
```