### PR TITLE
feat: [rttp] Add HTTP/1.1 compliance regression matrix for server/client parity

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,5 +2,6 @@
 members = [
   "rttp",
   "rttp_client",
+  "rttp_http11_test_fixtures",
 ]
 resolver = "2"

--- a/rttp/Cargo.toml
+++ b/rttp/Cargo.toml
@@ -26,6 +26,7 @@ rttp_client = { optional = true, path = "../rttp_client", features = [ "tls-nati
 async-std = { version = "1" }
 rcgen = "0.11"
 rustls = "0.23"
+rttp_http11_test_fixtures = { path = "../rttp_http11_test_fixtures" }
 
 
 [features]

--- a/rttp/tests/http11_compliance_matrix.rs
+++ b/rttp/tests/http11_compliance_matrix.rs
@@ -1,0 +1,180 @@
+use std::io::{Read, Write};
+use std::net::{Shutdown, TcpStream};
+use std::sync::mpsc;
+use std::thread;
+use std::time::Duration;
+
+use rttp::server::{HttpRequest, HttpResponse};
+use rttp_http11_test_fixtures as fixtures;
+
+#[test]
+fn model_parser_accepts_shared_fixed_length_request_fixture() {
+  let fixture = fixtures::request::fixed_length_post();
+
+  let request = HttpRequest::parse(fixture.raw).expect("fixed-length request should parse");
+
+  assert_eq!(fixture.method, request.method());
+  assert_eq!(fixture.path, request.path());
+  assert_eq!(fixture.query, request.query());
+  assert_eq!(fixture.version, request.version());
+  assert_eq!(Some(fixture.host), request.header("host"));
+  assert_eq!(fixture.body, request.body());
+}
+
+#[test]
+fn model_parser_rejects_shared_host_and_target_validation_fixtures() {
+  for fixture in fixtures::request::invalid_host_and_target_cases() {
+    let error = HttpRequest::parse(fixture.raw).expect_err(fixture.name);
+
+    assert_eq!(fixture.error, error.to_string(), "{}", fixture.name);
+  }
+}
+
+#[test]
+fn model_parser_rejects_shared_framing_ambiguity_fixtures() {
+  for fixture in fixtures::request::framing_ambiguity_cases() {
+    let error = HttpRequest::parse(fixture.raw).expect_err(fixture.name);
+
+    assert_eq!(fixture.error, error.to_string(), "{}", fixture.name);
+  }
+}
+
+#[test]
+fn live_socket2_server_accepts_shared_chunk_extensions_and_trailers_fixture() {
+  let fixture = fixtures::request::chunked_with_extensions_and_trailers();
+  let server = rttp::Http::server("127.0.0.1:0").expect("bind server");
+  let addr = server.local_addr().expect("server addr");
+  let (tx, rx) = mpsc::channel();
+
+  let handle = thread::spawn(move || {
+    server
+      .accept_one(|request| {
+        let trailers = fixture
+          .trailers
+          .iter()
+          .map(|(name, _)| (name.to_string(), request.trailer(name).map(str::to_string)))
+          .collect::<Vec<_>>();
+        tx.send((
+          request.method().to_string(),
+          request.target().to_string(),
+          request.body().to_vec(),
+          trailers,
+        ))
+        .expect("send parsed request");
+        HttpResponse::ok("accepted")
+      })
+      .expect("serve one request");
+  });
+
+  let mut stream = TcpStream::connect(addr).expect("connect server");
+  stream
+    .write_all(fixture.raw)
+    .expect("write chunked request");
+  stream.shutdown(Shutdown::Write).expect("shutdown write");
+
+  let mut response = String::new();
+  stream.read_to_string(&mut response).expect("read response");
+
+  let (method, target, body, trailers) = rx.recv().expect("parsed request");
+  assert_eq!(fixture.method, method);
+  assert_eq!(fixture.target, target);
+  assert_eq!(fixture.body, body.as_slice());
+  for ((name, value), (observed_name, observed_value)) in fixture.trailers.iter().zip(trailers) {
+    assert_eq!(*name, observed_name);
+    assert_eq!(Some((*value).to_string()), observed_value);
+  }
+  assert!(response.starts_with("HTTP/1.1 200 OK"));
+
+  handle.join().expect("server thread");
+}
+
+#[test]
+fn live_socket2_server_preserves_connection_lifetime_boundaries() {
+  let server = rttp::Http::server("127.0.0.1:0").expect("bind server");
+  let addr = server.local_addr().expect("server addr");
+  let (tx, rx) = mpsc::channel();
+
+  let handle = thread::spawn(move || {
+    server
+      .serve_requests(2, |request| {
+        tx.send((request.target().to_string(), request.body().to_vec()))
+          .expect("send parsed request");
+        HttpResponse::ok(format!("served {}", request.target()))
+      })
+      .expect("serve requests");
+  });
+
+  let mut stream = TcpStream::connect(addr).expect("connect server");
+  stream
+    .write_all(fixtures::request::keep_alive_pipeline())
+    .expect("write pipelined requests");
+  stream.shutdown(Shutdown::Write).expect("shutdown write");
+
+  let mut response = String::new();
+  stream
+    .read_to_string(&mut response)
+    .expect("read responses");
+
+  assert!(response.contains("served /matrix/first"));
+  assert!(response.contains("served /matrix/second"));
+  assert_eq!(
+    ("/matrix/first".to_string(), b"alpha".to_vec()),
+    rx.recv().expect("first request")
+  );
+  assert_eq!(
+    ("/matrix/second".to_string(), b"bravo!".to_vec()),
+    rx.recv().expect("second request")
+  );
+
+  handle.join().expect("server thread");
+}
+
+#[test]
+fn live_socket2_server_sends_continue_before_reading_shared_body_fixture() {
+  let fixture = fixtures::request::expect_continue_fixed_length();
+  let server = rttp::Http::server("127.0.0.1:0").expect("bind server");
+  let addr = server.local_addr().expect("server addr");
+  let (tx, rx) = mpsc::channel();
+
+  let handle = thread::spawn(move || {
+    server
+      .accept_one(|request| {
+        tx.send((request.target().to_string(), request.body().to_vec()))
+          .expect("send parsed request");
+        HttpResponse::ok("accepted")
+      })
+      .expect("serve one request");
+  });
+
+  let mut stream = TcpStream::connect(addr).expect("connect server");
+  stream
+    .set_read_timeout(Some(Duration::from_millis(250)))
+    .expect("set read timeout");
+  stream
+    .write_all(fixture.head)
+    .expect("write expect-continue head");
+
+  let mut interim = vec![0; fixtures::response::CONTINUE.len()];
+  stream
+    .read_exact(&mut interim)
+    .expect("read interim response");
+  assert_eq!(fixtures::response::CONTINUE, interim.as_slice());
+
+  stream
+    .write_all(fixture.body)
+    .expect("write expect-continue body");
+  stream.shutdown(Shutdown::Write).expect("shutdown write");
+
+  let mut response = String::new();
+  stream
+    .read_to_string(&mut response)
+    .expect("read final response");
+
+  assert!(response.starts_with("HTTP/1.1 200 OK"));
+  assert_eq!(
+    (fixture.target.to_string(), fixture.body.to_vec()),
+    rx.recv().expect("parsed request")
+  );
+
+  handle.join().expect("server thread");
+}

--- a/rttp_client/Cargo.toml
+++ b/rttp_client/Cargo.toml
@@ -66,3 +66,4 @@ tls-rustls  = ["rustls", "webpki-roots", "futures-rustls"]
 [dev-dependencies]
 rcgen = "0.11"
 rttp = { path = "../rttp" }
+rttp_http11_test_fixtures = { path = "../rttp_http11_test_fixtures" }

--- a/rttp_client/tests/http11_compliance_matrix.rs
+++ b/rttp_client/tests/http11_compliance_matrix.rs
@@ -1,0 +1,167 @@
+#[cfg(feature = "async")]
+use futures::executor::block_on;
+use rttp_client::HttpClient;
+use rttp_http11_test_fixtures as fixtures;
+
+fn client() -> HttpClient {
+  HttpClient::new()
+}
+
+#[test]
+fn sync_client_decodes_shared_chunk_extensions_and_trailers_fixture() {
+  let (addr, handle) = fixtures::spawn_socket2_raw_response_server(
+    fixtures::response::CHUNKED_WITH_EXTENSIONS_AND_TRAILERS,
+  );
+
+  let response = client()
+    .get()
+    .url(format!("http://{}/matrix/chunked", addr))
+    .emit()
+    .expect("sync response should parse");
+
+  assert_eq!(200, response.code());
+  assert_eq!("chunked body!", response.body().string().unwrap());
+  assert_eq!(Some(&"abc".to_string()), response.trailer_value("x-trace"));
+  assert_eq!(
+    Some(&"signed".to_string()),
+    response.trailer_value("X-SIGNATURE")
+  );
+
+  let request = handle.join().expect("raw response server thread");
+  assert!(String::from_utf8_lossy(&request).starts_with("GET /matrix/chunked HTTP/1.1"));
+}
+
+#[test]
+fn sync_client_rejects_shared_response_framing_ambiguity_fixture() {
+  let (addr, handle) = fixtures::spawn_socket2_raw_response_server(
+    fixtures::response::TRANSFER_ENCODING_WITH_CONTENT_LENGTH,
+  );
+
+  let error = client()
+    .get()
+    .url(format!("http://{}/matrix/ambiguous", addr))
+    .emit()
+    .expect_err("ambiguous response should be rejected");
+
+  assert!(
+    error.to_string().contains("Content-Length"),
+    "unexpected error: {error}"
+  );
+  handle.join().expect("raw response server thread");
+}
+
+#[test]
+fn sync_client_waits_for_shared_expect_continue_fixture() {
+  let fixture = fixtures::request::expect_continue_fixed_length();
+  let (addr, handle) = fixtures::spawn_socket2_expect_continue_server(
+    concat!(
+      "HTTP/1.1 200 OK\r\n",
+      "Content-Length: 8\r\n",
+      "Connection: close\r\n",
+      "\r\n",
+      "accepted"
+    )
+    .as_bytes(),
+  );
+
+  let response = client()
+    .post()
+    .url(format!("http://{}{}", addr, fixture.target))
+    .header(("Expect", "100-continue"))
+    .raw(String::from_utf8_lossy(fixture.body).as_ref())
+    .emit()
+    .expect("expect-continue response should parse");
+
+  assert_eq!(200, response.code());
+  assert_eq!("accepted", response.body().string().unwrap());
+
+  let request = handle.join().expect("raw response server thread");
+  assert!(String::from_utf8_lossy(&request).contains("Expect: 100-continue"));
+  assert!(request.ends_with(fixture.body));
+}
+
+#[test]
+#[cfg(feature = "async")]
+fn async_client_decodes_shared_chunk_extensions_and_trailers_fixture() {
+  let (addr, handle) = fixtures::spawn_socket2_raw_response_server(
+    fixtures::response::CHUNKED_WITH_EXTENSIONS_AND_TRAILERS,
+  );
+
+  block_on(async {
+    let response = client()
+      .get()
+      .url(format!("http://{}/matrix/chunked", addr))
+      .rasync()
+      .await
+      .expect("async response should parse");
+
+    assert_eq!(200, response.code());
+    assert_eq!("chunked body!", response.body().string().unwrap());
+    assert_eq!(Some(&"abc".to_string()), response.trailer_value("x-trace"));
+    assert_eq!(
+      Some(&"signed".to_string()),
+      response.trailer_value("X-SIGNATURE")
+    );
+  });
+
+  let request = handle.join().expect("raw response server thread");
+  assert!(String::from_utf8_lossy(&request).starts_with("GET /matrix/chunked HTTP/1.1"));
+}
+
+#[test]
+#[cfg(feature = "async")]
+fn async_client_rejects_shared_response_framing_ambiguity_fixture() {
+  let (addr, handle) = fixtures::spawn_socket2_raw_response_server(
+    fixtures::response::TRANSFER_ENCODING_WITH_CONTENT_LENGTH,
+  );
+
+  block_on(async {
+    let error = client()
+      .get()
+      .url(format!("http://{}/matrix/ambiguous", addr))
+      .rasync()
+      .await
+      .expect_err("ambiguous response should be rejected");
+
+    assert!(
+      error.to_string().contains("Content-Length"),
+      "unexpected error: {error}"
+    );
+  });
+
+  handle.join().expect("raw response server thread");
+}
+
+#[test]
+#[cfg(feature = "async")]
+fn async_client_waits_for_shared_expect_continue_fixture() {
+  let fixture = fixtures::request::expect_continue_fixed_length();
+  let (addr, handle) = fixtures::spawn_socket2_expect_continue_server(
+    concat!(
+      "HTTP/1.1 200 OK\r\n",
+      "Content-Length: 8\r\n",
+      "Connection: close\r\n",
+      "\r\n",
+      "accepted"
+    )
+    .as_bytes(),
+  );
+
+  block_on(async {
+    let response = client()
+      .post()
+      .url(format!("http://{}{}", addr, fixture.target))
+      .header(("Expect", "100-continue"))
+      .raw(String::from_utf8_lossy(fixture.body).as_ref())
+      .rasync()
+      .await
+      .expect("expect-continue response should parse");
+
+    assert_eq!(200, response.code());
+    assert_eq!("accepted", response.body().string().unwrap());
+  });
+
+  let request = handle.join().expect("raw response server thread");
+  assert!(String::from_utf8_lossy(&request).contains("Expect: 100-continue"));
+  assert!(request.ends_with(fixture.body));
+}

--- a/rttp_http11_test_fixtures/Cargo.toml
+++ b/rttp_http11_test_fixtures/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "rttp_http11_test_fixtures"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+socket2 = "0.5"

--- a/rttp_http11_test_fixtures/src/lib.rs
+++ b/rttp_http11_test_fixtures/src/lib.rs
@@ -1,0 +1,328 @@
+use std::io::{Read, Write};
+use std::net::{SocketAddr, TcpListener};
+use std::thread::{self, JoinHandle};
+use std::time::Duration;
+
+use socket2::{Domain, Protocol, Socket, Type};
+
+pub mod request {
+  pub struct FixedLengthRequest {
+    pub raw: &'static [u8],
+    pub method: &'static str,
+    pub path: &'static str,
+    pub query: Option<&'static str>,
+    pub version: &'static str,
+    pub host: &'static str,
+    pub body: &'static [u8],
+  }
+
+  pub struct InvalidRequest {
+    pub name: &'static str,
+    pub raw: &'static [u8],
+    pub error: &'static str,
+  }
+
+  pub struct ChunkedRequest {
+    pub raw: &'static [u8],
+    pub method: &'static str,
+    pub target: &'static str,
+    pub body: &'static [u8],
+    pub trailers: &'static [(&'static str, &'static str)],
+  }
+
+  pub struct ExpectContinueRequest {
+    pub head: &'static [u8],
+    pub body: &'static [u8],
+    pub target: &'static str,
+  }
+
+  pub fn fixed_length_post() -> FixedLengthRequest {
+    FixedLengthRequest {
+      raw: b"POST /matrix/fixed?case=shared HTTP/1.1\r\nHost: example.test\r\nContent-Length: 11\r\n\r\nhello=world",
+      method: "POST",
+      path: "/matrix/fixed",
+      query: Some("case=shared"),
+      version: "HTTP/1.1",
+      host: "example.test",
+      body: b"hello=world",
+    }
+  }
+
+  pub fn invalid_host_and_target_cases() -> &'static [InvalidRequest] {
+    &[
+      InvalidRequest {
+        name: "missing host",
+        raw: b"GET /matrix HTTP/1.1\r\n\r\n",
+        error: "HTTP/1.1 request requires exactly one Host header",
+      },
+      InvalidRequest {
+        name: "duplicate host",
+        raw: b"GET /matrix HTTP/1.1\r\nHost: example.test\r\nHost: other.test\r\n\r\n",
+        error: "HTTP/1.1 request requires exactly one Host header",
+      },
+      InvalidRequest {
+        name: "invalid origin target",
+        raw: b"GET matrix HTTP/1.1\r\nHost: example.test\r\n\r\n",
+        error: "invalid request target",
+      },
+      InvalidRequest {
+        name: "connect authority host mismatch",
+        raw: b"CONNECT example.test:443 HTTP/1.1\r\nHost: other.test:443\r\n\r\n",
+        error: "invalid Host header",
+      },
+    ]
+  }
+
+  pub fn framing_ambiguity_cases() -> &'static [InvalidRequest] {
+    &[
+      InvalidRequest {
+        name: "conflicting content length",
+        raw: b"POST /matrix HTTP/1.1\r\nHost: example.test\r\nContent-Length: 5\r\nContent-Length: 6\r\n\r\nhello",
+        error: "conflicting Content-Length headers",
+      },
+      InvalidRequest {
+        name: "transfer encoding with content length",
+        raw: b"POST /matrix HTTP/1.1\r\nHost: example.test\r\nTransfer-Encoding: chunked\r\nContent-Length: 5\r\n\r\nhello",
+        error: "Transfer-Encoding conflicts with Content-Length",
+      },
+    ]
+  }
+
+  pub fn chunked_with_extensions_and_trailers() -> ChunkedRequest {
+    ChunkedRequest {
+      raw: concat!(
+        "POST /matrix/chunked HTTP/1.1\r\n",
+        "Host: example.test\r\n",
+        "Transfer-Encoding: chunked\r\n",
+        "\r\n",
+        "5;foo=\"bar;baz\";answer=42\r\n",
+        "hello\r\n",
+        "6;token=value\r\n",
+        " world\r\n",
+        "0\r\n",
+        "X-Trace: abc\r\n",
+        "X-Signature: signed\r\n",
+        "\r\n"
+      )
+      .as_bytes(),
+      method: "POST",
+      target: "/matrix/chunked",
+      body: b"hello world",
+      trailers: &[("x-trace", "abc"), ("X-SIGNATURE", "signed")],
+    }
+  }
+
+  pub fn keep_alive_pipeline() -> &'static [u8] {
+    concat!(
+      "POST /matrix/first HTTP/1.1\r\n",
+      "Host: example.test\r\n",
+      "Connection: keep-alive\r\n",
+      "Content-Length: 5\r\n",
+      "\r\n",
+      "alpha",
+      "POST /matrix/second HTTP/1.1\r\n",
+      "Host: example.test\r\n",
+      "Connection: close\r\n",
+      "Content-Length: 6\r\n",
+      "\r\n",
+      "bravo!"
+    )
+    .as_bytes()
+  }
+
+  pub fn expect_continue_fixed_length() -> ExpectContinueRequest {
+    ExpectContinueRequest {
+      head: concat!(
+        "POST /matrix/continue HTTP/1.1\r\n",
+        "Host: example.test\r\n",
+        "Expect: 100-continue\r\n",
+        "Content-Length: 12\r\n",
+        "\r\n"
+      )
+      .as_bytes(),
+      body: b"request body",
+      target: "/matrix/continue",
+    }
+  }
+}
+
+pub mod response {
+  pub const CONTINUE: &[u8] = b"HTTP/1.1 100 Continue\r\n\r\n";
+
+  pub const CHUNKED_WITH_EXTENSIONS_AND_TRAILERS: &[u8] = concat!(
+    "HTTP/1.1 200 OK\r\n",
+    "Transfer-Encoding: chunked\r\n",
+    "\r\n",
+    "7;foo=\"bar;baz\";answer=42\r\n",
+    "chunked\r\n",
+    "6;token=value\r\n",
+    " body!\r\n",
+    "0\r\n",
+    "X-Trace: abc\r\n",
+    "X-Signature: signed\r\n",
+    "\r\n"
+  )
+  .as_bytes();
+
+  pub const TRANSFER_ENCODING_WITH_CONTENT_LENGTH: &[u8] = concat!(
+    "HTTP/1.1 200 OK\r\n",
+    "Transfer-Encoding: chunked\r\n",
+    "Content-Length: 13\r\n",
+    "\r\n",
+    "0\r\n",
+    "\r\n"
+  )
+  .as_bytes();
+}
+
+pub fn bind_socket2_tcp_listener(name: &str) -> (TcpListener, SocketAddr) {
+  let addr: SocketAddr = "127.0.0.1:0".parse().expect("parse local addr");
+  let socket = Socket::new(Domain::IPV4, Type::STREAM, Some(Protocol::TCP))
+    .unwrap_or_else(|err| panic!("create {name} socket: {err}"));
+  socket
+    .set_reuse_address(true)
+    .unwrap_or_else(|err| panic!("set {name} reuse addr: {err}"));
+  socket
+    .bind(&addr.into())
+    .unwrap_or_else(|err| panic!("bind {name}: {err}"));
+  socket
+    .listen(16)
+    .unwrap_or_else(|err| panic!("listen {name}: {err}"));
+  let listener = TcpListener::from(socket);
+  let addr = listener
+    .local_addr()
+    .unwrap_or_else(|err| panic!("read {name} local addr: {err}"));
+  (listener, addr)
+}
+
+pub fn read_http_request<R: Read>(stream: &mut R) -> Vec<u8> {
+  let mut request = Vec::new();
+  let mut buf = [0u8; 1024];
+  let mut content_length = None;
+
+  loop {
+    let Ok(read) = stream.read(&mut buf) else {
+      break;
+    };
+    if read == 0 {
+      break;
+    }
+
+    request.extend_from_slice(&buf[..read]);
+
+    let header_end = request.windows(4).position(|window| window == b"\r\n\r\n");
+    if content_length.is_none() {
+      if let Some(header_end) = header_end {
+        let headers = String::from_utf8_lossy(&request[..header_end + 4]);
+        content_length = headers
+          .lines()
+          .find_map(|line| {
+            let (name, value) = line.split_once(':')?;
+            if name.eq_ignore_ascii_case("content-length") {
+              value.trim().parse::<usize>().ok()
+            } else {
+              None
+            }
+          })
+          .or(Some(0));
+      }
+    }
+
+    if let (Some(header_end), Some(content_length)) = (header_end, content_length) {
+      let expected_len = header_end + 4 + content_length;
+      if request.len() >= expected_len {
+        break;
+      }
+    }
+  }
+
+  request
+}
+
+pub fn spawn_socket2_raw_response_server(
+  response: &'static [u8],
+) -> (SocketAddr, JoinHandle<Vec<u8>>) {
+  let (listener, addr) = bind_socket2_tcp_listener("raw response server");
+  let handle = thread::spawn(move || {
+    let Ok((mut stream, _)) = listener.accept() else {
+      return Vec::new();
+    };
+    stream
+      .set_read_timeout(Some(Duration::from_secs(2)))
+      .expect("set read timeout");
+    let request = read_http_request(&mut stream);
+    let _ = stream.write_all(response);
+    request
+  });
+  (addr, handle)
+}
+
+pub fn spawn_socket2_expect_continue_server(
+  final_response: &'static [u8],
+) -> (SocketAddr, JoinHandle<Vec<u8>>) {
+  let (listener, addr) = bind_socket2_tcp_listener("expect continue server");
+  let handle = thread::spawn(move || {
+    let Ok((mut stream, _)) = listener.accept() else {
+      return Vec::new();
+    };
+    stream
+      .set_read_timeout(Some(Duration::from_secs(2)))
+      .expect("set read timeout");
+
+    let mut request = read_until_header_end(&mut stream);
+    let content_length = request_content_length(&request).unwrap_or(0);
+    let _ = stream.write_all(response::CONTINUE);
+
+    let header_end = request
+      .windows(4)
+      .position(|window| window == b"\r\n\r\n")
+      .map(|position| position + 4)
+      .unwrap_or(request.len());
+    let body_bytes_read = request.len().saturating_sub(header_end);
+    if body_bytes_read < content_length {
+      let mut body = vec![0; content_length - body_bytes_read];
+      if stream.read_exact(&mut body).is_ok() {
+        request.extend_from_slice(&body);
+      }
+    }
+
+    let _ = stream.write_all(final_response);
+    request
+  });
+  (addr, handle)
+}
+
+fn read_until_header_end<R: Read>(stream: &mut R) -> Vec<u8> {
+  let mut request = Vec::new();
+  let mut buf = [0u8; 256];
+
+  loop {
+    let Ok(read) = stream.read(&mut buf) else {
+      break;
+    };
+    if read == 0 {
+      break;
+    }
+    request.extend_from_slice(&buf[..read]);
+    if request.windows(4).any(|window| window == b"\r\n\r\n") {
+      break;
+    }
+  }
+
+  request
+}
+
+fn request_content_length(request: &[u8]) -> Option<usize> {
+  let header_end = request
+    .windows(4)
+    .position(|window| window == b"\r\n\r\n")?;
+  let headers = String::from_utf8_lossy(&request[..header_end + 4]);
+  headers.lines().find_map(|line| {
+    let (name, value) = line.split_once(':')?;
+    if name.eq_ignore_ascii_case("content-length") {
+      value.trim().parse::<usize>().ok()
+    } else {
+      None
+    }
+  })
+}

--- a/rttp_http11_test_fixtures/src/lib.rs
+++ b/rttp_http11_test_fixtures/src/lib.rs
@@ -200,10 +200,7 @@ pub fn read_http_request<R: Read>(stream: &mut R) -> Vec<u8> {
   let mut buf = [0u8; 1024];
   let mut content_length = None;
 
-  loop {
-    let Ok(read) = stream.read(&mut buf) else {
-      break;
-    };
+  while let Ok(read) = stream.read(&mut buf) {
     if read == 0 {
       break;
     }
@@ -305,10 +302,7 @@ fn read_until_header_end<R: Read>(stream: &mut R) -> Vec<u8> {
   let mut request = Vec::new();
   let mut buf = [0u8; 256];
 
-  loop {
-    let Ok(read) = stream.read(&mut buf) else {
-      break;
-    };
+  while let Ok(read) = stream.read(&mut buf) {
     if read == 0 {
       break;
     }

--- a/rttp_http11_test_fixtures/src/lib.rs
+++ b/rttp_http11_test_fixtures/src/lib.rs
@@ -269,27 +269,36 @@ pub fn spawn_socket2_expect_continue_server(
       .set_read_timeout(Some(Duration::from_secs(2)))
       .expect("set read timeout");
 
-    let mut request = read_until_header_end(&mut stream);
-    let content_length = request_content_length(&request).unwrap_or(0);
-    let _ = stream.write_all(response::CONTINUE);
-
-    let header_end = request
-      .windows(4)
-      .position(|window| window == b"\r\n\r\n")
-      .map(|position| position + 4)
-      .unwrap_or(request.len());
-    let body_bytes_read = request.len().saturating_sub(header_end);
-    if body_bytes_read < content_length {
-      let mut body = vec![0; content_length - body_bytes_read];
-      if stream.read_exact(&mut body).is_ok() {
-        request.extend_from_slice(&body);
-      }
-    }
-
-    let _ = stream.write_all(final_response);
-    request
+    serve_expect_continue_stream(&mut stream, final_response)
   });
   (addr, handle)
+}
+
+fn serve_expect_continue_stream<S: Read + Write>(stream: &mut S, final_response: &[u8]) -> Vec<u8> {
+  let mut request = read_until_header_end(stream);
+  let content_length = request_content_length(&request).unwrap_or(0);
+
+  let header_end = request
+    .windows(4)
+    .position(|window| window == b"\r\n\r\n")
+    .map(|position| position + 4)
+    .unwrap_or(request.len());
+  let body_bytes_read = request.len().saturating_sub(header_end);
+  if body_bytes_read != 0 {
+    return Vec::new();
+  }
+
+  let _ = stream.write_all(response::CONTINUE);
+
+  if body_bytes_read < content_length {
+    let mut body = vec![0; content_length - body_bytes_read];
+    if stream.read_exact(&mut body).is_ok() {
+      request.extend_from_slice(&body);
+    }
+  }
+
+  let _ = stream.write_all(final_response);
+  request
 }
 
 fn read_until_header_end<R: Read>(stream: &mut R) -> Vec<u8> {
@@ -325,4 +334,65 @@ fn request_content_length(request: &[u8]) -> Option<usize> {
       None
     }
   })
+}
+
+#[cfg(test)]
+mod tests {
+  use super::{request, serve_expect_continue_stream};
+  use std::io::{self, Read, Write};
+
+  struct InMemoryStream {
+    read: Vec<u8>,
+    written: Vec<u8>,
+  }
+
+  impl InMemoryStream {
+    fn new(read: Vec<u8>) -> Self {
+      Self {
+        read,
+        written: Vec::new(),
+      }
+    }
+  }
+
+  impl Read for InMemoryStream {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+      let read = buf.len().min(self.read.len());
+      buf[..read].copy_from_slice(&self.read[..read]);
+      self.read.drain(..read);
+      Ok(read)
+    }
+  }
+
+  impl Write for InMemoryStream {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+      self.written.extend_from_slice(buf);
+      Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+      Ok(())
+    }
+  }
+
+  #[test]
+  fn expect_continue_server_rejects_premature_body_bytes() {
+    let fixture = request::expect_continue_fixed_length();
+    let mut request = Vec::new();
+    request.extend_from_slice(fixture.head);
+    request.extend_from_slice(fixture.body);
+    let mut stream = InMemoryStream::new(request);
+
+    assert_eq!(
+      Vec::<u8>::new(),
+      serve_expect_continue_stream(&mut stream, b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n")
+    );
+    assert!(
+      !stream
+        .written
+        .windows(super::response::CONTINUE.len())
+        .any(|window| window == super::response::CONTINUE),
+      "server must not send 100 Continue after premature body"
+    );
+  }
 }


### PR DESCRIPTION
Added a shared HTTP/1.1 test fixture crate and regression matrix covering server, sync client, and async client parity for connection lifetime, Host/target validation, Expect: 100-continue, chunk extensions, framing ambiguity, and trailers. Verified with formatting, full workspace tests, and async client matrix tests.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1311/
work_kind: code_work
branch: hbx-1311-rttp-add-http-1-1
base: main
commit: 093e45fd5053e47da41ad3b3bb360a5b2bf4c5df
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1311/
    url: https://plane.kahub.in/endless/browse/HBX-1311/
    close_policy: link_only
```