### PR TITLE
feat: [rttp] Add streaming request body support for client uploads and server handlers

### DIFF
--- a/rttp/src/server.rs
+++ b/rttp/src/server.rs
@@ -80,6 +80,13 @@ impl HttpServer {
     self.handle_next_connection(handler)
   }
 
+  pub fn accept_one_streaming<F>(&self, handler: F) -> io::Result<()>
+  where
+    F: FnOnce(Request, RequestBodyReader<'_, BufReader<TcpStream>>) -> HttpResponse,
+  {
+    self.handle_next_streaming_connection(handler)
+  }
+
   pub fn serve_requests<F>(&self, request_count: usize, mut handler: F) -> io::Result<()>
   where
     F: FnMut(Request) -> HttpResponse,
@@ -170,6 +177,34 @@ impl HttpServer {
     };
     let request_is_head = request.method() == "HEAD";
     let response = handler(request);
+    self.normalize_connection_error(response.write_to_with_default_connection_and_body(
+      reader.get_mut(),
+      DefaultConnectionHeader::ForceClose,
+      !request_is_head,
+    ))
+  }
+
+  fn handle_next_streaming_connection<F>(&self, handler: F) -> io::Result<()>
+  where
+    F: FnOnce(Request, RequestBodyReader<'_, BufReader<TcpStream>>) -> HttpResponse,
+  {
+    let (stream, _) = self.listener.accept()?;
+    self.configure_stream(&stream)?;
+    let mut reader = BufReader::new(stream);
+    let (request, body_kind) = match self.normalize_connection_error(
+      Request::read_next_head_from_with_continue(&mut reader).and_then(|request| {
+        request.ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "incomplete HTTP request"))
+      }),
+    ) {
+      Ok(request) => request,
+      Err(err) if is_bad_request_error(&err) => {
+        return self.normalize_connection_error(bad_request_response().write_to(reader.get_mut()));
+      }
+      Err(err) => return Err(err),
+    };
+    let request_is_head = request.method() == "HEAD";
+    let body = RequestBodyReader::new(&mut reader, body_kind, self.read_timeout.is_some());
+    let response = handler(request, body);
     self.normalize_connection_error(response.write_to_with_default_connection_and_body(
       reader.get_mut(),
       DefaultConnectionHeader::ForceClose,
@@ -357,6 +392,60 @@ impl Request {
     }
   }
 
+  fn read_next_head_from_with_continue<S>(
+    reader: &mut BufReader<S>,
+  ) -> io::Result<Option<(Self, RequestBodyKind)>>
+  where
+    S: Read + Write,
+  {
+    let mut raw = Vec::new();
+
+    loop {
+      let available = reader.fill_buf()?;
+      if available.is_empty() {
+        if raw.is_empty() {
+          return Ok(None);
+        }
+        return Err(io::Error::new(
+          io::ErrorKind::InvalidData,
+          "incomplete HTTP request",
+        ));
+      }
+
+      let mut combined = raw.clone();
+      combined.extend_from_slice(available);
+      match find_header_end(&combined) {
+        Some(header_end) => {
+          let take = header_end + 4 - raw.len();
+          reject_oversized_request_head(header_end + 4)?;
+          raw.extend_from_slice(&available[..take]);
+          reader.consume(take);
+          let head = parse_request_head(&raw[..header_end])?;
+          let body_kind = request_body_kind(&head.headers)?;
+          match body_kind {
+            RequestBodyKind::ContentLength(content_length) => {
+              reject_oversized_request_body(content_length)?;
+            }
+            RequestBodyKind::Chunked => {}
+          }
+          if request_needs_continue(&head.headers, body_kind)? {
+            write_continue_response(reader.get_mut())?;
+          }
+          return Ok(Some((
+            Self::from_head_and_body(head, Vec::new()),
+            body_kind,
+          )));
+        }
+        None => {
+          let take = available.len();
+          reject_oversized_request_head(raw.len().saturating_add(take))?;
+          raw.extend_from_slice(available);
+          reader.consume(take);
+        }
+      }
+    }
+  }
+
   #[cfg(test)]
   fn read_next_from_without_continue<R>(reader: &mut R) -> io::Result<Option<Self>>
   where
@@ -499,6 +588,126 @@ impl Request {
       headers: head.headers,
       trailers,
       body,
+    }
+  }
+}
+
+pub struct RequestBodyReader<'a, R: BufRead> {
+  reader: &'a mut R,
+  kind: RequestBodyKind,
+  remaining: usize,
+  chunk_remaining: usize,
+  chunk_needs_crlf: bool,
+  body_bytes_read: usize,
+  trailers: Vec<(String, String)>,
+  eof: bool,
+  normalize_timeouts: bool,
+}
+
+impl<'a, R: BufRead> RequestBodyReader<'a, R> {
+  fn new(reader: &'a mut R, kind: RequestBodyKind, normalize_timeouts: bool) -> Self {
+    let remaining = match kind {
+      RequestBodyKind::ContentLength(length) => length,
+      RequestBodyKind::Chunked => 0,
+    };
+    Self {
+      reader,
+      kind,
+      remaining,
+      chunk_remaining: 0,
+      chunk_needs_crlf: false,
+      body_bytes_read: 0,
+      trailers: Vec::new(),
+      eof: matches!(kind, RequestBodyKind::ContentLength(0)),
+      normalize_timeouts,
+    }
+  }
+
+  pub fn trailers(&self) -> &[(String, String)] {
+    &self.trailers
+  }
+
+  fn read_fixed_length(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+    if self.remaining == 0 || buf.is_empty() {
+      self.eof = self.remaining == 0;
+      return Ok(0);
+    }
+
+    let limit = buf.len().min(self.remaining);
+    let read = self
+      .reader
+      .read(&mut buf[..limit])
+      .map_err(|err| self.normalize_error(err))?;
+    if read == 0 {
+      return Err(io::Error::new(
+        io::ErrorKind::UnexpectedEof,
+        "incomplete HTTP request body",
+      ));
+    }
+    self.remaining -= read;
+    if self.remaining == 0 {
+      self.eof = true;
+    }
+    Ok(read)
+  }
+
+  fn read_chunked(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+    if self.eof || buf.is_empty() {
+      return Ok(0);
+    }
+
+    if self.chunk_needs_crlf {
+      consume_crlf(self.reader, &mut self.body_bytes_read)
+        .map_err(|err| self.normalize_error(err))?;
+      self.chunk_needs_crlf = false;
+    }
+
+    while self.chunk_remaining == 0 {
+      let line = read_bounded_crlf_line(self.reader, &mut self.body_bytes_read)
+        .map_err(|err| self.normalize_error(err))?;
+      let chunk_size = parse_chunk_size(&line)?;
+      if chunk_size == 0 {
+        self.trailers = read_trailers(self.reader, &mut self.body_bytes_read)
+          .map_err(|err| self.normalize_error(err))?;
+        self.eof = true;
+        return Ok(0);
+      }
+      add_request_body_bytes(&mut self.body_bytes_read, chunk_size)?;
+      self.chunk_remaining = chunk_size;
+    }
+
+    let limit = buf.len().min(self.chunk_remaining);
+    let read = self
+      .reader
+      .read(&mut buf[..limit])
+      .map_err(|err| self.normalize_error(err))?;
+    if read == 0 {
+      return Err(io::Error::new(
+        io::ErrorKind::UnexpectedEof,
+        "incomplete chunked request body",
+      ));
+    }
+    self.chunk_remaining -= read;
+    if self.chunk_remaining == 0 {
+      self.chunk_needs_crlf = true;
+    }
+    Ok(read)
+  }
+
+  fn normalize_error(&self, err: io::Error) -> io::Error {
+    if self.normalize_timeouts && err.kind() == io::ErrorKind::WouldBlock {
+      io::Error::new(io::ErrorKind::TimedOut, err)
+    } else {
+      err
+    }
+  }
+}
+
+impl<R: BufRead> Read for RequestBodyReader<'_, R> {
+  fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+    match self.kind {
+      RequestBodyKind::ContentLength(_) => self.read_fixed_length(buf),
+      RequestBodyKind::Chunked => self.read_chunked(buf),
     }
   }
 }

--- a/rttp/tests/test_server.rs
+++ b/rttp/tests/test_server.rs
@@ -90,6 +90,87 @@ fn server_accepts_get_request_and_writes_response() {
 }
 
 #[test]
+fn streaming_handler_reads_large_chunked_request_body_incrementally() {
+  let server = rttp::Http::server("127.0.0.1:0").expect("bind server");
+  let addr = server.local_addr().expect("server addr");
+  let (tx, rx) = mpsc::channel();
+
+  let handle = thread::spawn(move || {
+    server
+      .accept_one_streaming(|request, mut body| {
+        assert_eq!("POST", request.method());
+        assert_eq!("/upload", request.target());
+        let mut total = 0usize;
+        let mut buffer = [0u8; 8192];
+        loop {
+          let read = body.read(&mut buffer).expect("read streaming body");
+          if read == 0 {
+            break;
+          }
+          total += read;
+        }
+        tx.send(total).expect("send streamed byte count");
+        HttpResponse::ok(total.to_string())
+      })
+      .expect("serve streaming request");
+  });
+
+  let mut stream = TcpStream::connect(addr).expect("connect server");
+  stream
+    .write_all(b"POST /upload HTTP/1.1\r\nHost: localhost\r\nTransfer-Encoding: chunked\r\n\r\n")
+    .expect("write request head");
+  for _ in 0..128 {
+    stream.write_all(b"1000\r\n").expect("write chunk size");
+    stream.write_all(&vec![b'x'; 4096]).expect("write chunk");
+    stream.write_all(b"\r\n").expect("write chunk terminator");
+  }
+  stream
+    .write_all(b"0\r\nX-Done: yes\r\n\r\n")
+    .expect("write terminating chunk");
+
+  let mut response = String::new();
+  stream.read_to_string(&mut response).expect("read response");
+
+  assert_eq!(128 * 4096, rx.recv().expect("receive streamed byte count"));
+  assert_eq!(
+    "HTTP/1.1 200 OK\r\nContent-Length: 6\r\nConnection: close\r\n\r\n524288",
+    response
+  );
+
+  handle.join().expect("server thread");
+}
+
+#[test]
+fn streaming_handler_can_reject_before_reading_request_body() {
+  let server = rttp::Http::server("127.0.0.1:0").expect("bind server");
+  let addr = server.local_addr().expect("server addr");
+
+  let handle = thread::spawn(move || {
+    server
+      .accept_one_streaming(|request, _body| {
+        assert_eq!("/reject", request.target());
+        HttpResponse::new(413, "Payload Too Large").body("rejected")
+      })
+      .expect("serve streaming rejection");
+  });
+
+  let mut stream = TcpStream::connect(addr).expect("connect server");
+  stream
+    .write_all(b"POST /reject HTTP/1.1\r\nHost: localhost\r\nContent-Length: 1048576\r\n\r\nprefix")
+    .expect("write partial request");
+
+  let mut response = String::new();
+  stream.read_to_string(&mut response).expect("read response");
+
+  assert_eq!(
+    "HTTP/1.1 413 Payload Too Large\r\nContent-Length: 8\r\nConnection: close\r\n\r\nrejected",
+    response
+  );
+
+  handle.join().expect("server thread");
+}
+
+#[test]
 fn server_bind_falls_back_to_later_candidate_when_first_addr_is_occupied() {
   let (_occupied_listener, occupied_addr) = reserve_local_addr();
   let (available_listener, available_addr) = reserve_local_addr();

--- a/rttp_client/src/client.rs
+++ b/rttp_client/src/client.rs
@@ -1,10 +1,13 @@
 #[cfg(feature = "async")]
-use crate::connection::AsyncConnection;
-use crate::connection::BlockConnection;
+use crate::connection::{AsyncConnection, AsyncStreamingRequestBody};
+use crate::connection::{BlockConnection, StreamingRequestBody};
 use crate::request::{RawRequest, Request};
 use crate::response::Response;
 use crate::types::{Auth, Header, IntoHeader, IntoPara, Proxy, ToFormData, ToRoUrl};
 use crate::{error, Config};
+#[cfg(feature = "async")]
+use futures::io::AsyncRead;
+use std::io;
 
 #[derive(Debug)]
 pub struct HttpClient {
@@ -200,6 +203,49 @@ impl HttpClient {
     BlockConnection::new(request).call()
   }
 
+  pub fn emit_streaming_fixed<R>(
+    &mut self,
+    mut reader: R,
+    content_length: u64,
+  ) -> error::Result<Response>
+  where
+    R: io::Read,
+  {
+    if self.request.closed() {
+      return Err(error::connection_closed());
+    }
+    if self.request.has_configured_body() {
+      return Err(error::builder_with_message(
+        "streaming request body cannot be combined with buffered body fields",
+      ));
+    }
+    self.request.prepare_streaming_fixed_body(content_length);
+    let request = RawRequest::block_new(&mut self.request)?;
+    BlockConnection::new(request).call_streaming_body(StreamingRequestBody::Fixed {
+      reader: &mut reader,
+      content_length,
+    })
+  }
+
+  pub fn emit_streaming_chunked<R>(&mut self, mut reader: R) -> error::Result<Response>
+  where
+    R: io::Read,
+  {
+    if self.request.closed() {
+      return Err(error::connection_closed());
+    }
+    if self.request.has_configured_body() {
+      return Err(error::builder_with_message(
+        "streaming request body cannot be combined with buffered body fields",
+      ));
+    }
+    self.request.prepare_streaming_chunked_body();
+    let request = RawRequest::block_new(&mut self.request)?;
+    BlockConnection::new(request).call_streaming_body(StreamingRequestBody::Chunked {
+      reader: &mut reader,
+    })
+  }
+
   /// Async request emit
   ///
   /// # Examples
@@ -221,5 +267,54 @@ impl HttpClient {
     }
     let request = RawRequest::async_new(&mut self.request).await?;
     AsyncConnection::new(request).async_call().await
+  }
+
+  #[cfg(feature = "async")]
+  pub async fn rasync_streaming_fixed<R>(
+    &mut self,
+    mut reader: R,
+    content_length: u64,
+  ) -> error::Result<Response>
+  where
+    R: AsyncRead + Unpin,
+  {
+    if self.request.closed() {
+      return Err(error::connection_closed());
+    }
+    if self.request.has_configured_body() {
+      return Err(error::builder_with_message(
+        "streaming request body cannot be combined with buffered body fields",
+      ));
+    }
+    self.request.prepare_streaming_fixed_body(content_length);
+    let request = RawRequest::async_new(&mut self.request).await?;
+    AsyncConnection::new(request)
+      .async_call_streaming_body(AsyncStreamingRequestBody::Fixed {
+        reader: &mut reader,
+        content_length,
+      })
+      .await
+  }
+
+  #[cfg(feature = "async")]
+  pub async fn rasync_streaming_chunked<R>(&mut self, mut reader: R) -> error::Result<Response>
+  where
+    R: AsyncRead + Unpin,
+  {
+    if self.request.closed() {
+      return Err(error::connection_closed());
+    }
+    if self.request.has_configured_body() {
+      return Err(error::builder_with_message(
+        "streaming request body cannot be combined with buffered body fields",
+      ));
+    }
+    self.request.prepare_streaming_chunked_body();
+    let request = RawRequest::async_new(&mut self.request).await?;
+    AsyncConnection::new(request)
+      .async_call_streaming_body(AsyncStreamingRequestBody::Chunked {
+        reader: &mut reader,
+      })
+      .await
   }
 }

--- a/rttp_client/src/connection/async_connection.rs
+++ b/rttp_client/src/connection/async_connection.rs
@@ -196,6 +196,16 @@ pub struct AsyncConnection<'a> {
   conn: Connection<'a>,
 }
 
+pub(crate) enum AsyncStreamingRequestBody<'a> {
+  Fixed {
+    reader: &'a mut (dyn AsyncRead + Unpin),
+    content_length: u64,
+  },
+  Chunked {
+    reader: &'a mut (dyn AsyncRead + Unpin),
+  },
+}
+
 impl<'a> AsyncConnection<'a> {
   pub fn new(request: RawRequest<'a>) -> AsyncConnection<'a> {
     Self {
@@ -247,6 +257,24 @@ impl<'a> AsyncConnection<'a> {
       self.conn.closed_set(true);
       return Ok(response);
     }
+  }
+
+  pub async fn async_call_streaming_body(
+    mut self,
+    body: AsyncStreamingRequestBody<'_>,
+  ) -> error::Result<Response> {
+    if self.conn.proxy().is_some() {
+      return Err(error::builder_with_message(
+        "streaming request bodies do not support proxies",
+      ));
+    }
+
+    let url = self.conn.url().map_err(error::builder)?;
+    let parts = self.async_send_streaming_parts(&url, body).await?;
+    let response =
+      Response::with_trailers(self.conn.rourl().clone(), parts.binary, parts.trailers)?;
+    self.conn.closed_set(true);
+    Ok(response)
   }
 }
 
@@ -307,6 +335,30 @@ impl<'a> AsyncConnection<'a> {
         .write_all(body.bytes())
         .await
         .map_err(error::request)?;
+    }
+    stream.flush().await.map_err(error::request)
+  }
+
+  async fn async_write_streaming_request<S>(
+    &self,
+    stream: &mut S,
+    mut body: AsyncStreamingRequestBody<'_>,
+  ) -> error::Result<()>
+  where
+    S: AsyncWrite + Unpin,
+  {
+    stream
+      .write_all(self.conn.header().as_bytes())
+      .await
+      .map_err(error::request)?;
+    match &mut body {
+      AsyncStreamingRequestBody::Fixed {
+        reader,
+        content_length,
+      } => async_write_fixed_streaming_body(stream, *reader, *content_length).await?,
+      AsyncStreamingRequestBody::Chunked { reader } => {
+        async_write_chunked_streaming_body(stream, *reader).await?
+      }
     }
     stream.flush().await.map_err(error::request)
   }
@@ -631,6 +683,42 @@ impl<'a> AsyncConnection<'a> {
     self.async_send_with_stream_parts(url, stream).await
   }
 
+  async fn async_send_streaming_parts(
+    &self,
+    url: &Url,
+    body: AsyncStreamingRequestBody<'_>,
+  ) -> error::Result<ResponseParts> {
+    let addr = self.conn.addr(url)?;
+    let stream = self.async_tcp_stream(&addr).await?;
+
+    self
+      .async_send_streaming_with_stream_parts(url, stream, body)
+      .await
+  }
+
+  async fn async_send_streaming_with_stream_parts(
+    &self,
+    url: &Url,
+    stream: TcpStream,
+    body: AsyncStreamingRequestBody<'_>,
+  ) -> error::Result<ResponseParts> {
+    match url.scheme() {
+      "http" => {
+        let mut stream = AllowStdIo::new(stream);
+        self
+          .async_write_streaming_request(&mut stream, body)
+          .await?;
+        self.async_read_stream_parts(url, &mut stream).await
+      }
+      "https" => {
+        self
+          .async_send_https_streaming_parts(url, stream, body)
+          .await
+      }
+      _ => Err(error::url_bad_scheme(url.clone())),
+    }
+  }
+
   async fn async_send_with_stream_parts(
     &self,
     url: &Url,
@@ -682,6 +770,40 @@ impl<'a> AsyncConnection<'a> {
     {
       let _ = url;
       let _ = stream;
+      return Err(error::no_request_features(
+        "Not have any tls features, Can't request a https url",
+      ));
+    }
+  }
+
+  async fn async_send_https_streaming_parts(
+    &self,
+    url: &Url,
+    stream: TcpStream,
+    body: AsyncStreamingRequestBody<'_>,
+  ) -> error::Result<ResponseParts> {
+    #[cfg(feature = "tls-rustls")]
+    {
+      return self
+        .async_send_https_rustls_streaming_parts(url, stream, body)
+        .await;
+    }
+
+    #[cfg(all(feature = "tls-native", not(feature = "tls-rustls")))]
+    {
+      let _ = url;
+      let _ = stream;
+      let _ = body;
+      return Err(error::no_request_features(
+        "Async streaming HTTPS request bodies require the tls-rustls feature",
+      ));
+    }
+
+    #[cfg(not(any(feature = "tls-native", feature = "tls-rustls")))]
+    {
+      let _ = url;
+      let _ = stream;
+      let _ = body;
       return Err(error::no_request_features(
         "Not have any tls features, Can't request a https url",
       ));
@@ -750,6 +872,126 @@ impl<'a> AsyncConnection<'a> {
       ExpectContinueResult::Final(parts) => return Ok(parts),
     }
     self.async_read_stream_parts(url, &mut tls_stream).await
+  }
+
+  #[cfg(feature = "tls-rustls")]
+  async fn async_send_https_rustls_streaming_parts(
+    &self,
+    url: &Url,
+    stream: TcpStream,
+    body: AsyncStreamingRequestBody<'_>,
+  ) -> error::Result<ResponseParts> {
+    use futures_rustls::TlsConnector;
+    use rustls::pki_types::ServerName;
+    use rustls::{ClientConfig, RootCertStore};
+
+    use crate::connection::connection::{NoCertificateVerification, NoHostnameVerification};
+
+    let config = self.conn.config();
+    let mut root_store = RootCertStore::empty();
+    if config.verify_ssl_cert() {
+      root_store.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
+    }
+
+    let builder = ClientConfig::builder();
+    let rustls_config = if !config.verify_ssl_cert() {
+      builder
+        .dangerous()
+        .with_custom_certificate_verifier(Arc::new(NoCertificateVerification))
+        .with_no_client_auth()
+    } else if !config.verify_ssl_hostname() {
+      let verifier = rustls::client::WebPkiServerVerifier::builder(Arc::new(root_store))
+        .build()
+        .map_err(|e| error::bad_ssl(e.to_string()))?;
+      builder
+        .dangerous()
+        .with_custom_certificate_verifier(Arc::new(NoHostnameVerification::new(verifier)))
+        .with_no_client_auth()
+    } else {
+      builder
+        .with_root_certificates(root_store)
+        .with_no_client_auth()
+    };
+
+    let host = self.conn.host(url)?;
+    let server_name: ServerName<'static> = match host.parse::<std::net::IpAddr>() {
+      Ok(ip) => ServerName::IpAddress(ip.into()),
+      Err(_) => ServerName::try_from(host.as_str())
+        .map_err(|_| error::bad_ssl(format!("Invalid server name: {}", host)))?
+        .to_owned(),
+    };
+
+    let connector = TlsConnector::from(Arc::new(rustls_config));
+    let async_tcp = AllowStdIo::new(stream);
+    let mut tls_stream = connector
+      .connect(server_name, async_tcp)
+      .await
+      .map_err(|e| error::bad_ssl(e.to_string()))?;
+
+    self
+      .async_write_streaming_request(&mut tls_stream, body)
+      .await?;
+    self.async_read_stream_parts(url, &mut tls_stream).await
+  }
+}
+
+async fn async_write_fixed_streaming_body<S>(
+  writer: &mut S,
+  reader: &mut (dyn AsyncRead + Unpin),
+  content_length: u64,
+) -> error::Result<()>
+where
+  S: AsyncWrite + Unpin,
+{
+  let mut remaining = content_length;
+  let mut buffer = [0u8; 8 * 1024];
+  while remaining > 0 {
+    let limit = buffer.len().min(remaining as usize);
+    let read = reader
+      .read(&mut buffer[..limit])
+      .await
+      .map_err(error::request)?;
+    if read == 0 {
+      return Err(error::request(io::Error::new(
+        io::ErrorKind::UnexpectedEof,
+        "streaming request body ended before Content-Length",
+      )));
+    }
+    writer
+      .write_all(&buffer[..read])
+      .await
+      .map_err(error::request)?;
+    remaining -= read as u64;
+  }
+  Ok(())
+}
+
+async fn async_write_chunked_streaming_body<S>(
+  writer: &mut S,
+  reader: &mut (dyn AsyncRead + Unpin),
+) -> error::Result<()>
+where
+  S: AsyncWrite + Unpin,
+{
+  let mut buffer = [0u8; 8 * 1024];
+  loop {
+    let read = reader.read(&mut buffer).await.map_err(error::request)?;
+    if read == 0 {
+      writer
+        .write_all(b"0\r\n\r\n")
+        .await
+        .map_err(error::request)?;
+      return Ok(());
+    }
+    writer
+      .write_all(format!("{:x}\r\n", read).as_bytes())
+      .await
+      .map_err(error::request)?;
+    writer
+      .write_all(&buffer[..read])
+      .await
+      .map_err(error::request)?;
+    writer.write_all(CRLF).await.map_err(error::request)?;
   }
 }
 

--- a/rttp_client/src/connection/block_connection.rs
+++ b/rttp_client/src/connection/block_connection.rs
@@ -3,7 +3,7 @@ use std::io::Write;
 use socks::{Socks4Stream, Socks5Stream};
 use url::Url;
 
-use crate::connection::connection::{Connection, ExpectContinueResult};
+use crate::connection::connection::{Connection, ExpectContinueResult, StreamingRequestBody};
 use crate::connection::connection_reader::ResponseParts;
 use crate::error;
 use crate::request::RawRequest;
@@ -67,6 +67,21 @@ impl<'a> BlockConnection<'a> {
       self.conn.closed_set(true);
       return Ok(response);
     }
+  }
+
+  pub fn call_streaming_body(mut self, body: StreamingRequestBody<'_>) -> error::Result<Response> {
+    if self.conn.proxy().is_some() {
+      return Err(error::builder_with_message(
+        "streaming request bodies do not support proxies",
+      ));
+    }
+
+    let url = self.conn.url().map_err(error::builder)?;
+    let parts = self.conn.block_send_streaming_parts(&url, body)?;
+    let response =
+      Response::with_trailers(self.conn.rourl().clone(), parts.binary, parts.trailers)?;
+    self.conn.closed_set(true);
+    Ok(response)
   }
 }
 

--- a/rttp_client/src/connection/connection.rs
+++ b/rttp_client/src/connection/connection.rs
@@ -468,6 +468,16 @@ pub(crate) enum ExpectContinueResult {
   Final(ResponseParts),
 }
 
+pub(crate) enum StreamingRequestBody<'a> {
+  Fixed {
+    reader: &'a mut dyn io::Read,
+    content_length: u64,
+  },
+  Chunked {
+    reader: &'a mut dyn io::Read,
+  },
+}
+
 pub(crate) fn parse_proxy_connect_response(header: &[u8]) -> error::Result<()> {
   let header = String::from_utf8(header.to_vec())
     .map_err(|_| error::bad_proxy("parse proxy server response error."))?;
@@ -602,6 +612,27 @@ impl<'a> Connection<'a> {
     stream.flush().map_err(error::request)
   }
 
+  fn block_write_streaming_request<S>(
+    &self,
+    stream: &mut S,
+    mut body: StreamingRequestBody<'_>,
+  ) -> error::Result<()>
+  where
+    S: io::Write,
+  {
+    stream
+      .write_all(self.header().as_bytes())
+      .map_err(error::request)?;
+    match &mut body {
+      StreamingRequestBody::Fixed {
+        reader,
+        content_length,
+      } => write_fixed_streaming_body(stream, *reader, *content_length)?,
+      StreamingRequestBody::Chunked { reader } => write_chunked_streaming_body(stream, *reader)?,
+    }
+    stream.flush().map_err(error::request)
+  }
+
   pub(crate) fn block_read_stream_parts<S>(
     &self,
     url: &Url,
@@ -658,6 +689,35 @@ impl<'a> Connection<'a> {
     self.block_send_with_stream_parts(url, &mut stream)
   }
 
+  pub(crate) fn block_send_streaming_parts(
+    &self,
+    url: &Url,
+    body: StreamingRequestBody<'_>,
+  ) -> error::Result<ResponseParts> {
+    let addr = self.addr(url)?;
+    let mut stream = self.block_tcp_stream(&addr)?;
+    self.block_send_streaming_with_stream_parts(url, &mut stream, body)
+  }
+
+  fn block_send_streaming_with_stream_parts<S>(
+    &self,
+    url: &Url,
+    stream: &mut S,
+    body: StreamingRequestBody<'_>,
+  ) -> error::Result<ResponseParts>
+  where
+    S: io::Read + io::Write,
+  {
+    match url.scheme() {
+      "http" => {
+        self.block_write_streaming_request(stream, body)?;
+        self.block_read_stream_parts(url, stream)
+      }
+      "https" => self.block_send_https_streaming_parts(url, stream, body),
+      _ => Err(error::url_bad_scheme(url.clone())),
+    }
+  }
+
   pub(crate) fn block_send_with_stream_parts<S>(
     &self,
     url: &Url,
@@ -703,6 +763,21 @@ impl<'a> Connection<'a> {
     ))
   }
 
+  #[cfg(not(any(feature = "tls-native", feature = "tls-rustls")))]
+  fn block_send_https_streaming_parts<S>(
+    &self,
+    _url: &Url,
+    _stream: &mut S,
+    _body: StreamingRequestBody<'_>,
+  ) -> error::Result<ResponseParts>
+  where
+    S: io::Read + io::Write,
+  {
+    Err(error::no_request_features(
+      "Not have any tls features, Can't request a https url",
+    ))
+  }
+
   #[cfg(any(feature = "tls-native", feature = "tls-rustls"))]
   pub(crate) fn block_send_https_parts<S>(
     &self,
@@ -723,6 +798,30 @@ impl<'a> Connection<'a> {
     #[cfg(all(feature = "tls-rustls", not(feature = "tls-native")))]
     {
       return self.block_send_https_rustls_parts(url, stream);
+    }
+  }
+
+  #[cfg(any(feature = "tls-native", feature = "tls-rustls"))]
+  fn block_send_https_streaming_parts<S>(
+    &self,
+    url: &Url,
+    stream: &mut S,
+    body: StreamingRequestBody<'_>,
+  ) -> error::Result<ResponseParts>
+  where
+    S: io::Read + io::Write,
+  {
+    #[cfg(all(feature = "tls-native", feature = "tls-rustls"))]
+    {
+      return self.block_send_https_rustls_streaming_parts(url, stream, body);
+    }
+    #[cfg(all(feature = "tls-native", not(feature = "tls-rustls")))]
+    {
+      return self.block_send_https_native_streaming_parts(url, stream, body);
+    }
+    #[cfg(all(feature = "tls-rustls", not(feature = "tls-native")))]
+    {
+      return self.block_send_https_rustls_streaming_parts(url, stream, body);
     }
   }
 
@@ -750,6 +849,30 @@ impl<'a> Connection<'a> {
       ExpectContinueResult::BodySent => {}
       ExpectContinueResult::Final(parts) => return Ok(parts),
     }
+    self.block_read_stream_parts(url, &mut ssl_stream)
+  }
+
+  #[cfg(all(feature = "tls-native", not(feature = "tls-rustls")))]
+  fn block_send_https_native_streaming_parts<S>(
+    &self,
+    url: &Url,
+    stream: &mut S,
+    body: StreamingRequestBody<'_>,
+  ) -> error::Result<ResponseParts>
+  where
+    S: io::Read + io::Write,
+  {
+    let config = self.config();
+    let connector = native_tls::TlsConnector::builder()
+      .danger_accept_invalid_certs(!config.verify_ssl_cert())
+      .danger_accept_invalid_hostnames(!config.verify_ssl_hostname())
+      .build()
+      .map_err(error::request)?;
+    let mut ssl_stream = connector
+      .connect(&self.host(url)?[..], stream)
+      .map_err(|_| error::bad_ssl("Native tls handshake error"))?;
+
+    self.block_write_streaming_request(&mut ssl_stream, body)?;
     self.block_read_stream_parts(url, &mut ssl_stream)
   }
 
@@ -805,6 +928,99 @@ impl<'a> Connection<'a> {
       ExpectContinueResult::Final(parts) => return Ok(parts),
     }
     self.block_read_stream_parts(url, &mut tls)
+  }
+
+  #[cfg(feature = "tls-rustls")]
+  fn block_send_https_rustls_streaming_parts<S>(
+    &self,
+    url: &Url,
+    stream: &mut S,
+    body: StreamingRequestBody<'_>,
+  ) -> error::Result<ResponseParts>
+  where
+    S: io::Read + io::Write,
+  {
+    let config = self.config();
+    let mut root_store = RootCertStore::empty();
+    if config.verify_ssl_cert() {
+      root_store.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
+    }
+
+    let builder = ClientConfig::builder();
+    let rustls_config = if !config.verify_ssl_cert() {
+      builder
+        .dangerous()
+        .with_custom_certificate_verifier(Arc::new(NoCertificateVerification))
+        .with_no_client_auth()
+    } else if !config.verify_ssl_hostname() {
+      let verifier = WebPkiServerVerifier::builder(Arc::new(root_store))
+        .build()
+        .map_err(|e| error::bad_ssl(e.to_string()))?;
+      builder
+        .dangerous()
+        .with_custom_certificate_verifier(Arc::new(NoHostnameVerification::new(verifier)))
+        .with_no_client_auth()
+    } else {
+      builder
+        .with_root_certificates(root_store)
+        .with_no_client_auth()
+    };
+    let rc_config = Arc::new(rustls_config);
+    let host = self.host(url)?;
+    let server_name = match host.parse::<std::net::IpAddr>() {
+      Ok(ip) => ServerName::IpAddress(ip.into()),
+      Err(_) => ServerName::try_from(host.as_str())
+        .map_err(|_| error::bad_ssl(format!("Invalid server name: {}", host)))?
+        .to_owned(),
+    };
+    let client =
+      ClientConnection::new(rc_config, server_name).map_err(|e| error::bad_ssl(e.to_string()))?;
+    let mut tls = StreamOwned::new(client, stream);
+
+    self.block_write_streaming_request(&mut tls, body)?;
+    self.block_read_stream_parts(url, &mut tls)
+  }
+}
+
+fn write_fixed_streaming_body<W>(
+  writer: &mut W,
+  reader: &mut dyn io::Read,
+  content_length: u64,
+) -> error::Result<()>
+where
+  W: io::Write,
+{
+  let mut remaining = content_length;
+  let mut buffer = [0u8; 8 * 1024];
+  while remaining > 0 {
+    let limit = buffer.len().min(remaining as usize);
+    let read = reader.read(&mut buffer[..limit]).map_err(error::request)?;
+    if read == 0 {
+      return Err(error::request(io::Error::new(
+        io::ErrorKind::UnexpectedEof,
+        "streaming request body ended before Content-Length",
+      )));
+    }
+    writer.write_all(&buffer[..read]).map_err(error::request)?;
+    remaining -= read as u64;
+  }
+  Ok(())
+}
+
+fn write_chunked_streaming_body<W>(writer: &mut W, reader: &mut dyn io::Read) -> error::Result<()>
+where
+  W: io::Write,
+{
+  let mut buffer = [0u8; 8 * 1024];
+  loop {
+    let read = reader.read(&mut buffer).map_err(error::request)?;
+    if read == 0 {
+      writer.write_all(b"0\r\n\r\n").map_err(error::request)?;
+      return Ok(());
+    }
+    write!(writer, "{:x}\r\n", read).map_err(error::request)?;
+    writer.write_all(&buffer[..read]).map_err(error::request)?;
+    writer.write_all(b"\r\n").map_err(error::request)?;
   }
 }
 

--- a/rttp_client/src/connection/mod.rs
+++ b/rttp_client/src/connection/mod.rs
@@ -1,8 +1,11 @@
 #![allow(clippy::module_inception)]
 
 #[cfg(feature = "async")]
+pub(crate) use self::async_connection::AsyncStreamingRequestBody;
+#[cfg(feature = "async")]
 pub use self::async_connection::*;
 pub use self::block_connection::*;
+pub(crate) use self::connection::StreamingRequestBody;
 pub use self::connection_reader::{ConnectionReader, ResponseBodyReader, StreamingResponse};
 
 #[cfg(feature = "async")]

--- a/rttp_client/src/request/request.rs
+++ b/rttp_client/src/request/request.rs
@@ -220,6 +220,30 @@ impl Request {
       .headers
       .retain(|header| !is_sensitive_redirect_header(header.name()));
   }
+
+  pub(crate) fn has_configured_body(&self) -> bool {
+    self.raw.is_some() || !self.binary.is_empty() || !self.formdatas.is_empty()
+  }
+
+  pub(crate) fn prepare_streaming_fixed_body(&mut self, content_length: u64) {
+    self.headers.retain(|header| {
+      !header.name().eq_ignore_ascii_case("content-length")
+        && !header.name().eq_ignore_ascii_case("transfer-encoding")
+    });
+    self
+      .headers
+      .push(Header::new("Content-Length", content_length.to_string()));
+  }
+
+  pub(crate) fn prepare_streaming_chunked_body(&mut self) {
+    self.headers.retain(|header| {
+      !header.name().eq_ignore_ascii_case("content-length")
+        && !header.name().eq_ignore_ascii_case("transfer-encoding")
+    });
+    self
+      .headers
+      .push(Header::new("Transfer-Encoding", "chunked"));
+  }
 }
 
 #[derive(Clone)]

--- a/rttp_client/tests/test_http_async.rs
+++ b/rttp_client/tests/test_http_async.rs
@@ -6,17 +6,46 @@ use std::collections::HashMap;
 #[cfg(feature = "async")]
 use futures::executor::block_on;
 #[cfg(feature = "async")]
-use futures::io::AllowStdIo;
+use futures::io::{AllowStdIo, Cursor as AsyncCursor};
 #[cfg(feature = "async")]
 use rttp_client::types::Proxy;
 #[cfg(feature = "async")]
 use rttp_client::{async_streaming_response_after_header, Config, HttpClient};
 #[cfg(feature = "async")]
-use std::io::Cursor;
+use std::io::{Cursor, Read, Write};
+#[cfg(feature = "async")]
+use std::net::TcpListener;
+#[cfg(feature = "async")]
+use std::thread;
 
 #[cfg(feature = "async")]
 fn client() -> HttpClient {
   HttpClient::new()
+}
+
+#[cfg(feature = "async")]
+fn spawn_async_chunked_upload_capture_server() -> (std::net::SocketAddr, thread::JoinHandle<Vec<u8>>)
+{
+  let listener = TcpListener::bind("127.0.0.1:0").expect("bind async upload capture server");
+  let addr = listener.local_addr().expect("async upload capture addr");
+  let handle = thread::spawn(move || {
+    let (mut stream, _) = listener.accept().expect("accept async upload");
+    let mut request = Vec::new();
+    let mut byte = [0u8; 1];
+    while !request.ends_with(b"\r\n\r\n") {
+      stream.read_exact(&mut byte).expect("read request head");
+      request.push(byte[0]);
+    }
+    while !request.ends_with(b"\r\n0\r\n\r\n") {
+      stream.read_exact(&mut byte).expect("read chunked body");
+      request.push(byte[0]);
+    }
+    stream
+      .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 8\r\nConnection: close\r\n\r\nuploaded")
+      .expect("write response");
+    request
+  });
+  (addr, handle)
 }
 
 #[test]
@@ -61,6 +90,30 @@ fn test_async_chunked() {
       response.trailer("x-signature").map(|h| h.value().as_str())
     );
   });
+}
+
+#[test]
+#[cfg(feature = "async")]
+fn test_async_streaming_chunked_upload_writes_incremental_framing() {
+  let (addr, handle) = spawn_async_chunked_upload_capture_server();
+  block_on(async {
+    let payload = vec![b'a'; 96 * 1024];
+    let response = client()
+      .post()
+      .url(format!("http://{}/upload", addr))
+      .rasync_streaming_chunked(AsyncCursor::new(payload))
+      .await
+      .expect("async stream chunked upload");
+
+    assert_eq!("uploaded", response.body().string().unwrap());
+  });
+
+  let request = handle.join().expect("upload server thread");
+  let request = String::from_utf8(request).expect("request utf8");
+  assert!(request.starts_with("POST /upload HTTP/1.1\r\n"));
+  assert!(request.contains("\r\nTransfer-Encoding: chunked\r\n"));
+  assert!(!request.contains("\r\nContent-Length:"));
+  assert!(request.ends_with("\r\n0\r\n\r\n"));
 }
 
 #[test]

--- a/rttp_client/tests/test_http_basic.rs
+++ b/rttp_client/tests/test_http_basic.rs
@@ -1,12 +1,80 @@
 mod support;
 
 use std::collections::HashMap;
+use std::io::{self, Cursor, Read, Write};
+use std::net::TcpListener;
+use std::thread;
 
 use rttp_client::types::{Auth, Para, Proxy, RoUrl};
 use rttp_client::{Config, HttpClient};
 
 fn client() -> HttpClient {
   HttpClient::new()
+}
+
+fn spawn_streaming_upload_capture_server() -> (std::net::SocketAddr, thread::JoinHandle<Vec<u8>>) {
+  let listener = TcpListener::bind("127.0.0.1:0").expect("bind upload capture server");
+  let addr = listener.local_addr().expect("upload capture addr");
+  let handle = thread::spawn(move || {
+    let (mut stream, _) = listener.accept().expect("accept upload");
+    let mut request = Vec::new();
+    let mut byte = [0u8; 1];
+    while !request.ends_with(b"\r\n\r\n") {
+      stream.read_exact(&mut byte).expect("read request head");
+      request.push(byte[0]);
+    }
+    while !request.ends_with(b"\r\n0\r\n\r\n") {
+      if stream.read_exact(&mut byte).is_err() {
+        return request;
+      }
+      request.push(byte[0]);
+    }
+    stream
+      .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 8\r\nConnection: close\r\n\r\nuploaded")
+      .expect("write response");
+    request
+  });
+  (addr, handle)
+}
+
+fn spawn_fixed_upload_capture_server() -> (std::net::SocketAddr, thread::JoinHandle<Vec<u8>>) {
+  let listener = TcpListener::bind("127.0.0.1:0").expect("bind fixed upload capture server");
+  let addr = listener.local_addr().expect("fixed upload capture addr");
+  let handle = thread::spawn(move || {
+    let (mut stream, _) = listener.accept().expect("accept fixed upload");
+    let mut request = Vec::new();
+    let mut byte = [0u8; 1];
+    while !request.ends_with(b"\r\n\r\n") {
+      stream.read_exact(&mut byte).expect("read request head");
+      request.push(byte[0]);
+    }
+    let mut body = [0u8; 12];
+    stream.read_exact(&mut body).expect("read fixed body");
+    request.extend_from_slice(&body);
+    stream
+      .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nOK")
+      .expect("write response");
+    request
+  });
+  (addr, handle)
+}
+
+struct FailingReader {
+  sent: bool,
+}
+
+impl Read for FailingReader {
+  fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+    if self.sent {
+      return Err(io::Error::new(
+        io::ErrorKind::BrokenPipe,
+        "client cancelled",
+      ));
+    }
+    self.sent = true;
+    buf[..5].copy_from_slice(b"hello");
+    Ok(5)
+  }
 }
 
 #[test]
@@ -17,6 +85,54 @@ fn test_http() {
   let response = response.unwrap();
   assert_eq!("127.0.0.1", response.host());
   println!("{}", response);
+}
+
+#[test]
+fn test_streaming_chunked_upload_writes_incremental_framing() {
+  let (addr, handle) = spawn_streaming_upload_capture_server();
+  let payload = vec![b'a'; 96 * 1024];
+  let response = client()
+    .post()
+    .url(format!("http://{}/upload", addr))
+    .emit_streaming_chunked(Cursor::new(payload.clone()))
+    .expect("stream chunked upload");
+
+  assert_eq!("uploaded", response.body().string().unwrap());
+
+  let request = handle.join().expect("upload server thread");
+  let request = String::from_utf8(request).expect("request utf8");
+  assert!(request.starts_with("POST /upload HTTP/1.1\r\n"));
+  assert!(request.contains("\r\nTransfer-Encoding: chunked\r\n"));
+  assert!(!request.contains("\r\nContent-Length:"));
+  assert!(request.ends_with("\r\n0\r\n\r\n"));
+}
+
+#[test]
+fn test_streaming_fixed_upload_writes_content_length() {
+  let (addr, handle) = spawn_fixed_upload_capture_server();
+  let response = client()
+    .post()
+    .url(format!("http://{}/fixed", addr))
+    .emit_streaming_fixed(Cursor::new(b"request body".to_vec()), 12)
+    .expect("stream fixed upload");
+
+  assert_eq!("OK", response.body().string().unwrap());
+
+  let request = handle.join().expect("expect server thread");
+  assert!(String::from_utf8_lossy(&request).contains("\r\nContent-Length: 12\r\n"));
+  assert!(request.ends_with(b"request body"));
+}
+
+#[test]
+fn test_streaming_upload_returns_reader_eof_error() {
+  let (addr, _handle) = spawn_streaming_upload_capture_server();
+  let error = client()
+    .post()
+    .url(format!("http://{}/cancel", addr))
+    .emit_streaming_chunked(FailingReader { sent: false })
+    .expect_err("streaming reader error should abort upload");
+
+  assert!(error.to_string().contains("client cancelled"));
 }
 
 #[test]


### PR DESCRIPTION
Adds opt-in streaming request body APIs and server handler support for incremental uploads while preserving framing, limits, and timeout behavior. Verified with formatting, focused streaming tests, default workspace tests, and async-feature workspace tests.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1314/
work_kind: code_work
branch: hbx-1314-rttp-add-streaming-request-body
base: main
commit: b9f18a9e1a0b4c762c00dc8d9b9c453507d99ded
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1314/
    url: https://plane.kahub.in/endless/browse/HBX-1314/
    close_policy: link_only
```