### PR TITLE
feat: [rttp] Refresh trailer capability docs and examples after server/client parity

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,9 @@ rttp_client = "0.2"
 
 Direct TCP client connections are opened with `socket2`. SOCKS proxy handshakes
 are still delegated to the `socks` crate.
-Chunked responses are decoded by the client, and response trailers are available
-through the response trailer accessors.
+HTTP/1.x chunked responses are decoded by the client, and response trailers are
+available through `Response::trailers`, `Response::trailer`, and
+`Response::trailer_value`.
 
 ```rust,no_run
 use rttp_client::HttpClient;
@@ -60,6 +61,7 @@ fn main() -> std::io::Result<()> {
     println!("{} {}", request.method(), request.target());
     HttpResponse::ok("hello")
       .header("Transfer-Encoding", "chunked")
+      .header("Trailer", "X-Trace")
       .trailer("X-Trace", "abc")
   })
 }
@@ -71,18 +73,19 @@ connection, and `serve_requests` for a fixed number of sequential connections.
 Use `with_read_timeout` and `with_write_timeout` to apply socket-level
 timeouts to each accepted connection; pass `None` to leave the corresponding
 socket timeout unset. Add `Transfer-Encoding: chunked` to an `HttpResponse` to
-write the complete response body with chunked transfer framing instead of an
-automatic `Content-Length`; response trailers added with
-`HttpResponse::trailer` are written at the end of that chunked framing. The
-listener path uses `socket2`.
+write the complete response body with HTTP/1.x chunked transfer framing instead
+of an automatic `Content-Length`; response trailers added with
+`HttpResponse::trailer` are written after the terminating zero-size chunk. Add a
+`Trailer` response header when advertising which trailer fields will follow.
+The listener path uses `socket2`.
 
 The server is intentionally small: it handles blocking HTTP/1.x request parsing
 for local tests and simple embedded use. It accepts fixed `Content-Length` and
 chunked request bodies, exposes chunked request trailers, applies bounded
 request head/body validation, handles `HEAD` without writing a response body,
 honors `Connection` close/keep-alive semantics across a bounded
-`serve_requests` loop, writes response body framing consistently, and accepts
-`Expect: 100-continue`.
+`serve_requests` loop, writes response body framing and response trailers
+consistently, and accepts `Expect: 100-continue`.
 
 It is not a full RFC-covering web server and still does not implement server
 TLS or async accept loops.

--- a/rttp/README.md
+++ b/rttp/README.md
@@ -24,7 +24,9 @@ fn main() -> std::io::Result<()> {
     println!("{} {}", request.method(), request.target());
     HttpResponse::ok("hello")
       .header("Transfer-Encoding", "chunked")
+      .header("Trailer", "X-Trace, X-Signature")
       .trailer("X-Trace", "abc")
+      .trailer("X-Signature", "signed")
   })
 }
 ```
@@ -37,17 +39,20 @@ the same listener. `HttpServer::with_read_timeout` and
 connection; pass `None` to leave the corresponding socket timeout unset.
 
 Add `Transfer-Encoding: chunked` to an `HttpResponse` to write the complete
-response body with chunked transfer framing instead of an automatic
+response body with HTTP/1.x chunked transfer framing instead of an automatic
 `Content-Length` when the response status permits a message body. Response
-trailers added with `HttpResponse::trailer` are written at the end of that
-chunked framing.
+trailers added with `HttpResponse::trailer` are written after the terminating
+zero-size chunk, and can be inspected before serialization with
+`HttpResponse::trailers` or `HttpResponse::trailer_value`. Add a `Trailer`
+response header when advertising which trailer fields will follow.
 
 The server currently parses blocking HTTP/1.x requests for local tests and
 simple embedded use. It supports fixed `Content-Length` and chunked request
 bodies, preserves chunked request trailers on `Request`, bounds request
 head/body parsing, handles `HEAD` without writing a response body, honors
 `Connection` close/keep-alive semantics across a bounded `serve_requests` loop,
-writes response body framing consistently, and accepts `Expect: 100-continue`.
+writes response body framing and response trailers consistently, and accepts
+`Expect: 100-continue`.
 
 The server is intentionally not a full RFC-covering web server and still does
 not implement server TLS or async accept loops.

--- a/rttp_client/README.md
+++ b/rttp_client/README.md
@@ -22,8 +22,9 @@ rttp_client = { version = "0.2", features = ["async", "tls-rustls"] }
 
 Direct TCP connections use `socket2`. SOCKS proxy handshakes remain delegated to
 the `socks` crate.
-Chunked responses are decoded, and response trailers are exposed through
-`Response::trailers` and `Response::trailer`.
+HTTP/1.x chunked responses are decoded, and response trailers are exposed
+through `Response::trailers`, `Response::trailer`, and
+`Response::trailer_value` for both blocking and async request APIs.
 
 ## Examples
 


### PR DESCRIPTION
Refreshed public trailer documentation after server/client parity: top-level and crate READMEs now describe HTTP/1.x chunked response trailer support, server emission via `HttpResponse::trailer`, and client accessors for blocking and async responses.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1304/
work_kind: code_work
branch: hbx-1304-rttp-refresh-trailer-capability-docs
base: main
commit: 24a27008fb875ac201bc0d2019827eeb670dd458
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1304/
    url: https://plane.kahub.in/endless/browse/HBX-1304/
    close_policy: link_only
```