### PR TITLE
feat: [rttp] Enforce Host and request-target validation consistently

### DIFF
--- a/rttp/src/server.rs
+++ b/rttp/src/server.rs
@@ -1103,23 +1103,22 @@ fn validate_host_header(
     ));
   }
 
-  if matches!(
-    request_target_form(target),
-    Some(
-      RequestTargetForm::Origin
-        | RequestTargetForm::Absolute
-        | RequestTargetForm::Asterisk
-        | RequestTargetForm::Authority
-    )
-  ) && is_valid_host_authority(host, false)
-  {
-    Ok(())
-  } else {
-    Err(io::Error::new(
+  let host_matches_target = match request_target_form(target) {
+    Some(RequestTargetForm::Origin | RequestTargetForm::Absolute | RequestTargetForm::Asterisk) => {
+      true
+    }
+    Some(RequestTargetForm::Authority) => host == target,
+    None => false,
+  };
+
+  if !host_matches_target || !is_valid_host_authority(host, false) {
+    return Err(io::Error::new(
       io::ErrorKind::InvalidData,
       "invalid Host header",
-    ))
+    ));
   }
+
+  Ok(())
 }
 
 fn is_http_token(value: &str) -> bool {

--- a/rttp/src/server.rs
+++ b/rttp/src/server.rs
@@ -891,7 +891,7 @@ fn parse_request_head(raw: &[u8]) -> io::Result<RequestHead> {
   validate_request_line(method, target, version)?;
 
   let headers = parse_header_lines(lines)?;
-  validate_host_header_count(version, &headers)?;
+  validate_host_header(version, target, &headers)?;
 
   Ok(RequestHead {
     method: method.to_string(),
@@ -976,7 +976,7 @@ fn is_absolute_form_target(target: &str) -> bool {
   }
 
   let authority_end = rest.find(['/', '?']).unwrap_or(rest.len());
-  authority_end > 0
+  is_valid_host_authority(&rest[..authority_end], false)
 }
 
 fn is_uri_scheme(scheme: &str) -> bool {
@@ -989,17 +989,62 @@ fn is_uri_scheme(scheme: &str) -> bool {
 }
 
 fn is_authority_form_target(target: &str) -> bool {
-  if target
-    .bytes()
-    .any(|byte| matches!(byte, b'/' | b'?' | b'#'))
+  is_valid_host_authority(target, true)
+}
+
+fn is_valid_host_authority(authority: &str, require_port: bool) -> bool {
+  if authority.is_empty()
+    || authority
+      .bytes()
+      .any(|byte| matches!(byte, b'/' | b'?' | b'#' | b'@'))
   {
     return false;
   }
 
-  let Some((host, port)) = target.rsplit_once(':') else {
+  if let Some(rest) = authority.strip_prefix('[') {
+    let Some(end) = rest.find(']') else {
+      return false;
+    };
+    let host = &rest[..end];
+    let suffix = &rest[end + 1..];
+    if host.is_empty() || host.bytes().any(|byte| matches!(byte, b'[' | b']')) {
+      return false;
+    }
+    return validate_host_port_suffix(suffix, require_port);
+  }
+
+  let colon_count = authority.bytes().filter(|byte| *byte == b':').count();
+  match colon_count {
+    0 => !require_port && is_valid_reg_name_or_ipv4(authority),
+    1 => {
+      let Some((host, port)) = authority.rsplit_once(':') else {
+        return false;
+      };
+      is_valid_reg_name_or_ipv4(host) && is_valid_port(port)
+    }
+    _ => false,
+  }
+}
+
+fn validate_host_port_suffix(suffix: &str, require_port: bool) -> bool {
+  if suffix.is_empty() {
+    return !require_port;
+  }
+  let Some(port) = suffix.strip_prefix(':') else {
     return false;
   };
-  !host.is_empty() && !port.is_empty() && port.bytes().all(|byte| byte.is_ascii_digit())
+  is_valid_port(port)
+}
+
+fn is_valid_reg_name_or_ipv4(host: &str) -> bool {
+  !host.is_empty()
+    && host
+      .bytes()
+      .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'.' | b'_'))
+}
+
+fn is_valid_port(port: &str) -> bool {
+  !port.is_empty() && port.bytes().all(|byte| byte.is_ascii_digit())
 }
 
 fn parse_header_lines<'a>(
@@ -1032,22 +1077,47 @@ fn parse_header_lines<'a>(
   Ok(headers)
 }
 
-fn validate_host_header_count(version: &str, headers: &[(String, String)]) -> io::Result<()> {
+fn validate_host_header(
+  version: &str,
+  target: &str,
+  headers: &[(String, String)],
+) -> io::Result<()> {
   if version != "HTTP/1.1" {
     return Ok(());
   }
 
-  let host_header_count = headers
+  let mut host_headers = headers
     .iter()
-    .filter(|(name, _)| name.eq_ignore_ascii_case("Host"))
-    .count();
+    .filter(|(name, _)| name.eq_ignore_ascii_case("Host"));
+  let Some((_, host)) = host_headers.next() else {
+    return Err(io::Error::new(
+      io::ErrorKind::InvalidData,
+      "HTTP/1.1 request requires exactly one Host header",
+    ));
+  };
 
-  if host_header_count == 1 {
+  if host_headers.next().is_some() {
+    return Err(io::Error::new(
+      io::ErrorKind::InvalidData,
+      "HTTP/1.1 request requires exactly one Host header",
+    ));
+  }
+
+  if matches!(
+    request_target_form(target),
+    Some(
+      RequestTargetForm::Origin
+        | RequestTargetForm::Absolute
+        | RequestTargetForm::Asterisk
+        | RequestTargetForm::Authority
+    )
+  ) && is_valid_host_authority(host, false)
+  {
     Ok(())
   } else {
     Err(io::Error::new(
       io::ErrorKind::InvalidData,
-      "HTTP/1.1 request requires exactly one Host header",
+      "invalid Host header",
     ))
   }
 }

--- a/rttp/tests/test_server.rs
+++ b/rttp/tests/test_server.rs
@@ -751,6 +751,10 @@ fn server_rejects_request_target_forms_for_wrong_methods() {
 #[test]
 fn server_returns_bad_request_for_invalid_absolute_form_target() {
   assert_bad_request_without_handler(b"GET http:///path HTTP/1.1\r\nHost: localhost\r\n\r\n");
+  assert_bad_request_without_handler(b"GET http://:80/path HTTP/1.1\r\nHost: localhost\r\n\r\n");
+  assert_bad_request_without_handler(
+    b"GET http://example.test:port/path HTTP/1.1\r\nHost: localhost\r\n\r\n",
+  );
   assert_bad_request_without_handler(
     b"GET http://example.test/path#frag HTTP/1.1\r\nHost: localhost\r\n\r\n",
   );
@@ -1639,6 +1643,62 @@ fn server_rejects_invalid_second_request_target_on_kept_alive_connection() {
 
     handle.join().expect("server thread");
   }
+}
+
+#[test]
+fn server_rejects_invalid_second_host_without_corrupting_kept_alive_connection() {
+  let server = rttp::Http::server("127.0.0.1:0").expect("bind server");
+  let addr = server.local_addr().expect("server addr");
+  let (handler_tx, handler_rx) = mpsc::channel();
+  let (done_tx, done_rx) = mpsc::channel();
+
+  let handle = thread::spawn(move || {
+    let result = server.serve_requests(2, |request| {
+      let target = request.target().to_string();
+      handler_tx.send(target.clone()).expect("send parsed target");
+      HttpResponse::ok(format!("served {target}"))
+    });
+    done_tx.send(result).expect("send server result");
+  });
+
+  let mut stream = TcpStream::connect(addr).expect("connect server");
+  stream
+    .write_all(
+      concat!(
+        "GET /first HTTP/1.1\r\n",
+        "Host: localhost\r\n",
+        "Connection: keep-alive\r\n",
+        "\r\n",
+        "GET /second HTTP/1.1\r\n",
+        "Host: localhost/path\r\n",
+        "Connection: keep-alive\r\n",
+        "\r\n"
+      )
+      .as_bytes(),
+    )
+    .expect("write pipelined requests");
+  stream
+    .shutdown(std::net::Shutdown::Write)
+    .expect("shutdown write");
+
+  let mut response = String::new();
+  stream.read_to_string(&mut response).expect("read response");
+
+  assert_eq!(
+    concat!(
+      "HTTP/1.1 200 OK\r\nContent-Length: 13\r\n\r\nserved /first",
+      "HTTP/1.1 400 Bad Request\r\nContent-Length: 11\r\nConnection: close\r\n\r\nBad Request",
+    ),
+    response
+  );
+  assert_eq!("/first", handler_rx.recv().expect("receive first target"));
+  assert!(handler_rx.try_recv().is_err());
+  let result = done_rx
+    .recv_timeout(Duration::from_millis(250))
+    .expect("serve_requests returned after rejected second request");
+  assert!(result.is_ok(), "serve_requests failed: {result:?}");
+
+  handle.join().expect("server thread");
 }
 
 #[test]

--- a/rttp/tests/test_server.rs
+++ b/rttp/tests/test_server.rs
@@ -728,7 +728,7 @@ fn server_accepts_options_asterisk_request_target() {
 #[test]
 fn server_accepts_connect_authority_request_target() {
   let (response, handler_called) =
-    send_raw_request(b"CONNECT example.test:443 HTTP/1.1\r\nHost: example.test\r\n\r\n");
+    send_raw_request(b"CONNECT example.test:443 HTTP/1.1\r\nHost: example.test:443\r\n\r\n");
 
   assert!(handler_called);
   assert_eq!(

--- a/rttp/tests/test_server_models.rs
+++ b/rttp/tests/test_server_models.rs
@@ -163,6 +163,18 @@ fn rejects_http_11_request_with_invalid_host_header_value() {
 }
 
 #[test]
+fn rejects_connect_request_when_host_does_not_match_authority_target() {
+  for raw in [
+    b"CONNECT example.test:443 HTTP/1.1\r\nHost: other.test\r\n\r\n".as_slice(),
+    b"CONNECT example.test:443 HTTP/1.1\r\nHost: example.test\r\n\r\n",
+  ] {
+    let error = HttpRequest::parse(raw).expect_err("request should be rejected");
+
+    assert_eq!("invalid Host header", error.to_string());
+  }
+}
+
+#[test]
 fn accepts_http_10_request_without_host_header() {
   let request = HttpRequest::parse(b"GET /legacy HTTP/1.0\r\n\r\n").expect("request should parse");
 

--- a/rttp/tests/test_server_models.rs
+++ b/rttp/tests/test_server_models.rs
@@ -98,6 +98,10 @@ fn rejects_malformed_request_line_and_request_metadata() {
     b"GET / HTTP/2.0\r\nHost: example.test\r\n\r\n",
     b"GE(T / HTTP/1.1\r\nHost: example.test\r\n\r\n",
     b"GET /bad path HTTP/1.1\r\nHost: example.test\r\n\r\n",
+    b"GET http://:80/path HTTP/1.1\r\nHost: example.test\r\n\r\n",
+    b"GET http://example.test:port/path HTTP/1.1\r\nHost: example.test\r\n\r\n",
+    b"CONNECT example.test HTTP/1.1\r\nHost: example.test\r\n\r\n",
+    b"CONNECT example.test:port HTTP/1.1\r\nHost: example.test\r\n\r\n",
   ] {
     let _error = HttpRequest::parse(raw).expect_err("request should be rejected");
   }
@@ -142,6 +146,20 @@ fn rejects_http_11_request_with_multiple_host_headers() {
     "HTTP/1.1 request requires exactly one Host header",
     error.to_string()
   );
+}
+
+#[test]
+fn rejects_http_11_request_with_invalid_host_header_value() {
+  for raw in [
+    b"GET / HTTP/1.1\r\nHost: \r\n\r\n".as_slice(),
+    b"GET / HTTP/1.1\r\nHost: http://example.test\r\n\r\n",
+    b"GET / HTTP/1.1\r\nHost: example.test/path\r\n\r\n",
+    b"GET / HTTP/1.1\r\nHost: example.test:port\r\n\r\n",
+  ] {
+    let error = HttpRequest::parse(raw).expect_err("request should be rejected");
+
+    assert_eq!("invalid Host header", error.to_string());
+  }
 }
 
 #[test]

--- a/rttp_client/src/request/builder/build_header.rs
+++ b/rttp_client/src/request/builder/build_header.rs
@@ -23,7 +23,7 @@ impl<'a> RawBuilder<'a> {
     let mut builder = String::new();
 
     // let is_http = url.scheme() == "http";
-    let request_url = self.request_url(&url, false);
+    let request_url = self.request_url(&url, false)?;
     builder.push_str(&format!(
       "{} {} HTTP/1.1{}",
       self.request.method().to_uppercase(),
@@ -44,16 +44,20 @@ impl<'a> RawBuilder<'a> {
 }
 
 impl<'a> RawBuilder<'a> {
-  fn request_url(&self, url: &Url, full: bool) -> String {
+  fn request_url(&self, url: &Url, full: bool) -> error::Result<String> {
     if full {
-      return url.as_str().to_owned();
+      return Ok(url.as_str().to_owned());
+    }
+
+    if self.request.method().eq_ignore_ascii_case("connect") {
+      return connect_authority(url);
     }
 
     let mut result = url.path().to_string();
     if let Some(query) = url.query() {
       result.push_str(&format!("?{}", query));
     }
-    result
+    Ok(result)
   }
 
   fn found_header(&mut self, name: impl AsRef<str>) -> bool {
@@ -65,15 +69,47 @@ impl<'a> RawBuilder<'a> {
   }
 }
 
+fn connect_authority(url: &Url) -> error::Result<String> {
+  let host = url.host_str().ok_or(error::url_bad_host(url.clone()))?;
+  let port = url
+    .port_or_known_default()
+    .ok_or(error::url_bad_host(url.clone()))?;
+
+  Ok(format!("{}:{}", format_host_for_authority(host), port))
+}
+
+fn format_host_for_authority(host: &str) -> String {
+  if host.contains(':') && !host.starts_with('[') {
+    format!("[{}]", host)
+  } else {
+    host.to_string()
+  }
+}
+
 impl<'a> RawBuilder<'a> {
   fn auto_add_host(&mut self, url: &Url) -> error::Result<()> {
     if self.found_header("host") {
       return Ok(());
     }
     let host = url.host_str().ok_or(error::url_bad_host(url.clone()))?;
-    let header = match url.port() {
-      Some(port) => Header::new("Host", format!("{}:{}", host, port)),
-      None => Header::new("Host", host),
+    let host = format_host_for_authority(host);
+    let header = match (
+      self.request.method().eq_ignore_ascii_case("connect"),
+      url.port(),
+    ) {
+      (true, Some(port)) => Header::new("Host", format!("{}:{}", host, port)),
+      (true, None) => Header::new(
+        "Host",
+        format!(
+          "{}:{}",
+          host,
+          url
+            .port_or_known_default()
+            .ok_or(error::url_bad_host(url.clone()))?
+        ),
+      ),
+      (false, Some(port)) => Header::new("Host", format!("{}:{}", host, port)),
+      (false, None) => Header::new("Host", host),
     };
 
     self.request.headers_mut().push(header);

--- a/rttp_client/tests/test_raw_request_capture.rs
+++ b/rttp_client/tests/test_raw_request_capture.rs
@@ -317,3 +317,20 @@ fn custom_common_headers_are_not_overwritten_by_auto_headers() {
   assert_eq!(Some("application/json"), header_value(&text, "Accept"));
   assert_eq!(Some("keep-alive"), header_value(&text, "Connection"));
 }
+
+#[test]
+fn connect_method_uses_authority_form_request_target() {
+  let request = capture_request(|base_url| {
+    client()
+      .method("CONNECT")
+      .url(base_url)
+      .emit()
+      .expect("request should succeed");
+  });
+
+  let text = request_text(&request);
+  let request_line = text.lines().next().expect("request line");
+  let host = header_value(&text, "Host").expect("host header");
+
+  assert_eq!(format!("CONNECT {} HTTP/1.1", host), request_line);
+}


### PR DESCRIPTION
Implemented consistent HTTP/1.1 Host validation and request-target handling across the rttp server parser and client request builder. Invalid Host and malformed authority/absolute targets are now rejected server-side, kept-alive bad-request behavior is covered, and client CONNECT serialization now emits authority-form targets with matching Host handling. Formatting, focused tests, and full rttp/rttp_client test suites pass.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1307/
work_kind: code_work
branch: hbx-1307-rttp-enforce-host-and-request
base: main
commit: e38589a5323ad515fa99a0a437f1fca28b18b608
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1307/
    url: https://plane.kahub.in/endless/browse/HBX-1307/
    close_policy: link_only
```