### PR TITLE
feat: [rttp] Preserve percent-encoded path and query octets across redirects

### DIFF
--- a/rttp_client/src/client.rs
+++ b/rttp_client/src/client.rs
@@ -30,18 +30,6 @@ impl HttpClient {
     Default::default()
   }
 
-  pub(crate) fn with_request(request: Request) -> Self {
-    Self { request }
-  }
-}
-
-impl HttpClient {
-  /// Set count of this request auto redirect times.
-  pub(crate) fn count(&mut self, count: u32) -> &mut Self {
-    self.request.count_set(count);
-    self
-  }
-
   /// Reset this request, The request only use once, This function can reset request.
   pub fn reset(&mut self) -> &mut Self {
     self.request = Request::new();

--- a/rttp_client/src/connection/async_connection.rs
+++ b/rttp_client/src/connection/async_connection.rs
@@ -60,15 +60,16 @@ impl<'a> AsyncConnection<'a> {
           }
 
           let redirect_url = self.conn.resolve_redirect_url(&url, location)?;
-          if url == redirect_url {
+          if url == redirect_url.url {
             return Err(error::loop_detected(url));
           }
-          let strip_sensitive_headers = !self.conn.is_same_origin_url(&url, &redirect_url);
+          let strip_sensitive_headers = !self.conn.is_same_origin_url(&url, &redirect_url.url);
           self.conn.request_mut().redirect_status_set(response.code());
-          self
-            .conn
-            .request_mut()
-            .redirect_url_set(redirect_url.to_string(), strip_sensitive_headers)?;
+          self.conn.request_mut().redirect_url_set(
+            redirect_url.url.to_string(),
+            strip_sensitive_headers,
+            Some(&redirect_url.request_target),
+          )?;
           self.conn.request_mut().origin_mut().count_set(count + 1);
           continue;
         }

--- a/rttp_client/src/connection/block_connection.rs
+++ b/rttp_client/src/connection/block_connection.rs
@@ -5,10 +5,10 @@ use url::Url;
 
 use crate::connection::connection::{Connection, ExpectContinueResult};
 use crate::connection::connection_reader::ResponseParts;
+use crate::error;
 use crate::request::RawRequest;
 use crate::response::Response;
 use crate::types::{Proxy, ProxyType};
-use crate::{error, HttpClient};
 
 pub struct BlockConnection<'a> {
   conn: Connection<'a>,
@@ -22,49 +22,51 @@ impl<'a> BlockConnection<'a> {
   }
 
   pub fn call(mut self) -> error::Result<Response> {
-    let url = self.conn.url().map_err(error::builder)?;
-    let proxy = self.conn.proxy().clone();
-    let parts = if let Some(proxy) = proxy.as_ref() {
-      self.call_with_proxy(&url, proxy)?
-    } else {
-      self.conn.block_send_parts(&url)?
-    };
+    loop {
+      let url = self.conn.url().map_err(error::builder)?;
+      let proxy = self.conn.proxy().clone();
+      let parts = if let Some(proxy) = proxy.as_ref() {
+        self.call_with_proxy(&url, proxy)?
+      } else {
+        self.conn.block_send_parts(&url)?
+      };
 
-    let config = self.conn.config();
-    let response =
-      Response::with_trailers(self.conn.rourl().clone(), parts.binary, parts.trailers)?;
+      let response =
+        Response::with_trailers(self.conn.rourl().clone(), parts.binary, parts.trailers)?;
+      let config = self.conn.config().clone();
 
-    if let Some(location) = response.location() {
-      let req_url = url.as_str();
-      if req_url == location {
-        return Err(error::loop_detected(url));
-      }
-      if !config.auto_redirect() {
-        self.conn.closed_set(true);
-        return Ok(response);
-      }
-      let count = self.conn.count();
-      if count > config.max_redirect() {
-        return Err(error::too_many_redirects(url));
+      if let Some(location) = response.location() {
+        let req_url = url.as_str();
+        if req_url == location {
+          return Err(error::loop_detected(url));
+        }
+        if !config.auto_redirect() {
+          self.conn.closed_set(true);
+          return Ok(response);
+        }
+        let count = self.conn.count();
+        if count > config.max_redirect() {
+          return Err(error::too_many_redirects(url));
+        }
+
+        let redirect_url = self.conn.resolve_redirect_url(&url, location)?;
+        if url == redirect_url.url {
+          return Err(error::loop_detected(url));
+        }
+        let strip_sensitive_headers = !self.conn.is_same_origin_url(&url, &redirect_url.url);
+        self.conn.request_mut().redirect_status_set(response.code());
+        self.conn.request_mut().redirect_url_set(
+          redirect_url.url.to_string(),
+          strip_sensitive_headers,
+          Some(&redirect_url.request_target),
+        )?;
+        self.conn.request_mut().origin_mut().count_set(count + 1);
+        continue;
       }
 
-      let redirect_url = self.conn.resolve_redirect_url(&url, location)?;
-      if url == redirect_url {
-        return Err(error::loop_detected(url));
-      }
-      let mut request = self.conn.request().origin().clone();
-      request.redirect_status_set(response.code());
-      if !self.conn.is_same_origin_url(&url, &redirect_url) {
-        request.remove_sensitive_redirect_headers();
-      }
-      return HttpClient::with_request(request)
-        .url(redirect_url.to_string())
-        .count(count + 1)
-        .emit();
+      self.conn.closed_set(true);
+      return Ok(response);
     }
-
-    self.conn.closed_set(true);
-    Ok(response)
   }
 }
 

--- a/rttp_client/src/connection/connection.rs
+++ b/rttp_client/src/connection/connection.rs
@@ -145,6 +145,11 @@ pub struct Connection<'a> {
   request: RawRequest<'a>,
 }
 
+pub(crate) struct RedirectUrl {
+  pub(crate) url: Url,
+  pub(crate) request_target: String,
+}
+
 impl<'a> Connection<'a> {
   pub fn new(request: RawRequest<'a>) -> Connection<'a> {
     Self { request }
@@ -230,20 +235,45 @@ impl<'a> Connection<'a> {
   pub fn proxy_http_header(&self, url: &Url, proxy: &Proxy) -> String {
     let header = self.header();
     let (_, rest) = header.split_once("\r\n").unwrap_or(("", ""));
+    let request_target = self
+      .request
+      .request_target()
+      .map(|target| format!("{}{}", &url[..url::Position::BeforePath], target))
+      .unwrap_or_else(|| absolute_url(url));
     let mut proxy_header = format!(
       "{} {} HTTP/1.1\r\n{}",
       self.request.origin().method().to_uppercase(),
-      absolute_url(url),
+      request_target,
       rest
     );
     append_proxy_authorization_header(&mut proxy_header, proxy);
     proxy_header
   }
 
-  pub fn resolve_redirect_url(&self, url: &Url, location: &str) -> error::Result<Url> {
-    url
+  pub fn resolve_redirect_url(&self, url: &Url, location: &str) -> error::Result<RedirectUrl> {
+    let mut redirect = url
       .join(location)
-      .map_err(|_| error::bad_url(url.clone(), "Bad redirect location"))
+      .map_err(|_| error::bad_url(url.clone(), "Bad redirect location"))?;
+    let (path, query) = raw_redirect_path_and_query(url, self.request.request_target(), location)
+      .unwrap_or_else(|| {
+        (
+          redirect.path().to_string(),
+          redirect.query().map(str::to_string),
+        )
+      });
+    redirect.set_path(&path);
+    redirect.set_query(query.as_deref());
+
+    let mut request_target = path;
+    if let Some(query) = query {
+      request_target.push('?');
+      request_target.push_str(&query);
+    }
+
+    Ok(RedirectUrl {
+      url: redirect,
+      request_target,
+    })
   }
 
   pub fn is_same_origin_url(&self, url: &Url, redirect: &Url) -> bool {
@@ -259,6 +289,116 @@ fn absolute_url(url: &Url) -> String {
   let mut absolute = url.clone();
   absolute.set_fragment(None);
   absolute.to_string()
+}
+
+fn raw_redirect_path_and_query(
+  base: &Url,
+  base_request_target: Option<&str>,
+  location: &str,
+) -> Option<(String, Option<String>)> {
+  let (base_path, base_query) = base_request_target
+    .and_then(raw_request_target_path_and_query)
+    .unwrap_or_else(|| (base.path(), base.query()));
+  let location = location.trim();
+  let location = location
+    .split_once('#')
+    .map_or(location, |(before, _)| before);
+  if location.is_empty() {
+    return Some((base_path.to_string(), base_query.map(str::to_string)));
+  }
+  if let Some(rest) = location.strip_prefix("//") {
+    return Some(raw_path_and_query_after_authority(rest));
+  }
+  if let Some(rest) = strip_absolute_url_scheme(location) {
+    if let Some(rest) = rest.strip_prefix("//") {
+      return Some(raw_path_and_query_after_authority(rest));
+    }
+    return None;
+  }
+  if let Some(query) = location.strip_prefix('?') {
+    return Some((base_path.to_string(), Some(query.to_string())));
+  }
+
+  let (path, query) = split_path_and_query(location);
+  if path.starts_with('/') {
+    return Some((remove_literal_dot_segments(path), query.map(str::to_string)));
+  }
+
+  let mut merged = base_path_directory(base_path);
+  merged.push_str(path);
+  Some((
+    remove_literal_dot_segments(&merged),
+    query.map(str::to_string),
+  ))
+}
+
+fn raw_request_target_path_and_query(target: &str) -> Option<(&str, Option<&str>)> {
+  if target.starts_with('/') {
+    return Some(split_path_and_query(target));
+  }
+  None
+}
+
+fn strip_absolute_url_scheme(location: &str) -> Option<&str> {
+  let scheme_end = location.find(':')?;
+  let scheme = &location[..scheme_end];
+  if scheme.is_empty() || !scheme.as_bytes()[0].is_ascii_alphabetic() {
+    return None;
+  }
+  if !scheme
+    .bytes()
+    .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'+' | b'-' | b'.'))
+  {
+    return None;
+  }
+  Some(&location[scheme_end + 1..])
+}
+
+fn raw_path_and_query_after_authority(rest: &str) -> (String, Option<String>) {
+  let path_start = rest
+    .find(|ch| matches!(ch, '/' | '?' | '#'))
+    .unwrap_or(rest.len());
+  let path_and_query = &rest[path_start..];
+  if path_and_query.is_empty() {
+    return ("/".to_string(), None);
+  }
+  if let Some(query) = path_and_query.strip_prefix('?') {
+    return ("/".to_string(), Some(query.to_string()));
+  }
+  let (path, query) = split_path_and_query(path_and_query);
+  (remove_literal_dot_segments(path), query.map(str::to_string))
+}
+
+fn split_path_and_query(value: &str) -> (&str, Option<&str>) {
+  value
+    .split_once('?')
+    .map_or((value, None), |(path, query)| (path, Some(query)))
+}
+
+fn base_path_directory(path: &str) -> String {
+  let directory_end = path.rfind('/').map_or(0, |index| index + 1);
+  path[..directory_end].to_string()
+}
+
+fn remove_literal_dot_segments(path: &str) -> String {
+  let mut segments: Vec<&str> = Vec::new();
+  for segment in path.split('/') {
+    match segment {
+      "." => {}
+      ".." => {
+        if segments.last().is_some_and(|last| !last.is_empty()) {
+          segments.pop();
+        }
+      }
+      _ => segments.push(segment),
+    }
+  }
+  let normalized = segments.join("/");
+  if normalized.is_empty() {
+    "/".to_string()
+  } else {
+    normalized
+  }
 }
 
 fn is_same_origin(left: &Url, right: &Url) -> bool {

--- a/rttp_client/src/connection/connection.rs
+++ b/rttp_client/src/connection/connection.rs
@@ -379,13 +379,22 @@ fn base_path_directory(path: &str) -> String {
 }
 
 fn remove_literal_dot_segments(path: &str) -> String {
+  let raw_segments: Vec<&str> = path.split('/').collect();
   let mut segments: Vec<&str> = Vec::new();
-  for segment in path.split('/') {
+  for (index, segment) in raw_segments.iter().enumerate() {
+    let is_last = index + 1 == raw_segments.len();
     match segment {
-      "." => {}
-      ".." => {
+      &"." => {
+        if is_last {
+          segments.push("");
+        }
+      }
+      &".." => {
         if segments.last().is_some_and(|last| !last.is_empty()) {
           segments.pop();
+        }
+        if is_last {
+          segments.push("");
         }
       }
       _ => segments.push(segment),

--- a/rttp_client/src/connection/connection.rs
+++ b/rttp_client/src/connection/connection.rs
@@ -383,13 +383,13 @@ fn remove_literal_dot_segments(path: &str) -> String {
   let mut segments: Vec<&str> = Vec::new();
   for (index, segment) in raw_segments.iter().enumerate() {
     let is_last = index + 1 == raw_segments.len();
-    match segment {
-      &"." => {
+    match *segment {
+      "." => {
         if is_last {
           segments.push("");
         }
       }
-      &".." => {
+      ".." => {
         if segments.last().is_some_and(|last| !last.is_empty()) {
           segments.pop();
         }

--- a/rttp_client/src/connection/connection.rs
+++ b/rttp_client/src/connection/connection.rs
@@ -355,9 +355,7 @@ fn strip_absolute_url_scheme(location: &str) -> Option<&str> {
 }
 
 fn raw_path_and_query_after_authority(rest: &str) -> (String, Option<String>) {
-  let path_start = rest
-    .find(|ch| matches!(ch, '/' | '?' | '#'))
-    .unwrap_or(rest.len());
+  let path_start = rest.find(['/', '?', '#']).unwrap_or(rest.len());
   let path_and_query = &rest[path_start..];
   if path_and_query.is_empty() {
     return ("/".to_string(), None);

--- a/rttp_client/src/request/raw_request.rs
+++ b/rttp_client/src/request/raw_request.rs
@@ -1,12 +1,9 @@
 use crate::error;
 use crate::request::builder::RawBuilder;
-#[cfg(feature = "async")]
 use crate::request::is_sensitive_redirect_header;
 use crate::request::{Request, RequestBody};
-#[cfg(feature = "async")]
 use crate::types::Header;
 use crate::types::RoUrl;
-#[cfg(feature = "async")]
 use crate::types::{ToRoUrl, ToUrl};
 
 #[derive(Debug)]
@@ -39,6 +36,14 @@ impl<'a> RawRequest<'a> {
     &self.header
   }
 
+  pub(crate) fn request_target(&self) -> Option<&str> {
+    self
+      .header
+      .lines()
+      .next()
+      .and_then(|line| line.split_whitespace().nth(1))
+  }
+
   pub fn body(&self) -> &Option<RequestBody> {
     &self.body
   }
@@ -51,7 +56,6 @@ impl<'a> RawRequest<'a> {
     self.origin
   }
 
-  #[cfg(feature = "async")]
   pub(crate) fn redirect_status_set(&mut self, status_code: u32) {
     self.origin.redirect_status_set(status_code);
     if status_code == 303 && !self.origin.method().eq_ignore_ascii_case("head") {
@@ -60,19 +64,25 @@ impl<'a> RawRequest<'a> {
     }
   }
 
-  #[cfg(feature = "async")]
   pub(crate) fn redirect_url_set<S: ToRoUrl>(
     &mut self,
     rourl: S,
     strip_sensitive_headers: bool,
+    request_target: Option<&str>,
   ) -> error::Result<()> {
     let rourl = rourl.to_rourl();
     let url = rourl.to_url()?;
     let host_header = Self::redirect_host_header(&url)?;
-    let mut request_target = url.path().to_string();
-    if let Some(query) = url.query() {
-      request_target.push_str(&format!("?{}", query));
-    }
+    let request_target = request_target.map_or_else(
+      || {
+        let mut request_target = url.path().to_string();
+        if let Some(query) = url.query() {
+          request_target.push_str(&format!("?{}", query));
+        }
+        request_target
+      },
+      str::to_string,
+    );
 
     self.origin.url_set(&rourl);
     if strip_sensitive_headers {
@@ -99,7 +109,6 @@ impl<'a> RawRequest<'a> {
     Ok(())
   }
 
-  #[cfg(feature = "async")]
   fn redirect_host_header(url: &url::Url) -> error::Result<Header> {
     let host = url.host_str().ok_or(error::url_bad_host(url.clone()))?;
     Ok(match url.port() {
@@ -108,7 +117,6 @@ impl<'a> RawRequest<'a> {
     })
   }
 
-  #[cfg(feature = "async")]
   fn redirect_host_set(&mut self, header: Header) {
     if let Some(origin_header) = self
       .origin
@@ -122,7 +130,6 @@ impl<'a> RawRequest<'a> {
     }
   }
 
-  #[cfg(feature = "async")]
   fn redirect_header_host_set(rest: &str, header: &Header) -> String {
     let mut rewritten = String::new();
     let mut replaced = false;
@@ -148,7 +155,6 @@ impl<'a> RawRequest<'a> {
     }
   }
 
-  #[cfg(feature = "async")]
   fn redirect_sensitive_headers_strip(rest: &str) -> String {
     let mut rewritten = String::new();
 
@@ -168,7 +174,6 @@ impl<'a> RawRequest<'a> {
     rewritten
   }
 
-  #[cfg(feature = "async")]
   fn redirect_body_headers_remove(header: &str) -> String {
     let Some((request_line, rest)) = header.split_once("\r\n") else {
       return header.to_string();

--- a/rttp_client/tests/test_http_async.rs
+++ b/rttp_client/tests/test_http_async.rs
@@ -754,6 +754,45 @@ fn test_async_auto_redirect_resolves_query_only_location() {
 
 #[test]
 #[cfg(feature = "async")]
+fn test_async_auto_redirect_preserves_percent_encoded_path_and_query_octets() {
+  block_on(async {
+    assert_async_redirect_resolves_to_target(
+      |_| "/files/%2e%2e/a%2fb/c%FF?next=%2fdone%3fx%3d1%FF&space=a%20b".to_string(),
+      "/files/%2e%2e/a%2fb/c%FF?next=%2fdone%3fx%3d1%FF&space=a%20b",
+    )
+    .await;
+  });
+}
+
+#[test]
+#[cfg(feature = "async")]
+fn test_async_auto_redirect_uses_preserved_percent_encoded_path_as_relative_base() {
+  let (addr, _handle) = support::spawn_redirect_chain_server(
+    vec![
+      ("/start", "/files/%2e%2e/a/"),
+      ("/files/%2e%2e/a/", "next%2fhop?token=%2e%2e"),
+    ],
+    3,
+  );
+  block_on(async {
+    let response = client()
+      .config(Config::builder().auto_redirect(true).max_redirect(2))
+      .get()
+      .url(format!("http://{}/start", addr))
+      .rasync()
+      .await;
+
+    assert!(response.is_ok());
+    let response = response.unwrap();
+    assert_eq!(
+      "/files/%2e%2e/a/next%2fhop?token=%2e%2e",
+      response.body().string().unwrap()
+    );
+  });
+}
+
+#[test]
+#[cfg(feature = "async")]
 fn test_async_auto_redirect_preserves_chain_that_finishes_within_max_redirect() {
   let (addr, _handle) = support::spawn_redirect_chain_server(
     vec![("/start", "/hop-one"), ("/hop-one", "/final?done=1")],

--- a/rttp_client/tests/test_http_basic.rs
+++ b/rttp_client/tests/test_http_basic.rs
@@ -802,6 +802,16 @@ fn test_auto_redirect_resolves_relative_path_location() {
 }
 
 #[test]
+fn test_auto_redirect_preserves_trailing_slash_for_dot_segment_location() {
+  assert_redirect_resolves_to_target(|_| ".".to_string(), "/redirect/");
+}
+
+#[test]
+fn test_auto_redirect_preserves_trailing_slash_for_parent_dot_segment_location() {
+  assert_redirect_resolves_to_target(|_| "/a/b/..".to_string(), "/a/");
+}
+
+#[test]
 fn test_auto_redirect_resolves_query_only_location() {
   assert_redirect_resolves_to_target(|_| "?page=2".to_string(), "/redirect/from?page=2");
 }

--- a/rttp_client/tests/test_http_basic.rs
+++ b/rttp_client/tests/test_http_basic.rs
@@ -807,6 +807,37 @@ fn test_auto_redirect_resolves_query_only_location() {
 }
 
 #[test]
+fn test_auto_redirect_preserves_percent_encoded_path_and_query_octets() {
+  assert_redirect_resolves_to_target(
+    |_| "/files/%2e%2e/a%2fb/c%FF?next=%2fdone%3fx%3d1%FF&space=a%20b".to_string(),
+    "/files/%2e%2e/a%2fb/c%FF?next=%2fdone%3fx%3d1%FF&space=a%20b",
+  );
+}
+
+#[test]
+fn test_auto_redirect_uses_preserved_percent_encoded_path_as_relative_base() {
+  let (addr, _handle) = support::spawn_redirect_chain_server(
+    vec![
+      ("/start", "/files/%2e%2e/a/"),
+      ("/files/%2e%2e/a/", "next%2fhop?token=%2e%2e"),
+    ],
+    3,
+  );
+  let response = client()
+    .config(Config::builder().auto_redirect(true).max_redirect(2))
+    .get()
+    .url(format!("http://{}/start", addr))
+    .emit();
+
+  assert!(response.is_ok());
+  let response = response.unwrap();
+  assert_eq!(
+    "/files/%2e%2e/a/next%2fhop?token=%2e%2e",
+    response.body().string().unwrap()
+  );
+}
+
+#[test]
 fn test_auto_redirect_preserves_chain_that_finishes_within_max_redirect() {
   let (addr, _handle) = support::spawn_redirect_chain_server(
     vec![("/start", "/hop-one"), ("/hop-one", "/final?done=1")],


### PR DESCRIPTION
Implemented redirect handling that preserves percent-encoded path and query octets across single and chained redirects, including encoded dot segments. Sync, async, and proxy request-target construction now use the preserved raw target. Verified with the rttp_client async-enabled test suite.

## Metadata
```yaml
version: 1
issue: default:1b98de78-062a-461d-9b98-e1b9266bfc8d
work_kind: code_work
branch: hbx-1320-rttp-preserve-percent-encoded-path
base: main
commit: 10f1d6c61bf5900cf2ed006c904b46c0582649cc
```