### PR TITLE
feat: [rttp] Apply missing HTTP/2 prior-knowledge review repairs after PR #87

### DIFF
--- a/rttp_client/src/client.rs
+++ b/rttp_client/src/client.rs
@@ -208,6 +208,11 @@ impl HttpClient {
     if self.request.closed() {
       return Err(error::connection_closed());
     }
+    if self.request.proxy().is_some() {
+      return Err(error::builder_with_message(
+        "HTTP/2 prior-knowledge client does not support proxies",
+      ));
+    }
     let request = RawRequest::block_new(&mut self.request)?;
     crate::http2::PriorKnowledgeClient::new(request).get()
   }

--- a/rttp_client/src/http2.rs
+++ b/rttp_client/src/http2.rs
@@ -15,6 +15,7 @@ const CLIENT_PREFACE: &[u8; 24] = b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n";
 const FRAME_DATA: u8 = 0x0;
 const FRAME_HEADERS: u8 = 0x1;
 const FRAME_SETTINGS: u8 = 0x4;
+const FRAME_WINDOW_UPDATE: u8 = 0x8;
 const FRAME_CONTINUATION: u8 = 0x9;
 
 const FLAG_END_STREAM: u8 = 0x1;
@@ -279,6 +280,8 @@ fn read_single_stream_response(stream: &mut TcpStream, url: RoUrl) -> error::Res
         body.extend_from_slice(&frame.payload);
         if frame.flags & FLAG_END_STREAM == FLAG_END_STREAM {
           break;
+        } else if !frame.payload.is_empty() {
+          write_window_updates(stream, STREAM_ID, frame.payload.len())?;
         }
       }
       (_, STREAM_ID) => {}
@@ -358,6 +361,23 @@ fn write_frame(
   header[5..9].copy_from_slice(&(stream_id & 0x7fff_ffff).to_be_bytes());
   stream.write_all(&header).map_err(error::request)?;
   stream.write_all(payload).map_err(error::request)
+}
+
+fn write_window_updates(
+  stream: &mut TcpStream,
+  stream_id: u32,
+  consumed: usize,
+) -> error::Result<()> {
+  if consumed > 0x7fff_ffff {
+    return Err(error::response(io::Error::new(
+      io::ErrorKind::InvalidData,
+      "HTTP/2 DATA frame exceeds WINDOW_UPDATE increment range",
+    )));
+  }
+  let payload = (consumed as u32).to_be_bytes();
+  write_frame(stream, FRAME_WINDOW_UPDATE, 0, stream_id, &payload)?;
+  write_frame(stream, FRAME_WINDOW_UPDATE, 0, 0, &payload)?;
+  stream.flush().map_err(error::request)
 }
 
 fn encode_literal_indexed_name_without_indexing(
@@ -551,9 +571,47 @@ fn static_header(index: usize) -> error::Result<(&'static str, &'static str)> {
     18 => Ok(("accept-ranges", "")),
     19 => Ok(("accept", "")),
     20 => Ok(("access-control-allow-origin", "")),
+    21 => Ok(("age", "")),
+    22 => Ok(("allow", "")),
+    23 => Ok(("authorization", "")),
+    24 => Ok(("cache-control", "")),
+    25 => Ok(("content-disposition", "")),
+    26 => Ok(("content-encoding", "")),
+    27 => Ok(("content-language", "")),
+    28 => Ok(("content-length", "")),
+    29 => Ok(("content-location", "")),
+    30 => Ok(("content-range", "")),
     31 => Ok(("content-type", "")),
+    32 => Ok(("cookie", "")),
     33 => Ok(("date", "")),
+    34 => Ok(("etag", "")),
+    35 => Ok(("expect", "")),
+    36 => Ok(("expires", "")),
+    37 => Ok(("from", "")),
+    38 => Ok(("host", "")),
+    39 => Ok(("if-match", "")),
+    40 => Ok(("if-modified-since", "")),
+    41 => Ok(("if-none-match", "")),
+    42 => Ok(("if-range", "")),
+    43 => Ok(("if-unmodified-since", "")),
+    44 => Ok(("last-modified", "")),
+    45 => Ok(("link", "")),
+    46 => Ok(("location", "")),
+    47 => Ok(("max-forwards", "")),
+    48 => Ok(("proxy-authenticate", "")),
+    49 => Ok(("proxy-authorization", "")),
+    50 => Ok(("range", "")),
+    51 => Ok(("referer", "")),
+    52 => Ok(("refresh", "")),
+    53 => Ok(("retry-after", "")),
     54 => Ok(("server", "")),
+    55 => Ok(("set-cookie", "")),
+    56 => Ok(("strict-transport-security", "")),
+    57 => Ok(("transfer-encoding", "")),
+    58 => Ok(("user-agent", "")),
+    59 => Ok(("vary", "")),
+    60 => Ok(("via", "")),
+    61 => Ok(("www-authenticate", "")),
     _ => Err(error::bad_response("unsupported HPACK static table index")),
   }
 }

--- a/rttp_client/tests/http2_prior_knowledge.rs
+++ b/rttp_client/tests/http2_prior_knowledge.rs
@@ -3,12 +3,15 @@
 use std::io::{Read, Write};
 use std::net::{SocketAddr, TcpListener};
 use std::thread;
+use std::time::Duration;
 
+use rttp_client::types::Proxy;
 use rttp_client::HttpClient;
 
 const FRAME_DATA: u8 = 0x0;
 const FRAME_HEADERS: u8 = 0x1;
 const FRAME_SETTINGS: u8 = 0x4;
+const FRAME_WINDOW_UPDATE: u8 = 0x8;
 
 const FLAG_END_STREAM: u8 = 0x1;
 const FLAG_END_HEADERS: u8 = 0x4;
@@ -94,6 +97,96 @@ fn prior_knowledge_get_sends_h2_handshake_and_reads_single_response_stream() {
     .any(|window| window == b"/hello?via=h2"));
 }
 
+#[test]
+fn prior_knowledge_rejects_configured_proxy_before_connecting() {
+  let err = HttpClient::new()
+    .get()
+    .url("http://127.0.0.1:9/proxy")
+    .proxy(Proxy::http("127.0.0.1", 8080))
+    .emit_http2_prior_knowledge()
+    .expect_err("prior knowledge does not support proxies");
+
+  assert!(err.is_builder());
+  assert!(err.to_string().contains("does not support proxies"));
+}
+
+#[test]
+fn prior_knowledge_decodes_content_length_from_hpack_static_index() {
+  let (addr, handle) = spawn_h2_prior_knowledge_peer_with_response(
+    &[0x88, 0x0f, 13, 2, b'1', b'3'],
+    &[b"hello over h2"],
+  );
+
+  let response = HttpClient::new()
+    .get()
+    .url(format!("http://{}/content-length", addr))
+    .emit_http2_prior_knowledge()
+    .expect("h2 response with content-length static index");
+
+  assert_eq!(200, response.code());
+  assert_eq!(
+    Some(&"13".to_string()),
+    response.header_value("content-length")
+  );
+  assert_eq!("hello over h2", response.body().string().unwrap());
+
+  handle.join().expect("h2 peer thread");
+}
+
+#[test]
+fn prior_knowledge_sends_window_updates_for_non_final_data_frames() {
+  let listener = TcpListener::bind("127.0.0.1:0").expect("bind h2 peer");
+  let addr = listener.local_addr().expect("h2 peer addr");
+
+  let handle = thread::spawn(move || {
+    let (mut stream, _) = listener.accept().expect("accept h2 client");
+    stream
+      .set_read_timeout(Some(Duration::from_secs(2)))
+      .expect("set h2 peer read timeout");
+    complete_h2_request_handshake(&mut stream);
+
+    write_frame(&mut stream, FRAME_SETTINGS, FLAG_ACK, 0, &[]);
+    write_frame(&mut stream, FRAME_HEADERS, FLAG_END_HEADERS, 1, &[0x88]);
+    write_frame(&mut stream, FRAME_DATA, 0, 1, b"first chunk");
+
+    let stream_update = read_frame(&mut stream);
+    assert_eq!(FRAME_WINDOW_UPDATE, stream_update.frame_type);
+    assert_eq!(1, stream_update.stream_id);
+    assert_eq!(
+      b"first chunk".len() as u32,
+      window_update_increment(&stream_update)
+    );
+
+    let connection_update = read_frame(&mut stream);
+    assert_eq!(FRAME_WINDOW_UPDATE, connection_update.frame_type);
+    assert_eq!(0, connection_update.stream_id);
+    assert_eq!(
+      b"first chunk".len() as u32,
+      window_update_increment(&connection_update)
+    );
+
+    write_frame(
+      &mut stream,
+      FRAME_DATA,
+      FLAG_END_STREAM,
+      1,
+      b" and final chunk",
+    );
+  });
+
+  let response = HttpClient::new()
+    .get()
+    .url(format!("http://{}/window-update", addr))
+    .emit_http2_prior_knowledge()
+    .expect("h2 response requiring window updates");
+
+  assert_eq!(
+    "first chunk and final chunk",
+    response.body().string().unwrap()
+  );
+  handle.join().expect("h2 peer thread");
+}
+
 struct Frame {
   frame_type: u8,
   flags: u8,
@@ -113,6 +206,78 @@ fn read_frame(stream: &mut impl Read) -> Frame {
     stream_id: u32::from_be_bytes([header[5] & 0x7f, header[6], header[7], header[8]]),
     payload,
   }
+}
+
+fn spawn_h2_prior_knowledge_peer_with_response(
+  header_block: &'static [u8],
+  data_frames: &'static [&'static [u8]],
+) -> (SocketAddr, thread::JoinHandle<()>) {
+  let listener = TcpListener::bind("127.0.0.1:0").expect("bind h2 peer");
+  let addr = listener.local_addr().expect("h2 peer addr");
+
+  let handle = thread::spawn(move || {
+    let (mut stream, _) = listener.accept().expect("accept h2 client");
+    complete_h2_request_handshake(&mut stream);
+
+    write_frame(&mut stream, FRAME_SETTINGS, FLAG_ACK, 0, &[]);
+    write_frame(
+      &mut stream,
+      FRAME_HEADERS,
+      FLAG_END_HEADERS,
+      1,
+      header_block,
+    );
+    for (index, data) in data_frames.iter().enumerate() {
+      let flags = if index + 1 == data_frames.len() {
+        FLAG_END_STREAM
+      } else {
+        0
+      };
+      write_frame(&mut stream, FRAME_DATA, flags, 1, data);
+    }
+  });
+
+  (addr, handle)
+}
+
+fn complete_h2_request_handshake(stream: &mut impl ReadWrite) {
+  let mut preface = [0; 24];
+  stream
+    .read_exact(&mut preface)
+    .expect("read client preface");
+  assert_eq!(b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n", &preface);
+
+  let client_settings = read_frame(stream);
+  assert_eq!(FRAME_SETTINGS, client_settings.frame_type);
+  assert_eq!(0, client_settings.stream_id);
+  assert_eq!(0, client_settings.payload.len());
+
+  write_frame(stream, FRAME_SETTINGS, 0, 0, &[]);
+
+  let client_settings_ack = read_frame(stream);
+  assert_eq!(FRAME_SETTINGS, client_settings_ack.frame_type);
+  assert_eq!(FLAG_ACK, client_settings_ack.flags);
+  assert_eq!(0, client_settings_ack.stream_id);
+  assert_eq!(0, client_settings_ack.payload.len());
+
+  let request_headers = read_frame(stream);
+  assert_eq!(FRAME_HEADERS, request_headers.frame_type);
+  assert_eq!(FLAG_END_STREAM | FLAG_END_HEADERS, request_headers.flags);
+  assert_eq!(1, request_headers.stream_id);
+}
+
+trait ReadWrite: Read + Write {}
+
+impl<T> ReadWrite for T where T: Read + Write {}
+
+fn window_update_increment(frame: &Frame) -> u32 {
+  assert_eq!(4, frame.payload.len());
+  u32::from_be_bytes([
+    frame.payload[0] & 0x7f,
+    frame.payload[1],
+    frame.payload[2],
+    frame.payload[3],
+  ])
 }
 
 fn write_frame(stream: &mut impl Write, frame_type: u8, flags: u8, stream_id: u32, payload: &[u8]) {


### PR DESCRIPTION
Restores missing HTTP/2 prior-knowledge review repairs: explicit proxy rejection, DATA flow-control WINDOW_UPDATE handling, full HPACK static table decoding, and regression coverage.

## Source References
Related GitHub pull requests:
- [fewensa/rttp#87](https://github.com/fewensa/rttp/pull/87)

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1324/
work_kind: code_work
branch: hbx-1324-rttp-apply-missing-http-2
base: main
commit: fa34c68f98eccae04127aed2eeb21bd9788245e9
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1324/
    url: https://plane.kahub.in/endless/browse/HBX-1324/
    close_policy: link_only
  - kind: github_pull_request
    canonical: fewensa/rttp#87
    url: https://github.com/fewensa/rttp/pull/87
    github_repository: fewensa/rttp
    number: 87
    close_policy: link_only
```