### PR TITLE
feat: [rttp] Align Expect 100-continue across server and sync/async clients

### DIFF
--- a/rttp/tests/test_server.rs
+++ b/rttp/tests/test_server.rs
@@ -585,6 +585,51 @@ fn server_returns_bad_request_for_unsupported_expectation_without_calling_handle
 }
 
 #[test]
+fn server_rejects_unsupported_expectation_before_body_is_sent() {
+  let server = rttp::Http::server("127.0.0.1:0").expect("bind server");
+  let addr = server.local_addr().expect("server addr");
+  let (tx, rx) = mpsc::channel();
+
+  let handle = thread::spawn(move || {
+    server
+      .accept_one(|request| {
+        tx.send(request).expect("send parsed request");
+        HttpResponse::ok("unexpected")
+      })
+      .expect("serve one request");
+  });
+
+  let mut stream = TcpStream::connect(addr).expect("connect server");
+  stream
+    .set_read_timeout(Some(Duration::from_millis(250)))
+    .expect("set read timeout");
+  stream
+    .write_all(
+      concat!(
+        "POST /submit HTTP/1.1\r\n",
+        "Host: localhost\r\n",
+        "Expect: magic\r\n",
+        "Content-Length: 5\r\n",
+        "\r\n"
+      )
+      .as_bytes(),
+    )
+    .expect("write request head");
+
+  let expected =
+    b"HTTP/1.1 400 Bad Request\r\nContent-Length: 11\r\nConnection: close\r\n\r\nBad Request";
+  let mut response = vec![0; expected.len()];
+  stream
+    .read_exact(&mut response)
+    .expect("read final response");
+
+  assert_eq!(expected, response.as_slice());
+  assert!(rx.try_recv().is_err());
+
+  handle.join().expect("server thread");
+}
+
+#[test]
 fn server_returns_bad_request_for_expect_with_conflicting_body_framing_without_continue() {
   let (response, handler_called) = send_raw_request(
     concat!(

--- a/rttp_client/src/connection/async_connection.rs
+++ b/rttp_client/src/connection/async_connection.rs
@@ -8,7 +8,10 @@ use url::Url;
 #[cfg(feature = "tls-rustls")]
 use std::sync::Arc;
 
-use crate::connection::connection::{connect_tcp_stream, read_proxy_connect_response, Connection};
+use crate::connection::connection::{
+  connect_tcp_stream, read_proxy_connect_response, request_expects_continue, Connection,
+  ExpectContinueResult,
+};
 use crate::connection::connection_reader::{
   is_skippable_informational_status, response_body_kind, response_status_code, ResponseBodyKind,
   ResponseParts, MAX_CHUNKED_RESPONSE_LINE_BYTES,
@@ -109,6 +112,34 @@ impl<'a> AsyncConnection<'a> {
     Ok(())
   }
 
+  async fn async_write_request_header_with<S>(
+    &self,
+    stream: &mut S,
+    header: &str,
+  ) -> error::Result<()>
+  where
+    S: AsyncWrite + Unpin,
+  {
+    stream
+      .write_all(header.as_bytes())
+      .await
+      .map_err(error::request)?;
+    stream.flush().await.map_err(error::request)
+  }
+
+  async fn async_write_request_body<S>(&self, stream: &mut S) -> error::Result<()>
+  where
+    S: AsyncWrite + Unpin,
+  {
+    if let Some(body) = self.conn.body() {
+      stream
+        .write_all(body.bytes())
+        .await
+        .map_err(error::request)?;
+    }
+    stream.flush().await.map_err(error::request)
+  }
+
   async fn async_read_stream_parts<S>(
     &self,
     _url: &Url,
@@ -117,7 +148,7 @@ impl<'a> AsyncConnection<'a> {
   where
     S: AsyncRead + Unpin,
   {
-    let mut binary = loop {
+    let binary = loop {
       let header = async_read_response_header(stream).await?;
       let status_code = response_status_code(&header)?;
       if is_skippable_informational_status(status_code) {
@@ -125,6 +156,19 @@ impl<'a> AsyncConnection<'a> {
       }
       break header;
     };
+    self
+      .async_read_stream_parts_after_header(stream, binary)
+      .await
+  }
+
+  async fn async_read_stream_parts_after_header<S>(
+    &self,
+    stream: &mut S,
+    mut binary: Vec<u8>,
+  ) -> error::Result<ResponseParts>
+  where
+    S: AsyncRead + Unpin,
+  {
     let mut trailers = Vec::new();
     match response_body_kind(&binary, self.conn.expect_no_response_body())? {
       ResponseBodyKind::NoBody => {}
@@ -149,6 +193,48 @@ impl<'a> AsyncConnection<'a> {
       }
     }
     Ok(ResponseParts { binary, trailers })
+  }
+
+  async fn async_send_expect_continue_parts<S>(
+    &self,
+    stream: &mut S,
+  ) -> error::Result<ExpectContinueResult>
+  where
+    S: AsyncRead + AsyncWrite + Unpin,
+  {
+    self
+      .async_send_expect_continue_parts_with_header(stream, self.conn.header())
+      .await
+  }
+
+  async fn async_send_expect_continue_parts_with_header<S>(
+    &self,
+    stream: &mut S,
+    header: &str,
+  ) -> error::Result<ExpectContinueResult>
+  where
+    S: AsyncRead + AsyncWrite + Unpin,
+  {
+    if !request_expects_continue(header, self.conn.body().as_ref()) {
+      return Ok(ExpectContinueResult::NotUsed);
+    }
+
+    self.async_write_request_header_with(stream, header).await?;
+    loop {
+      let header = async_read_response_header(stream).await?;
+      let status_code = response_status_code(&header)?;
+      if status_code == 100 {
+        self.async_write_request_body(stream).await?;
+        return Ok(ExpectContinueResult::BodySent);
+      }
+      if is_skippable_informational_status(status_code) {
+        continue;
+      }
+      return self
+        .async_read_stream_parts_after_header(stream, header)
+        .await
+        .map(ExpectContinueResult::Final);
+    }
   }
 }
 
@@ -318,7 +404,11 @@ impl<'a> AsyncConnection<'a> {
   where
     S: AsyncRead + AsyncWrite + Unpin,
   {
-    self.async_write_stream(stream).await?;
+    match self.async_send_expect_continue_parts(stream).await? {
+      ExpectContinueResult::NotUsed => self.async_write_stream(stream).await?,
+      ExpectContinueResult::BodySent => {}
+      ExpectContinueResult::Final(parts) => return Ok(parts),
+    }
     self.async_read_stream_parts(url, stream).await
   }
 
@@ -401,7 +491,14 @@ impl<'a> AsyncConnection<'a> {
       .await
       .map_err(|e| error::bad_ssl(e.to_string()))?;
 
-    self.async_write_stream(&mut tls_stream).await?;
+    match self
+      .async_send_expect_continue_parts(&mut tls_stream)
+      .await?
+    {
+      ExpectContinueResult::NotUsed => self.async_write_stream(&mut tls_stream).await?,
+      ExpectContinueResult::BodySent => {}
+      ExpectContinueResult::Final(parts) => return Ok(parts),
+    }
     self.async_read_stream_parts(url, &mut tls_stream).await
   }
 }
@@ -429,7 +526,14 @@ impl<'a> AsyncConnection<'a> {
     let mut stream = AllowStdIo::new(stream);
     let header = self.conn.proxy_http_header(url, proxy);
 
-    self.async_write_request(&mut stream, &header).await?;
+    match self
+      .async_send_expect_continue_parts_with_header(&mut stream, &header)
+      .await?
+    {
+      ExpectContinueResult::NotUsed => self.async_write_request(&mut stream, &header).await?,
+      ExpectContinueResult::BodySent => {}
+      ExpectContinueResult::Final(parts) => return Ok(parts),
+    }
     self.async_read_stream_parts(url, &mut stream).await
   }
 

--- a/rttp_client/src/connection/block_connection.rs
+++ b/rttp_client/src/connection/block_connection.rs
@@ -3,7 +3,7 @@ use std::io::Write;
 use socks::{Socks4Stream, Socks5Stream};
 use url::Url;
 
-use crate::connection::connection::Connection;
+use crate::connection::connection::{Connection, ExpectContinueResult};
 use crate::connection::connection_reader::ResponseParts;
 use crate::request::RawRequest;
 use crate::response::Response;
@@ -90,13 +90,22 @@ impl<'a> BlockConnection<'a> {
     let mut stream = self.conn.block_tcp_stream(&addr)?;
     let header = self.conn.proxy_http_header(url, proxy);
 
-    stream
-      .write_all(header.as_bytes())
-      .map_err(error::request)?;
-    if let Some(body) = self.conn.body() {
-      stream.write_all(body.bytes()).map_err(error::request)?;
+    match self
+      .conn
+      .block_send_expect_continue_parts_with_header(&mut stream, &header)?
+    {
+      ExpectContinueResult::NotUsed => {
+        stream
+          .write_all(header.as_bytes())
+          .map_err(error::request)?;
+        if let Some(body) = self.conn.body() {
+          stream.write_all(body.bytes()).map_err(error::request)?;
+        }
+        stream.flush().map_err(error::request)?;
+      }
+      ExpectContinueResult::BodySent => {}
+      ExpectContinueResult::Final(parts) => return Ok(parts),
     }
-    stream.flush().map_err(error::request)?;
 
     self.conn.block_read_stream_parts(url, &mut stream)
   }

--- a/rttp_client/src/connection/connection.rs
+++ b/rttp_client/src/connection/connection.rs
@@ -9,7 +9,10 @@ use std::sync::Arc;
 
 use url::Url;
 
-use crate::connection::connection_reader::{ConnectionReader, ResponseParts};
+use crate::connection::connection_reader::{
+  is_skippable_informational_status, read_response_header, read_response_parts_after_header,
+  response_status_code, ConnectionReader, ResponseParts,
+};
 use crate::request::{RawRequest, RequestBody};
 use crate::types::{Proxy, RoUrl, ToUrl};
 use crate::{error, Config};
@@ -299,6 +302,25 @@ where
   Ok(())
 }
 
+pub(crate) fn request_expects_continue(header: &str, body: Option<&RequestBody>) -> bool {
+  if body.is_none_or(|body| body.len() == 0) {
+    return false;
+  }
+
+  header.lines().skip(1).any(|line| {
+    let Some((name, value)) = line.split_once(':') else {
+      return false;
+    };
+    name.eq_ignore_ascii_case("Expect") && value.trim().eq_ignore_ascii_case("100-continue")
+  })
+}
+
+pub(crate) enum ExpectContinueResult {
+  NotUsed,
+  BodySent,
+  Final(ResponseParts),
+}
+
 pub(crate) fn parse_proxy_connect_response(header: &[u8]) -> error::Result<()> {
   let header = String::from_utf8(header.to_vec())
     .map_err(|_| error::bad_proxy("parse proxy server response error."))?;
@@ -409,6 +431,30 @@ impl<'a> Connection<'a> {
     write_http_request(stream, self.header(), self.body().as_ref())
   }
 
+  pub(crate) fn block_write_request_header_with<S>(
+    &self,
+    stream: &mut S,
+    header: &str,
+  ) -> error::Result<()>
+  where
+    S: io::Write,
+  {
+    stream
+      .write_all(header.as_bytes())
+      .map_err(error::request)?;
+    stream.flush().map_err(error::request)
+  }
+
+  fn block_write_request_body<S>(&self, stream: &mut S) -> error::Result<()>
+  where
+    S: io::Write,
+  {
+    if let Some(body) = self.body() {
+      stream.write_all(body.bytes()).map_err(error::request)?;
+    }
+    stream.flush().map_err(error::request)
+  }
+
   pub(crate) fn block_read_stream_parts<S>(
     &self,
     url: &Url,
@@ -419,6 +465,44 @@ impl<'a> Connection<'a> {
   {
     let mut reader = ConnectionReader::new(url, stream, self.expect_no_response_body());
     reader.response_parts()
+  }
+
+  pub(crate) fn block_send_expect_continue_parts<S>(
+    &self,
+    stream: &mut S,
+  ) -> error::Result<ExpectContinueResult>
+  where
+    S: io::Read + io::Write,
+  {
+    self.block_send_expect_continue_parts_with_header(stream, self.header())
+  }
+
+  pub(crate) fn block_send_expect_continue_parts_with_header<S>(
+    &self,
+    stream: &mut S,
+    header: &str,
+  ) -> error::Result<ExpectContinueResult>
+  where
+    S: io::Read + io::Write,
+  {
+    if !request_expects_continue(header, self.body().as_ref()) {
+      return Ok(ExpectContinueResult::NotUsed);
+    }
+
+    self.block_write_request_header_with(stream, header)?;
+    loop {
+      let header = read_response_header(stream)?;
+      let status_code = response_status_code(&header)?;
+      if status_code == 100 {
+        self.block_write_request_body(stream)?;
+        return Ok(ExpectContinueResult::BodySent);
+      }
+      if is_skippable_informational_status(status_code) {
+        continue;
+      }
+      return read_response_parts_after_header(stream, self.expect_no_response_body(), header)
+        .map(ExpectContinueResult::Final);
+    }
   }
 
   pub(crate) fn block_send_parts(&self, url: &Url) -> error::Result<ResponseParts> {
@@ -450,7 +534,11 @@ impl<'a> Connection<'a> {
   where
     S: io::Read + io::Write,
   {
-    self.block_write_stream(stream)?;
+    match self.block_send_expect_continue_parts(stream)? {
+      ExpectContinueResult::NotUsed => self.block_write_stream(stream)?,
+      ExpectContinueResult::BodySent => {}
+      ExpectContinueResult::Final(parts) => return Ok(parts),
+    }
     self.block_read_stream_parts(url, stream)
   }
 
@@ -510,7 +598,11 @@ impl<'a> Connection<'a> {
       .connect(&self.host(url)?[..], stream)
       .map_err(|_| error::bad_ssl("Native tls handshake error"))?;
 
-    self.block_write_stream(&mut ssl_stream)?;
+    match self.block_send_expect_continue_parts(&mut ssl_stream)? {
+      ExpectContinueResult::NotUsed => self.block_write_stream(&mut ssl_stream)?,
+      ExpectContinueResult::BodySent => {}
+      ExpectContinueResult::Final(parts) => return Ok(parts),
+    }
     self.block_read_stream_parts(url, &mut ssl_stream)
   }
 
@@ -560,7 +652,11 @@ impl<'a> Connection<'a> {
       ClientConnection::new(rc_config, server_name).map_err(|e| error::bad_ssl(e.to_string()))?;
     let mut tls = StreamOwned::new(client, stream);
 
-    self.block_write_stream(&mut tls)?;
+    match self.block_send_expect_continue_parts(&mut tls)? {
+      ExpectContinueResult::NotUsed => self.block_write_stream(&mut tls)?,
+      ExpectContinueResult::BodySent => {}
+      ExpectContinueResult::Final(parts) => return Ok(parts),
+    }
     self.block_read_stream_parts(url, &mut tls)
   }
 }

--- a/rttp_client/src/connection/connection_reader.rs
+++ b/rttp_client/src/connection/connection_reader.rs
@@ -69,7 +69,7 @@ pub(crate) fn read_response_parts<R>(
 where
   R: Read + ?Sized,
 {
-  let mut binary = loop {
+  let binary = loop {
     let header = read_response_header(reader)?;
     let status_code = response_status_code(&header)?;
     if is_skippable_informational_status(status_code) {
@@ -77,6 +77,17 @@ where
     }
     break header;
   };
+  read_response_parts_after_header(reader, expect_no_body, binary)
+}
+
+pub(crate) fn read_response_parts_after_header<R>(
+  reader: &mut R,
+  expect_no_body: bool,
+  mut binary: Vec<u8>,
+) -> error::Result<ResponseParts>
+where
+  R: Read + ?Sized,
+{
   let mut trailers = Vec::new();
   match response_body_kind(&binary, expect_no_body)? {
     ResponseBodyKind::NoBody => {}
@@ -99,7 +110,7 @@ where
   Ok(ResponseParts { binary, trailers })
 }
 
-fn read_response_header<R>(reader: &mut R) -> error::Result<Vec<u8>>
+pub(crate) fn read_response_header<R>(reader: &mut R) -> error::Result<Vec<u8>>
 where
   R: Read + ?Sized,
 {

--- a/rttp_client/tests/support/mod.rs
+++ b/rttp_client/tests/support/mod.rs
@@ -452,6 +452,115 @@ pub fn spawn_continue_then_ok_server() -> (SocketAddr, JoinHandle<()>) {
   spawn_informational_then_ok_server("100 Continue")
 }
 
+pub fn spawn_expect_continue_gate_server() -> (SocketAddr, JoinHandle<Vec<u8>>) {
+  let (listener, addr) = bind_local_http_listener("expect continue gate server");
+  let handle = thread::spawn(move || {
+    let Ok((mut stream, _)) = listener.accept() else {
+      return Vec::new();
+    };
+
+    stream
+      .set_read_timeout(Some(Duration::from_millis(100)))
+      .expect("set gate read timeout");
+
+    let mut request_head = Vec::new();
+    let mut byte = [0u8; 1];
+    while !request_head.ends_with(b"\r\n\r\n") {
+      stream
+        .read_exact(&mut byte)
+        .expect("read expect request head");
+      request_head.push(byte[0]);
+    }
+
+    let mut premature_body = [0u8; 1];
+    match stream.read(&mut premature_body) {
+      Err(err)
+        if matches!(
+          err.kind(),
+          io::ErrorKind::WouldBlock | io::ErrorKind::TimedOut
+        ) => {}
+      Ok(0) => {}
+      Ok(_) => return Vec::new(),
+      Err(err) => panic!("unexpected gate read error: {err}"),
+    }
+
+    stream
+      .write_all(b"HTTP/1.1 100 Continue\r\n\r\n")
+      .expect("write continue");
+
+    let mut request = request_head;
+    let mut body = [0u8; 12];
+    stream.read_exact(&mut body).expect("read expect body");
+    request.extend_from_slice(&body);
+
+    stream
+      .write_all(
+        concat!(
+          "HTTP/1.1 200 OK\r\n",
+          "Content-Length: 8\r\n",
+          "Connection: close\r\n",
+          "\r\n",
+          "accepted"
+        )
+        .as_bytes(),
+      )
+      .expect("write final response");
+
+    request
+  });
+  (addr, handle)
+}
+
+pub fn spawn_expect_continue_reject_gate_server() -> (SocketAddr, JoinHandle<Vec<u8>>) {
+  let (listener, addr) = bind_local_http_listener("expect continue reject gate server");
+  let handle = thread::spawn(move || {
+    let Ok((mut stream, _)) = listener.accept() else {
+      return Vec::new();
+    };
+
+    stream
+      .set_read_timeout(Some(Duration::from_millis(100)))
+      .expect("set reject gate read timeout");
+
+    let mut request_head = Vec::new();
+    let mut byte = [0u8; 1];
+    while !request_head.ends_with(b"\r\n\r\n") {
+      stream
+        .read_exact(&mut byte)
+        .expect("read expect request head");
+      request_head.push(byte[0]);
+    }
+
+    let mut premature_body = [0u8; 1];
+    match stream.read(&mut premature_body) {
+      Err(err)
+        if matches!(
+          err.kind(),
+          io::ErrorKind::WouldBlock | io::ErrorKind::TimedOut
+        ) => {}
+      Ok(0) => {}
+      Ok(_) => return Vec::new(),
+      Err(err) => panic!("unexpected reject gate read error: {err}"),
+    }
+
+    stream
+      .write_all(
+        concat!(
+          "HTTP/1.1 417 Expectation Failed\r\n",
+          "Content-Length: 18\r\n",
+          "Connection: close\r\n",
+          "\r\n",
+          "Expectation Failed"
+        )
+        .as_bytes(),
+      )
+      .expect("write expectation failed");
+
+    request_head
+  });
+  (addr, handle)
+}
+
 pub fn spawn_informational_then_ok_server(status: &'static str) -> (SocketAddr, JoinHandle<()>) {
   let socket = Socket::new(Domain::IPV4, Type::STREAM, Some(Protocol::TCP))
     .expect("create continue server socket");
@@ -464,7 +573,15 @@ pub fn spawn_informational_then_ok_server(status: &'static str) -> (SocketAddr, 
 
   let handle = thread::spawn(move || {
     if let Ok((mut stream, _)) = listener.accept() {
-      let _ = read_http_request(&mut stream);
+      let mut request_head = Vec::new();
+      let mut byte = [0u8; 1];
+      while !request_head.ends_with(b"\r\n\r\n") {
+        if stream.read_exact(&mut byte).is_err() {
+          return;
+        }
+        request_head.push(byte[0]);
+      }
+
       let response = format!(
         concat!(
           "HTTP/1.1 {}\r\n",
@@ -480,7 +597,29 @@ pub fn spawn_informational_then_ok_server(status: &'static str) -> (SocketAddr, 
         ),
         status
       );
-      let _ = stream.write_all(response.as_bytes());
+      let Some((interim, final_response)) = response.split_once("HTTP/1.1 200 OK\r\n") else {
+        return;
+      };
+      let _ = stream.write_all(interim.as_bytes());
+
+      let content_length = String::from_utf8_lossy(&request_head)
+        .lines()
+        .find_map(|line| {
+          let (name, value) = line.split_once(':')?;
+          if name.eq_ignore_ascii_case("content-length") {
+            value.trim().parse::<usize>().ok()
+          } else {
+            None
+          }
+        })
+        .unwrap_or(0);
+      let mut body = vec![0u8; content_length];
+      if stream.read_exact(&mut body).is_err() {
+        return;
+      }
+
+      let final_response = format!("HTTP/1.1 200 OK\r\n{final_response}");
+      let _ = stream.write_all(final_response.as_bytes());
     }
   });
 

--- a/rttp_client/tests/test_http_async.rs
+++ b/rttp_client/tests/test_http_async.rs
@@ -206,6 +206,57 @@ fn test_async_client_skips_100_continue_before_final_response() {
 
 #[test]
 #[cfg(feature = "async")]
+fn test_async_client_waits_for_100_continue_before_sending_body() {
+  let (addr, handle) = support::spawn_expect_continue_gate_server();
+  block_on(async {
+    let response = client()
+      .post()
+      .url(format!("http://{}/continue-gate", addr))
+      .header(("Expect", "100-continue"))
+      .raw("request body")
+      .rasync()
+      .await
+      .unwrap();
+
+    assert_eq!(200, response.code());
+    assert_eq!("accepted", response.body().string().unwrap());
+  });
+
+  let request = handle.join().expect("expect continue gate thread");
+  assert!(!request.is_empty(), "body was sent before 100 Continue");
+  assert!(String::from_utf8_lossy(&request).contains("Expect: 100-continue"));
+  assert!(request.ends_with(b"request body"));
+}
+
+#[test]
+#[cfg(feature = "async")]
+fn test_async_client_does_not_send_body_when_expect_continue_gets_final_response() {
+  let (addr, handle) = support::spawn_expect_continue_reject_gate_server();
+  block_on(async {
+    let response = client()
+      .post()
+      .url(format!("http://{}/continue-reject", addr))
+      .header(("Expect", "100-continue"))
+      .raw("request body")
+      .rasync()
+      .await
+      .unwrap();
+
+    assert_eq!(417, response.code());
+    assert_eq!("Expectation Failed", response.body().string().unwrap());
+  });
+
+  let request = handle.join().expect("expect continue reject gate thread");
+  assert!(
+    !request.is_empty(),
+    "body was sent before final expectation response"
+  );
+  assert!(String::from_utf8_lossy(&request).contains("Expect: 100-continue"));
+  assert!(!request.ends_with(b"request body"));
+}
+
+#[test]
+#[cfg(feature = "async")]
 fn test_async_client_skips_103_early_hints_before_final_response() {
   let (addr, _handle) = support::spawn_informational_then_ok_server("103 Early Hints");
   block_on(async {

--- a/rttp_client/tests/test_http_basic.rs
+++ b/rttp_client/tests/test_http_basic.rs
@@ -258,6 +258,49 @@ fn test_sync_client_skips_100_continue_before_final_response() {
 }
 
 #[test]
+fn test_sync_client_waits_for_100_continue_before_sending_body() {
+  let (addr, handle) = support::spawn_expect_continue_gate_server();
+  let response = client()
+    .post()
+    .url(format!("http://{}/continue-gate", addr))
+    .header(("Expect", "100-continue"))
+    .raw("request body")
+    .emit()
+    .unwrap();
+
+  assert_eq!(200, response.code());
+  assert_eq!("accepted", response.body().string().unwrap());
+
+  let request = handle.join().expect("expect continue gate thread");
+  assert!(!request.is_empty(), "body was sent before 100 Continue");
+  assert!(String::from_utf8_lossy(&request).contains("Expect: 100-continue"));
+  assert!(request.ends_with(b"request body"));
+}
+
+#[test]
+fn test_sync_client_does_not_send_body_when_expect_continue_gets_final_response() {
+  let (addr, handle) = support::spawn_expect_continue_reject_gate_server();
+  let response = client()
+    .post()
+    .url(format!("http://{}/continue-reject", addr))
+    .header(("Expect", "100-continue"))
+    .raw("request body")
+    .emit()
+    .unwrap();
+
+  assert_eq!(417, response.code());
+  assert_eq!("Expectation Failed", response.body().string().unwrap());
+
+  let request = handle.join().expect("expect continue reject gate thread");
+  assert!(
+    !request.is_empty(),
+    "body was sent before final expectation response"
+  );
+  assert!(String::from_utf8_lossy(&request).contains("Expect: 100-continue"));
+  assert!(!request.ends_with(b"request body"));
+}
+
+#[test]
 fn test_sync_client_skips_103_early_hints_before_final_response() {
   let (addr, _handle) = support::spawn_informational_then_ok_server("103 Early Hints");
   let response = client()


### PR DESCRIPTION
Aligns Expect: 100-continue behavior across the socket2 server and sync/async clients. Clients now wait for interim 100 before sending request bodies and stop before body transmission when a final response arrives early. Added live raw TCP and rttp client coverage for accepted and rejected expectation flows. Verification passed with formatting, focused Expect/continue tests, and the workspace test suite.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1308/
work_kind: code_work
branch: hbx-1308-rttp-align-expect-100-continue
base: main
commit: 4a80ae9a75fc2f7513162dfcba0321eb9150cda0
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1308/
    url: https://plane.kahub.in/endless/browse/HBX-1308/
    close_policy: link_only
```