### PR TITLE
feat: [rttp] Support CONNECT and HTTP/1.1 Upgrade socket handoff

### DIFF
--- a/rttp/src/server.rs
+++ b/rttp/src/server.rs
@@ -1,6 +1,6 @@
 use std::error::Error;
 use std::fmt;
-use std::io::{self, BufRead, BufReader, Read, Write};
+use std::io::{self, BufRead, BufReader, Cursor, Read, Write};
 use std::net::{SocketAddr, TcpListener, TcpStream, ToSocketAddrs};
 use std::time::Duration;
 
@@ -85,6 +85,13 @@ impl HttpServer {
     F: FnOnce(Request, RequestBodyReader<'_, BufReader<TcpStream>>) -> HttpResponse,
   {
     self.handle_next_streaming_connection(handler)
+  }
+
+  pub fn accept_one_handoff<F>(&self, handler: F) -> io::Result<()>
+  where
+    F: FnOnce(Request) -> HttpHandoff,
+  {
+    self.handle_next_handoff_connection(handler)
   }
 
   pub fn serve_requests<F>(&self, request_count: usize, mut handler: F) -> io::Result<()>
@@ -212,6 +219,45 @@ impl HttpServer {
     ))
   }
 
+  fn handle_next_handoff_connection<F>(&self, handler: F) -> io::Result<()>
+  where
+    F: FnOnce(Request) -> HttpHandoff,
+  {
+    let (stream, _) = self.listener.accept()?;
+    self.configure_stream(&stream)?;
+    let mut reader = BufReader::new(stream);
+    let request = match self.normalize_connection_error(
+      Request::read_next_head_from_with_continue(&mut reader).and_then(|request| {
+        request
+          .map(|(request, _)| request)
+          .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "incomplete HTTP request"))
+      }),
+    ) {
+      Ok(request) => request,
+      Err(err) if is_bad_request_error(&err) => {
+        return self.normalize_connection_error(bad_request_response().write_to(reader.get_mut()));
+      }
+      Err(err) => return Err(err),
+    };
+
+    let handoff = handler(request.clone());
+    if !handoff.valid_for(&request) {
+      return self.normalize_connection_error(bad_request_response().write_to(reader.get_mut()));
+    }
+
+    match handoff {
+      HttpHandoff::Response(response) => self.normalize_connection_error(
+        response.write_to_with_default_connection(reader.get_mut(), DefaultConnectionHeader::Close),
+      ),
+      HttpHandoff::Connect { response, handler } | HttpHandoff::Upgrade { response, handler } => {
+        self.normalize_connection_error(response.write_handoff_head_to(reader.get_mut()))?;
+        let buffered = reader.buffer().to_vec();
+        let stream = HandoffStream::new(buffered, reader.into_inner());
+        handler(stream)
+      }
+    }
+  }
+
   fn configure_stream(&self, stream: &TcpStream) -> io::Result<()> {
     stream.set_read_timeout(self.read_timeout)?;
     stream.set_write_timeout(self.write_timeout)
@@ -227,6 +273,108 @@ impl HttpServer {
         err
       }
     })
+  }
+}
+
+pub struct HandoffStream {
+  buffered: Cursor<Vec<u8>>,
+  stream: TcpStream,
+}
+
+impl HandoffStream {
+  fn new(buffered: Vec<u8>, stream: TcpStream) -> Self {
+    Self {
+      buffered: Cursor::new(buffered),
+      stream,
+    }
+  }
+
+  pub fn get_ref(&self) -> &TcpStream {
+    &self.stream
+  }
+
+  pub fn get_mut(&mut self) -> &mut TcpStream {
+    &mut self.stream
+  }
+
+  pub fn into_inner(self) -> TcpStream {
+    self.stream
+  }
+}
+
+impl Read for HandoffStream {
+  fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+    let read = self.buffered.read(buf)?;
+    if read == 0 {
+      self.stream.read(buf)
+    } else {
+      Ok(read)
+    }
+  }
+}
+
+impl Write for HandoffStream {
+  fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+    self.stream.write(buf)
+  }
+
+  fn flush(&mut self) -> io::Result<()> {
+    self.stream.flush()
+  }
+}
+
+type HandoffHandler = Box<dyn FnOnce(HandoffStream) -> io::Result<()> + Send + 'static>;
+
+pub enum HttpHandoff {
+  Response(HttpResponse),
+  Connect {
+    response: HttpResponse,
+    handler: HandoffHandler,
+  },
+  Upgrade {
+    response: HttpResponse,
+    handler: HandoffHandler,
+  },
+}
+
+impl HttpHandoff {
+  pub fn response(response: HttpResponse) -> Self {
+    Self::Response(response)
+  }
+
+  pub fn connect<F>(response: HttpResponse, handler: F) -> Self
+  where
+    F: FnOnce(HandoffStream) -> io::Result<()> + Send + 'static,
+  {
+    Self::Connect {
+      response,
+      handler: Box::new(handler),
+    }
+  }
+
+  pub fn upgrade<F>(response: HttpResponse, handler: F) -> Self
+  where
+    F: FnOnce(HandoffStream) -> io::Result<()> + Send + 'static,
+  {
+    Self::Upgrade {
+      response,
+      handler: Box::new(handler),
+    }
+  }
+
+  fn valid_for(&self, request: &Request) -> bool {
+    match self {
+      Self::Response(_) => true,
+      Self::Connect { .. } => {
+        request.method().eq_ignore_ascii_case("CONNECT")
+          && is_authority_form_request_target(request.target())
+      }
+      Self::Upgrade { .. } => {
+        !request.method().eq_ignore_ascii_case("CONNECT")
+          && request.header("Upgrade").is_some()
+          && request.connection_header_has_token("upgrade")
+      }
+    }
   }
 }
 
@@ -961,6 +1109,30 @@ impl HttpResponse {
     writer.write_all(b"\r\n")
   }
 
+  fn write_handoff_head_to<W>(&self, writer: &mut W) -> io::Result<()>
+  where
+    W: Write,
+  {
+    write!(
+      writer,
+      "{} {} {}\r\n",
+      self.version, self.status_code, self.reason
+    )?;
+
+    let connection_header_index = self.connection_header_index();
+    for (index, header) in self.headers.iter().enumerate() {
+      if !header.name.eq_ignore_ascii_case("Content-Length")
+        && (!header.name.eq_ignore_ascii_case("Connection")
+          || Some(index) == connection_header_index)
+      {
+        write!(writer, "{}: {}\r\n", header.name, header.value)?;
+      }
+    }
+
+    writer.write_all(b"\r\n")?;
+    writer.flush()
+  }
+
   fn write_body_to<W>(&self, writer: &mut W) -> io::Result<()>
   where
     W: Write,
@@ -1080,6 +1252,22 @@ fn reject_oversized_request_body(length: usize) -> io::Result<()> {
   } else {
     Ok(())
   }
+}
+
+fn is_authority_form_request_target(target: &str) -> bool {
+  if target.is_empty()
+    || target.starts_with('/')
+    || target.starts_with('*')
+    || target.contains("://")
+    || target.contains(['/', '?', '#'])
+  {
+    return false;
+  }
+
+  let Some((host, port)) = target.rsplit_once(':') else {
+    return false;
+  };
+  !host.is_empty() && !port.is_empty() && port.bytes().all(|byte| byte.is_ascii_digit())
 }
 
 fn checked_request_message_len(header_end: usize, content_length: usize) -> io::Result<usize> {

--- a/rttp/tests/connect_upgrade_handoff.rs
+++ b/rttp/tests/connect_upgrade_handoff.rs
@@ -1,0 +1,147 @@
+use std::io::{Read, Write};
+use std::net::TcpStream;
+use std::thread;
+
+use rttp::server::{HttpHandoff, HttpResponse};
+
+#[test]
+fn connect_authority_form_hands_off_socket_after_response_boundary() {
+  let server = rttp::Http::server("127.0.0.1:0").expect("bind server");
+  let addr = server.local_addr().expect("server addr");
+
+  let handle = thread::spawn(move || {
+    server
+      .accept_one_handoff(|request| {
+        assert_eq!("CONNECT", request.method());
+        assert_eq!("example.com:443", request.target());
+        HttpHandoff::connect(
+          HttpResponse::new(200, "Connection Established"),
+          |mut stream| {
+            let mut ping = [0u8; 4];
+            stream.read_exact(&mut ping)?;
+            assert_eq!(b"ping", &ping);
+            stream.write_all(b"pong")?;
+            Ok(())
+          },
+        )
+      })
+      .expect("serve connect handoff");
+  });
+
+  let mut stream = TcpStream::connect(addr).expect("connect server");
+  stream
+    .write_all(b"CONNECT example.com:443 HTTP/1.1\r\nHost: example.com:443\r\n\r\nping")
+    .expect("write connect request");
+
+  let mut response_and_tunnel = Vec::new();
+  let mut buffer = [0u8; 128];
+  loop {
+    let read = stream.read(&mut buffer).expect("read tunnel response");
+    assert_ne!(0, read);
+    response_and_tunnel.extend_from_slice(&buffer[..read]);
+    if response_and_tunnel.ends_with(b"pong") {
+      break;
+    }
+  }
+
+  assert_eq!(
+    b"HTTP/1.1 200 Connection Established\r\n\r\npong",
+    response_and_tunnel.as_slice()
+  );
+
+  handle.join().expect("server thread");
+}
+
+#[test]
+fn upgrade_request_hands_off_socket_and_preserves_buffered_bytes() {
+  let server = rttp::Http::server("127.0.0.1:0").expect("bind server");
+  let addr = server.local_addr().expect("server addr");
+
+  let handle = thread::spawn(move || {
+    server
+      .accept_one_handoff(|request| {
+        assert_eq!("GET", request.method());
+        assert_eq!(Some("websocket"), request.header("Upgrade"));
+        HttpHandoff::upgrade(
+          HttpResponse::new(101, "Switching Protocols")
+            .header("Connection", "Upgrade")
+            .header("Upgrade", "websocket"),
+          |mut stream| {
+            let mut hello = [0u8; 5];
+            stream.read_exact(&mut hello)?;
+            assert_eq!(b"hello", &hello);
+            stream.write_all(b"world")?;
+            Ok(())
+          },
+        )
+      })
+      .expect("serve upgrade handoff");
+  });
+
+  let mut stream = TcpStream::connect(addr).expect("connect server");
+  stream
+    .write_all(
+      b"GET /chat HTTP/1.1\r\nHost: localhost\r\nConnection: keep-alive, Upgrade\r\nUpgrade: websocket\r\n\r\nhello",
+    )
+    .expect("write upgrade request");
+
+  let mut response_and_upgraded = Vec::new();
+  let mut buffer = [0u8; 128];
+  loop {
+    let read = stream.read(&mut buffer).expect("read upgrade response");
+    assert_ne!(0, read);
+    response_and_upgraded.extend_from_slice(&buffer[..read]);
+    if response_and_upgraded.ends_with(b"world") {
+      break;
+    }
+  }
+
+  assert_eq!(
+    concat!(
+      "HTTP/1.1 101 Switching Protocols\r\n",
+      "Connection: Upgrade\r\n",
+      "Upgrade: websocket\r\n",
+      "\r\n",
+      "world"
+    )
+    .as_bytes(),
+    response_and_upgraded.as_slice()
+  );
+
+  handle.join().expect("server thread");
+}
+
+#[test]
+fn invalid_connect_handoff_request_returns_bad_request_without_handoff() {
+  let server = rttp::Http::server("127.0.0.1:0").expect("bind server");
+  let addr = server.local_addr().expect("server addr");
+
+  let handle = thread::spawn(move || {
+    server
+      .accept_one_handoff(|_request| {
+        HttpHandoff::connect(
+          HttpResponse::new(200, "Connection Established"),
+          |_stream| panic!("invalid CONNECT target must not be handed off"),
+        )
+      })
+      .expect("serve invalid connect");
+  });
+
+  let mut stream = TcpStream::connect(addr).expect("connect server");
+  stream
+    .write_all(b"CONNECT /not-authority HTTP/1.1\r\nHost: localhost\r\n\r\n")
+    .expect("write invalid connect request");
+  stream
+    .shutdown(std::net::Shutdown::Write)
+    .expect("shutdown client write");
+
+  let mut response = String::new();
+  stream.read_to_string(&mut response).expect("read response");
+
+  assert_eq!(
+    "HTTP/1.1 400 Bad Request\r\nContent-Length: 11\r\nConnection: close\r\n\r\nBad Request",
+    response
+  );
+
+  handle.join().expect("server thread");
+}

--- a/rttp_client/src/client.rs
+++ b/rttp_client/src/client.rs
@@ -1,6 +1,6 @@
 #[cfg(feature = "async")]
 use crate::connection::{AsyncConnection, AsyncStreamingRequestBody};
-use crate::connection::{BlockConnection, StreamingRequestBody};
+use crate::connection::{BlockConnection, HandoffConnection, StreamingRequestBody};
 use crate::request::{RawRequest, Request};
 use crate::response::Response;
 use crate::types::{Auth, Header, IntoHeader, IntoPara, Proxy, ToFormData, ToRoUrl};
@@ -244,6 +244,33 @@ impl HttpClient {
     BlockConnection::new(request).call_streaming_body(StreamingRequestBody::Chunked {
       reader: &mut reader,
     })
+  }
+
+  pub fn connect(&mut self) -> error::Result<HandoffConnection> {
+    if self.request.closed() {
+      return Err(error::connection_closed());
+    }
+    if self.request.has_configured_body() {
+      return Err(error::builder_with_message(
+        "CONNECT socket handoff cannot be combined with a request body",
+      ));
+    }
+    self.request.method_set("CONNECT");
+    let request = RawRequest::block_new(&mut self.request)?;
+    BlockConnection::new(request).call_connect_handoff()
+  }
+
+  pub fn upgrade(&mut self) -> error::Result<HandoffConnection> {
+    if self.request.closed() {
+      return Err(error::connection_closed());
+    }
+    if self.request.has_configured_body() {
+      return Err(error::builder_with_message(
+        "Upgrade socket handoff cannot be combined with a request body",
+      ));
+    }
+    let request = RawRequest::block_new(&mut self.request)?;
+    BlockConnection::new(request).call_upgrade_handoff()
   }
 
   /// Async request emit

--- a/rttp_client/src/connection/block_connection.rs
+++ b/rttp_client/src/connection/block_connection.rs
@@ -3,7 +3,9 @@ use std::io::Write;
 use socks::{Socks4Stream, Socks5Stream};
 use url::Url;
 
-use crate::connection::connection::{Connection, ExpectContinueResult, StreamingRequestBody};
+use crate::connection::connection::{
+  Connection, ExpectContinueResult, HandoffConnection, HandoffKind, StreamingRequestBody,
+};
 use crate::connection::connection_reader::ResponseParts;
 use crate::error;
 use crate::request::RawRequest;
@@ -82,6 +84,30 @@ impl<'a> BlockConnection<'a> {
       Response::with_trailers(self.conn.rourl().clone(), parts.binary, parts.trailers)?;
     self.conn.closed_set(true);
     Ok(response)
+  }
+
+  pub fn call_connect_handoff(mut self) -> error::Result<HandoffConnection> {
+    if self.conn.proxy().is_some() {
+      return Err(error::builder_with_message(
+        "CONNECT socket handoff does not support proxies",
+      ));
+    }
+    let url = self.conn.url().map_err(error::builder)?;
+    let handoff = self.conn.block_send_handoff(&url, HandoffKind::Connect)?;
+    self.conn.closed_set(true);
+    Ok(handoff)
+  }
+
+  pub fn call_upgrade_handoff(mut self) -> error::Result<HandoffConnection> {
+    if self.conn.proxy().is_some() {
+      return Err(error::builder_with_message(
+        "Upgrade socket handoff does not support proxies",
+      ));
+    }
+    let url = self.conn.url().map_err(error::builder)?;
+    let handoff = self.conn.block_send_handoff(&url, HandoffKind::Upgrade)?;
+    self.conn.closed_set(true);
+    Ok(handoff)
   }
 }
 

--- a/rttp_client/src/connection/connection.rs
+++ b/rttp_client/src/connection/connection.rs
@@ -1,4 +1,4 @@
-use std::{io, net::ToSocketAddrs, time};
+use std::{io, net::TcpStream, net::ToSocketAddrs, time};
 
 use socket2::{Domain, Protocol, Socket, Type};
 
@@ -14,6 +14,7 @@ use crate::connection::connection_reader::{
   response_status_code, ConnectionReader, ResponseParts,
 };
 use crate::request::{RawRequest, RequestBody};
+use crate::response::Response;
 use crate::types::{Proxy, RoUrl, ToUrl};
 use crate::{error, Config};
 
@@ -143,6 +144,34 @@ impl ServerCertVerifier for NoHostnameVerification {
 
 pub struct Connection<'a> {
   request: RawRequest<'a>,
+}
+
+#[derive(Debug)]
+pub struct HandoffConnection {
+  response: Response,
+  stream: TcpStream,
+}
+
+impl HandoffConnection {
+  pub(crate) fn new(response: Response, stream: TcpStream) -> Self {
+    Self { response, stream }
+  }
+
+  pub fn response(&self) -> &Response {
+    &self.response
+  }
+
+  pub fn stream(&self) -> &TcpStream {
+    &self.stream
+  }
+
+  pub fn stream_mut(&mut self) -> &mut TcpStream {
+    &mut self.stream
+  }
+
+  pub fn into_parts(self) -> (Response, TcpStream) {
+    (self.response, self.stream)
+  }
 }
 
 pub(crate) struct RedirectUrl {
@@ -282,6 +311,11 @@ impl<'a> Connection<'a> {
 
   pub fn expect_no_response_body(&self) -> bool {
     self.request.origin().method().eq_ignore_ascii_case("head")
+      || self
+        .request
+        .origin()
+        .method()
+        .eq_ignore_ascii_case("connect")
   }
 }
 
@@ -462,10 +496,39 @@ pub(crate) fn request_expects_continue(header: &str, body: Option<&RequestBody>)
   })
 }
 
+fn response_header_has_upgrade(header: &[u8]) -> error::Result<bool> {
+  let header = String::from_utf8(header.to_vec()).map_err(error::response)?;
+  let mut has_upgrade_header = false;
+  let mut connection_has_upgrade = false;
+
+  for line in header.lines().skip(1) {
+    let Some((name, value)) = line.split_once(':') else {
+      continue;
+    };
+    if name.eq_ignore_ascii_case("Upgrade") && !value.trim().is_empty() {
+      has_upgrade_header = true;
+    }
+    if name.eq_ignore_ascii_case("Connection")
+      && value
+        .split(',')
+        .any(|token| token.trim().eq_ignore_ascii_case("upgrade"))
+    {
+      connection_has_upgrade = true;
+    }
+  }
+
+  Ok(has_upgrade_header && connection_has_upgrade)
+}
+
 pub(crate) enum ExpectContinueResult {
   NotUsed,
   BodySent,
   Final(ResponseParts),
+}
+
+pub(crate) enum HandoffKind {
+  Connect,
+  Upgrade,
 }
 
 pub(crate) enum StreamingRequestBody<'a> {
@@ -687,6 +750,49 @@ impl<'a> Connection<'a> {
     let addr = self.addr(url)?;
     let mut stream = self.block_tcp_stream(&addr)?;
     self.block_send_with_stream_parts(url, &mut stream)
+  }
+
+  pub(crate) fn block_send_handoff(
+    &self,
+    url: &Url,
+    kind: HandoffKind,
+  ) -> error::Result<HandoffConnection> {
+    if url.scheme() != "http" {
+      return Err(error::builder_with_message(
+        "socket handoff only supports plain http URLs",
+      ));
+    }
+
+    let addr = self.addr(url)?;
+    let mut stream = self.block_tcp_stream(&addr)?;
+    self.block_write_stream(&mut stream)?;
+
+    let header = read_response_header(&mut stream)?;
+    let status_code = response_status_code(&header)?;
+    match kind {
+      HandoffKind::Connect if (200..300).contains(&status_code) => {
+        let response = Response::with_trailers(self.rourl().clone(), header, Vec::new())?;
+        Ok(HandoffConnection::new(response, stream))
+      }
+      HandoffKind::Upgrade if status_code == 101 && response_header_has_upgrade(&header)? => {
+        let response = Response::with_trailers(self.rourl().clone(), header, Vec::new())?;
+        Ok(HandoffConnection::new(response, stream))
+      }
+      HandoffKind::Connect => {
+        let _ = read_response_parts_after_header(&mut stream, false, header)?;
+        Err(error::bad_response(format!(
+          "CONNECT failed with HTTP status {}",
+          status_code
+        )))
+      }
+      HandoffKind::Upgrade => {
+        let _ = read_response_parts_after_header(&mut stream, false, header)?;
+        Err(error::bad_response(format!(
+          "Upgrade failed with HTTP status {}",
+          status_code
+        )))
+      }
+    }
   }
 
   pub(crate) fn block_send_streaming_parts(

--- a/rttp_client/src/connection/mod.rs
+++ b/rttp_client/src/connection/mod.rs
@@ -5,6 +5,7 @@ pub(crate) use self::async_connection::AsyncStreamingRequestBody;
 #[cfg(feature = "async")]
 pub use self::async_connection::*;
 pub use self::block_connection::*;
+pub use self::connection::HandoffConnection;
 pub(crate) use self::connection::StreamingRequestBody;
 pub use self::connection_reader::{ConnectionReader, ResponseBodyReader, StreamingResponse};
 

--- a/rttp_client/tests/test_connect_upgrade_handoff.rs
+++ b/rttp_client/tests/test_connect_upgrade_handoff.rs
@@ -1,0 +1,131 @@
+use std::io::{Read, Write};
+use std::net::TcpListener;
+use std::thread;
+
+use rttp_client::HttpClient;
+
+fn read_request_head(stream: &mut impl Read) -> Vec<u8> {
+  let mut request = Vec::new();
+  let mut byte = [0u8; 1];
+  while !request.ends_with(b"\r\n\r\n") {
+    stream.read_exact(&mut byte).expect("read request byte");
+    request.push(byte[0]);
+  }
+  request
+}
+
+#[test]
+fn connect_returns_socket_after_successful_tunnel_response() {
+  let listener = TcpListener::bind("127.0.0.1:0").expect("bind tunnel server");
+  let addr = listener.local_addr().expect("tunnel server addr");
+
+  let handle = thread::spawn(move || {
+    let (mut stream, _) = listener.accept().expect("accept tunnel");
+    let request = read_request_head(&mut stream);
+    let request = String::from_utf8(request).expect("request utf8");
+    assert!(request.starts_with(&format!("CONNECT {} HTTP/1.1\r\n", addr)));
+    stream
+      .write_all(b"HTTP/1.1 200 Connection Established\r\n\r\n")
+      .expect("write connect response");
+    let mut ping = [0u8; 4];
+    stream.read_exact(&mut ping).expect("read tunnel payload");
+    assert_eq!(b"ping", &ping);
+    stream.write_all(b"pong").expect("write tunnel payload");
+  });
+
+  let mut tunnel = HttpClient::new()
+    .url(format!("http://{}", addr))
+    .connect()
+    .expect("establish tunnel");
+
+  assert_eq!(200, tunnel.response().code());
+  tunnel.stream_mut().write_all(b"ping").expect("write ping");
+  let mut pong = [0u8; 4];
+  tunnel
+    .stream_mut()
+    .read_exact(&mut pong)
+    .expect("read pong");
+  assert_eq!(b"pong", &pong);
+
+  handle.join().expect("server thread");
+}
+
+#[test]
+fn upgrade_returns_socket_after_101_and_does_not_parse_upgraded_bytes() {
+  let listener = TcpListener::bind("127.0.0.1:0").expect("bind upgrade server");
+  let addr = listener.local_addr().expect("upgrade server addr");
+
+  let handle = thread::spawn(move || {
+    let (mut stream, _) = listener.accept().expect("accept upgrade");
+    let request = String::from_utf8(read_request_head(&mut stream)).expect("request utf8");
+    assert!(request.starts_with("GET /chat HTTP/1.1\r\n"));
+    assert!(request.contains("\r\nConnection: Upgrade\r\n"));
+    assert!(request.contains("\r\nUpgrade: websocket\r\n"));
+    stream
+      .write_all(
+        b"HTTP/1.1 101 Switching Protocols\r\nConnection: Upgrade\r\nUpgrade: websocket\r\n\r\nserver-bytes",
+      )
+      .expect("write upgrade response and bytes");
+    let mut client_bytes = [0u8; 12];
+    stream
+      .read_exact(&mut client_bytes)
+      .expect("read upgraded client bytes");
+    assert_eq!(b"client-bytes", &client_bytes);
+  });
+
+  let mut upgraded = HttpClient::new()
+    .url(format!("http://{}/chat", addr))
+    .header(("Connection", "Upgrade"))
+    .header(("Upgrade", "websocket"))
+    .upgrade()
+    .expect("upgrade connection");
+
+  assert_eq!(101, upgraded.response().code());
+  assert_eq!(
+    Some(&"websocket".to_string()),
+    upgraded.response().header_value("Upgrade")
+  );
+  let mut server_bytes = [0u8; 12];
+  upgraded
+    .stream_mut()
+    .read_exact(&mut server_bytes)
+    .expect("read upgraded server bytes");
+  assert_eq!(b"server-bytes", &server_bytes);
+  upgraded
+    .stream_mut()
+    .write_all(b"client-bytes")
+    .expect("write upgraded client bytes");
+
+  handle.join().expect("server thread");
+}
+
+#[test]
+fn failed_upgrade_reads_http_response_and_closes_socket() {
+  let listener = TcpListener::bind("127.0.0.1:0").expect("bind failed upgrade server");
+  let addr = listener.local_addr().expect("failed upgrade server addr");
+
+  let handle = thread::spawn(move || {
+    let (mut stream, _) = listener.accept().expect("accept failed upgrade");
+    let _request = read_request_head(&mut stream);
+    stream
+      .write_all(
+        b"HTTP/1.1 426 Upgrade Required\r\nContent-Length: 16\r\nConnection: close\r\n\r\nupgrade required",
+      )
+      .expect("write failed upgrade response");
+    let mut extra = [0u8; 1];
+    assert_eq!(0, stream.read(&mut extra).expect("client should close"));
+  });
+
+  let err = HttpClient::new()
+    .url(format!("http://{}/chat", addr))
+    .header(("Connection", "Upgrade"))
+    .header(("Upgrade", "websocket"))
+    .upgrade()
+    .expect_err("non-101 upgrade must fail");
+
+  assert!(err
+    .to_string()
+    .contains("Upgrade failed with HTTP status 426"));
+
+  handle.join().expect("server thread");
+}


### PR DESCRIPTION
Adds server and sync-client CONNECT/HTTP Upgrade socket handoff support with validation, response-boundary handling, and raw socket integration tests. Verification passed with formatting, focused handoff tests, and the full workspace test suite.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1315/
work_kind: code_work
branch: hbx-1315-rttp-support-connect-and-http
base: main
commit: b9babaf6207b3cb2c853e64b6bc45e1b8a8ad675
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1315/
    url: https://plane.kahub.in/endless/browse/HBX-1315/
    close_policy: link_only
```