### PR TITLE
feat: [rttp] Add chunk extension parsing and validation for request and response bodies

### DIFF
--- a/rttp/src/server.rs
+++ b/rttp/src/server.rs
@@ -1358,16 +1358,127 @@ where
 fn parse_chunk_size(line: &[u8]) -> io::Result<usize> {
   let line = std::str::from_utf8(line)
     .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "chunk size is not UTF-8"))?;
-  let size = line
-    .trim_end_matches("\r\n")
-    .split(';')
-    .next()
-    .map(str::trim)
-    .filter(|value| !value.is_empty())
-    .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "empty chunk size"))?;
+  let line = line.trim_end_matches("\r\n");
+  let (size, extensions) = line
+    .split_once(';')
+    .map_or((line, None), |(size, extensions)| (size, Some(extensions)));
+  let size = size.trim();
+  if size.is_empty() {
+    return Err(io::Error::new(
+      io::ErrorKind::InvalidData,
+      "empty chunk size",
+    ));
+  }
+  if let Some(extensions) = extensions {
+    validate_chunk_extensions(extensions.as_bytes())?;
+  }
 
   usize::from_str_radix(size, 16)
     .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "invalid chunk size"))
+}
+
+fn validate_chunk_extensions(mut bytes: &[u8]) -> io::Result<()> {
+  loop {
+    bytes = trim_bws(bytes);
+    let token_len = bytes
+      .iter()
+      .position(|byte| !is_tchar(*byte))
+      .unwrap_or(bytes.len());
+    if token_len == 0 {
+      return Err(invalid_chunk_extension());
+    }
+    bytes = trim_bws(&bytes[token_len..]);
+
+    if let Some(rest) = bytes.strip_prefix(b"=") {
+      bytes = trim_bws(rest);
+      if let Some(rest) = bytes.strip_prefix(b"\"") {
+        bytes = parse_quoted_chunk_extension(rest)?;
+      } else {
+        let value_len = bytes
+          .iter()
+          .position(|byte| !is_tchar(*byte))
+          .unwrap_or(bytes.len());
+        if value_len == 0 {
+          return Err(invalid_chunk_extension());
+        }
+        bytes = &bytes[value_len..];
+      }
+      bytes = trim_bws(bytes);
+    }
+
+    if bytes.is_empty() {
+      return Ok(());
+    }
+    if let Some(rest) = bytes.strip_prefix(b";") {
+      bytes = rest;
+    } else {
+      return Err(invalid_chunk_extension());
+    }
+  }
+}
+
+fn parse_quoted_chunk_extension(mut bytes: &[u8]) -> io::Result<&[u8]> {
+  loop {
+    let Some((&byte, rest)) = bytes.split_first() else {
+      return Err(invalid_chunk_extension());
+    };
+    match byte {
+      b'"' => return Ok(rest),
+      b'\\' => {
+        let Some((&escaped, rest)) = rest.split_first() else {
+          return Err(invalid_chunk_extension());
+        };
+        if !is_quoted_pair_char(escaped) {
+          return Err(invalid_chunk_extension());
+        }
+        bytes = rest;
+      }
+      byte if is_qdtext(byte) => bytes = rest,
+      _ => return Err(invalid_chunk_extension()),
+    }
+  }
+}
+
+fn trim_bws(bytes: &[u8]) -> &[u8] {
+  let start = bytes
+    .iter()
+    .position(|byte| *byte != b' ' && *byte != b'\t')
+    .unwrap_or(bytes.len());
+  &bytes[start..]
+}
+
+fn is_tchar(byte: u8) -> bool {
+  byte.is_ascii_alphanumeric()
+    || matches!(
+      byte,
+      b'!'
+        | b'#'
+        | b'$'
+        | b'%'
+        | b'&'
+        | b'\''
+        | b'*'
+        | b'+'
+        | b'-'
+        | b'.'
+        | b'^'
+        | b'_'
+        | b'`'
+        | b'|'
+        | b'~'
+    )
+}
+
+fn is_qdtext(byte: u8) -> bool {
+  matches!(byte, b'\t' | b' ' | b'!' | 0x23..=0x5b | 0x5d..=0x7e | 0x80..=0xff)
+}
+
+fn is_quoted_pair_char(byte: u8) -> bool {
+  matches!(byte, b'\t' | b' ' | 0x21..=0x7e | 0x80..=0xff)
+}
+
+fn invalid_chunk_extension() -> io::Error {
+  io::Error::new(io::ErrorKind::InvalidData, "invalid chunk extension")
 }
 
 fn consume_crlf<R>(reader: &mut R, body_bytes_read: &mut usize) -> io::Result<()>

--- a/rttp/src/server.rs
+++ b/rttp/src/server.rs
@@ -1356,13 +1356,16 @@ where
 }
 
 fn parse_chunk_size(line: &[u8]) -> io::Result<usize> {
-  let line = std::str::from_utf8(line)
-    .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "chunk size is not UTF-8"))?;
-  let line = line.trim_end_matches("\r\n");
+  let line = line.strip_suffix(b"\r\n").unwrap_or(line);
   let (size, extensions) = line
-    .split_once(';')
-    .map_or((line, None), |(size, extensions)| (size, Some(extensions)));
-  let size = size.trim();
+    .iter()
+    .position(|byte| *byte == b';')
+    .map_or((line, None), |index| {
+      (&line[..index], Some(&line[index + 1..]))
+    });
+  let size = std::str::from_utf8(size)
+    .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "chunk size is not UTF-8"))?
+    .trim();
   if size.is_empty() {
     return Err(io::Error::new(
       io::ErrorKind::InvalidData,
@@ -1370,7 +1373,7 @@ fn parse_chunk_size(line: &[u8]) -> io::Result<usize> {
     ));
   }
   if let Some(extensions) = extensions {
-    validate_chunk_extensions(extensions.as_bytes())?;
+    validate_chunk_extensions(extensions)?;
   }
 
   usize::from_str_radix(size, 16)
@@ -1671,6 +1674,26 @@ mod tests {
     assert_eq!("GET", second.method());
     assert_eq!("/second", second.target());
     assert!(reader.fill_buf().expect("remaining bytes").is_empty());
+  }
+
+  #[test]
+  fn read_next_from_accepts_obs_text_in_quoted_chunk_extensions() {
+    let raw = b"POST /chunked HTTP/1.1\r\n\
+Host: example.test\r\n\
+Transfer-Encoding: chunked\r\n\
+\r\n\
+5;meta=\"\xff\"\r\n\
+hello\r\n\
+0\r\n\
+\r\n";
+    let mut reader = BufReader::new(Cursor::new(raw));
+
+    let request = Request::read_next_from(&mut reader)
+      .expect("chunk extension with obs-text should parse")
+      .expect("request should be present");
+
+    assert_eq!("/chunked", request.target());
+    assert_eq!(b"hello", request.body());
   }
 
   #[test]

--- a/rttp/tests/test_server.rs
+++ b/rttp/tests/test_server.rs
@@ -1210,6 +1210,56 @@ fn server_preserves_chunked_request_trailers() {
 }
 
 #[test]
+fn server_accepts_quoted_chunk_extensions() {
+  let server = rttp::Http::server("127.0.0.1:0").expect("bind server");
+  let addr = server.local_addr().expect("server addr");
+  let (tx, rx) = mpsc::channel();
+
+  let handle = thread::spawn(move || {
+    server
+      .accept_one(|request| {
+        tx.send(request).expect("send parsed request");
+        HttpResponse::ok("accepted")
+      })
+      .expect("serve one request");
+  });
+
+  let mut stream = TcpStream::connect(addr).expect("connect server");
+  stream
+    .write_all(
+      concat!(
+        "POST /upload HTTP/1.1\r\n",
+        "Host: localhost\r\n",
+        "Transfer-Encoding: chunked\r\n",
+        "\r\n",
+        "7;foo=\"bar;baz\";answer=42\r\nchunked\r\n",
+        "6;empty;quoted=\"\\\\\\\"\"\r\n body!\r\n",
+        "0;done=\"yes\"\r\n",
+        "X-Trace: abc\r\n",
+        "\r\n"
+      )
+      .as_bytes(),
+    )
+    .expect("write request");
+  stream
+    .shutdown(std::net::Shutdown::Write)
+    .expect("shutdown write");
+
+  let mut response = String::new();
+  stream.read_to_string(&mut response).expect("read response");
+
+  let request: Request = rx.recv().expect("receive parsed request");
+  assert_eq!(b"chunked body!", request.body());
+  assert_eq!(Some("abc"), request.trailer("x-trace"));
+  assert_eq!(
+    "HTTP/1.1 200 OK\r\nContent-Length: 8\r\nConnection: close\r\n\r\naccepted",
+    response
+  );
+
+  handle.join().expect("server thread");
+}
+
+#[test]
 fn server_exposes_empty_trailers_for_chunked_request_without_trailers() {
   let server = rttp::Http::server("127.0.0.1:0").expect("bind server");
   let addr = server.local_addr().expect("server addr");
@@ -1256,6 +1306,33 @@ fn server_exposes_empty_trailers_for_chunked_request_without_trailers() {
   );
 
   handle.join().expect("server thread");
+}
+
+#[test]
+fn server_returns_bad_request_for_malformed_chunk_extension() {
+  assert_bad_request_without_handler(
+    concat!(
+      "POST /upload HTTP/1.1\r\n",
+      "Host: localhost\r\n",
+      "Transfer-Encoding: chunked\r\n",
+      "\r\n",
+      "7;bad name=value\r\nchunked\r\n",
+      "0\r\n\r\n"
+    )
+    .as_bytes(),
+  );
+
+  assert_bad_request_without_handler(
+    concat!(
+      "POST /upload HTTP/1.1\r\n",
+      "Host: localhost\r\n",
+      "Transfer-Encoding: chunked\r\n",
+      "\r\n",
+      "7;foo=\"unterminated\r\nchunked\r\n",
+      "0\r\n\r\n"
+    )
+    .as_bytes(),
+  );
 }
 
 #[test]

--- a/rttp_client/src/connection/async_connection.rs
+++ b/rttp_client/src/connection/async_connection.rs
@@ -317,15 +317,119 @@ where
 
 fn parse_chunk_size(line: &[u8]) -> error::Result<usize> {
   let line = std::str::from_utf8(line).map_err(error::response)?;
-  let size = line
-    .trim_end_matches("\r\n")
-    .split(';')
-    .next()
-    .map(str::trim)
-    .filter(|value| !value.is_empty())
-    .ok_or_else(|| error::bad_response("Chunk size line is empty"))?;
+  let line = line.trim_end_matches("\r\n");
+  let (size, extensions) = line
+    .split_once(';')
+    .map_or((line, None), |(size, extensions)| (size, Some(extensions)));
+  let size = size.trim();
+  if size.is_empty() {
+    return Err(error::bad_response("Chunk size line is empty"));
+  }
+  if let Some(extensions) = extensions {
+    validate_chunk_extensions(extensions.as_bytes())?;
+  }
 
   usize::from_str_radix(size, 16).map_err(|_| error::bad_response("Invalid chunk size"))
+}
+
+fn validate_chunk_extensions(mut bytes: &[u8]) -> error::Result<()> {
+  loop {
+    bytes = trim_bws(bytes);
+    let token_len = bytes
+      .iter()
+      .position(|byte| !is_tchar(*byte))
+      .unwrap_or(bytes.len());
+    if token_len == 0 {
+      return Err(error::bad_response("Invalid chunk extension"));
+    }
+    bytes = trim_bws(&bytes[token_len..]);
+
+    if let Some(rest) = bytes.strip_prefix(b"=") {
+      bytes = trim_bws(rest);
+      if let Some(rest) = bytes.strip_prefix(b"\"") {
+        bytes = parse_quoted_chunk_extension(rest)?;
+      } else {
+        let value_len = bytes
+          .iter()
+          .position(|byte| !is_tchar(*byte))
+          .unwrap_or(bytes.len());
+        if value_len == 0 {
+          return Err(error::bad_response("Invalid chunk extension"));
+        }
+        bytes = &bytes[value_len..];
+      }
+      bytes = trim_bws(bytes);
+    }
+
+    if bytes.is_empty() {
+      return Ok(());
+    }
+    if let Some(rest) = bytes.strip_prefix(b";") {
+      bytes = rest;
+    } else {
+      return Err(error::bad_response("Invalid chunk extension"));
+    }
+  }
+}
+
+fn parse_quoted_chunk_extension(mut bytes: &[u8]) -> error::Result<&[u8]> {
+  loop {
+    let Some((&byte, rest)) = bytes.split_first() else {
+      return Err(error::bad_response("Invalid chunk extension"));
+    };
+    match byte {
+      b'"' => return Ok(rest),
+      b'\\' => {
+        let Some((&escaped, rest)) = rest.split_first() else {
+          return Err(error::bad_response("Invalid chunk extension"));
+        };
+        if !is_quoted_pair_char(escaped) {
+          return Err(error::bad_response("Invalid chunk extension"));
+        }
+        bytes = rest;
+      }
+      byte if is_qdtext(byte) => bytes = rest,
+      _ => return Err(error::bad_response("Invalid chunk extension")),
+    }
+  }
+}
+
+fn trim_bws(bytes: &[u8]) -> &[u8] {
+  let start = bytes
+    .iter()
+    .position(|byte| *byte != b' ' && *byte != b'\t')
+    .unwrap_or(bytes.len());
+  &bytes[start..]
+}
+
+fn is_tchar(byte: u8) -> bool {
+  byte.is_ascii_alphanumeric()
+    || matches!(
+      byte,
+      b'!'
+        | b'#'
+        | b'$'
+        | b'%'
+        | b'&'
+        | b'\''
+        | b'*'
+        | b'+'
+        | b'-'
+        | b'.'
+        | b'^'
+        | b'_'
+        | b'`'
+        | b'|'
+        | b'~'
+    )
+}
+
+fn is_qdtext(byte: u8) -> bool {
+  matches!(byte, b'\t' | b' ' | b'!' | 0x23..=0x5b | 0x5d..=0x7e | 0x80..=0xff)
+}
+
+fn is_quoted_pair_char(byte: u8) -> bool {
+  matches!(byte, b'\t' | b' ' | 0x21..=0x7e | 0x80..=0xff)
 }
 
 async fn async_consume_crlf<S>(stream: &mut S) -> error::Result<()>

--- a/rttp_client/src/connection/async_connection.rs
+++ b/rttp_client/src/connection/async_connection.rs
@@ -317,17 +317,19 @@ where
 }
 
 fn parse_chunk_size(line: &[u8]) -> error::Result<usize> {
-  let line = std::str::from_utf8(line).map_err(error::response)?;
-  let line = line.trim_end_matches("\r\n");
+  let line = line.strip_suffix(CRLF).unwrap_or(line);
   let (size, extensions) = line
-    .split_once(';')
-    .map_or((line, None), |(size, extensions)| (size, Some(extensions)));
-  let size = size.trim();
+    .iter()
+    .position(|byte| *byte == b';')
+    .map_or((line, None), |index| {
+      (&line[..index], Some(&line[index + 1..]))
+    });
+  let size = std::str::from_utf8(size).map_err(error::response)?.trim();
   if size.is_empty() {
     return Err(error::bad_response("Chunk size line is empty"));
   }
   if let Some(extensions) = extensions {
-    validate_chunk_extensions(extensions.as_bytes())?;
+    validate_chunk_extensions(extensions)?;
   }
 
   usize::from_str_radix(size, 16).map_err(|_| error::bad_response("Invalid chunk size"))

--- a/rttp_client/src/connection/connection_reader.rs
+++ b/rttp_client/src/connection/connection_reader.rs
@@ -267,17 +267,19 @@ where
 }
 
 fn parse_chunk_size(line: &[u8]) -> error::Result<usize> {
-  let line = std::str::from_utf8(line).map_err(error::response)?;
-  let line = line.trim_end_matches("\r\n");
+  let line = line.strip_suffix(CRLF).unwrap_or(line);
   let (size, extensions) = line
-    .split_once(';')
-    .map_or((line, None), |(size, extensions)| (size, Some(extensions)));
-  let size = size.trim();
+    .iter()
+    .position(|byte| *byte == b';')
+    .map_or((line, None), |index| {
+      (&line[..index], Some(&line[index + 1..]))
+    });
+  let size = std::str::from_utf8(size).map_err(error::response)?.trim();
   if size.is_empty() {
     return Err(error::bad_response("Chunk size line is empty"));
   }
   if let Some(extensions) = extensions {
-    validate_chunk_extensions(extensions.as_bytes())?;
+    validate_chunk_extensions(extensions)?;
   }
 
   usize::from_str_radix(size, 16).map_err(|_| error::bad_response("Invalid chunk size"))

--- a/rttp_client/src/connection/connection_reader.rs
+++ b/rttp_client/src/connection/connection_reader.rs
@@ -268,15 +268,119 @@ where
 
 fn parse_chunk_size(line: &[u8]) -> error::Result<usize> {
   let line = std::str::from_utf8(line).map_err(error::response)?;
-  let size = line
-    .trim_end_matches("\r\n")
-    .split(';')
-    .next()
-    .map(str::trim)
-    .filter(|value| !value.is_empty())
-    .ok_or_else(|| error::bad_response("Chunk size line is empty"))?;
+  let line = line.trim_end_matches("\r\n");
+  let (size, extensions) = line
+    .split_once(';')
+    .map_or((line, None), |(size, extensions)| (size, Some(extensions)));
+  let size = size.trim();
+  if size.is_empty() {
+    return Err(error::bad_response("Chunk size line is empty"));
+  }
+  if let Some(extensions) = extensions {
+    validate_chunk_extensions(extensions.as_bytes())?;
+  }
 
   usize::from_str_radix(size, 16).map_err(|_| error::bad_response("Invalid chunk size"))
+}
+
+fn validate_chunk_extensions(mut bytes: &[u8]) -> error::Result<()> {
+  loop {
+    bytes = trim_bws(bytes);
+    let token_len = bytes
+      .iter()
+      .position(|byte| !is_tchar(*byte))
+      .unwrap_or(bytes.len());
+    if token_len == 0 {
+      return Err(error::bad_response("Invalid chunk extension"));
+    }
+    bytes = trim_bws(&bytes[token_len..]);
+
+    if let Some(rest) = bytes.strip_prefix(b"=") {
+      bytes = trim_bws(rest);
+      if let Some(rest) = bytes.strip_prefix(b"\"") {
+        bytes = parse_quoted_chunk_extension(rest)?;
+      } else {
+        let value_len = bytes
+          .iter()
+          .position(|byte| !is_tchar(*byte))
+          .unwrap_or(bytes.len());
+        if value_len == 0 {
+          return Err(error::bad_response("Invalid chunk extension"));
+        }
+        bytes = &bytes[value_len..];
+      }
+      bytes = trim_bws(bytes);
+    }
+
+    if bytes.is_empty() {
+      return Ok(());
+    }
+    if let Some(rest) = bytes.strip_prefix(b";") {
+      bytes = rest;
+    } else {
+      return Err(error::bad_response("Invalid chunk extension"));
+    }
+  }
+}
+
+fn parse_quoted_chunk_extension(mut bytes: &[u8]) -> error::Result<&[u8]> {
+  loop {
+    let Some((&byte, rest)) = bytes.split_first() else {
+      return Err(error::bad_response("Invalid chunk extension"));
+    };
+    match byte {
+      b'"' => return Ok(rest),
+      b'\\' => {
+        let Some((&escaped, rest)) = rest.split_first() else {
+          return Err(error::bad_response("Invalid chunk extension"));
+        };
+        if !is_quoted_pair_char(escaped) {
+          return Err(error::bad_response("Invalid chunk extension"));
+        }
+        bytes = rest;
+      }
+      byte if is_qdtext(byte) => bytes = rest,
+      _ => return Err(error::bad_response("Invalid chunk extension")),
+    }
+  }
+}
+
+fn trim_bws(bytes: &[u8]) -> &[u8] {
+  let start = bytes
+    .iter()
+    .position(|byte| *byte != b' ' && *byte != b'\t')
+    .unwrap_or(bytes.len());
+  &bytes[start..]
+}
+
+fn is_tchar(byte: u8) -> bool {
+  byte.is_ascii_alphanumeric()
+    || matches!(
+      byte,
+      b'!'
+        | b'#'
+        | b'$'
+        | b'%'
+        | b'&'
+        | b'\''
+        | b'*'
+        | b'+'
+        | b'-'
+        | b'.'
+        | b'^'
+        | b'_'
+        | b'`'
+        | b'|'
+        | b'~'
+    )
+}
+
+fn is_qdtext(byte: u8) -> bool {
+  matches!(byte, b'\t' | b' ' | b'!' | 0x23..=0x5b | 0x5d..=0x7e | 0x80..=0xff)
+}
+
+fn is_quoted_pair_char(byte: u8) -> bool {
+  matches!(byte, b'\t' | b' ' | 0x21..=0x7e | 0x80..=0xff)
 }
 
 fn consume_crlf<R>(reader: &mut R) -> error::Result<()>

--- a/rttp_client/tests/test_http_async.rs
+++ b/rttp_client/tests/test_http_async.rs
@@ -92,6 +92,31 @@ fn test_async_chunked_quoted_extensions_are_accepted() {
 
 #[test]
 #[cfg(feature = "async")]
+fn test_async_chunked_quoted_extensions_accept_obs_text() {
+  let mut response = b"HTTP/1.1 200 OK\r\n\
+Transfer-Encoding: chunked\r\n\
+Connection: close\r\n\
+\r\n\
+7;meta=\""
+    .to_vec();
+  response.push(0xff);
+  response.extend_from_slice(b"\"\r\nchunked\r\n0\r\n\r\n");
+
+  let (addr, _handle) = support::spawn_chunked_response_server(response);
+  block_on(async {
+    let response = client()
+      .get()
+      .url(format!("http://{}/chunked", addr))
+      .rasync()
+      .await
+      .unwrap();
+
+    assert_eq!("chunked", response.body().string().unwrap());
+  });
+}
+
+#[test]
+#[cfg(feature = "async")]
 fn test_async_chunked_malformed_extension_is_rejected() {
   let (addr, _handle) = support::spawn_chunked_response_server(concat!(
     "HTTP/1.1 200 OK\r\n",

--- a/rttp_client/tests/test_http_async.rs
+++ b/rttp_client/tests/test_http_async.rs
@@ -61,6 +61,65 @@ fn test_async_chunked() {
 
 #[test]
 #[cfg(feature = "async")]
+fn test_async_chunked_quoted_extensions_are_accepted() {
+  let (addr, _handle) = support::spawn_chunked_response_server(concat!(
+    "HTTP/1.1 200 OK\r\n",
+    "Transfer-Encoding: chunked\r\n",
+    "Connection: close\r\n",
+    "\r\n",
+    "7;foo=\"bar;baz\";answer=42\r\nchunked\r\n",
+    "6;empty;quoted=\"\\\\\\\"\"\r\n body!\r\n",
+    "0;done=\"yes\"\r\n",
+    "X-Trace: abc\r\n",
+    "\r\n"
+  ));
+
+  block_on(async {
+    let response = client()
+      .get()
+      .url(format!("http://{}/chunked", addr))
+      .rasync()
+      .await
+      .unwrap();
+
+    assert_eq!("chunked body!", response.body().string().unwrap());
+    assert_eq!(
+      Some("abc"),
+      response.trailer("x-trace").map(|h| h.value().as_str())
+    );
+  });
+}
+
+#[test]
+#[cfg(feature = "async")]
+fn test_async_chunked_malformed_extension_is_rejected() {
+  let (addr, _handle) = support::spawn_chunked_response_server(concat!(
+    "HTTP/1.1 200 OK\r\n",
+    "Transfer-Encoding: chunked\r\n",
+    "Connection: close\r\n",
+    "\r\n",
+    "7;bad name=value\r\nchunked\r\n",
+    "0\r\n",
+    "\r\n"
+  ));
+
+  block_on(async {
+    let error = client()
+      .get()
+      .url(format!("http://{}/chunked", addr))
+      .rasync()
+      .await
+      .expect_err("malformed chunk extension should be rejected");
+
+    assert!(
+      error.to_string().contains("Invalid chunk extension"),
+      "unexpected error: {error}"
+    );
+  });
+}
+
+#[test]
+#[cfg(feature = "async")]
 fn test_async_chunked_oversized_extension_is_rejected() {
   let extension = "a".repeat(16 * 1024);
   let response = format!(

--- a/rttp_client/tests/test_http_basic.rs
+++ b/rttp_client/tests/test_http_basic.rs
@@ -133,6 +133,57 @@ fn test_chunked_with_trailers_decodes_body() {
 }
 
 #[test]
+fn test_chunked_quoted_extensions_are_accepted() {
+  let (addr, _handle) = support::spawn_chunked_response_server(concat!(
+    "HTTP/1.1 200 OK\r\n",
+    "Transfer-Encoding: chunked\r\n",
+    "Connection: close\r\n",
+    "\r\n",
+    "7;foo=\"bar;baz\";answer=42\r\nchunked\r\n",
+    "6;empty;quoted=\"\\\\\\\"\"\r\n body!\r\n",
+    "0;done=\"yes\"\r\n",
+    "X-Trace: abc\r\n",
+    "\r\n"
+  ));
+
+  let response = client()
+    .get()
+    .url(format!("http://{}/chunked", addr))
+    .emit()
+    .unwrap();
+
+  assert_eq!("chunked body!", response.body().string().unwrap());
+  assert_eq!(
+    Some("abc"),
+    response.trailer("x-trace").map(|h| h.value().as_str())
+  );
+}
+
+#[test]
+fn test_chunked_malformed_extension_is_rejected() {
+  let (addr, _handle) = support::spawn_chunked_response_server(concat!(
+    "HTTP/1.1 200 OK\r\n",
+    "Transfer-Encoding: chunked\r\n",
+    "Connection: close\r\n",
+    "\r\n",
+    "7;bad name=value\r\nchunked\r\n",
+    "0\r\n",
+    "\r\n"
+  ));
+
+  let error = client()
+    .get()
+    .url(format!("http://{}/chunked", addr))
+    .emit()
+    .expect_err("malformed chunk extension should be rejected");
+
+  assert!(
+    error.to_string().contains("Invalid chunk extension"),
+    "unexpected error: {error}"
+  );
+}
+
+#[test]
 fn test_chunked_oversized_extension_is_rejected() {
   let extension = "a".repeat(16 * 1024);
   let response = format!(

--- a/rttp_client/tests/test_http_basic.rs
+++ b/rttp_client/tests/test_http_basic.rs
@@ -160,6 +160,27 @@ fn test_chunked_quoted_extensions_are_accepted() {
 }
 
 #[test]
+fn test_chunked_quoted_extensions_accept_obs_text() {
+  let mut response = b"HTTP/1.1 200 OK\r\n\
+Transfer-Encoding: chunked\r\n\
+Connection: close\r\n\
+\r\n\
+7;meta=\""
+    .to_vec();
+  response.push(0xff);
+  response.extend_from_slice(b"\"\r\nchunked\r\n0\r\n\r\n");
+
+  let (addr, _handle) = support::spawn_chunked_response_server(response);
+  let response = client()
+    .get()
+    .url(format!("http://{}/chunked", addr))
+    .emit()
+    .unwrap();
+
+  assert_eq!("chunked", response.body().string().unwrap());
+}
+
+#[test]
 fn test_chunked_malformed_extension_is_rejected() {
   let (addr, _handle) = support::spawn_chunked_response_server(concat!(
     "HTTP/1.1 200 OK\r\n",


### PR DESCRIPTION
Chunk extension parsing now validates request and response chunk metadata consistently across server, sync client, and async client paths while preserving body bytes and trailers for valid extensions. Malformed extensions are rejected and existing oversized-line/body protections remain in force. Formatting, focused chunked tests, async chunked tests, and the full workspace test suite pass.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1309/
work_kind: code_work
branch: hbx-1309-rttp-add-chunk-extension-parsing
base: main
commit: 22546f2d25e3358f0ce21d5c62203de669e4cea9
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1309/
    url: https://plane.kahub.in/endless/browse/HBX-1309/
    close_policy: link_only
```