### PR TITLE
feat: [rttp] Add HTTP/2 prior-knowledge client handshake and single-stream GET

### DIFF
--- a/rttp_client/Cargo.toml
+++ b/rttp_client/Cargo.toml
@@ -46,6 +46,7 @@ futures-rustls   = { optional = true, version = "0.26" }
 [features]
 default = []
 async = []
+http2 = []
 tls-native  = ["native-tls", "async-native-tls"]
 tls-rustls  = ["rustls", "webpki-roots", "futures-rustls"]
 

--- a/rttp_client/src/client.rs
+++ b/rttp_client/src/client.rs
@@ -203,6 +203,15 @@ impl HttpClient {
     BlockConnection::new(request).call()
   }
 
+  #[cfg(feature = "http2")]
+  pub fn emit_http2_prior_knowledge(&mut self) -> error::Result<Response> {
+    if self.request.closed() {
+      return Err(error::connection_closed());
+    }
+    let request = RawRequest::block_new(&mut self.request)?;
+    crate::http2::PriorKnowledgeClient::new(request).get()
+  }
+
   pub fn emit_streaming_fixed<R>(
     &mut self,
     mut reader: R,

--- a/rttp_client/src/http2.rs
+++ b/rttp_client/src/http2.rs
@@ -1,0 +1,559 @@
+use std::io::{self, Read, Write};
+use std::net::{TcpStream, ToSocketAddrs};
+use std::time::Duration;
+
+use socket2::{Domain, Protocol, Socket, Type};
+use url::Url;
+
+use crate::request::RawRequest;
+use crate::response::Response;
+use crate::types::{RoUrl, ToUrl};
+use crate::{error, Config};
+
+const CLIENT_PREFACE: &[u8; 24] = b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n";
+
+const FRAME_DATA: u8 = 0x0;
+const FRAME_HEADERS: u8 = 0x1;
+const FRAME_SETTINGS: u8 = 0x4;
+const FRAME_CONTINUATION: u8 = 0x9;
+
+const FLAG_END_STREAM: u8 = 0x1;
+const FLAG_ACK: u8 = 0x1;
+const FLAG_END_HEADERS: u8 = 0x4;
+
+const STREAM_ID: u32 = 1;
+
+pub struct PriorKnowledgeClient<'a> {
+  request: RawRequest<'a>,
+}
+
+impl<'a> PriorKnowledgeClient<'a> {
+  pub(crate) fn new(request: RawRequest<'a>) -> Self {
+    Self { request }
+  }
+
+  pub fn get(mut self) -> error::Result<Response> {
+    if !self.request.origin().method().eq_ignore_ascii_case("GET") {
+      return Err(error::builder_with_message(
+        "HTTP/2 prior-knowledge client currently supports GET only",
+      ));
+    }
+    if self.request.body().is_some() {
+      return Err(error::builder_with_message(
+        "HTTP/2 prior-knowledge GET cannot send a request body",
+      ));
+    }
+
+    let url = self.request.url().to_url().map_err(error::builder)?;
+    if url.scheme() != "http" {
+      return Err(error::url_bad_scheme(url));
+    }
+
+    let mut stream = connect_tcp_stream(addr(&url)?, self.request.origin().config())?;
+    write_connection_preface(&mut stream)?;
+    read_settings_and_ack(&mut stream)?;
+    write_get_headers(&mut stream, &self.request, &url)?;
+    let response = read_single_stream_response(&mut stream, self.request.url().clone())?;
+    self.request.origin_mut().closed_set(true);
+    Ok(response)
+  }
+}
+
+fn addr(url: &Url) -> error::Result<String> {
+  let host = url.host_str().ok_or(error::url_bad_host(url.clone()))?;
+  let port = url
+    .port_or_known_default()
+    .ok_or(error::url_bad_host(url.clone()))?;
+  Ok(format!("{}:{}", host, port))
+}
+
+fn connect_tcp_stream<A>(addr: A, config: &Config) -> error::Result<TcpStream>
+where
+  A: ToSocketAddrs,
+{
+  let timeout_read = timeout_duration("read", config.read_timeout())?;
+  let timeout_write = timeout_duration("write", config.write_timeout())?;
+  let mut last_err = None;
+
+  for addr in addr.to_socket_addrs().map_err(error::request)? {
+    let socket = match Socket::new(Domain::for_address(addr), Type::STREAM, Some(Protocol::TCP)) {
+      Ok(socket) => socket,
+      Err(err) => {
+        last_err = Some(err);
+        continue;
+      }
+    };
+    if let Err(err) = socket.set_read_timeout(Some(timeout_read)) {
+      last_err = Some(err);
+      continue;
+    }
+    if let Err(err) = socket.set_write_timeout(Some(timeout_write)) {
+      last_err = Some(err);
+      continue;
+    }
+    if let Err(err) = socket.connect(&addr.into()) {
+      last_err = Some(err);
+      continue;
+    }
+    return Ok(socket.into());
+  }
+
+  Err(error::request(last_err.unwrap_or_else(|| {
+    io::Error::new(io::ErrorKind::NotFound, "no socket address resolved")
+  })))
+}
+
+fn timeout_duration(name: &'static str, millis: u64) -> error::Result<Duration> {
+  if millis == 0 {
+    return Err(error::request(io::Error::new(
+      io::ErrorKind::InvalidInput,
+      format!("{} timeout must be greater than 0", name),
+    )));
+  }
+  Ok(Duration::from_millis(millis))
+}
+
+fn write_connection_preface(stream: &mut TcpStream) -> error::Result<()> {
+  stream.write_all(CLIENT_PREFACE).map_err(error::request)?;
+  write_frame(stream, FRAME_SETTINGS, 0, 0, &[])?;
+  stream.flush().map_err(error::request)
+}
+
+fn read_settings_and_ack(stream: &mut TcpStream) -> error::Result<()> {
+  loop {
+    let frame = read_frame(stream)?;
+    if frame.frame_type != FRAME_SETTINGS {
+      return Err(error::bad_response(
+        "HTTP/2 peer did not start with a SETTINGS frame",
+      ));
+    }
+    if frame.flags & FLAG_ACK == FLAG_ACK {
+      if frame.payload.is_empty() {
+        continue;
+      }
+      return Err(error::bad_response(
+        "HTTP/2 SETTINGS ACK frame must not contain payload",
+      ));
+    }
+    if frame.stream_id != 0 || frame.payload.len() % 6 != 0 {
+      return Err(error::bad_response("invalid HTTP/2 SETTINGS frame"));
+    }
+    write_frame(stream, FRAME_SETTINGS, FLAG_ACK, 0, &[])?;
+    stream.flush().map_err(error::request)?;
+    return Ok(());
+  }
+}
+
+fn write_get_headers(
+  stream: &mut TcpStream,
+  request: &RawRequest<'_>,
+  url: &Url,
+) -> error::Result<()> {
+  let header_block = encode_request_headers(request, url)?;
+  write_frame(
+    stream,
+    FRAME_HEADERS,
+    FLAG_END_STREAM | FLAG_END_HEADERS,
+    STREAM_ID,
+    &header_block,
+  )?;
+  stream.flush().map_err(error::request)
+}
+
+fn encode_request_headers(request: &RawRequest<'_>, url: &Url) -> error::Result<Vec<u8>> {
+  let mut block = Vec::new();
+  block.push(0x82);
+  if url.scheme() == "http" {
+    block.push(0x86);
+  } else {
+    return Err(error::url_bad_scheme(url.clone()));
+  }
+
+  let path = request_target(url);
+  if path == "/" {
+    block.push(0x84);
+  } else {
+    encode_literal_indexed_name_without_indexing(&mut block, 4, path.as_bytes())?;
+  }
+  encode_literal_indexed_name_without_indexing(&mut block, 1, authority(url)?.as_bytes())?;
+
+  for (name, value) in regular_headers(request.header()) {
+    encode_literal_new_name_without_indexing(&mut block, name.as_bytes(), value.as_bytes())?;
+  }
+
+  Ok(block)
+}
+
+fn request_target(url: &Url) -> String {
+  let mut target = url.path().to_string();
+  if target.is_empty() {
+    target.push('/');
+  }
+  if let Some(query) = url.query() {
+    target.push('?');
+    target.push_str(query);
+  }
+  target
+}
+
+fn authority(url: &Url) -> error::Result<String> {
+  let host = url.host_str().ok_or(error::url_bad_host(url.clone()))?;
+  let host = if host.contains(':') && !host.starts_with('[') {
+    format!("[{}]", host)
+  } else {
+    host.to_string()
+  };
+  Ok(match url.port() {
+    Some(port) => format!("{}:{}", host, port),
+    None => host,
+  })
+}
+
+fn regular_headers(header: &str) -> Vec<(String, String)> {
+  header
+    .lines()
+    .skip(1)
+    .filter_map(|line| line.split_once(':'))
+    .map(|(name, value)| (name.trim().to_ascii_lowercase(), value.trim().to_string()))
+    .filter(|(name, _)| {
+      !matches!(
+        name.as_str(),
+        "connection"
+          | "host"
+          | "keep-alive"
+          | "proxy-connection"
+          | "te"
+          | "transfer-encoding"
+          | "upgrade"
+      )
+    })
+    .collect()
+}
+
+fn read_single_stream_response(stream: &mut TcpStream, url: RoUrl) -> error::Result<Response> {
+  let mut header_block = Vec::new();
+  let mut headers = Vec::new();
+  let mut body = Vec::new();
+  let mut status = None;
+  let mut in_header_continuation = false;
+
+  loop {
+    let frame = read_frame(stream)?;
+    match (frame.frame_type, frame.stream_id) {
+      (FRAME_SETTINGS, 0) => {
+        if frame.flags & FLAG_ACK == 0 {
+          write_frame(stream, FRAME_SETTINGS, FLAG_ACK, 0, &[])?;
+          stream.flush().map_err(error::request)?;
+        } else if !frame.payload.is_empty() {
+          return Err(error::bad_response(
+            "HTTP/2 SETTINGS ACK frame must not contain payload",
+          ));
+        }
+      }
+      (FRAME_HEADERS, STREAM_ID) => {
+        header_block.extend_from_slice(&frame.payload);
+        if frame.flags & FLAG_END_HEADERS == FLAG_END_HEADERS {
+          let decoded = decode_header_block(&header_block)?;
+          status = decoded.status;
+          headers = decoded.headers;
+          header_block.clear();
+          in_header_continuation = false;
+        } else {
+          in_header_continuation = true;
+        }
+        if frame.flags & FLAG_END_STREAM == FLAG_END_STREAM {
+          break;
+        }
+      }
+      (FRAME_CONTINUATION, STREAM_ID) if in_header_continuation => {
+        header_block.extend_from_slice(&frame.payload);
+        if frame.flags & FLAG_END_HEADERS == FLAG_END_HEADERS {
+          let decoded = decode_header_block(&header_block)?;
+          status = decoded.status;
+          headers = decoded.headers;
+          header_block.clear();
+          in_header_continuation = false;
+        }
+      }
+      (FRAME_DATA, STREAM_ID) => {
+        body.extend_from_slice(&frame.payload);
+        if frame.flags & FLAG_END_STREAM == FLAG_END_STREAM {
+          break;
+        }
+      }
+      (_, STREAM_ID) => {}
+      (_, 0) => {}
+      _ => {}
+    }
+  }
+
+  if in_header_continuation {
+    return Err(error::bad_response("incomplete HTTP/2 header block"));
+  }
+
+  let status = status.ok_or_else(|| error::bad_response("missing HTTP/2 :status header"))?;
+  build_response(url, status, &headers, body)
+}
+
+fn build_response(
+  url: RoUrl,
+  status: u32,
+  headers: &[(String, String)],
+  body: Vec<u8>,
+) -> error::Result<Response> {
+  let mut binary = format!("HTTP/2 {}\r\n", status).into_bytes();
+  for (name, value) in headers {
+    binary.extend_from_slice(name.as_bytes());
+    binary.extend_from_slice(b": ");
+    binary.extend_from_slice(value.as_bytes());
+    binary.extend_from_slice(b"\r\n");
+  }
+  binary.extend_from_slice(b"\r\n");
+  binary.extend_from_slice(&body);
+  Response::new(url, binary)
+}
+
+struct Frame {
+  frame_type: u8,
+  flags: u8,
+  stream_id: u32,
+  payload: Vec<u8>,
+}
+
+fn read_frame(stream: &mut TcpStream) -> error::Result<Frame> {
+  let mut header = [0; 9];
+  stream.read_exact(&mut header).map_err(error::response)?;
+  let length = ((header[0] as usize) << 16) | ((header[1] as usize) << 8) | header[2] as usize;
+  let mut payload = vec![0; length];
+  stream.read_exact(&mut payload).map_err(error::response)?;
+  Ok(Frame {
+    frame_type: header[3],
+    flags: header[4],
+    stream_id: u32::from_be_bytes([header[5] & 0x7f, header[6], header[7], header[8]]),
+    payload,
+  })
+}
+
+fn write_frame(
+  stream: &mut TcpStream,
+  frame_type: u8,
+  flags: u8,
+  stream_id: u32,
+  payload: &[u8],
+) -> error::Result<()> {
+  if payload.len() > 16_777_215 {
+    return Err(error::request(io::Error::new(
+      io::ErrorKind::InvalidInput,
+      "HTTP/2 frame payload is too large",
+    )));
+  }
+
+  let length = payload.len();
+  let mut header = [0; 9];
+  header[0] = ((length >> 16) & 0xff) as u8;
+  header[1] = ((length >> 8) & 0xff) as u8;
+  header[2] = (length & 0xff) as u8;
+  header[3] = frame_type;
+  header[4] = flags;
+  header[5..9].copy_from_slice(&(stream_id & 0x7fff_ffff).to_be_bytes());
+  stream.write_all(&header).map_err(error::request)?;
+  stream.write_all(payload).map_err(error::request)
+}
+
+fn encode_literal_indexed_name_without_indexing(
+  block: &mut Vec<u8>,
+  name_index: u8,
+  value: &[u8],
+) -> error::Result<()> {
+  if name_index > 15 {
+    return Err(error::request(io::Error::new(
+      io::ErrorKind::InvalidInput,
+      "HPACK literal indexed name is too large for the minimal encoder",
+    )));
+  }
+  block.push(name_index);
+  encode_string(block, value)
+}
+
+fn encode_literal_new_name_without_indexing(
+  block: &mut Vec<u8>,
+  name: &[u8],
+  value: &[u8],
+) -> error::Result<()> {
+  block.push(0);
+  encode_string(block, name)?;
+  encode_string(block, value)
+}
+
+fn encode_string(block: &mut Vec<u8>, value: &[u8]) -> error::Result<()> {
+  encode_integer(block, value.len(), 7, 0)?;
+  block.extend_from_slice(value);
+  Ok(())
+}
+
+fn encode_integer(
+  block: &mut Vec<u8>,
+  mut value: usize,
+  prefix_bits: u8,
+  first_byte_prefix: u8,
+) -> error::Result<()> {
+  let max_prefix = (1usize << prefix_bits) - 1;
+  if value < max_prefix {
+    block.push(first_byte_prefix | value as u8);
+    return Ok(());
+  }
+
+  block.push(first_byte_prefix | max_prefix as u8);
+  value -= max_prefix;
+  while value >= 128 {
+    block.push((value % 128) as u8 + 128);
+    value /= 128;
+  }
+  block.push(value as u8);
+  Ok(())
+}
+
+struct DecodedHeaders {
+  status: Option<u32>,
+  headers: Vec<(String, String)>,
+}
+
+fn decode_header_block(block: &[u8]) -> error::Result<DecodedHeaders> {
+  let mut cursor = 0;
+  let mut status = None;
+  let mut headers = Vec::new();
+
+  while cursor < block.len() {
+    let byte = block[cursor];
+    if byte & 0x80 == 0x80 {
+      let index = decode_integer(block, &mut cursor, 7)?;
+      let (name, value) = static_header(index)?;
+      push_decoded_header(name, value, &mut status, &mut headers)?;
+      continue;
+    }
+
+    let (name, value) = if byte & 0x40 == 0x40 {
+      decode_literal(block, &mut cursor, 6)?
+    } else if byte & 0x20 == 0x20 {
+      return Err(error::bad_response(
+        "HTTP/2 dynamic table size updates are not supported",
+      ));
+    } else {
+      decode_literal(block, &mut cursor, 4)?
+    };
+    push_decoded_header(&name, &value, &mut status, &mut headers)?;
+  }
+
+  Ok(DecodedHeaders { status, headers })
+}
+
+fn decode_literal(
+  block: &[u8],
+  cursor: &mut usize,
+  prefix_bits: u8,
+) -> error::Result<(String, String)> {
+  let name_index = decode_integer(block, cursor, prefix_bits)?;
+  let name = if name_index == 0 {
+    decode_string(block, cursor)?
+  } else {
+    static_header(name_index)?.0.to_string()
+  };
+  let value = decode_string(block, cursor)?;
+  Ok((name, value))
+}
+
+fn decode_integer(block: &[u8], cursor: &mut usize, prefix_bits: u8) -> error::Result<usize> {
+  if *cursor >= block.len() {
+    return Err(error::bad_response("truncated HPACK integer"));
+  }
+
+  let max_prefix = (1usize << prefix_bits) - 1;
+  let mut value = (block[*cursor] as usize) & max_prefix;
+  *cursor += 1;
+  if value < max_prefix {
+    return Ok(value);
+  }
+
+  let mut shift = 0;
+  loop {
+    if *cursor >= block.len() {
+      return Err(error::bad_response("truncated HPACK integer"));
+    }
+    let byte = block[*cursor];
+    *cursor += 1;
+    value += ((byte & 0x7f) as usize) << shift;
+    if byte & 0x80 == 0 {
+      return Ok(value);
+    }
+    shift += 7;
+  }
+}
+
+fn decode_string(block: &[u8], cursor: &mut usize) -> error::Result<String> {
+  if *cursor >= block.len() {
+    return Err(error::bad_response("truncated HPACK string"));
+  }
+  let huffman = block[*cursor] & 0x80 == 0x80;
+  let len = decode_integer(block, cursor, 7)?;
+  if huffman {
+    return Err(error::bad_response(
+      "HPACK Huffman strings are not supported by the minimal decoder",
+    ));
+  }
+  let end = cursor
+    .checked_add(len)
+    .ok_or_else(|| error::bad_response("HPACK string length overflow"))?;
+  if end > block.len() {
+    return Err(error::bad_response("truncated HPACK string"));
+  }
+  let value = String::from_utf8(block[*cursor..end].to_vec()).map_err(error::response)?;
+  *cursor = end;
+  Ok(value)
+}
+
+fn push_decoded_header(
+  name: &str,
+  value: &str,
+  status: &mut Option<u32>,
+  headers: &mut Vec<(String, String)>,
+) -> error::Result<()> {
+  if name == ":status" {
+    *status = Some(
+      value
+        .parse::<u32>()
+        .map_err(|_| error::bad_response("invalid HTTP/2 :status header"))?,
+    );
+  } else if !name.starts_with(':') {
+    headers.push((name.to_string(), value.to_string()));
+  }
+  Ok(())
+}
+
+fn static_header(index: usize) -> error::Result<(&'static str, &'static str)> {
+  match index {
+    1 => Ok((":authority", "")),
+    2 => Ok((":method", "GET")),
+    3 => Ok((":method", "POST")),
+    4 => Ok((":path", "/")),
+    5 => Ok((":path", "/index.html")),
+    6 => Ok((":scheme", "http")),
+    7 => Ok((":scheme", "https")),
+    8 => Ok((":status", "200")),
+    9 => Ok((":status", "204")),
+    10 => Ok((":status", "206")),
+    11 => Ok((":status", "304")),
+    12 => Ok((":status", "400")),
+    13 => Ok((":status", "404")),
+    14 => Ok((":status", "500")),
+    15 => Ok(("accept-charset", "")),
+    16 => Ok(("accept-encoding", "gzip, deflate")),
+    17 => Ok(("accept-language", "")),
+    18 => Ok(("accept-ranges", "")),
+    19 => Ok(("accept", "")),
+    20 => Ok(("access-control-allow-origin", "")),
+    31 => Ok(("content-type", "")),
+    33 => Ok(("date", "")),
+    54 => Ok(("server", "")),
+    _ => Err(error::bad_response("unsupported HPACK static table index")),
+  }
+}

--- a/rttp_client/src/lib.rs
+++ b/rttp_client/src/lib.rs
@@ -59,6 +59,8 @@ pub use self::connection::{ConnectionReader, ResponseBodyReader, StreamingRespon
 mod client;
 mod config;
 mod connection;
+#[cfg(feature = "http2")]
+pub mod http2;
 mod request;
 
 pub mod error;

--- a/rttp_client/tests/http2_prior_knowledge.rs
+++ b/rttp_client/tests/http2_prior_knowledge.rs
@@ -1,0 +1,130 @@
+#![cfg(feature = "http2")]
+
+use std::io::{Read, Write};
+use std::net::{SocketAddr, TcpListener};
+use std::thread;
+
+use rttp_client::HttpClient;
+
+const FRAME_DATA: u8 = 0x0;
+const FRAME_HEADERS: u8 = 0x1;
+const FRAME_SETTINGS: u8 = 0x4;
+
+const FLAG_END_STREAM: u8 = 0x1;
+const FLAG_END_HEADERS: u8 = 0x4;
+const FLAG_ACK: u8 = 0x1;
+
+fn spawn_h2_prior_knowledge_peer() -> (SocketAddr, thread::JoinHandle<Vec<u8>>) {
+  let listener = TcpListener::bind("127.0.0.1:0").expect("bind h2 peer");
+  let addr = listener.local_addr().expect("h2 peer addr");
+
+  let handle = thread::spawn(move || {
+    let (mut stream, _) = listener.accept().expect("accept h2 client");
+    let mut preface = [0; 24];
+    stream
+      .read_exact(&mut preface)
+      .expect("read client preface");
+    assert_eq!(b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n", &preface);
+
+    let client_settings = read_frame(&mut stream);
+    assert_eq!(FRAME_SETTINGS, client_settings.frame_type);
+    assert_eq!(0, client_settings.stream_id);
+    assert_eq!(0, client_settings.payload.len());
+
+    write_frame(&mut stream, FRAME_SETTINGS, 0, 0, &[]);
+
+    let client_settings_ack = read_frame(&mut stream);
+    assert_eq!(FRAME_SETTINGS, client_settings_ack.frame_type);
+    assert_eq!(FLAG_ACK, client_settings_ack.flags);
+    assert_eq!(0, client_settings_ack.stream_id);
+    assert_eq!(0, client_settings_ack.payload.len());
+
+    let request_headers = read_frame(&mut stream);
+    assert_eq!(FRAME_HEADERS, request_headers.frame_type);
+    assert_eq!(FLAG_END_STREAM | FLAG_END_HEADERS, request_headers.flags);
+    assert_eq!(1, request_headers.stream_id);
+
+    write_frame(&mut stream, FRAME_SETTINGS, FLAG_ACK, 0, &[]);
+    write_frame(
+      &mut stream,
+      FRAME_HEADERS,
+      FLAG_END_HEADERS,
+      1,
+      &[
+        0x88, 0x0f, 16, 10, b't', b'e', b'x', b't', b'/', b'p', b'l', b'a', b'i', b'n',
+      ],
+    );
+    write_frame(
+      &mut stream,
+      FRAME_DATA,
+      FLAG_END_STREAM,
+      1,
+      b"hello over h2",
+    );
+
+    request_headers.payload
+  });
+
+  (addr, handle)
+}
+
+#[test]
+fn prior_knowledge_get_sends_h2_handshake_and_reads_single_response_stream() {
+  let (addr, handle) = spawn_h2_prior_knowledge_peer();
+
+  let response = HttpClient::new()
+    .get()
+    .url(format!("http://{}/hello?via=h2", addr))
+    .emit_http2_prior_knowledge()
+    .expect("single h2 GET response");
+
+  assert_eq!(200, response.code());
+  assert_eq!("HTTP/2", response.version());
+  assert_eq!(
+    Some(&"text/plain".to_string()),
+    response.header_value("content-type")
+  );
+  assert_eq!("hello over h2", response.body().string().unwrap());
+
+  let request_header_block = handle.join().expect("h2 peer thread");
+  assert!(request_header_block.contains(&0x82));
+  assert!(request_header_block.contains(&0x86));
+  assert!(request_header_block
+    .windows(b"/hello?via=h2".len())
+    .any(|window| window == b"/hello?via=h2"));
+}
+
+struct Frame {
+  frame_type: u8,
+  flags: u8,
+  stream_id: u32,
+  payload: Vec<u8>,
+}
+
+fn read_frame(stream: &mut impl Read) -> Frame {
+  let mut header = [0; 9];
+  stream.read_exact(&mut header).expect("read frame header");
+  let length = ((header[0] as usize) << 16) | ((header[1] as usize) << 8) | header[2] as usize;
+  let mut payload = vec![0; length];
+  stream.read_exact(&mut payload).expect("read frame payload");
+  Frame {
+    frame_type: header[3],
+    flags: header[4],
+    stream_id: u32::from_be_bytes([header[5] & 0x7f, header[6], header[7], header[8]]),
+    payload,
+  }
+}
+
+fn write_frame(stream: &mut impl Write, frame_type: u8, flags: u8, stream_id: u32, payload: &[u8]) {
+  let length = payload.len();
+  let mut header = [0; 9];
+  header[0] = ((length >> 16) & 0xff) as u8;
+  header[1] = ((length >> 8) & 0xff) as u8;
+  header[2] = (length & 0xff) as u8;
+  header[3] = frame_type;
+  header[4] = flags;
+  header[5..9].copy_from_slice(&(stream_id & 0x7fff_ffff).to_be_bytes());
+  stream.write_all(&header).expect("write frame header");
+  stream.write_all(payload).expect("write frame payload");
+  stream.flush().expect("flush frame");
+}


### PR DESCRIPTION
Adds opt-in HTTP/2 prior-knowledge h2c single-stream GET support for rttp_client while preserving default HTTP/1.1 behavior. Verified with formatting, focused HTTP/2 integration coverage, and the full workspace test suite.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1317/
work_kind: code_work
branch: hbx-1317-rttp-add-http-2-prior
base: main
commit: 8a9ee2c754278131ec09c1fbcbec0ac43232e228
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1317/
    url: https://plane.kahub.in/endless/browse/HBX-1317/
    close_policy: link_only
```