### PR TITLE
feat: [rttp] Prepare HTTP/2 client and server support over socket2 connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ request APIs and TLS implementations:
 | name | comment |
 |------|---------|
 | async | Async request APIs |
+| http2 | Prior-knowledge h2c GET over direct `socket2` TCP connections |
 | tls-native | HTTPS with `native-tls` |
 | tls-rustls | HTTPS with `rustls` |
 
@@ -25,6 +26,10 @@ are still delegated to the `socks` crate.
 HTTP/1.x chunked responses are decoded by the client, and response trailers are
 available through `Response::trailers`, `Response::trailer`, and
 `Response::trailer_value`.
+With the `http2` feature enabled, `emit_http2_prior_knowledge` sends a minimal
+prior-knowledge h2c GET request over a direct socket2 TCP connection. TLS ALPN,
+proxy tunneling, request bodies, and general HTTP/2 multiplexing are not part of
+that initial client path.
 
 ```rust,no_run
 use rttp_client::HttpClient;
@@ -85,7 +90,10 @@ chunked request bodies, exposes chunked request trailers, applies bounded
 request head/body validation, handles `HEAD` without writing a response body,
 honors `Connection` close/keep-alive semantics across a bounded
 `serve_requests` loop, writes response body framing and response trailers
-consistently, and accepts `Expect: 100-continue`.
+consistently, and accepts `Expect: 100-continue`. On the same socket2 listener,
+the accept path detects the HTTP/2 client preface and dispatches prior-knowledge
+h2c requests to a minimal single-stream handler. TLS ALPN and full HTTP/2
+multiplexing remain outside this server path.
 
 It is not a full RFC-covering web server and still does not implement server
 TLS or async accept loops.

--- a/rttp/Cargo.toml
+++ b/rttp/Cargo.toml
@@ -35,9 +35,10 @@ default = []
 
 client = ["rttp_client"]
 async = ["client", "rttp_client/async"]
+http2 = ["client", "rttp_client/http2"]
 tls-native = ["client", "rttp_client/tls-native"]
 tls-rustls = ["client", "rttp_client/tls-rustls"]
-all = ["client", "async", "tls-native", "tls-rustls"]
+all = ["client", "async", "http2", "tls-native", "tls-rustls"]
 
 
 #[target.'cfg(feature = "all")'.dependencies]

--- a/rttp/README.md
+++ b/rttp/README.md
@@ -52,16 +52,20 @@ bodies, preserves chunked request trailers on `Request`, bounds request
 head/body parsing, handles `HEAD` without writing a response body, honors
 `Connection` close/keep-alive semantics across a bounded `serve_requests` loop,
 writes response body framing and response trailers consistently, and accepts
-`Expect: 100-continue`.
+`Expect: 100-continue`. On the same socket2 listener, the accept path detects
+the HTTP/2 client preface and dispatches prior-knowledge h2c requests to a
+minimal single-stream handler.
 
 The server is intentionally not a full RFC-covering web server and still does
-not implement server TLS or async accept loops.
+not implement server TLS, TLS ALPN, full HTTP/2 multiplexing, or async accept
+loops.
 
 ## Client feature
 
 Enable the `client` feature to access `rttp::Http::client`, or enable `async`,
-`tls-native`, `tls-rustls`, or `all` for the corresponding `rttp_client`
-capabilities.
+`http2`, `tls-native`, `tls-rustls`, or `all` for the corresponding
+`rttp_client` capabilities. The `http2` feature exposes the minimal
+prior-knowledge h2c GET client path; TLS ALPN remains a later integration point.
 
 Direct TCP client connections use `socket2`. SOCKS proxy handshakes remain
 delegated to the `socks` crate.

--- a/rttp/tests/http2_feature.rs
+++ b/rttp/tests/http2_feature.rs
@@ -1,0 +1,34 @@
+#![cfg(feature = "http2")]
+
+use std::sync::mpsc;
+use std::thread;
+
+use rttp::server::HttpResponse;
+
+#[test]
+fn wrapper_http2_feature_exposes_prior_knowledge_client_path() {
+  let server = rttp::Http::server("127.0.0.1:0").expect("bind server");
+  let addr = server.local_addr().expect("server addr");
+  let (tx, rx) = mpsc::channel();
+
+  let handle = thread::spawn(move || {
+    server
+      .accept_one(|request| {
+        tx.send(request.version().to_string())
+          .expect("send request version");
+        HttpResponse::ok("wrapper h2")
+      })
+      .expect("serve h2 request");
+  });
+
+  let response = rttp::Http::client()
+    .url(format!("http://{}/wrapper", addr))
+    .emit_http2_prior_knowledge()
+    .expect("wrapper h2 response");
+
+  assert_eq!("HTTP/2", rx.recv().expect("receive request version"));
+  assert_eq!("HTTP/2", response.version());
+  assert_eq!("wrapper h2", response.body().string().unwrap());
+
+  handle.join().expect("server thread");
+}

--- a/rttp_client/README.md
+++ b/rttp_client/README.md
@@ -7,6 +7,7 @@ optional features add async request APIs and TLS implementations.
 | name | comment |
 |------|---------|
 | async | Async request APIs |
+| http2 | Prior-knowledge h2c GET over direct `socket2` TCP connections |
 | tls-native | HTTPS with `native-tls` |
 | tls-rustls | HTTPS with `rustls` |
 
@@ -25,6 +26,10 @@ the `socks` crate.
 HTTP/1.x chunked responses are decoded, and response trailers are exposed
 through `Response::trailers`, `Response::trailer`, and
 `Response::trailer_value` for both blocking and async request APIs.
+With the `http2` feature enabled, `emit_http2_prior_knowledge` sends a minimal
+prior-knowledge h2c GET request over a direct socket2 TCP connection. TLS ALPN,
+proxy tunneling, request bodies, and general HTTP/2 multiplexing are not part of
+that initial client path.
 
 ## Examples
 

--- a/rttp_client/src/lib.rs
+++ b/rttp_client/src/lib.rs
@@ -4,11 +4,15 @@
 //! | name | comment |
 //! |------|---------|
 //! | async | Async request APIs |
+//! | http2 | Prior-knowledge h2c GET over direct `socket2` TCP connections |
 //! | tls-native | HTTPS with `native-tls` |
 //! | tls-rustls | HTTPS with `rustls` |
 //!
 //! Direct TCP connections use `socket2`. SOCKS proxy handshakes remain delegated
 //! to the `socks` crate.
+//! With the `http2` feature enabled, `emit_http2_prior_knowledge` sends a
+//! minimal prior-knowledge h2c GET request over a direct socket2 TCP connection.
+//! TLS ALPN and full HTTP/2 multiplexing are not part of that initial path.
 //!
 //! ```rust,no_run
 //! use rttp_client::HttpClient;


### PR DESCRIPTION
Exposed and verified the wrapper HTTP/2 feature path for prior-knowledge h2c over socket2, with documentation updated to clarify current support and remaining HTTP/2 non-goals.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1316/
work_kind: code_work
branch: hbx-1316-rttp-prepare-http-2-client
base: main
commit: c757624433c411a9ba48a069c4c00e452f103198
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1316/
    url: https://plane.kahub.in/endless/browse/HBX-1316/
    close_policy: link_only
```