### PR TITLE
feat: [rttp] Add streaming response body reader for sync and async clients

### DIFF
--- a/rttp_client/src/connection/async_connection.rs
+++ b/rttp_client/src/connection/async_connection.rs
@@ -13,7 +13,7 @@ use crate::connection::connection::{
   ExpectContinueResult,
 };
 use crate::connection::connection_reader::{
-  is_skippable_informational_status, response_body_kind, response_status_code,
+  is_skippable_informational_status, response_body_kind, response_headers, response_status_code,
   validate_response_trailer_header, ResponseBodyKind, ResponseParts,
   MAX_CHUNKED_RESPONSE_LINE_BYTES,
 };
@@ -22,6 +22,175 @@ use crate::request::RawRequest;
 use crate::response::Response;
 use crate::types::{Header, Proxy, ProxyType};
 const CRLF: &[u8] = b"\r\n";
+
+pub struct AsyncStreamingResponse<'a, S: AsyncRead + Unpin + ?Sized> {
+  head: Vec<u8>,
+  body: AsyncResponseBodyReader<'a, S>,
+}
+
+impl<'a, S: AsyncRead + Unpin + ?Sized> AsyncStreamingResponse<'a, S> {
+  pub fn code(&self) -> error::Result<u16> {
+    response_status_code(&self.head)
+  }
+
+  pub fn headers(&self) -> error::Result<Vec<Header>> {
+    response_headers(&self.head)
+  }
+
+  pub fn head(&self) -> &[u8] {
+    &self.head
+  }
+
+  pub fn body_mut(&mut self) -> &mut AsyncResponseBodyReader<'a, S> {
+    &mut self.body
+  }
+
+  pub fn trailers(&self) -> &Vec<Header> {
+    self.body.trailers()
+  }
+
+  pub fn trailer<SName: AsRef<str>>(&self, name: SName) -> Option<&Header> {
+    self
+      .trailers()
+      .iter()
+      .find(|header| header.name().eq_ignore_ascii_case(name.as_ref()))
+  }
+
+  pub fn trailer_value<SName: AsRef<str>>(&self, name: SName) -> Option<&String> {
+    self.trailer(name).map(|header| header.value())
+  }
+
+  async fn read_to_parts(mut self) -> error::Result<ResponseParts> {
+    let mut binary = self.head;
+    self.body.read_to_end(&mut binary).await?;
+    Ok(ResponseParts {
+      binary,
+      trailers: self.body.trailers().clone(),
+    })
+  }
+}
+
+pub struct AsyncResponseBodyReader<'a, S: AsyncRead + Unpin + ?Sized> {
+  stream: &'a mut S,
+  kind: ResponseBodyKind,
+  remaining: usize,
+  chunk_remaining: usize,
+  chunk_needs_crlf: bool,
+  trailers: Vec<Header>,
+  eof: bool,
+}
+
+impl<'a, S: AsyncRead + Unpin + ?Sized> AsyncResponseBodyReader<'a, S> {
+  fn new(stream: &'a mut S, kind: ResponseBodyKind) -> Self {
+    let remaining = match kind {
+      ResponseBodyKind::ContentLength(length) => length,
+      _ => 0,
+    };
+    let eof = matches!(kind, ResponseBodyKind::NoBody);
+    Self {
+      stream,
+      kind,
+      remaining,
+      chunk_remaining: 0,
+      chunk_needs_crlf: false,
+      trailers: Vec::new(),
+      eof,
+    }
+  }
+
+  pub fn trailers(&self) -> &Vec<Header> {
+    &self.trailers
+  }
+
+  pub async fn read(&mut self, buf: &mut [u8]) -> error::Result<usize> {
+    match self.kind {
+      ResponseBodyKind::NoBody => Ok(0),
+      ResponseBodyKind::ContentLength(_) => self.read_fixed_length(buf).await,
+      ResponseBodyKind::Chunked => self.read_chunked(buf).await,
+      ResponseBodyKind::UntilEof => {
+        let read = self.stream.read(buf).await.map_err(error::request)?;
+        if read == 0 {
+          self.eof = true;
+        }
+        Ok(read)
+      }
+    }
+  }
+
+  pub async fn read_to_end(&mut self, body: &mut Vec<u8>) -> error::Result<usize> {
+    let start = body.len();
+    let mut buf = [0u8; 8 * 1024];
+    loop {
+      let read = self.read(&mut buf).await?;
+      if read == 0 {
+        return Ok(body.len() - start);
+      }
+      body.extend_from_slice(&buf[..read]);
+    }
+  }
+
+  async fn read_fixed_length(&mut self, buf: &mut [u8]) -> error::Result<usize> {
+    if self.remaining == 0 || buf.is_empty() {
+      self.eof = self.remaining == 0;
+      return Ok(0);
+    }
+
+    let limit = buf.len().min(self.remaining);
+    let read = self
+      .stream
+      .read(&mut buf[..limit])
+      .await
+      .map_err(error::request)?;
+    if read == 0 {
+      return Err(error::request(io::Error::new(
+        io::ErrorKind::UnexpectedEof,
+        "failed to fill whole buffer",
+      )));
+    }
+    self.remaining -= read;
+    if self.remaining == 0 {
+      self.eof = true;
+    }
+    Ok(read)
+  }
+
+  async fn read_chunked(&mut self, buf: &mut [u8]) -> error::Result<usize> {
+    if self.eof || buf.is_empty() {
+      return Ok(0);
+    }
+
+    if self.chunk_needs_crlf {
+      async_consume_crlf(self.stream).await?;
+      self.chunk_needs_crlf = false;
+    }
+
+    while self.chunk_remaining == 0 {
+      let line = async_read_bounded_crlf_line(self.stream, MAX_CHUNKED_RESPONSE_LINE_BYTES).await?;
+      let chunk_size = parse_chunk_size(&line)?;
+      if chunk_size == 0 {
+        self.trailers = async_read_trailers(self.stream).await?;
+        self.eof = true;
+        return Ok(0);
+      }
+      self.chunk_remaining = chunk_size;
+    }
+
+    let limit = buf.len().min(self.chunk_remaining);
+    let read = self
+      .stream
+      .read(&mut buf[..limit])
+      .await
+      .map_err(error::request)?;
+    if read == 0 {
+      return Err(error::bad_response("Unexpected end of chunked body"));
+    }
+    self.chunk_remaining -= read;
+    if self.chunk_remaining == 0 {
+      self.chunk_needs_crlf = true;
+    }
+    Ok(read)
+  }
+}
 
 pub struct AsyncConnection<'a> {
   conn: Connection<'a>,
@@ -150,14 +319,7 @@ impl<'a> AsyncConnection<'a> {
   where
     S: AsyncRead + Unpin,
   {
-    let binary = loop {
-      let header = async_read_response_header(stream).await?;
-      let status_code = response_status_code(&header)?;
-      if is_skippable_informational_status(status_code) {
-        continue;
-      }
-      break header;
-    };
+    let binary = async_read_response_head(stream).await?;
     self
       .async_read_stream_parts_after_header(stream, binary)
       .await
@@ -166,35 +328,15 @@ impl<'a> AsyncConnection<'a> {
   async fn async_read_stream_parts_after_header<S>(
     &self,
     stream: &mut S,
-    mut binary: Vec<u8>,
+    binary: Vec<u8>,
   ) -> error::Result<ResponseParts>
   where
     S: AsyncRead + Unpin,
   {
-    let mut trailers = Vec::new();
-    match response_body_kind(&binary, self.conn.expect_no_response_body())? {
-      ResponseBodyKind::NoBody => {}
-      ResponseBodyKind::Chunked => {
-        let chunked = async_read_chunked_response_body(stream).await?;
-        binary.extend_from_slice(&chunked.body);
-        trailers = chunked.trailers;
-      }
-      ResponseBodyKind::ContentLength(content_length) => {
-        let current_len = binary.len();
-        binary.resize(current_len + content_length, 0);
-        stream
-          .read_exact(&mut binary[current_len..])
-          .await
-          .map_err(error::request)?;
-      }
-      ResponseBodyKind::UntilEof => {
-        stream
-          .read_to_end(&mut binary)
-          .await
-          .map_err(error::request)?;
-      }
-    }
-    Ok(ResponseParts { binary, trailers })
+    async_streaming_response_after_header(stream, self.conn.expect_no_response_body(), binary)
+      .await?
+      .read_to_parts()
+      .await
   }
 
   async fn async_send_expect_continue_parts<S>(
@@ -240,9 +382,38 @@ impl<'a> AsyncConnection<'a> {
   }
 }
 
+async fn async_read_response_head<S>(stream: &mut S) -> error::Result<Vec<u8>>
+where
+  S: AsyncRead + Unpin + ?Sized,
+{
+  loop {
+    let header = async_read_response_header(stream).await?;
+    let status_code = response_status_code(&header)?;
+    if is_skippable_informational_status(status_code) {
+      continue;
+    }
+    return Ok(header);
+  }
+}
+
+pub async fn async_streaming_response_after_header<S>(
+  stream: &mut S,
+  expect_no_body: bool,
+  head: Vec<u8>,
+) -> error::Result<AsyncStreamingResponse<'_, S>>
+where
+  S: AsyncRead + Unpin + ?Sized,
+{
+  let kind = response_body_kind(&head, expect_no_body)?;
+  Ok(AsyncStreamingResponse {
+    head,
+    body: AsyncResponseBodyReader::new(stream, kind),
+  })
+}
+
 async fn async_read_response_header<S>(stream: &mut S) -> error::Result<Vec<u8>>
 where
-  S: AsyncRead + Unpin,
+  S: AsyncRead + Unpin + ?Sized,
 {
   let mut header = Vec::new();
   let mut byte = [0u8; 1];
@@ -263,39 +434,9 @@ where
   }
 }
 
-struct ChunkedResponseBody {
-  body: Vec<u8>,
-  trailers: Vec<Header>,
-}
-
-async fn async_read_chunked_response_body<S>(stream: &mut S) -> error::Result<ChunkedResponseBody>
-where
-  S: AsyncRead + Unpin,
-{
-  let mut body = Vec::new();
-
-  loop {
-    let line = async_read_bounded_crlf_line(stream, MAX_CHUNKED_RESPONSE_LINE_BYTES).await?;
-    let chunk_size = parse_chunk_size(&line)?;
-
-    if chunk_size == 0 {
-      let trailers = async_read_trailers(stream).await?;
-      return Ok(ChunkedResponseBody { body, trailers });
-    }
-
-    let current_len = body.len();
-    body.resize(current_len + chunk_size, 0);
-    stream
-      .read_exact(&mut body[current_len..])
-      .await
-      .map_err(error::request)?;
-    async_consume_crlf(stream).await?;
-  }
-}
-
 async fn async_read_bounded_crlf_line<S>(stream: &mut S, max_len: usize) -> error::Result<Vec<u8>>
 where
-  S: AsyncRead + Unpin,
+  S: AsyncRead + Unpin + ?Sized,
 {
   let mut line = Vec::new();
   let mut byte = [0u8; 1];
@@ -438,7 +579,7 @@ fn is_quoted_pair_char(byte: u8) -> bool {
 
 async fn async_consume_crlf<S>(stream: &mut S) -> error::Result<()>
 where
-  S: AsyncRead + Unpin,
+  S: AsyncRead + Unpin + ?Sized,
 {
   let mut suffix = [0u8; 2];
   stream.read_exact(&mut suffix).await.map_err(|err| {
@@ -457,7 +598,7 @@ where
 
 async fn async_read_trailers<S>(stream: &mut S) -> error::Result<Vec<Header>>
 where
-  S: AsyncRead + Unpin,
+  S: AsyncRead + Unpin + ?Sized,
 {
   let mut trailers = Vec::new();
   loop {
@@ -692,5 +833,84 @@ impl<'a> AsyncConnection<'a> {
     }
     .map_err(error::request)?;
     self.conn.block_send_with_stream_parts(url, &mut stream)
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use std::io::Cursor;
+
+  use futures::executor::block_on;
+  use futures::io::AllowStdIo;
+
+  use super::{async_read_response_head, async_streaming_response_after_header};
+
+  #[test]
+  fn async_streaming_response_reads_fixed_length_body_incrementally() {
+    block_on(async {
+      let raw = concat!(
+        "HTTP/1.1 200 OK\r\n",
+        "Content-Length: 5\r\n",
+        "X-Trace: head\r\n",
+        "\r\n",
+        "hello",
+        "next"
+      );
+      let mut cursor = AllowStdIo::new(Cursor::new(raw.as_bytes()));
+      let head = async_read_response_head(&mut cursor).await.unwrap();
+      let mut response = async_streaming_response_after_header(&mut cursor, false, head)
+        .await
+        .unwrap();
+      let mut buf = [0; 2];
+
+      assert_eq!(200, response.code().unwrap());
+      assert_eq!(
+        Some("head"),
+        response
+          .headers()
+          .unwrap()
+          .iter()
+          .find(|header| header.name().eq_ignore_ascii_case("x-trace"))
+          .map(|header| header.value().as_str())
+      );
+      assert_eq!(2, response.body_mut().read(&mut buf).await.unwrap());
+      assert_eq!(b"he", &buf);
+      assert_eq!(2, response.body_mut().read(&mut buf).await.unwrap());
+      assert_eq!(b"ll", &buf);
+      assert_eq!(1, response.body_mut().read(&mut buf).await.unwrap());
+      assert_eq!(b"o", &buf[..1]);
+      assert_eq!(0, response.body_mut().read(&mut buf).await.unwrap());
+      assert!(response.trailers().is_empty());
+    });
+  }
+
+  #[test]
+  fn async_streaming_response_reads_chunked_body_and_exposes_trailers_after_eof() {
+    block_on(async {
+      let raw = concat!(
+        "HTTP/1.1 200 OK\r\n",
+        "Transfer-Encoding: chunked\r\n",
+        "\r\n",
+        "2\r\nhe\r\n",
+        "3\r\nllo\r\n",
+        "0\r\n",
+        "X-Trace: abc\r\n",
+        "\r\n"
+      );
+      let mut cursor = AllowStdIo::new(Cursor::new(raw.as_bytes()));
+      let head = async_read_response_head(&mut cursor).await.unwrap();
+      let mut response = async_streaming_response_after_header(&mut cursor, false, head)
+        .await
+        .unwrap();
+      let mut body = Vec::new();
+
+      response.body_mut().read_to_end(&mut body).await.unwrap();
+
+      assert_eq!(b"hello", body.as_slice());
+      assert_eq!(
+        Some("abc"),
+        response.trailer_value("x-trace").map(String::as_str)
+      );
+    });
   }
 }

--- a/rttp_client/src/connection/connection_reader.rs
+++ b/rttp_client/src/connection/connection_reader.rs
@@ -5,7 +5,7 @@ use url::Url;
 
 use crate::error;
 use crate::response::Response;
-use crate::types::{Header, RoUrl};
+use crate::types::{Header, IntoHeader, RoUrl};
 
 const HEADER_END: &[u8] = b"\r\n\r\n";
 const CRLF: &[u8] = b"\r\n";
@@ -22,6 +22,159 @@ pub(crate) enum ResponseBodyKind {
 pub(crate) struct ResponseParts {
   pub(crate) binary: Vec<u8>,
   pub(crate) trailers: Vec<Header>,
+}
+
+pub struct StreamingResponse<'a, R: Read + ?Sized> {
+  url: RoUrl,
+  head: Vec<u8>,
+  body: ResponseBodyReader<'a, R>,
+}
+
+impl<'a, R: Read + ?Sized> StreamingResponse<'a, R> {
+  pub fn code(&self) -> error::Result<u16> {
+    response_status_code(&self.head)
+  }
+
+  pub fn headers(&self) -> error::Result<Vec<Header>> {
+    response_headers(&self.head)
+  }
+
+  pub fn head(&self) -> &[u8] {
+    &self.head
+  }
+
+  pub fn body_mut(&mut self) -> &mut ResponseBodyReader<'a, R> {
+    &mut self.body
+  }
+
+  pub fn trailers(&self) -> &Vec<Header> {
+    self.body.trailers()
+  }
+
+  pub fn trailer<S: AsRef<str>>(&self, name: S) -> Option<&Header> {
+    self
+      .trailers()
+      .iter()
+      .find(|header| header.name().eq_ignore_ascii_case(name.as_ref()))
+  }
+
+  pub fn trailer_value<S: AsRef<str>>(&self, name: S) -> Option<&String> {
+    self.trailer(name).map(|header| header.value())
+  }
+
+  pub fn read_to_response(mut self) -> error::Result<Response> {
+    let mut binary = self.head.clone();
+    self.body.read_to_end(&mut binary).map_err(error::request)?;
+    Response::with_trailers(self.url, binary, self.body.trailers().clone())
+  }
+}
+
+pub struct ResponseBodyReader<'a, R: Read + ?Sized> {
+  reader: &'a mut R,
+  kind: ResponseBodyKind,
+  remaining: usize,
+  chunk_remaining: usize,
+  chunk_needs_crlf: bool,
+  trailers: Vec<Header>,
+  eof: bool,
+}
+
+impl<'a, R: Read + ?Sized> ResponseBodyReader<'a, R> {
+  fn new(reader: &'a mut R, kind: ResponseBodyKind) -> Self {
+    let remaining = match kind {
+      ResponseBodyKind::ContentLength(length) => length,
+      _ => 0,
+    };
+    let eof = matches!(kind, ResponseBodyKind::NoBody);
+    Self {
+      reader,
+      kind,
+      remaining,
+      chunk_remaining: 0,
+      chunk_needs_crlf: false,
+      trailers: Vec::new(),
+      eof,
+    }
+  }
+
+  pub fn trailers(&self) -> &Vec<Header> {
+    &self.trailers
+  }
+
+  fn read_fixed_length(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+    if self.remaining == 0 || buf.is_empty() {
+      self.eof = self.remaining == 0;
+      return Ok(0);
+    }
+
+    let limit = buf.len().min(self.remaining);
+    let read = self.reader.read(&mut buf[..limit])?;
+    if read == 0 {
+      return Err(io::Error::new(
+        io::ErrorKind::UnexpectedEof,
+        "failed to fill whole buffer",
+      ));
+    }
+    self.remaining -= read;
+    if self.remaining == 0 {
+      self.eof = true;
+    }
+    Ok(read)
+  }
+
+  fn read_chunked(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+    if self.eof || buf.is_empty() {
+      return Ok(0);
+    }
+
+    if self.chunk_needs_crlf {
+      consume_crlf(self.reader).map_err(to_io_error)?;
+      self.chunk_needs_crlf = false;
+    }
+
+    while self.chunk_remaining == 0 {
+      let line = read_bounded_crlf_line(self.reader, MAX_CHUNKED_RESPONSE_LINE_BYTES)
+        .map_err(to_io_error)?;
+      let chunk_size = parse_chunk_size(&line).map_err(to_io_error)?;
+      if chunk_size == 0 {
+        self.trailers = read_trailers(self.reader).map_err(to_io_error)?;
+        self.eof = true;
+        return Ok(0);
+      }
+      self.chunk_remaining = chunk_size;
+    }
+
+    let limit = buf.len().min(self.chunk_remaining);
+    let read = self.reader.read(&mut buf[..limit])?;
+    if read == 0 {
+      return Err(io::Error::new(
+        io::ErrorKind::UnexpectedEof,
+        "Unexpected end of chunked body",
+      ));
+    }
+    self.chunk_remaining -= read;
+    if self.chunk_remaining == 0 {
+      self.chunk_needs_crlf = true;
+    }
+    Ok(read)
+  }
+}
+
+impl<R: Read + ?Sized> Read for ResponseBodyReader<'_, R> {
+  fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+    match self.kind {
+      ResponseBodyKind::NoBody => Ok(0),
+      ResponseBodyKind::ContentLength(_) => self.read_fixed_length(buf),
+      ResponseBodyKind::Chunked => self.read_chunked(buf),
+      ResponseBodyKind::UntilEof => {
+        let read = self.reader.read(buf)?;
+        if read == 0 {
+          self.eof = true;
+        }
+        Ok(read)
+      }
+    }
+  }
 }
 
 #[allow(dead_code)]
@@ -53,10 +206,19 @@ impl<'a> ConnectionReader<'a> {
     read_response_parts(self.reader, self.expect_no_body)
   }
 
+  pub fn streaming_response(&mut self) -> error::Result<StreamingResponse<'_, dyn io::Read + '_>> {
+    let head = read_response_head(self.reader)?;
+    let kind = response_body_kind(&head, self.expect_no_body)?;
+    Ok(StreamingResponse {
+      url: RoUrl::from(self.url.clone()),
+      head,
+      body: ResponseBodyReader::new(self.reader, kind),
+    })
+  }
+
   #[allow(dead_code)]
   pub fn response(&mut self) -> error::Result<Response> {
-    let parts = self.response_parts()?;
-    Response::with_trailers(RoUrl::from(self.url.clone()), parts.binary, parts.trailers)
+    self.streaming_response()?.read_to_response()
   }
 
   // todo Connection reader will read more type from io::Reader, like Chunk data, and Stream data.
@@ -69,15 +231,22 @@ pub(crate) fn read_response_parts<R>(
 where
   R: Read + ?Sized,
 {
-  let binary = loop {
+  let binary = read_response_head(reader)?;
+  read_response_parts_after_header(reader, expect_no_body, binary)
+}
+
+fn read_response_head<R>(reader: &mut R) -> error::Result<Vec<u8>>
+where
+  R: Read + ?Sized,
+{
+  loop {
     let header = read_response_header(reader)?;
     let status_code = response_status_code(&header)?;
     if is_skippable_informational_status(status_code) {
       continue;
     }
-    break header;
-  };
-  read_response_parts_after_header(reader, expect_no_body, binary)
+    return Ok(header);
+  }
 }
 
 pub(crate) fn read_response_parts_after_header<R>(
@@ -92,15 +261,17 @@ where
   match response_body_kind(&binary, expect_no_body)? {
     ResponseBodyKind::NoBody => {}
     ResponseBodyKind::Chunked => {
-      let chunked = read_chunked_response_body(reader)?;
-      binary.extend_from_slice(&chunked.body);
-      trailers = chunked.trailers;
+      let mut body_reader = ResponseBodyReader::new(reader, ResponseBodyKind::Chunked);
+      body_reader
+        .read_to_end(&mut binary)
+        .map_err(error::request)?;
+      trailers = body_reader.trailers().clone();
     }
     ResponseBodyKind::ContentLength(content_length) => {
-      let current_len = binary.len();
-      binary.resize(current_len + content_length, 0);
-      reader
-        .read_exact(&mut binary[current_len..])
+      let mut body_reader =
+        ResponseBodyReader::new(reader, ResponseBodyKind::ContentLength(content_length));
+      body_reader
+        .read_to_end(&mut binary)
         .map_err(error::request)?;
     }
     ResponseBodyKind::UntilEof => {
@@ -108,6 +279,18 @@ where
     }
   }
   Ok(ResponseParts { binary, trailers })
+}
+
+pub(crate) fn response_headers(header: &[u8]) -> error::Result<Vec<Header>> {
+  let header = String::from_utf8(header.to_vec()).map_err(error::response)?;
+  Ok(
+    header
+      .lines()
+      .skip(1)
+      .filter(|line| !line.is_empty())
+      .flat_map(|line| line.into_headers())
+      .collect(),
+  )
 }
 
 pub(crate) fn read_response_header<R>(reader: &mut R) -> error::Result<Vec<u8>>
@@ -228,36 +411,6 @@ pub(crate) fn response_body_kind(
     Ok(ResponseBodyKind::ContentLength(content_length))
   } else {
     Ok(ResponseBodyKind::UntilEof)
-  }
-}
-
-#[derive(Debug)]
-struct ChunkedResponseBody {
-  body: Vec<u8>,
-  trailers: Vec<Header>,
-}
-
-fn read_chunked_response_body<R>(reader: &mut R) -> error::Result<ChunkedResponseBody>
-where
-  R: Read + ?Sized,
-{
-  let mut body = Vec::new();
-
-  loop {
-    let line = read_bounded_crlf_line(reader, MAX_CHUNKED_RESPONSE_LINE_BYTES)?;
-    let chunk_size = parse_chunk_size(&line)?;
-
-    if chunk_size == 0 {
-      let trailers = read_trailers(reader)?;
-      return Ok(ChunkedResponseBody { body, trailers });
-    }
-
-    let current_len = body.len();
-    body.resize(current_len + chunk_size, 0);
-    reader
-      .read_exact(&mut body[current_len..])
-      .map_err(error::request)?;
-    consume_crlf(reader)?;
   }
 }
 
@@ -449,6 +602,10 @@ fn parse_trailer_line(line: &[u8]) -> error::Result<Header> {
   Ok(Header::new(name, value))
 }
 
+fn to_io_error(err: error::Error) -> io::Error {
+  io::Error::new(io::ErrorKind::InvalidData, err)
+}
+
 pub(crate) fn validate_response_trailer_header(name: &str, value: &str) -> error::Result<()> {
   if !is_http_token(name) || !value.bytes().all(is_header_value_byte) {
     return Err(error::bad_response("Invalid trailer header"));
@@ -534,6 +691,72 @@ mod tests {
     let text = String::from_utf8(binary).unwrap();
 
     assert!(text.ends_with("\r\n\r\nWikipedia"));
+  }
+
+  #[test]
+  fn streaming_response_reads_fixed_length_body_incrementally() {
+    let raw = concat!(
+      "HTTP/1.1 200 OK\r\n",
+      "Content-Length: 5\r\n",
+      "X-Trace: head\r\n",
+      "\r\n",
+      "hello",
+      "next"
+    );
+    let url = url::Url::parse("http://localhost").unwrap();
+    let mut cursor = Cursor::new(raw.as_bytes());
+    let mut reader = ConnectionReader::new(&url, &mut cursor, false);
+
+    let mut response = reader.streaming_response().unwrap();
+    let mut buf = [0; 2];
+
+    assert_eq!(200, response.code().unwrap());
+    assert_eq!(
+      Some("head"),
+      response
+        .headers()
+        .unwrap()
+        .iter()
+        .find(|header| header.name().eq_ignore_ascii_case("x-trace"))
+        .map(|header| header.value().as_str())
+    );
+    assert_eq!(2, response.body_mut().read(&mut buf).unwrap());
+    assert_eq!(b"he", &buf);
+    assert_eq!(2, response.body_mut().read(&mut buf).unwrap());
+    assert_eq!(b"ll", &buf);
+    assert_eq!(1, response.body_mut().read(&mut buf).unwrap());
+    assert_eq!(b"o", &buf[..1]);
+    assert_eq!(0, response.body_mut().read(&mut buf).unwrap());
+    assert!(response.trailers().is_empty());
+    drop(response);
+    assert_eq!((raw.len() - "next".len()) as u64, cursor.position());
+  }
+
+  #[test]
+  fn streaming_response_reads_chunked_body_and_exposes_trailers_after_eof() {
+    let raw = concat!(
+      "HTTP/1.1 200 OK\r\n",
+      "Transfer-Encoding: chunked\r\n",
+      "\r\n",
+      "2\r\nhe\r\n",
+      "3\r\nllo\r\n",
+      "0\r\n",
+      "X-Trace: abc\r\n",
+      "\r\n"
+    );
+    let url = url::Url::parse("http://localhost").unwrap();
+    let mut cursor = Cursor::new(raw.as_bytes());
+    let mut reader = ConnectionReader::new(&url, &mut cursor, false);
+
+    let mut response = reader.streaming_response().unwrap();
+    let mut body = Vec::new();
+    response.body_mut().read_to_end(&mut body).unwrap();
+
+    assert_eq!(b"hello", body.as_slice());
+    assert_eq!(
+      Some("abc"),
+      response.trailer_value("x-trace").map(String::as_str)
+    );
   }
 
   #[test]
@@ -656,7 +879,10 @@ mod tests {
       bytes: Cursor::new(b"4\r\nWiki"),
     };
 
-    let err = super::read_chunked_response_body(&mut reader).unwrap_err();
+    let mut body_reader = super::ResponseBodyReader::new(&mut reader, ResponseBodyKind::Chunked);
+    let mut body = Vec::new();
+
+    let err = body_reader.read_to_end(&mut body).unwrap_err();
 
     assert!(
       err.to_string().contains("terminator read timed out"),

--- a/rttp_client/src/connection/connection_reader.rs
+++ b/rttp_client/src/connection/connection_reader.rs
@@ -603,7 +603,14 @@ fn parse_trailer_line(line: &[u8]) -> error::Result<Header> {
 }
 
 fn to_io_error(err: error::Error) -> io::Error {
-  io::Error::new(io::ErrorKind::InvalidData, err)
+  if let Some(kind) = std::error::Error::source(&err)
+    .and_then(|source| source.downcast_ref::<io::Error>())
+    .map(|source| source.kind())
+  {
+    io::Error::new(kind, err)
+  } else {
+    io::Error::new(io::ErrorKind::InvalidData, err)
+  }
 }
 
 pub(crate) fn validate_response_trailer_header(name: &str, value: &str) -> error::Result<()> {
@@ -884,6 +891,7 @@ mod tests {
 
     let err = body_reader.read_to_end(&mut body).unwrap_err();
 
+    assert_eq!(io::ErrorKind::TimedOut, err.kind());
     assert!(
       err.to_string().contains("terminator read timed out"),
       "unexpected error: {err}"

--- a/rttp_client/src/connection/mod.rs
+++ b/rttp_client/src/connection/mod.rs
@@ -3,6 +3,7 @@
 #[cfg(feature = "async")]
 pub use self::async_connection::*;
 pub use self::block_connection::*;
+pub use self::connection_reader::{ConnectionReader, ResponseBodyReader, StreamingResponse};
 
 #[cfg(feature = "async")]
 mod async_connection;

--- a/rttp_client/src/lib.rs
+++ b/rttp_client/src/lib.rs
@@ -50,6 +50,9 @@
 
 pub use self::client::*;
 pub use self::config::*;
+#[cfg(feature = "async")]
+pub use self::connection::{AsyncResponseBodyReader, AsyncStreamingResponse};
+pub use self::connection::{ConnectionReader, ResponseBodyReader, StreamingResponse};
 
 mod client;
 mod config;

--- a/rttp_client/src/lib.rs
+++ b/rttp_client/src/lib.rs
@@ -51,7 +51,9 @@
 pub use self::client::*;
 pub use self::config::*;
 #[cfg(feature = "async")]
-pub use self::connection::{AsyncResponseBodyReader, AsyncStreamingResponse};
+pub use self::connection::{
+  async_streaming_response_after_header, AsyncResponseBodyReader, AsyncStreamingResponse,
+};
 pub use self::connection::{ConnectionReader, ResponseBodyReader, StreamingResponse};
 
 mod client;

--- a/rttp_client/tests/test_http_async.rs
+++ b/rttp_client/tests/test_http_async.rs
@@ -6,9 +6,13 @@ use std::collections::HashMap;
 #[cfg(feature = "async")]
 use futures::executor::block_on;
 #[cfg(feature = "async")]
+use futures::io::AllowStdIo;
+#[cfg(feature = "async")]
 use rttp_client::types::Proxy;
 #[cfg(feature = "async")]
-use rttp_client::{Config, HttpClient};
+use rttp_client::{async_streaming_response_after_header, Config, HttpClient};
+#[cfg(feature = "async")]
+use std::io::Cursor;
 
 #[cfg(feature = "async")]
 fn client() -> HttpClient {
@@ -56,6 +60,25 @@ fn test_async_chunked() {
       Some("signed"),
       response.trailer("x-signature").map(|h| h.value().as_str())
     );
+  });
+}
+
+#[test]
+#[cfg(feature = "async")]
+fn test_async_streaming_response_constructor_is_exported() {
+  block_on(async {
+    let head = concat!("HTTP/1.1 200 OK\r\n", "Content-Length: 5\r\n", "\r\n")
+      .as_bytes()
+      .to_vec();
+    let mut stream = AllowStdIo::new(Cursor::new(b"hello"));
+    let mut response = async_streaming_response_after_header(&mut stream, false, head)
+      .await
+      .unwrap();
+    let mut body = Vec::new();
+
+    response.body_mut().read_to_end(&mut body).await.unwrap();
+
+    assert_eq!(b"hello", body.as_slice());
   });
 }
 


### PR DESCRIPTION
Implemented sync and async streaming response body readers for HTTP/1.1 clients. Buffered response APIs now aggregate through the streaming reader while preserving existing behavior, error compatibility, headers, status metadata, and trailers after EOF. Verification passed with formatting, focused sync/async streaming tests, and workspace tests.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1313/
work_kind: code_work
branch: hbx-1313-rttp-add-streaming-response-body
base: main
commit: 8eb6b76071264643c1aaaadd972aa39f1dd4d575
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1313/
    url: https://plane.kahub.in/endless/browse/HBX-1313/
    close_policy: link_only
```