### PR TITLE
feat: [rttp] Reject ambiguous Content-Length and Transfer-Encoding combinations

### DIFF
--- a/rttp/src/server.rs
+++ b/rttp/src/server.rs
@@ -1196,17 +1196,20 @@ fn optional_header_content_length(headers: &[(String, String)]) -> io::Result<Op
     .iter()
     .filter(|(name, _)| name.eq_ignore_ascii_case("Content-Length"))
   {
-    let parsed = value
-      .parse::<usize>()
-      .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "invalid Content-Length header"))?;
-    if length
-      .replace(parsed)
-      .is_some_and(|previous| previous != parsed)
-    {
-      return Err(io::Error::new(
-        io::ErrorKind::InvalidData,
-        "conflicting Content-Length headers",
-      ));
+    for token in value.split(',') {
+      let parsed = token
+        .trim()
+        .parse::<usize>()
+        .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "invalid Content-Length header"))?;
+      if length
+        .replace(parsed)
+        .is_some_and(|previous| previous != parsed)
+      {
+        return Err(io::Error::new(
+          io::ErrorKind::InvalidData,
+          "conflicting Content-Length headers",
+        ));
+      }
     }
   }
 
@@ -1221,12 +1224,15 @@ fn request_body_kind(headers: &[(String, String)]) -> io::Result<RequestBodyKind
     .iter()
     .filter(|(name, _)| name.eq_ignore_ascii_case("Transfer-Encoding"))
   {
-    transfer_codings.extend(
-      value
-        .split(',')
-        .map(str::trim)
-        .filter(|token| !token.is_empty()),
-    );
+    for token in value.split(',').map(str::trim) {
+      if token.is_empty() {
+        return Err(io::Error::new(
+          io::ErrorKind::InvalidData,
+          "unsupported Transfer-Encoding request body",
+        ));
+      }
+      transfer_codings.push(token);
+    }
   }
 
   if transfer_codings.is_empty() {

--- a/rttp/tests/test_server.rs
+++ b/rttp/tests/test_server.rs
@@ -1058,6 +1058,26 @@ fn server_accepts_duplicate_matching_content_length_request_body() {
 }
 
 #[test]
+fn server_accepts_matching_comma_separated_content_length_values() {
+  let (response, handler_called) = send_raw_request(
+    concat!(
+      "POST /upload HTTP/1.1\r\n",
+      "Host: localhost\r\n",
+      "Content-Length: 5, 5\r\n",
+      "\r\n",
+      "hello"
+    )
+    .as_bytes(),
+  );
+
+  assert!(handler_called);
+  assert_eq!(
+    "HTTP/1.1 200 OK\r\nContent-Length: 10\r\nConnection: close\r\n\r\nunexpected",
+    response
+  );
+}
+
+#[test]
 fn server_returns_bad_request_for_conflicting_duplicate_content_length() {
   assert_bad_request_without_handler(
     concat!(
@@ -1065,6 +1085,20 @@ fn server_returns_bad_request_for_conflicting_duplicate_content_length() {
       "Host: localhost\r\n",
       "Content-Length: 5\r\n",
       "Content-Length: 6\r\n",
+      "\r\n",
+      "hello!"
+    )
+    .as_bytes(),
+  );
+}
+
+#[test]
+fn server_returns_bad_request_for_conflicting_comma_separated_content_length_values() {
+  assert_bad_request_without_handler(
+    concat!(
+      "POST /upload HTTP/1.1\r\n",
+      "Host: localhost\r\n",
+      "Content-Length: 5, 6\r\n",
       "\r\n",
       "hello!"
     )

--- a/rttp_client/src/connection/connection_reader.rs
+++ b/rttp_client/src/connection/connection_reader.rs
@@ -168,9 +168,10 @@ pub(crate) fn response_body_kind(
   let header = String::from_utf8_lossy(header);
   let lines = header.lines().skip(1);
   let mut content_length = None;
+  let mut has_content_length = false;
   let mut invalid_content_length = false;
   let mut conflicting_content_length = false;
-  let mut chunked = false;
+  let mut transfer_codings = Vec::new();
 
   for line in lines {
     let Some((name, value)) = line.split_once(':') else {
@@ -178,12 +179,18 @@ pub(crate) fn response_body_kind(
     };
 
     if name.eq_ignore_ascii_case("Transfer-Encoding") {
-      chunked = value
-        .split(',')
-        .any(|token| token.trim().eq_ignore_ascii_case("chunked"));
+      for token in value.split(',').map(str::trim) {
+        if token.is_empty() {
+          return Err(error::bad_response(
+            "Unsupported Transfer-Encoding response body",
+          ));
+        }
+        transfer_codings.push(token);
+      }
     }
 
     if name.eq_ignore_ascii_case("Content-Length") {
+      has_content_length = true;
       for token in value.split(',') {
         let Ok(length) = token.trim().parse::<usize>() else {
           invalid_content_length = true;
@@ -199,9 +206,21 @@ pub(crate) fn response_body_kind(
     }
   }
 
-  if chunked {
-    Ok(ResponseBodyKind::Chunked)
-  } else if conflicting_content_length {
+  if !transfer_codings.is_empty() {
+    if has_content_length {
+      return Err(error::bad_response(
+        "Transfer-Encoding conflicts with Content-Length",
+      ));
+    }
+    if transfer_codings.len() == 1 && transfer_codings[0].eq_ignore_ascii_case("chunked") {
+      return Ok(ResponseBodyKind::Chunked);
+    }
+    return Err(error::bad_response(
+      "Unsupported Transfer-Encoding response body",
+    ));
+  }
+
+  if conflicting_content_length {
     Err(error::bad_response("Conflicting Content-Length headers"))
   } else if invalid_content_length {
     Err(error::bad_response("Invalid Content-Length header"))
@@ -518,7 +537,7 @@ mod tests {
   }
 
   #[test]
-  fn test_chunked_extensions_and_trailers_are_preserved() {
+  fn test_non_chunked_transfer_coding_before_chunked_is_rejected() {
     let raw = concat!(
       "HTTP/1.1 200 OK\r\n",
       "Transfer-Encoding: gzip, chunked\r\n",
@@ -532,16 +551,16 @@ mod tests {
     let url = url::Url::parse("http://localhost").unwrap();
     let mut cursor = Cursor::new(raw.as_bytes());
     let mut reader = ConnectionReader::new(&url, &mut cursor, false);
-    let response = reader.response().unwrap();
 
-    assert_eq!("chunked body!", response.body().string().unwrap());
-    assert_eq!(
-      Some(&"gzip, chunked".to_string()),
-      response.header_value("Transfer-Encoding")
-    );
-    assert_eq!(
-      Some("abc"),
-      response.trailer_value("x-trace").map(String::as_str)
+    let error = reader
+      .response()
+      .expect_err("unsupported transfer coding should be rejected");
+
+    assert!(
+      error
+        .to_string()
+        .contains("Unsupported Transfer-Encoding response body"),
+      "unexpected error: {error}"
     );
   }
 
@@ -750,7 +769,7 @@ mod tests {
   }
 
   #[test]
-  fn test_transfer_encoding_chunked_takes_precedence_over_content_length() {
+  fn test_transfer_encoding_chunked_with_content_length_is_rejected() {
     let raw = concat!(
       "HTTP/1.1 200 OK\r\n",
       "Content-Length: 999\r\n",
@@ -763,8 +782,15 @@ mod tests {
     let mut cursor = Cursor::new(raw.as_bytes());
     let mut reader = ConnectionReader::new(&url, &mut cursor, false);
 
-    let response = reader.response().unwrap();
+    let error = reader
+      .response()
+      .expect_err("Transfer-Encoding with Content-Length should be rejected");
 
-    assert_eq!("OK", response.body().string().unwrap());
+    assert!(
+      error
+        .to_string()
+        .contains("Transfer-Encoding conflicts with Content-Length"),
+      "unexpected error: {error}"
+    );
   }
 }

--- a/rttp_client/tests/test_http_async.rs
+++ b/rttp_client/tests/test_http_async.rs
@@ -117,6 +117,65 @@ Connection: close\r\n\
 
 #[test]
 #[cfg(feature = "async")]
+fn test_async_transfer_encoding_chunked_with_content_length_is_rejected() {
+  let (addr, _handle) = support::spawn_chunked_response_server(concat!(
+    "HTTP/1.1 200 OK\r\n",
+    "Transfer-Encoding: chunked\r\n",
+    "Content-Length: 2\r\n",
+    "Connection: close\r\n",
+    "\r\n",
+    "2\r\nOK\r\n",
+    "0\r\n\r\n"
+  ));
+
+  block_on(async {
+    let error = client()
+      .get()
+      .url(format!("http://{}/chunked", addr))
+      .rasync()
+      .await
+      .expect_err("ambiguous response framing should be rejected");
+
+    assert!(
+      error
+        .to_string()
+        .contains("Transfer-Encoding conflicts with Content-Length"),
+      "unexpected error: {error}"
+    );
+  });
+}
+
+#[test]
+#[cfg(feature = "async")]
+fn test_async_non_chunked_transfer_coding_before_chunked_is_rejected() {
+  let (addr, _handle) = support::spawn_chunked_response_server(concat!(
+    "HTTP/1.1 200 OK\r\n",
+    "Transfer-Encoding: gzip, chunked\r\n",
+    "Connection: close\r\n",
+    "\r\n",
+    "2\r\nOK\r\n",
+    "0\r\n\r\n"
+  ));
+
+  block_on(async {
+    let error = client()
+      .get()
+      .url(format!("http://{}/chunked", addr))
+      .rasync()
+      .await
+      .expect_err("unsupported transfer coding should be rejected");
+
+    assert!(
+      error
+        .to_string()
+        .contains("Unsupported Transfer-Encoding response body"),
+      "unexpected error: {error}"
+    );
+  });
+}
+
+#[test]
+#[cfg(feature = "async")]
 fn test_async_chunked_malformed_extension_is_rejected() {
   let (addr, _handle) = support::spawn_chunked_response_server(concat!(
     "HTTP/1.1 200 OK\r\n",

--- a/rttp_client/tests/test_http_basic.rs
+++ b/rttp_client/tests/test_http_basic.rs
@@ -181,6 +181,57 @@ Connection: close\r\n\
 }
 
 #[test]
+fn test_transfer_encoding_chunked_with_content_length_is_rejected() {
+  let (addr, _handle) = support::spawn_chunked_response_server(concat!(
+    "HTTP/1.1 200 OK\r\n",
+    "Transfer-Encoding: chunked\r\n",
+    "Content-Length: 2\r\n",
+    "Connection: close\r\n",
+    "\r\n",
+    "2\r\nOK\r\n",
+    "0\r\n\r\n"
+  ));
+
+  let error = client()
+    .get()
+    .url(format!("http://{}/chunked", addr))
+    .emit()
+    .expect_err("ambiguous response framing should be rejected");
+
+  assert!(
+    error
+      .to_string()
+      .contains("Transfer-Encoding conflicts with Content-Length"),
+    "unexpected error: {error}"
+  );
+}
+
+#[test]
+fn test_non_chunked_transfer_coding_before_chunked_is_rejected() {
+  let (addr, _handle) = support::spawn_chunked_response_server(concat!(
+    "HTTP/1.1 200 OK\r\n",
+    "Transfer-Encoding: gzip, chunked\r\n",
+    "Connection: close\r\n",
+    "\r\n",
+    "2\r\nOK\r\n",
+    "0\r\n\r\n"
+  ));
+
+  let error = client()
+    .get()
+    .url(format!("http://{}/chunked", addr))
+    .emit()
+    .expect_err("unsupported transfer coding should be rejected");
+
+  assert!(
+    error
+      .to_string()
+      .contains("Unsupported Transfer-Encoding response body"),
+    "unexpected error: {error}"
+  );
+}
+
+#[test]
 fn test_chunked_malformed_extension_is_rejected() {
   let (addr, _handle) = support::spawn_chunked_response_server(concat!(
     "HTTP/1.1 200 OK\r\n",


### PR DESCRIPTION
Strict HTTP/1.1 framing validation is now enforced across server requests and sync/async client responses. Ambiguous Content-Length values and invalid Transfer-Encoding plus Content-Length combinations are rejected, with regression coverage for raw wire and live parser paths.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1310/
work_kind: code_work
branch: hbx-1310-rttp-reject-ambiguous-content-length
base: main
commit: a3548449fa592e86712f3989994e2db028283bd7
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1310/
    url: https://plane.kahub.in/endless/browse/HBX-1310/
    close_policy: link_only
```