### PR TITLE
feat: [rttp] Reject conflicting outbound Host and authority combinations

### DIFF
--- a/rttp_client/src/request/builder/build_header.rs
+++ b/rttp_client/src/request/builder/build_header.rs
@@ -88,31 +88,27 @@ fn format_host_for_authority(host: &str) -> String {
 
 impl<'a> RawBuilder<'a> {
   fn auto_add_host(&mut self, url: &Url) -> error::Result<()> {
-    if self.found_header("host") {
-      return Ok(());
-    }
-    let host = url.host_str().ok_or(error::url_bad_host(url.clone()))?;
-    let host = format_host_for_authority(host);
-    let header = match (
-      self.request.method().eq_ignore_ascii_case("connect"),
-      url.port(),
-    ) {
-      (true, Some(port)) => Header::new("Host", format!("{}:{}", host, port)),
-      (true, None) => Header::new(
-        "Host",
+    let host = expected_host_header(url, self.request.method())?;
+    if let Some(header) = self
+      .request
+      .headers()
+      .iter()
+      .find(|item| item.name().eq_ignore_ascii_case("host"))
+    {
+      if header.value().eq_ignore_ascii_case(host.value()) {
+        return Ok(());
+      }
+      return Err(error::bad_url(
+        url.clone(),
         format!(
-          "{}:{}",
-          host,
-          url
-            .port_or_known_default()
-            .ok_or(error::url_bad_host(url.clone()))?
+          "Host header '{}' conflicts with URL authority '{}'",
+          header.value(),
+          host.value()
         ),
-      ),
-      (false, Some(port)) => Header::new("Host", format!("{}:{}", host, port)),
-      (false, None) => Header::new("Host", host),
-    };
+      ));
+    }
 
-    self.request.headers_mut().push(header);
+    self.request.headers_mut().push(host);
     Ok(())
   }
 
@@ -126,7 +122,29 @@ impl<'a> RawBuilder<'a> {
       .push(Header::new("Connection", "Close"));
     Ok(())
   }
+}
 
+fn expected_host_header(url: &Url, method: &str) -> error::Result<Header> {
+  let host = url.host_str().ok_or(error::url_bad_host(url.clone()))?;
+  let host = format_host_for_authority(host);
+  Ok(match (method.eq_ignore_ascii_case("connect"), url.port()) {
+    (true, Some(port)) => Header::new("Host", format!("{}:{}", host, port)),
+    (true, None) => Header::new(
+      "Host",
+      format!(
+        "{}:{}",
+        host,
+        url
+          .port_or_known_default()
+          .ok_or(error::url_bad_host(url.clone()))?
+      ),
+    ),
+    (false, Some(port)) => Header::new("Host", format!("{}:{}", host, port)),
+    (false, None) => Header::new("Host", host),
+  })
+}
+
+impl<'a> RawBuilder<'a> {
   fn auto_add_ua(&mut self) -> error::Result<()> {
     if self.found_header("user-agent") {
       return Ok(());

--- a/rttp_client/tests/support/local_http.rs
+++ b/rttp_client/tests/support/local_http.rs
@@ -1,6 +1,7 @@
 use std::io::{Read, Write};
 use std::net::{SocketAddr, TcpListener};
 use std::thread::{self, JoinHandle};
+use std::time::{Duration, Instant};
 
 pub const HTTP_OK_RESPONSE: &[u8] =
   b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nOK";
@@ -83,6 +84,33 @@ pub fn capture_raw_http_request() -> (SocketAddr, JoinHandle<Vec<u8>>) {
     let request = read_http_request(&mut stream);
     let _ = stream.write_all(HTTP_OK_RESPONSE);
     request
+  });
+  (addr, handle)
+}
+
+pub fn capture_optional_raw_http_request(timeout: Duration) -> (SocketAddr, JoinHandle<Vec<u8>>) {
+  let (listener, addr) = bind_local_http_listener("optional raw request capture server");
+  listener
+    .set_nonblocking(true)
+    .expect("set optional raw request capture server nonblocking");
+  let handle = thread::spawn(move || {
+    let deadline = Instant::now() + timeout;
+    loop {
+      match listener.accept() {
+        Ok((mut stream, _)) => {
+          let request = read_http_request(&mut stream);
+          let _ = stream.write_all(HTTP_OK_RESPONSE);
+          return request;
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+          if Instant::now() >= deadline {
+            return Vec::new();
+          }
+          thread::sleep(Duration::from_millis(10));
+        }
+        Err(_) => return Vec::new(),
+      }
+    }
   });
   (addr, handle)
 }

--- a/rttp_client/tests/support/mod.rs
+++ b/rttp_client/tests/support/mod.rs
@@ -122,6 +122,10 @@ pub fn capture_raw_http_request() -> (SocketAddr, JoinHandle<Vec<u8>>) {
   local_http::capture_raw_http_request()
 }
 
+pub fn capture_optional_raw_http_request(timeout: Duration) -> (SocketAddr, JoinHandle<Vec<u8>>) {
+  local_http::capture_optional_raw_http_request(timeout)
+}
+
 pub fn spawn_chunked_server() -> (SocketAddr, JoinHandle<()>) {
   spawn_chunked_response_server(concat!(
     "HTTP/1.1 200 OK\r\n",

--- a/rttp_client/tests/test_http_basic.rs
+++ b/rttp_client/tests/test_http_basic.rs
@@ -30,7 +30,7 @@ fn test_multi() {
     .url(RoUrl::with(format!("http://{}/?id=1&name=jack#none", addr)).para("name=Julia"))
     .path("post")
     .header("User-Agent: Mozilla/5.0")
-    .header("Host: localhost")
+    .header(("Host", addr.to_string().as_str()))
     .para("name=Chico")
     .para(&"name=文".to_string())
     .para(para_map)

--- a/rttp_client/tests/test_raw_request_capture.rs
+++ b/rttp_client/tests/test_raw_request_capture.rs
@@ -1,6 +1,9 @@
 mod support;
 
+#[cfg(feature = "async")]
+use futures::executor::block_on;
 use rttp_client::HttpClient;
+use std::time::Duration;
 
 fn client() -> HttpClient {
   HttpClient::new()
@@ -10,6 +13,12 @@ fn capture_request(request: impl FnOnce(String)) -> Vec<u8> {
   let (addr, handle) = support::capture_raw_http_request();
   request(format!("http://{}", addr));
   handle.join().expect("raw request capture server")
+}
+
+fn capture_optional_request(request: impl FnOnce(String)) -> Vec<u8> {
+  let (addr, handle) = support::capture_optional_raw_http_request(Duration::from_millis(250));
+  request(format!("http://{}", addr));
+  handle.join().expect("optional raw request capture server")
 }
 
 fn request_text(request: &[u8]) -> String {
@@ -299,10 +308,13 @@ fn multipart_form_body_sends_generated_content_type_and_content_length() {
 #[test]
 fn custom_common_headers_are_not_overwritten_by_auto_headers() {
   let request = capture_request(|base_url| {
+    let authority = base_url
+      .strip_prefix("http://")
+      .expect("test URL should be http");
     client()
       .get()
       .url(format!("{}/headers", base_url))
-      .header("Host: example.test")
+      .header(("Host", authority))
       .header("User-Agent: custom-agent/1.0")
       .header("Accept: application/json")
       .header("Connection: keep-alive")
@@ -311,11 +323,144 @@ fn custom_common_headers_are_not_overwritten_by_auto_headers() {
   });
 
   let text = request_text(&request);
+  let authority = header_value(&text, "Host").expect("host header");
 
-  assert_eq!(Some("example.test"), header_value(&text, "Host"));
+  assert!(authority.starts_with("127.0.0.1:"));
   assert_eq!(Some("custom-agent/1.0"), header_value(&text, "User-Agent"));
   assert_eq!(Some("application/json"), header_value(&text, "Accept"));
   assert_eq!(Some("keep-alive"), header_value(&text, "Connection"));
+}
+
+#[test]
+fn matching_explicit_host_header_is_preserved() {
+  let request = capture_request(|base_url| {
+    let authority = base_url
+      .strip_prefix("http://")
+      .expect("test URL should be http");
+    client()
+      .get()
+      .url(format!("{}/headers", base_url))
+      .header(("Host", authority))
+      .emit()
+      .expect("request should succeed");
+  });
+
+  let text = request_text(&request);
+  let authority = header_value(&text, "Host").expect("host header");
+
+  assert!(authority.starts_with("127.0.0.1:"));
+  assert!(text.starts_with("GET /headers HTTP/1.1\r\n"));
+}
+
+#[test]
+fn conflicting_explicit_host_header_is_rejected_before_sending_request() {
+  let request = capture_optional_request(|base_url| {
+    let error = client()
+      .get()
+      .url(format!("{}/headers", base_url))
+      .header(("Host", "example.test"))
+      .emit()
+      .expect_err("conflicting host should be rejected");
+
+    assert!(error.is_builder());
+    assert!(error.to_string().contains("Host header"));
+  });
+
+  assert_eq!(b"", request.as_slice());
+}
+
+#[test]
+fn missing_host_header_is_generated_from_url_authority() {
+  let request = capture_request(|base_url| {
+    client()
+      .get()
+      .url(format!("{}/headers", base_url))
+      .emit()
+      .expect("request should succeed");
+  });
+
+  let text = request_text(&request);
+  let authority = text
+    .lines()
+    .find_map(|line| line.strip_prefix("Host: "))
+    .expect("generated host header");
+
+  assert!(authority.starts_with("127.0.0.1:"));
+  assert!(text.starts_with("GET /headers HTTP/1.1\r\n"));
+}
+
+#[test]
+#[cfg(feature = "async")]
+fn async_matching_explicit_host_header_is_preserved() {
+  let request = {
+    let (addr, handle) = support::capture_raw_http_request();
+    block_on(async {
+      let base_url = format!("http://{}", addr);
+      let authority = base_url
+        .strip_prefix("http://")
+        .expect("test URL should be http");
+      client()
+        .get()
+        .url(format!("{}/headers", base_url))
+        .header(("Host", authority))
+        .rasync()
+        .await
+        .expect("request should succeed");
+    });
+    handle.join().expect("raw request capture server")
+  };
+
+  let text = request_text(&request);
+  let authority = header_value(&text, "Host").expect("host header");
+
+  assert!(authority.starts_with("127.0.0.1:"));
+  assert!(text.starts_with("GET /headers HTTP/1.1\r\n"));
+}
+
+#[test]
+#[cfg(feature = "async")]
+fn async_conflicting_explicit_host_header_is_rejected_before_sending_request() {
+  let request = {
+    let (addr, handle) = support::capture_optional_raw_http_request(Duration::from_millis(250));
+    block_on(async {
+      let error = client()
+        .get()
+        .url(format!("http://{}/headers", addr))
+        .header(("Host", "example.test"))
+        .rasync()
+        .await
+        .expect_err("conflicting host should be rejected");
+
+      assert!(error.is_builder());
+      assert!(error.to_string().contains("Host header"));
+    });
+    handle.join().expect("optional raw request capture server")
+  };
+
+  assert_eq!(b"", request.as_slice());
+}
+
+#[test]
+#[cfg(feature = "async")]
+fn async_missing_host_header_is_generated_from_url_authority() {
+  let request = {
+    let (addr, handle) = support::capture_raw_http_request();
+    block_on(async {
+      client()
+        .get()
+        .url(format!("http://{}/headers", addr))
+        .rasync()
+        .await
+        .expect("request should succeed");
+    });
+    handle.join().expect("raw request capture server")
+  };
+
+  let text = request_text(&request);
+  let authority = header_value(&text, "Host").expect("generated host header");
+
+  assert!(authority.starts_with("127.0.0.1:"));
+  assert!(text.starts_with("GET /headers HTTP/1.1\r\n"));
 }
 
 #[test]


### PR DESCRIPTION
rttp_client now rejects conflicting explicit Host headers before sending HTTP/1.1 requests, while preserving matching Host headers and generated Host behavior across sync and async APIs. Added local raw-request capture coverage and verified formatting, focused async/sync framing tests, and the full workspace test suite.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1321/
work_kind: code_work
branch: hbx-1321-rttp-reject-conflicting-outbound-host
base: main
commit: bd055ddad9d52d5e053c57eaf2200cfd7ebee59c
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1321/
    url: https://plane.kahub.in/endless/browse/HBX-1321/
    close_policy: link_only
```