### PR TITLE
feat: [rttp] Add malformed chunk-size and trailer termination regression tests

### DIFF
--- a/rttp/src/server.rs
+++ b/rttp/src/server.rs
@@ -1703,6 +1703,90 @@ hello\r\n\
   }
 
   #[test]
+  fn read_next_from_rejects_invalid_chunk_size_characters() {
+    let raw = concat!(
+      "POST /chunked HTTP/1.1\r\n",
+      "Host: example.test\r\n",
+      "Transfer-Encoding: chunked\r\n",
+      "\r\n",
+      "5G\r\nhello\r\n",
+      "0\r\n",
+      "\r\n"
+    );
+    let mut reader = BufReader::new(Cursor::new(raw.as_bytes()));
+
+    let error = Request::read_next_from(&mut reader).expect_err("invalid chunk size should fail");
+
+    assert_eq!(io::ErrorKind::InvalidData, error.kind());
+    assert_eq!("invalid chunk size", error.to_string());
+  }
+
+  #[test]
+  fn read_next_from_rejects_oversized_chunk_size_line() {
+    let chunk_size = "1".repeat(MAX_REQUEST_BODY_BYTES);
+    let raw = format!(
+      concat!(
+        "POST /chunked HTTP/1.1\r\n",
+        "Host: example.test\r\n",
+        "Transfer-Encoding: chunked\r\n",
+        "\r\n",
+        "{}\r\n",
+        "x\r\n",
+        "0\r\n",
+        "\r\n"
+      ),
+      chunk_size
+    );
+    let mut reader = BufReader::new(Cursor::new(raw.as_bytes()));
+
+    let error =
+      Request::read_next_from(&mut reader).expect_err("oversized chunk size line should fail");
+
+    assert_eq!(io::ErrorKind::InvalidData, error.kind());
+    assert_eq!("request body is too large", error.to_string());
+  }
+
+  #[test]
+  fn read_next_from_rejects_missing_crlf_after_chunk_data() {
+    let raw = concat!(
+      "POST /chunked HTTP/1.1\r\n",
+      "Host: example.test\r\n",
+      "Transfer-Encoding: chunked\r\n",
+      "\r\n",
+      "5\r\nhello",
+      "0\r\n",
+      "\r\n"
+    );
+    let mut reader = BufReader::new(Cursor::new(raw.as_bytes()));
+
+    let error =
+      Request::read_next_from(&mut reader).expect_err("missing chunk data terminator should fail");
+
+    assert_eq!(io::ErrorKind::InvalidData, error.kind());
+    assert_eq!("invalid chunk terminator", error.to_string());
+  }
+
+  #[test]
+  fn read_next_from_rejects_malformed_trailer_termination() {
+    let raw = concat!(
+      "POST /chunked HTTP/1.1\r\n",
+      "Host: example.test\r\n",
+      "Transfer-Encoding: chunked\r\n",
+      "\r\n",
+      "5\r\nhello\r\n",
+      "0\r\n",
+      "X-Trace: abc\r\n"
+    );
+    let mut reader = BufReader::new(Cursor::new(raw.as_bytes()));
+
+    let error =
+      Request::read_next_from(&mut reader).expect_err("missing trailer terminator should fail");
+
+    assert_eq!(io::ErrorKind::UnexpectedEof, error.kind());
+    assert_eq!("incomplete chunked request body", error.to_string());
+  }
+
+  #[test]
   fn connection_close_request_marks_keep_alive_loop_terminal() {
     let raw = concat!(
       "POST /final HTTP/1.1\r\n",

--- a/rttp/tests/test_server.rs
+++ b/rttp/tests/test_server.rs
@@ -1589,16 +1589,17 @@ fn server_returns_bad_request_for_invalid_chunk_terminator() {
 fn server_closes_keep_alive_after_malformed_chunked_request() {
   let server = rttp::Http::server("127.0.0.1:0").expect("bind server");
   let addr = server.local_addr().expect("server addr");
-  let (tx, rx) = mpsc::channel();
+  let (handler_tx, handler_rx) = mpsc::channel();
+  let (done_tx, done_rx) = mpsc::channel();
 
   let handle = thread::spawn(move || {
-    server
-      .accept_one(|request| {
-        tx.send(request.target().to_string())
-          .expect("send parsed target");
-        HttpResponse::ok(format!("served {}", request.target()))
-      })
-      .expect("serve one request");
+    let result = server.serve_requests(2, |request| {
+      handler_tx
+        .send(request.target().to_string())
+        .expect("send parsed target");
+      HttpResponse::ok(format!("served {}", request.target()))
+    });
+    done_tx.send(result).expect("send server result");
   });
 
   let mut stream = TcpStream::connect(addr).expect("connect server");
@@ -1630,12 +1631,23 @@ fn server_closes_keep_alive_after_malformed_chunked_request() {
   let mut response = String::new();
   stream.read_to_string(&mut response).expect("read response");
 
-  handle.join().expect("server thread");
-  assert!(rx.try_recv().is_err());
+  assert!(handler_rx.try_recv().is_err());
   assert_eq!(
     "HTTP/1.1 400 Bad Request\r\nContent-Length: 11\r\nConnection: close\r\n\r\nBad Request",
     response
   );
+
+  let second_stream = TcpStream::connect(addr).expect("connect second client");
+  second_stream
+    .shutdown(std::net::Shutdown::Write)
+    .expect("shutdown second write");
+
+  let result = done_rx
+    .recv_timeout(Duration::from_millis(250))
+    .expect("serve_requests returned after second connection");
+  assert!(result.is_ok(), "serve_requests failed: {result:?}");
+
+  handle.join().expect("server thread");
 }
 
 #[test]

--- a/rttp/tests/test_server.rs
+++ b/rttp/tests/test_server.rs
@@ -1586,6 +1586,59 @@ fn server_returns_bad_request_for_invalid_chunk_terminator() {
 }
 
 #[test]
+fn server_closes_keep_alive_after_malformed_chunked_request() {
+  let server = rttp::Http::server("127.0.0.1:0").expect("bind server");
+  let addr = server.local_addr().expect("server addr");
+  let (tx, rx) = mpsc::channel();
+
+  let handle = thread::spawn(move || {
+    server
+      .accept_one(|request| {
+        tx.send(request.target().to_string())
+          .expect("send parsed target");
+        HttpResponse::ok(format!("served {}", request.target()))
+      })
+      .expect("serve one request");
+  });
+
+  let mut stream = TcpStream::connect(addr).expect("connect server");
+  stream
+    .set_read_timeout(Some(Duration::from_millis(250)))
+    .expect("set read timeout");
+  stream
+    .write_all(
+      concat!(
+        "POST /broken HTTP/1.1\r\n",
+        "Host: localhost\r\n",
+        "Connection: keep-alive\r\n",
+        "Transfer-Encoding: chunked\r\n",
+        "\r\n",
+        "5\r\nhello",
+        "XX",
+        "GET /leaked HTTP/1.1\r\n",
+        "Host: localhost\r\n",
+        "Connection: keep-alive\r\n",
+        "\r\n"
+      )
+      .as_bytes(),
+    )
+    .expect("write malformed pipelined request");
+  stream
+    .shutdown(std::net::Shutdown::Write)
+    .expect("shutdown write");
+
+  let mut response = String::new();
+  stream.read_to_string(&mut response).expect("read response");
+
+  handle.join().expect("server thread");
+  assert!(rx.try_recv().is_err());
+  assert_eq!(
+    "HTTP/1.1 400 Bad Request\r\nContent-Length: 11\r\nConnection: close\r\n\r\nBad Request",
+    response
+  );
+}
+
+#[test]
 fn server_returns_bad_request_for_unsupported_transfer_encoding() {
   let (response, handler_called) =
     send_raw_request(b"POST /upload HTTP/1.1\r\nHost: localhost\r\nTransfer-Encoding: gzip, chunked\r\n\r\n0\r\n\r\n");

--- a/rttp_client/tests/test_http_async.rs
+++ b/rttp_client/tests/test_http_async.rs
@@ -237,6 +237,34 @@ fn test_async_chunked_malformed_extension_is_rejected() {
 
 #[test]
 #[cfg(feature = "async")]
+fn test_async_chunked_missing_crlf_after_chunk_data_is_rejected() {
+  let (addr, _handle) = support::spawn_chunked_response_server(concat!(
+    "HTTP/1.1 200 OK\r\n",
+    "Transfer-Encoding: chunked\r\n",
+    "Connection: close\r\n",
+    "\r\n",
+    "2\r\nOK",
+    "0\r\n",
+    "\r\n"
+  ));
+
+  block_on(async {
+    let error = client()
+      .get()
+      .url(format!("http://{}/chunked", addr))
+      .rasync()
+      .await
+      .expect_err("missing chunk data terminator should be rejected");
+
+    assert!(
+      error.to_string().contains("Invalid chunk terminator"),
+      "unexpected error: {error}"
+    );
+  });
+}
+
+#[test]
+#[cfg(feature = "async")]
 fn test_async_chunked_oversized_extension_is_rejected() {
   let extension = "a".repeat(16 * 1024);
   let response = format!(

--- a/rttp_client/tests/test_http_basic.rs
+++ b/rttp_client/tests/test_http_basic.rs
@@ -285,6 +285,30 @@ fn test_chunked_malformed_extension_is_rejected() {
 }
 
 #[test]
+fn test_chunked_missing_crlf_after_chunk_data_is_rejected() {
+  let (addr, _handle) = support::spawn_chunked_response_server(concat!(
+    "HTTP/1.1 200 OK\r\n",
+    "Transfer-Encoding: chunked\r\n",
+    "Connection: close\r\n",
+    "\r\n",
+    "2\r\nOK",
+    "0\r\n",
+    "\r\n"
+  ));
+
+  let error = client()
+    .get()
+    .url(format!("http://{}/chunked", addr))
+    .emit()
+    .expect_err("missing chunk data terminator should be rejected");
+
+  assert!(
+    error.to_string().contains("Invalid chunk terminator"),
+    "unexpected error: {error}"
+  );
+}
+
+#[test]
 fn test_chunked_oversized_extension_is_rejected() {
   let extension = "a".repeat(16 * 1024);
   let response = format!(


### PR DESCRIPTION
Added regression coverage for malformed HTTP/1.1 chunk framing across server parser, live keep-alive request handling, and sync/async client response parsing. Formatting, focused chunk tests, workspace tests, and async-feature workspace tests pass.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1323/
work_kind: code_work
branch: hbx-1323-rttp-add-malformed-chunk-size
base: main
commit: 741cce839524a9339288cc43382208f8228b2579
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1323/
    url: https://plane.kahub.in/endless/browse/HBX-1323/
    close_policy: link_only
```