### PR TITLE
feat: [rttp] Normalize HTTP/1.1 connection persistence and close semantics

### DIFF
--- a/rttp/src/server.rs
+++ b/rttp/src/server.rs
@@ -130,7 +130,7 @@ impl HttpServer {
       let close_after_response =
         request_closes_connection || response_closes_connection || served == request_limit;
       let default_connection = if close_after_response {
-        DefaultConnectionHeader::Close
+        DefaultConnectionHeader::ForceClose
       } else if request_uses_http10_defaults {
         DefaultConnectionHeader::KeepAlive
       } else {
@@ -172,7 +172,7 @@ impl HttpServer {
     let response = handler(request);
     self.normalize_connection_error(response.write_to_with_default_connection_and_body(
       reader.get_mut(),
-      DefaultConnectionHeader::Close,
+      DefaultConnectionHeader::ForceClose,
       !request_is_head,
     ))
   }
@@ -603,6 +603,7 @@ pub struct HttpResponse {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum DefaultConnectionHeader {
   Close,
+  ForceClose,
   KeepAlive,
   Omit,
 }
@@ -702,7 +703,7 @@ impl HttpResponse {
       if !header.name.eq_ignore_ascii_case("Content-Length")
         && (self.allows_body() || !header.name.eq_ignore_ascii_case("Transfer-Encoding"))
         && (!header.name.eq_ignore_ascii_case("Connection")
-          || (default_connection != DefaultConnectionHeader::Close
+          || (default_connection != DefaultConnectionHeader::ForceClose
             && Some(index) == connection_header_index))
       {
         write!(writer, "{}: {}\r\n", header.name, header.value)?;
@@ -712,9 +713,13 @@ impl HttpResponse {
     if self.allows_body() && !self.uses_chunked_transfer_encoding() {
       write!(writer, "Content-Length: {}\r\n", self.body.len())?;
     }
-    if default_connection == DefaultConnectionHeader::Close || connection_header_index.is_none() {
+    if default_connection == DefaultConnectionHeader::ForceClose
+      || connection_header_index.is_none()
+    {
       match default_connection {
-        DefaultConnectionHeader::Close => writer.write_all(b"Connection: close\r\n")?,
+        DefaultConnectionHeader::Close | DefaultConnectionHeader::ForceClose => {
+          writer.write_all(b"Connection: close\r\n")?
+        }
         DefaultConnectionHeader::KeepAlive => writer.write_all(b"Connection: keep-alive\r\n")?,
         DefaultConnectionHeader::Omit => {}
       }

--- a/rttp/src/server.rs
+++ b/rttp/src/server.rs
@@ -702,7 +702,8 @@ impl HttpResponse {
       if !header.name.eq_ignore_ascii_case("Content-Length")
         && (self.allows_body() || !header.name.eq_ignore_ascii_case("Transfer-Encoding"))
         && (!header.name.eq_ignore_ascii_case("Connection")
-          || Some(index) == connection_header_index)
+          || (default_connection != DefaultConnectionHeader::Close
+            && Some(index) == connection_header_index))
       {
         write!(writer, "{}: {}\r\n", header.name, header.value)?;
       }
@@ -711,7 +712,7 @@ impl HttpResponse {
     if self.allows_body() && !self.uses_chunked_transfer_encoding() {
       write!(writer, "Content-Length: {}\r\n", self.body.len())?;
     }
-    if connection_header_index.is_none() {
+    if default_connection == DefaultConnectionHeader::Close || connection_header_index.is_none() {
       match default_connection {
         DefaultConnectionHeader::Close => writer.write_all(b"Connection: close\r\n")?,
         DefaultConnectionHeader::KeepAlive => writer.write_all(b"Connection: keep-alive\r\n")?,

--- a/rttp/tests/test_server.rs
+++ b/rttp/tests/test_server.rs
@@ -1968,6 +1968,29 @@ fn server_stops_one_connection_after_connection_close_request() {
 }
 
 #[test]
+fn server_overrides_keep_alive_response_header_when_it_will_close() {
+  let server = rttp::Http::server("127.0.0.1:0").expect("bind server");
+  let addr = server.local_addr().expect("server addr");
+
+  let handle = thread::spawn(move || {
+    server
+      .serve_requests(1, |_request| {
+        HttpResponse::ok("terminal").header("Connection", "keep-alive")
+      })
+      .expect("serve request");
+  });
+
+  let response = send_request(addr, b"GET /terminal HTTP/1.1\r\nHost: localhost\r\n\r\n");
+
+  assert_eq!(
+    "HTTP/1.1 200 OK\r\nContent-Length: 8\r\nConnection: close\r\n\r\nterminal",
+    response
+  );
+
+  handle.join().expect("server thread");
+}
+
+#[test]
 fn response_write_to_omits_content_length_and_body_for_204() {
   let response = HttpResponse::new(204, "No Content").body("ignored");
   let mut serialized = Vec::new();

--- a/rttp/tests/test_server_models.rs
+++ b/rttp/tests/test_server_models.rs
@@ -248,6 +248,28 @@ fn serializes_at_most_one_connection_header() {
 }
 
 #[test]
+fn write_to_preserves_explicit_connection_header() {
+  let response = HttpResponse::ok("ok").header("Connection", "keep-alive");
+  let mut serialized = Vec::new();
+
+  response
+    .write_to(&mut serialized)
+    .expect("response should serialize");
+
+  assert_eq!(
+    concat!(
+      "HTTP/1.1 200 OK\r\n",
+      "Connection: keep-alive\r\n",
+      "Content-Length: 2\r\n",
+      "\r\n",
+      "ok"
+    )
+    .as_bytes(),
+    serialized.as_slice()
+  );
+}
+
+#[test]
 fn serializes_chunked_response_body_when_transfer_encoding_is_chunked() {
   let response = HttpResponse::new(200, "OK")
     .header("Transfer-Encoding", "chunked")

--- a/rttp_client/tests/support/mod.rs
+++ b/rttp_client/tests/support/mod.rs
@@ -417,6 +417,37 @@ pub fn spawn_keep_alive_server() -> (SocketAddr, JoinHandle<()>) {
   (addr, handle)
 }
 
+pub fn spawn_eof_delimited_response_server(body: &'static str) -> (SocketAddr, JoinHandle<()>) {
+  let (listener, addr) = bind_local_http_listener("eof delimited response server");
+  let handle = thread::spawn(move || {
+    if let Ok((mut stream, _)) = listener.accept() {
+      let _ = read_http_request(&mut stream);
+      let response = concat!("HTTP/1.1 200 OK\r\n", "Connection: close\r\n", "\r\n");
+      let _ = stream.write_all(response.as_bytes());
+      let _ = stream.write_all(body.as_bytes());
+    }
+  });
+  (addr, handle)
+}
+
+pub fn spawn_truncated_content_length_server() -> (SocketAddr, JoinHandle<()>) {
+  let (listener, addr) = bind_local_http_listener("truncated content length server");
+  let handle = thread::spawn(move || {
+    if let Ok((mut stream, _)) = listener.accept() {
+      let _ = read_http_request(&mut stream);
+      let response = concat!(
+        "HTTP/1.1 200 OK\r\n",
+        "Content-Length: 10\r\n",
+        "Connection: close\r\n",
+        "\r\n",
+        "short"
+      );
+      let _ = stream.write_all(response.as_bytes());
+    }
+  });
+  (addr, handle)
+}
+
 pub fn spawn_continue_then_ok_server() -> (SocketAddr, JoinHandle<()>) {
   spawn_informational_then_ok_server("100 Continue")
 }

--- a/rttp_client/tests/test_http_async.rs
+++ b/rttp_client/tests/test_http_async.rs
@@ -691,6 +691,42 @@ fn test_async_http_proxy_with_auth_uses_proxy_authorization_header() {
 
 #[test]
 #[cfg(feature = "async")]
+fn test_async_eof_delimited_response_body_is_read_to_connection_close() {
+  let (addr, _handle) = support::spawn_eof_delimited_response_server("async eof body");
+  block_on(async {
+    let response = client().url(format!("http://{}/eof", addr)).rasync().await;
+
+    assert!(response.is_ok());
+    let response = response.unwrap();
+    assert_eq!("async eof body", response.body().string().unwrap());
+    assert_eq!(
+      Some(&"close".to_string()),
+      response.header_value("Connection")
+    );
+  });
+}
+
+#[test]
+#[cfg(feature = "async")]
+fn test_async_truncated_content_length_response_is_rejected() {
+  let (addr, _handle) = support::spawn_truncated_content_length_server();
+  block_on(async {
+    let error = client()
+      .url(format!("http://{}/truncated", addr))
+      .rasync()
+      .await
+      .expect_err("truncated fixed-length body should be rejected");
+
+    assert!(
+      error.to_string().contains("failed to fill whole buffer")
+        || error.to_string().contains("unexpected end of file"),
+      "unexpected error: {error}"
+    );
+  });
+}
+
+#[test]
+#[cfg(feature = "async")]
 fn test_async_proxy_socks5() {
   let (addr, _handle) = support::spawn_http_server();
   let (proxy_addr, _proxy_handle) = support::spawn_socks5_proxy_server();

--- a/rttp_client/tests/test_http_basic.rs
+++ b/rttp_client/tests/test_http_basic.rs
@@ -786,6 +786,35 @@ fn test_connection_closed() {
 }
 
 #[test]
+fn test_eof_delimited_response_body_is_read_to_connection_close() {
+  let (addr, _handle) = support::spawn_eof_delimited_response_server("connection delimited");
+  let response = client().url(format!("http://{}/eof", addr)).emit();
+
+  assert!(response.is_ok());
+  let response = response.unwrap();
+  assert_eq!("connection delimited", response.body().string().unwrap());
+  assert_eq!(
+    Some(&"close".to_string()),
+    response.header_value("Connection")
+  );
+}
+
+#[test]
+fn test_truncated_content_length_response_is_rejected() {
+  let (addr, _handle) = support::spawn_truncated_content_length_server();
+  let error = client()
+    .url(format!("http://{}/truncated", addr))
+    .emit()
+    .expect_err("truncated fixed-length body should be rejected");
+
+  assert!(
+    error.to_string().contains("failed to fill whole buffer")
+      || error.to_string().contains("unexpected end of file"),
+    "unexpected error: {error}"
+  );
+}
+
+#[test]
 fn test_basic_auth() {
   let (addr, _handle) = support::spawn_auth_echo_server();
   let response = client()


### PR DESCRIPTION
Implemented explicit HTTP connection close normalization for server responses and added live sync/async client coverage for EOF-delimited responses and truncated fixed-length bodies. Verified with formatting, focused connection tests, and the full workspace test suite.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1306/
work_kind: code_work
branch: hbx-1306-rttp-normalize-http-1-1
base: main
commit: 9b75d1f5ab31917c81bdb5c442f8731d5ca37350
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1306/
    url: https://plane.kahub.in/endless/browse/HBX-1306/
    close_policy: link_only
```