### PR TITLE
feat(rttp): add HttpResponse trailer API

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,9 @@ fn main() -> std::io::Result<()> {
 
   server.accept_one(|request| {
     println!("{} {}", request.method(), request.target());
-    HttpResponse::ok("hello").header("Transfer-Encoding", "chunked")
+    HttpResponse::ok("hello")
+      .header("Transfer-Encoding", "chunked")
+      .trailer("X-Trace", "abc")
   })
 }
 ```
@@ -70,7 +72,9 @@ Use `with_read_timeout` and `with_write_timeout` to apply socket-level
 timeouts to each accepted connection; pass `None` to leave the corresponding
 socket timeout unset. Add `Transfer-Encoding: chunked` to an `HttpResponse` to
 write the complete response body with chunked transfer framing instead of an
-automatic `Content-Length`. The listener path uses `socket2`.
+automatic `Content-Length`; response trailers added with
+`HttpResponse::trailer` are written at the end of that chunked framing. The
+listener path uses `socket2`.
 
 The server is intentionally small: it handles blocking HTTP/1.x request parsing
 for local tests and simple embedded use. It accepts fixed `Content-Length` and

--- a/rttp/README.md
+++ b/rttp/README.md
@@ -22,7 +22,9 @@ fn main() -> std::io::Result<()> {
 
   server.accept_one(|request| {
     println!("{} {}", request.method(), request.target());
-    HttpResponse::ok("hello").header("Transfer-Encoding", "chunked")
+    HttpResponse::ok("hello")
+      .header("Transfer-Encoding", "chunked")
+      .trailer("X-Trace", "abc")
   })
 }
 ```
@@ -36,7 +38,9 @@ connection; pass `None` to leave the corresponding socket timeout unset.
 
 Add `Transfer-Encoding: chunked` to an `HttpResponse` to write the complete
 response body with chunked transfer framing instead of an automatic
-`Content-Length` when the response status permits a message body.
+`Content-Length` when the response status permits a message body. Response
+trailers added with `HttpResponse::trailer` are written at the end of that
+chunked framing.
 
 The server currently parses blocking HTTP/1.x requests for local tests and
 simple embedded use. It supports fixed `Content-Length` and chunked request

--- a/rttp/src/server.rs
+++ b/rttp/src/server.rs
@@ -597,6 +597,7 @@ pub struct HttpResponse {
   status_code: u16,
   reason: String,
   headers: Vec<HttpHeader>,
+  trailers: Vec<HttpHeader>,
   body: Vec<u8>,
 }
 
@@ -614,6 +615,7 @@ impl HttpResponse {
       status_code,
       reason: reason.as_ref().to_string(),
       headers: Vec::new(),
+      trailers: Vec::new(),
       body: Vec::new(),
     }
   }
@@ -629,6 +631,27 @@ impl HttpResponse {
     assert_valid_header_component(value);
     self.headers.push(HttpHeader::new(name, value));
     self
+  }
+
+  pub fn trailer<N: AsRef<str>, V: AsRef<str>>(mut self, name: N, value: V) -> Self {
+    let name = name.as_ref();
+    let value = value.as_ref();
+    assert_valid_header_component(name);
+    assert_valid_header_component(value);
+    self.trailers.push(HttpHeader::new(name, value));
+    self
+  }
+
+  pub fn trailers(&self) -> &[HttpHeader] {
+    &self.trailers
+  }
+
+  pub fn trailer_value<S: AsRef<str>>(&self, name: S) -> Option<&str> {
+    self
+      .trailers
+      .iter()
+      .find(|trailer| trailer.name.eq_ignore_ascii_case(name.as_ref()))
+      .map(|trailer| trailer.value.as_str())
   }
 
   pub fn body<B: AsRef<[u8]>>(mut self, body: B) -> Self {
@@ -729,7 +752,11 @@ impl HttpResponse {
     if self.uses_chunked_transfer_encoding() {
       write!(writer, "{:x}\r\n", self.body.len())?;
       writer.write_all(&self.body)?;
-      writer.write_all(b"\r\n0\r\n\r\n")
+      writer.write_all(b"\r\n0\r\n")?;
+      for trailer in &self.trailers {
+        write!(writer, "{}: {}\r\n", trailer.name, trailer.value)?;
+      }
+      writer.write_all(b"\r\n")
     } else {
       writer.write_all(&self.body)
     }

--- a/rttp/src/server.rs
+++ b/rttp/src/server.rs
@@ -638,6 +638,7 @@ impl HttpResponse {
     let value = value.as_ref();
     assert_valid_header_component(name);
     assert_valid_header_component(value);
+    assert_allowed_trailer_name(name);
     self.trailers.push(HttpHeader::new(name, value));
     self
   }
@@ -1354,6 +1355,20 @@ fn assert_valid_header_component(component: &str) {
     !component.contains('\r') && !component.contains('\n'),
     "response headers must not contain CR or LF"
   );
+}
+
+fn assert_allowed_trailer_name(name: &str) {
+  assert!(
+    !is_forbidden_trailer_name(name),
+    "response trailers must not contain framing or routing fields"
+  );
+}
+
+fn is_forbidden_trailer_name(name: &str) -> bool {
+  matches!(
+    name.to_ascii_lowercase().as_str(),
+    "connection" | "content-length" | "host" | "te" | "trailer" | "transfer-encoding" | "upgrade"
+  )
 }
 
 fn response_status_allows_body(status_code: u16) -> bool {

--- a/rttp/tests/test_server_models.rs
+++ b/rttp/tests/test_server_models.rs
@@ -271,9 +271,48 @@ fn serializes_chunked_response_body_when_transfer_encoding_is_chunked() {
 }
 
 #[test]
+fn serializes_chunked_response_trailers() {
+  let response = HttpResponse::new(200, "OK")
+    .header("Transfer-Encoding", "chunked")
+    .trailer("X-Trace", "abc")
+    .trailer("X-Signature", "signed")
+    .body("hello");
+
+  let serialized = response.to_bytes();
+
+  assert_eq!(2, response.trailers().len());
+  assert_eq!(Some("abc"), response.trailer_value("x-trace"));
+  assert_eq!(Some("signed"), response.trailer_value("X-SIGNATURE"));
+  assert_eq!(
+    concat!(
+      "HTTP/1.1 200 OK\r\n",
+      "Transfer-Encoding: chunked\r\n",
+      "\r\n",
+      "5\r\n",
+      "hello\r\n",
+      "0\r\n",
+      "X-Trace: abc\r\n",
+      "X-Signature: signed\r\n",
+      "\r\n"
+    )
+    .as_bytes(),
+    serialized.as_slice()
+  );
+}
+
+#[test]
 fn rejects_response_headers_with_crlf() {
   let result = std::panic::catch_unwind(|| {
     let _response = HttpResponse::new(302, "Found").header("Location", "/safe\r\nX-Evil: true");
+  });
+
+  assert!(result.is_err());
+}
+
+#[test]
+fn rejects_response_trailers_with_crlf() {
+  let result = std::panic::catch_unwind(|| {
+    let _response = HttpResponse::new(200, "OK").trailer("X-Trace", "safe\r\nX-Evil: true");
   });
 
   assert!(result.is_err());

--- a/rttp/tests/test_server_models.rs
+++ b/rttp/tests/test_server_models.rs
@@ -319,6 +319,25 @@ fn rejects_response_trailers_with_crlf() {
 }
 
 #[test]
+fn rejects_forbidden_response_trailer_names() {
+  for name in [
+    "Content-Length",
+    "transfer-encoding",
+    "Host",
+    "Connection",
+    "TE",
+    "Trailer",
+    "Upgrade",
+  ] {
+    let result = std::panic::catch_unwind(|| {
+      let _response = HttpResponse::new(200, "OK").trailer(name, "unsafe");
+    });
+
+    assert!(result.is_err(), "{name} trailer should be rejected");
+  }
+}
+
+#[test]
 fn serializes_empty_http_response_without_content_length_for_204() {
   let response = HttpResponse::new(204, "No Content");
 


### PR DESCRIPTION
Implemented server-side `HttpResponse` trailer support, including builder/accessor APIs, chunked trailer serialization, validation coverage, and README usage notes.

## Metadata
```yaml
version: 1
issue: default:ec01c9b4-06e1-4e6b-ad11-d99efe89f485
work_kind: code_work
branch: hbx-1300-rttp-add-httpresponse-trailer-api
base: main
commit: e0fd6c97bfc2961ac3d8dcc39c65645893fbc5b9
```