### PR TITLE
feat: [rttp] Add sync and async client parity tests for live response trailers

### DIFF
--- a/rttp_client/Cargo.toml
+++ b/rttp_client/Cargo.toml
@@ -65,3 +65,4 @@ tls-rustls  = ["rustls", "webpki-roots", "futures-rustls"]
 
 [dev-dependencies]
 rcgen = "0.11"
+rttp = { path = "../rttp" }

--- a/rttp_client/tests/support/mod.rs
+++ b/rttp_client/tests/support/mod.rs
@@ -6,6 +6,7 @@ use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr, TcpListener, TcpStream};
 use std::thread::{self, JoinHandle};
 use std::time::Duration;
 
+use rttp::server::HttpResponse;
 use socket2::{Domain, Protocol, Socket, Type};
 
 #[path = "local_http.rs"]
@@ -134,6 +135,22 @@ pub fn spawn_chunked_server() -> (SocketAddr, JoinHandle<()>) {
     "X-Signature: signed\r\n",
     "\r\n"
   ))
+}
+
+pub fn spawn_socket2_chunked_trailer_server() -> (SocketAddr, JoinHandle<()>) {
+  let server = rttp::Http::server("127.0.0.1:0").expect("bind socket2 trailer server");
+  let addr = server.local_addr().expect("socket2 trailer server addr");
+  let handle = thread::spawn(move || {
+    server
+      .accept_one(|_request| {
+        HttpResponse::ok("socket2 chunked body")
+          .header("Transfer-Encoding", "chunked")
+          .trailer("X-Trace", "abc")
+          .trailer("X-Signature", "signed")
+      })
+      .expect("serve socket2 trailer response");
+  });
+  (addr, handle)
 }
 
 pub fn spawn_chunked_response_server(response: impl Into<Vec<u8>>) -> (SocketAddr, JoinHandle<()>) {

--- a/rttp_client/tests/test_http_async.rs
+++ b/rttp_client/tests/test_http_async.rs
@@ -61,6 +61,39 @@ fn test_async_chunked() {
 
 #[test]
 #[cfg(feature = "async")]
+fn test_async_socket2_server_chunked_trailers_match_sync_accessors() {
+  let (addr, _handle) = support::spawn_socket2_chunked_trailer_server();
+  block_on(async {
+    let response = client()
+      .get()
+      .url(format!("http://{}/chunked", addr))
+      .rasync()
+      .await
+      .unwrap();
+
+    assert_eq!("socket2 chunked body", response.body().string().unwrap());
+    assert_eq!(2, response.trailers().len());
+    assert_eq!(
+      Some("abc"),
+      response.trailer("X-TRACE").map(|h| h.value().as_str())
+    );
+    assert_eq!(
+      Some("abc"),
+      response.trailer_value("x-trace").map(String::as_str)
+    );
+    assert_eq!(
+      Some("signed"),
+      response.trailer("x-signature").map(|h| h.value().as_str())
+    );
+    assert_eq!(
+      Some("signed"),
+      response.trailer_value("X-SIGNATURE").map(String::as_str)
+    );
+  });
+}
+
+#[test]
+#[cfg(feature = "async")]
 fn test_async_chunked_quoted_extensions_are_accepted() {
   let (addr, _handle) = support::spawn_chunked_response_server(concat!(
     "HTTP/1.1 200 OK\r\n",

--- a/rttp_client/tests/test_http_basic.rs
+++ b/rttp_client/tests/test_http_basic.rs
@@ -94,6 +94,35 @@ fn test_chunked() {
 }
 
 #[test]
+fn test_socket2_server_chunked_trailers_are_exposed_case_insensitively() {
+  let (addr, _handle) = support::spawn_socket2_chunked_trailer_server();
+  let response = client()
+    .get()
+    .url(format!("http://{}/chunked", addr))
+    .emit()
+    .unwrap();
+
+  assert_eq!("socket2 chunked body", response.body().string().unwrap());
+  assert_eq!(2, response.trailers().len());
+  assert_eq!(
+    Some("abc"),
+    response.trailer("x-trace").map(|h| h.value().as_str())
+  );
+  assert_eq!(
+    Some("abc"),
+    response.trailer_value("X-TRACE").map(String::as_str)
+  );
+  assert_eq!(
+    Some("signed"),
+    response.trailer("X-SIGNATURE").map(|h| h.value().as_str())
+  );
+  assert_eq!(
+    Some("signed"),
+    response.trailer_value("x-signature").map(String::as_str)
+  );
+}
+
+#[test]
 fn test_chunked_without_trailers_exposes_empty_trailers() {
   let (addr, _handle) = support::spawn_chunked_server_without_trailers();
   let response = client()
@@ -310,6 +339,32 @@ fn test_chunked_oversized_trailer_is_rejected() {
     error
       .to_string()
       .contains("chunked response line is too large"),
+    "unexpected error: {error}"
+  );
+}
+
+#[test]
+fn test_forbidden_chunked_response_trailer_is_rejected() {
+  let response = concat!(
+    "HTTP/1.1 200 OK\r\n",
+    "Transfer-Encoding: chunked\r\n",
+    "Connection: close\r\n",
+    "\r\n",
+    "2\r\nOK\r\n",
+    "0\r\n",
+    "WWW-Authenticate: unsafe\r\n",
+    "\r\n"
+  );
+  let (addr, _handle) = support::spawn_chunked_response_server(response);
+
+  let error = client()
+    .get()
+    .url(format!("http://{}/chunked", addr))
+    .emit()
+    .expect_err("forbidden chunk trailer should be rejected");
+
+  assert!(
+    error.to_string().contains("Forbidden trailer header"),
     "unexpected error: {error}"
   );
 }


### PR DESCRIPTION
Implemented live response trailer parity coverage for rttp_client sync and async clients. Tests now use the rttp socket2 server for valid chunked response trailers, verify case-insensitive trailer access through all response trailer APIs, and add sync negative coverage for forbidden trailer responses aligned with async behavior. Verification passed with formatting, focused trailer tests, and the workspace test suite.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1303/
work_kind: code_work
branch: hbx-1303-rttp-add-sync-and-async
base: main
commit: 3f2458cb6e86edba87d86a4d65ab171cdda8ae43
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1303/
    url: https://plane.kahub.in/endless/browse/HBX-1303/
    close_policy: link_only
```