### PR TITLE
feat: [rttp] Add HTTP/2 multiplexing and flow-control regression coverage

### DIFF
--- a/rttp/src/server.rs
+++ b/rttp/src/server.rs
@@ -11,11 +11,15 @@ const MAX_REQUEST_BODY_BYTES: usize = 1024 * 1024;
 const HTTP2_CLIENT_PREFACE: &[u8; 24] = b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n";
 const HTTP2_FRAME_DATA: u8 = 0x0;
 const HTTP2_FRAME_HEADERS: u8 = 0x1;
+const HTTP2_FRAME_RST_STREAM: u8 = 0x3;
 const HTTP2_FRAME_SETTINGS: u8 = 0x4;
+const HTTP2_FRAME_GOAWAY: u8 = 0x7;
+const HTTP2_FRAME_WINDOW_UPDATE: u8 = 0x8;
 const HTTP2_FRAME_CONTINUATION: u8 = 0x9;
 const HTTP2_FLAG_END_STREAM: u8 = 0x1;
 const HTTP2_FLAG_ACK: u8 = 0x1;
 const HTTP2_FLAG_END_HEADERS: u8 = 0x4;
+const HTTP2_DEFAULT_MAX_FRAME_SIZE: usize = 16 * 1024;
 
 pub struct HttpServer {
   listener: TcpListener,
@@ -130,7 +134,7 @@ impl HttpServer {
     let stream = match self.detect_connection_protocol(stream)? {
       AcceptedConnection::Http1(stream) => stream,
       AcceptedConnection::Http2(stream) => {
-        return self.handle_http2_connection(stream, handler).map(|()| 1);
+        return self.handle_http2_connection(stream, request_limit, handler);
       }
     };
     let mut reader = BufReader::new(stream);
@@ -188,9 +192,11 @@ impl HttpServer {
       AcceptedConnection::Http1(stream) => stream,
       AcceptedConnection::Http2(stream) => {
         let mut handler = Some(handler);
-        return self.handle_http2_connection(stream, &mut |request| {
-          handler.take().expect("single h2 request handler")(request)
-        });
+        return self
+          .handle_http2_connection(stream, 1, &mut |request| {
+            handler.take().expect("single h2 request handler")(request)
+          })
+          .map(|_| ());
       }
     };
     let mut reader = BufReader::new(stream);
@@ -319,7 +325,12 @@ impl HttpServer {
     Ok(AcceptedConnection::Http1(Http1Stream::Plain(stream)))
   }
 
-  fn handle_http2_connection<F>(&self, mut stream: TcpStream, handler: &mut F) -> io::Result<()>
+  fn handle_http2_connection<F>(
+    &self,
+    mut stream: TcpStream,
+    request_limit: usize,
+    handler: &mut F,
+  ) -> io::Result<usize>
   where
     F: FnMut(Request) -> HttpResponse,
   {
@@ -351,14 +362,126 @@ impl HttpServer {
     ))?;
     self.normalize_connection_error(stream.flush())?;
 
-    let request = self.normalize_connection_error(read_http2_single_request(&mut stream))?;
-    let request_is_head = request.method() == "HEAD";
-    let response = handler(request);
-    self.normalize_connection_error(write_http2_response(
-      &mut stream,
-      &response,
-      !request_is_head,
-    ))
+    let mut streams = Vec::<Http2RequestStream>::new();
+    let mut served = 0;
+
+    while served < request_limit {
+      let frame = self.normalize_connection_error(read_http2_frame(&mut stream))?;
+      match (frame.frame_type, frame.stream_id) {
+        (HTTP2_FRAME_SETTINGS, 0) => {
+          if frame.flags & HTTP2_FLAG_ACK == HTTP2_FLAG_ACK {
+            if !frame.payload.is_empty() {
+              return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "HTTP/2 SETTINGS ACK frame must not contain payload",
+              ));
+            }
+          } else if frame.payload.len() % 6 == 0 {
+            self.normalize_connection_error(write_http2_frame(
+              &mut stream,
+              HTTP2_FRAME_SETTINGS,
+              HTTP2_FLAG_ACK,
+              0,
+              &[],
+            ))?;
+            self.normalize_connection_error(stream.flush())?;
+          } else {
+            return Err(io::Error::new(
+              io::ErrorKind::InvalidData,
+              "invalid HTTP/2 SETTINGS frame",
+            ));
+          }
+        }
+        (HTTP2_FRAME_HEADERS, id) if id != 0 => {
+          let request_stream = http2_request_stream(&mut streams, id);
+          request_stream
+            .header_block
+            .extend_from_slice(&frame.payload);
+          if frame.flags & HTTP2_FLAG_END_HEADERS == HTTP2_FLAG_END_HEADERS {
+            request_stream.decoded_headers =
+              Some(decode_http2_request_headers(&request_stream.header_block)?);
+            request_stream.header_block.clear();
+            request_stream.in_header_continuation = false;
+          } else {
+            request_stream.in_header_continuation = true;
+          }
+          if frame.flags & HTTP2_FLAG_END_STREAM == HTTP2_FLAG_END_STREAM {
+            request_stream.end_stream = true;
+          }
+        }
+        (HTTP2_FRAME_CONTINUATION, id) if id != 0 => {
+          if let Some(request_stream) = streams
+            .iter_mut()
+            .find(|request_stream| request_stream.stream_id == id)
+          {
+            if request_stream.in_header_continuation {
+              request_stream
+                .header_block
+                .extend_from_slice(&frame.payload);
+              if frame.flags & HTTP2_FLAG_END_HEADERS == HTTP2_FLAG_END_HEADERS {
+                request_stream.decoded_headers =
+                  Some(decode_http2_request_headers(&request_stream.header_block)?);
+                request_stream.header_block.clear();
+                request_stream.in_header_continuation = false;
+              }
+            }
+          }
+        }
+        (HTTP2_FRAME_DATA, id) if id != 0 => {
+          if let Some(request_stream) = streams
+            .iter_mut()
+            .find(|request_stream| request_stream.stream_id == id)
+          {
+            let new_len = request_stream
+              .body
+              .len()
+              .checked_add(frame.payload.len())
+              .ok_or_else(|| {
+                io::Error::new(io::ErrorKind::InvalidData, "request body is too large")
+              })?;
+            reject_oversized_request_body(new_len)?;
+            request_stream.body.extend_from_slice(&frame.payload);
+            if !frame.payload.is_empty() {
+              write_http2_window_update(&mut stream, 0, frame.payload.len())?;
+              write_http2_window_update(&mut stream, id, frame.payload.len())?;
+            }
+            if frame.flags & HTTP2_FLAG_END_STREAM == HTTP2_FLAG_END_STREAM {
+              request_stream.end_stream = true;
+            }
+          }
+        }
+        (HTTP2_FRAME_RST_STREAM, id) if id != 0 => {
+          streams.retain(|request_stream| request_stream.stream_id != id);
+        }
+        (HTTP2_FRAME_GOAWAY, 0) => break,
+        (HTTP2_FRAME_WINDOW_UPDATE, _) => {}
+        (_, 0) => {}
+        _ => {}
+      }
+
+      while served < request_limit {
+        let Some(index) = streams
+          .iter()
+          .position(|request_stream| request_stream.is_complete())
+        else {
+          break;
+        };
+        let request_stream = streams.remove(index);
+        let stream_id = request_stream.stream_id;
+        let request = request_stream.into_request()?;
+        let request_is_head = request.method() == "HEAD";
+        let response = handler(request);
+        self.normalize_connection_error(write_http2_response(
+          &mut stream,
+          stream_id,
+          &response,
+          !request_is_head,
+        ))?;
+        served += 1;
+      }
+    }
+
+    Ok(served)
   }
 
   fn normalize_connection_error<T>(&self, result: io::Result<T>) -> io::Result<T> {
@@ -416,6 +539,54 @@ struct Http2Frame {
   payload: Vec<u8>,
 }
 
+struct Http2RequestStream {
+  stream_id: u32,
+  header_block: Vec<u8>,
+  decoded_headers: Option<DecodedHttp2RequestHeaders>,
+  body: Vec<u8>,
+  end_stream: bool,
+  in_header_continuation: bool,
+}
+
+impl Http2RequestStream {
+  fn new(stream_id: u32) -> Self {
+    Self {
+      stream_id,
+      header_block: Vec::new(),
+      decoded_headers: None,
+      body: Vec::new(),
+      end_stream: false,
+      in_header_continuation: false,
+    }
+  }
+
+  fn is_complete(&self) -> bool {
+    self.decoded_headers.is_some() && self.end_stream && !self.in_header_continuation
+  }
+
+  fn into_request(self) -> io::Result<Request> {
+    let decoded_headers = self.decoded_headers.ok_or_else(|| {
+      io::Error::new(io::ErrorKind::InvalidData, "missing HTTP/2 request headers")
+    })?;
+    decoded_headers.into_request(self.body)
+  }
+}
+
+fn http2_request_stream(
+  streams: &mut Vec<Http2RequestStream>,
+  stream_id: u32,
+) -> &mut Http2RequestStream {
+  if let Some(index) = streams
+    .iter()
+    .position(|request_stream| request_stream.stream_id == stream_id)
+  {
+    return &mut streams[index];
+  }
+
+  streams.push(Http2RequestStream::new(stream_id));
+  streams.last_mut().expect("new HTTP/2 request stream")
+}
+
 fn read_http2_frame(stream: &mut TcpStream) -> io::Result<Http2Frame> {
   let mut header = [0; 9];
   stream.read_exact(&mut header)?;
@@ -456,84 +627,30 @@ fn write_http2_frame(
   stream.write_all(payload)
 }
 
-fn read_http2_single_request(stream: &mut TcpStream) -> io::Result<Request> {
-  let mut header_block = Vec::new();
-  let mut body = Vec::new();
-  let mut stream_id = None;
-  let mut end_stream = false;
-  let mut in_header_continuation = false;
-  let mut decoded_headers = None;
-
-  while !end_stream || decoded_headers.is_none() {
-    let frame = read_http2_frame(stream)?;
-    match (frame.frame_type, frame.stream_id) {
-      (HTTP2_FRAME_SETTINGS, 0) => {
-        if frame.flags & HTTP2_FLAG_ACK == HTTP2_FLAG_ACK {
-          if !frame.payload.is_empty() {
-            return Err(io::Error::new(
-              io::ErrorKind::InvalidData,
-              "HTTP/2 SETTINGS ACK frame must not contain payload",
-            ));
-          }
-        } else if frame.payload.len() % 6 == 0 {
-          write_http2_frame(stream, HTTP2_FRAME_SETTINGS, HTTP2_FLAG_ACK, 0, &[])?;
-          stream.flush()?;
-        } else {
-          return Err(io::Error::new(
-            io::ErrorKind::InvalidData,
-            "invalid HTTP/2 SETTINGS frame",
-          ));
-        }
-      }
-      (HTTP2_FRAME_HEADERS, id) if id != 0 && stream_id.is_none_or(|seen| seen == id) => {
-        stream_id = Some(id);
-        header_block.extend_from_slice(&frame.payload);
-        if frame.flags & HTTP2_FLAG_END_HEADERS == HTTP2_FLAG_END_HEADERS {
-          decoded_headers = Some(decode_http2_request_headers(&header_block)?);
-          header_block.clear();
-          in_header_continuation = false;
-        } else {
-          in_header_continuation = true;
-        }
-        if frame.flags & HTTP2_FLAG_END_STREAM == HTTP2_FLAG_END_STREAM {
-          end_stream = true;
-        }
-      }
-      (HTTP2_FRAME_CONTINUATION, id) if stream_id == Some(id) && in_header_continuation => {
-        header_block.extend_from_slice(&frame.payload);
-        if frame.flags & HTTP2_FLAG_END_HEADERS == HTTP2_FLAG_END_HEADERS {
-          decoded_headers = Some(decode_http2_request_headers(&header_block)?);
-          header_block.clear();
-          in_header_continuation = false;
-        }
-      }
-      (HTTP2_FRAME_DATA, id) if stream_id == Some(id) => {
-        let new_len = body
-          .len()
-          .checked_add(frame.payload.len())
-          .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "request body is too large"))?;
-        reject_oversized_request_body(new_len)?;
-        body.extend_from_slice(&frame.payload);
-        if frame.flags & HTTP2_FLAG_END_STREAM == HTTP2_FLAG_END_STREAM {
-          end_stream = true;
-        }
-      }
-      (_, 0) => {}
-      (_, id) if stream_id.is_none_or(|seen| seen == id) => {}
-      _ => {}
-    }
-  }
-
-  if in_header_continuation {
+fn write_http2_window_update(
+  stream: &mut TcpStream,
+  stream_id: u32,
+  increment: usize,
+) -> io::Result<()> {
+  let increment = u32::try_from(increment).map_err(|_| {
+    io::Error::new(
+      io::ErrorKind::InvalidInput,
+      "HTTP/2 window update increment is too large",
+    )
+  })?;
+  if increment == 0 || increment > 0x7fff_ffff {
     return Err(io::Error::new(
-      io::ErrorKind::InvalidData,
-      "incomplete HTTP/2 header block",
+      io::ErrorKind::InvalidInput,
+      "invalid HTTP/2 window update increment",
     ));
   }
-
-  let decoded_headers = decoded_headers
-    .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "missing HTTP/2 request headers"))?;
-  decoded_headers.into_request(body)
+  write_http2_frame(
+    stream,
+    HTTP2_FRAME_WINDOW_UPDATE,
+    0,
+    stream_id,
+    &increment.to_be_bytes(),
+  )
 }
 
 struct DecodedHttp2RequestHeaders {
@@ -686,6 +803,7 @@ fn decode_http2_string(block: &[u8], cursor: &mut usize) -> io::Result<String> {
 
 fn write_http2_response(
   stream: &mut TcpStream,
+  stream_id: u32,
   response: &HttpResponse,
   write_body: bool,
 ) -> io::Result<()> {
@@ -694,7 +812,7 @@ fn write_http2_response(
     stream,
     HTTP2_FRAME_HEADERS,
     HTTP2_FLAG_END_HEADERS,
-    1,
+    stream_id,
     &headers,
   )?;
   let body = if write_body && response.allows_body() {
@@ -702,7 +820,21 @@ fn write_http2_response(
   } else {
     &[]
   };
-  write_http2_frame(stream, HTTP2_FRAME_DATA, HTTP2_FLAG_END_STREAM, 1, body)?;
+  if body.is_empty() {
+    write_http2_frame(
+      stream,
+      HTTP2_FRAME_DATA,
+      HTTP2_FLAG_END_STREAM,
+      stream_id,
+      &[],
+    )?;
+  } else {
+    for (index, chunk) in body.chunks(HTTP2_DEFAULT_MAX_FRAME_SIZE).enumerate() {
+      let end_stream = (index + 1) * HTTP2_DEFAULT_MAX_FRAME_SIZE >= body.len();
+      let flags = if end_stream { HTTP2_FLAG_END_STREAM } else { 0 };
+      write_http2_frame(stream, HTTP2_FRAME_DATA, flags, stream_id, chunk)?;
+    }
+  }
   stream.flush()
 }
 

--- a/rttp/src/server.rs
+++ b/rttp/src/server.rs
@@ -366,7 +366,15 @@ impl HttpServer {
     let mut served = 0;
 
     while served < request_limit {
-      let frame = self.normalize_connection_error(read_http2_frame(&mut stream))?;
+      let frame = match self.normalize_connection_error(read_http2_frame(&mut stream)) {
+        Ok(frame) => frame,
+        Err(err)
+          if err.kind() == io::ErrorKind::UnexpectedEof && served > 0 && streams.is_empty() =>
+        {
+          break;
+        }
+        Err(err) => return Err(err),
+      };
       match (frame.frame_type, frame.stream_id) {
         (HTTP2_FRAME_SETTINGS, 0) => {
           if frame.flags & HTTP2_FLAG_ACK == HTTP2_FLAG_ACK {

--- a/rttp/tests/test_server.rs
+++ b/rttp/tests/test_server.rs
@@ -230,6 +230,60 @@ fn server_accepts_http2_prior_knowledge_get_and_writes_single_stream_response() 
 }
 
 #[test]
+fn serve_requests_accepts_next_connection_after_http2_client_closes_cleanly() {
+  let server = rttp::Http::server("127.0.0.1:0").expect("bind server");
+  let addr = server.local_addr().expect("server addr");
+  let (tx, rx) = mpsc::channel();
+
+  let handle = thread::spawn(move || {
+    server
+      .serve_requests(2, |request| {
+        tx.send(request.target().to_string())
+          .expect("send served target");
+        HttpResponse::ok(format!("response for {}", request.target()))
+      })
+      .expect("serve h2 then h1 requests");
+  });
+
+  {
+    let mut stream = TcpStream::connect(addr).expect("connect h2 server");
+    stream
+      .set_read_timeout(Some(Duration::from_secs(2)))
+      .expect("set h2 read timeout");
+    complete_h2_server_handshake(&mut stream);
+
+    write_h2_frame(
+      &mut stream,
+      H2_FRAME_HEADERS,
+      H2_FLAG_END_HEADERS | H2_FLAG_END_STREAM,
+      1,
+      &h2_get_headers(b"/h2-once", addr.to_string().as_bytes()),
+    );
+
+    let response_headers = read_h2_frame_skipping_window_updates(&mut stream);
+    assert_eq!(H2_FRAME_HEADERS, response_headers.frame_type);
+    assert_eq!(1, response_headers.stream_id);
+
+    let response_body = read_h2_frame_skipping_window_updates(&mut stream);
+    assert_eq!(H2_FRAME_DATA, response_body.frame_type);
+    assert_eq!(H2_FLAG_END_STREAM, response_body.flags);
+    assert_eq!(1, response_body.stream_id);
+    assert_eq!(b"response for /h2-once", response_body.payload.as_slice());
+  }
+
+  let response = send_request(addr, b"GET /after-h2 HTTP/1.1\r\nHost: localhost\r\n\r\n");
+
+  assert_eq!("/h2-once", rx.recv().expect("h2 target"));
+  assert_eq!("/after-h2", rx.recv().expect("h1 target"));
+  assert_eq!(
+    "HTTP/1.1 200 OK\r\nContent-Length: 22\r\nConnection: close\r\n\r\nresponse for /after-h2",
+    response
+  );
+
+  handle.join().expect("server thread");
+}
+
+#[test]
 fn server_accepts_http2_prior_knowledge_headers_and_data_before_calling_handler() {
   let server = rttp::Http::server("127.0.0.1:0").expect("bind server");
   let addr = server.local_addr().expect("server addr");

--- a/rttp/tests/test_server.rs
+++ b/rttp/tests/test_server.rs
@@ -10,7 +10,10 @@ use rttp_client::HttpClient;
 const H2_PREFACE: &[u8; 24] = b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n";
 const H2_FRAME_DATA: u8 = 0x0;
 const H2_FRAME_HEADERS: u8 = 0x1;
+const H2_FRAME_RST_STREAM: u8 = 0x3;
 const H2_FRAME_SETTINGS: u8 = 0x4;
+const H2_FRAME_GOAWAY: u8 = 0x7;
+const H2_FRAME_WINDOW_UPDATE: u8 = 0x8;
 const H2_FLAG_END_STREAM: u8 = 0x1;
 const H2_FLAG_ACK: u8 = 0x1;
 const H2_FLAG_END_HEADERS: u8 = 0x4;
@@ -57,11 +60,51 @@ fn read_h2_frame(stream: &mut TcpStream) -> H2Frame {
   }
 }
 
+fn read_h2_frame_skipping_window_updates(stream: &mut TcpStream) -> H2Frame {
+  loop {
+    let frame = read_h2_frame(stream);
+    if frame.frame_type != H2_FRAME_WINDOW_UPDATE {
+      return frame;
+    }
+  }
+}
+
 fn h2_literal_indexed_name(name_index: u8, value: &[u8]) -> Vec<u8> {
   assert!(value.len() < 128);
   let mut encoded = vec![name_index, value.len() as u8];
   encoded.extend_from_slice(value);
   encoded
+}
+
+fn h2_get_headers(path: &[u8], authority: &[u8]) -> Vec<u8> {
+  let mut headers = vec![0x82, 0x86];
+  headers.extend(h2_literal_indexed_name(4, path));
+  headers.extend(h2_literal_indexed_name(1, authority));
+  headers
+}
+
+fn h2_post_headers(path: &[u8], authority: &[u8]) -> Vec<u8> {
+  let mut headers = vec![0x83, 0x86];
+  headers.extend(h2_literal_indexed_name(4, path));
+  headers.extend(h2_literal_indexed_name(1, authority));
+  headers
+}
+
+fn complete_h2_server_handshake(stream: &mut TcpStream) {
+  stream.write_all(H2_PREFACE).expect("write h2 preface");
+  write_h2_frame(stream, H2_FRAME_SETTINGS, 0, 0, &[]);
+
+  let settings = read_h2_frame(stream);
+  assert_eq!(H2_FRAME_SETTINGS, settings.frame_type);
+  assert_eq!(0, settings.flags);
+  assert_eq!(0, settings.stream_id);
+
+  let settings_ack = read_h2_frame(stream);
+  assert_eq!(H2_FRAME_SETTINGS, settings_ack.frame_type);
+  assert_eq!(H2_FLAG_ACK, settings_ack.flags);
+  assert_eq!(0, settings_ack.stream_id);
+
+  write_h2_frame(stream, H2_FRAME_SETTINGS, H2_FLAG_ACK, 0, &[]);
 }
 
 fn send_raw_request(raw: &[u8]) -> (String, bool) {
@@ -242,16 +285,166 @@ fn server_accepts_http2_prior_knowledge_headers_and_data_before_calling_handler(
     b"body over h2",
   );
 
-  let response_headers = read_h2_frame(&mut stream);
+  let response_headers = read_h2_frame_skipping_window_updates(&mut stream);
   assert_eq!(H2_FRAME_HEADERS, response_headers.frame_type);
   assert_eq!(H2_FLAG_END_HEADERS, response_headers.flags);
   assert_eq!(1, response_headers.stream_id);
 
-  let response_body = read_h2_frame(&mut stream);
+  let response_body = read_h2_frame_skipping_window_updates(&mut stream);
   assert_eq!(H2_FRAME_DATA, response_body.frame_type);
   assert_eq!(H2_FLAG_END_STREAM, response_body.flags);
   assert_eq!(1, response_body.stream_id);
   assert_eq!(b"stored", response_body.payload.as_slice());
+
+  handle.join().expect("server thread");
+}
+
+#[test]
+fn server_handles_multiple_interleaved_http2_streams_on_one_connection() {
+  let server = rttp::Http::server("127.0.0.1:0").expect("bind server");
+  let addr = server.local_addr().expect("server addr");
+  let (tx, rx) = mpsc::channel();
+
+  let handle = thread::spawn(move || {
+    server
+      .serve_requests(2, |request| {
+        tx.send(request.target().to_string())
+          .expect("send h2 target");
+        HttpResponse::ok(format!("response for {}", request.target()))
+      })
+      .expect("serve multiplexed h2 requests");
+  });
+
+  let mut stream = TcpStream::connect(addr).expect("connect h2 server");
+  stream
+    .set_read_timeout(Some(Duration::from_secs(2)))
+    .expect("set h2 read timeout");
+  complete_h2_server_handshake(&mut stream);
+
+  let first_headers = h2_post_headers(b"/first", addr.to_string().as_bytes());
+  write_h2_frame(
+    &mut stream,
+    H2_FRAME_HEADERS,
+    H2_FLAG_END_HEADERS,
+    1,
+    &first_headers,
+  );
+
+  let second_headers = h2_get_headers(b"/second", addr.to_string().as_bytes());
+  write_h2_frame(
+    &mut stream,
+    H2_FRAME_HEADERS,
+    H2_FLAG_END_HEADERS | H2_FLAG_END_STREAM,
+    3,
+    &second_headers,
+  );
+
+  write_h2_frame(&mut stream, H2_FRAME_DATA, 0, 1, b"one ");
+  write_h2_frame(&mut stream, H2_FRAME_DATA, H2_FLAG_END_STREAM, 1, b"body");
+
+  let mut response_streams = Vec::new();
+  let mut response_bodies = Vec::new();
+  while response_bodies.len() < 2 {
+    let frame = read_h2_frame(&mut stream);
+    if frame.frame_type == H2_FRAME_DATA && frame.flags & H2_FLAG_END_STREAM == H2_FLAG_END_STREAM {
+      response_streams.push(frame.stream_id);
+      response_bodies.push(String::from_utf8(frame.payload).expect("h2 body utf8"));
+    }
+  }
+
+  assert_eq!(
+    vec!["/second", "/first"],
+    vec![
+      rx.recv().expect("first h2 target"),
+      rx.recv().expect("second h2 target"),
+    ]
+  );
+  assert!(response_streams.contains(&1));
+  assert!(response_streams.contains(&3));
+  assert!(response_bodies.contains(&"response for /first".to_string()));
+  assert!(response_bodies.contains(&"response for /second".to_string()));
+
+  handle.join().expect("server thread");
+}
+
+#[test]
+fn server_ignores_reset_stream_and_serves_surviving_http2_stream() {
+  let server = rttp::Http::server("127.0.0.1:0").expect("bind server");
+  let addr = server.local_addr().expect("server addr");
+  let (tx, rx) = mpsc::channel();
+
+  let handle = thread::spawn(move || {
+    server
+      .serve_requests(1, |request| {
+        tx.send(request.target().to_string())
+          .expect("send h2 target");
+        HttpResponse::ok("survivor")
+      })
+      .expect("serve h2 reset/goaway sequence");
+  });
+
+  let mut stream = TcpStream::connect(addr).expect("connect h2 server");
+  stream
+    .set_read_timeout(Some(Duration::from_secs(2)))
+    .expect("set h2 read timeout");
+  complete_h2_server_handshake(&mut stream);
+
+  write_h2_frame(
+    &mut stream,
+    H2_FRAME_HEADERS,
+    H2_FLAG_END_HEADERS,
+    1,
+    &h2_post_headers(b"/reset-me", addr.to_string().as_bytes()),
+  );
+  write_h2_frame(&mut stream, H2_FRAME_DATA, 0, 1, b"partial");
+  write_h2_frame(&mut stream, H2_FRAME_RST_STREAM, 0, 1, &0u32.to_be_bytes());
+
+  write_h2_frame(
+    &mut stream,
+    H2_FRAME_HEADERS,
+    H2_FLAG_END_HEADERS | H2_FLAG_END_STREAM,
+    3,
+    &h2_get_headers(b"/survivor", addr.to_string().as_bytes()),
+  );
+
+  let mut saw_survivor = false;
+  while !saw_survivor {
+    let frame = read_h2_frame(&mut stream);
+    if frame.frame_type == H2_FRAME_DATA && frame.stream_id == 3 {
+      assert_eq!(b"survivor", frame.payload.as_slice());
+      saw_survivor = true;
+    }
+  }
+
+  assert_eq!("/survivor", rx.recv().expect("survivor h2 target"));
+
+  handle.join().expect("server thread");
+}
+
+#[test]
+fn server_stops_http2_connection_on_goaway_without_calling_handler() {
+  let server = rttp::Http::server("127.0.0.1:0").expect("bind server");
+  let addr = server.local_addr().expect("server addr");
+
+  let handle = thread::spawn(move || {
+    server
+      .serve_requests(1, |_| panic!("GOAWAY must not call handler"))
+      .expect("serve h2 goaway");
+  });
+
+  let mut stream = TcpStream::connect(addr).expect("connect h2 server");
+  stream
+    .set_read_timeout(Some(Duration::from_secs(2)))
+    .expect("set h2 read timeout");
+  complete_h2_server_handshake(&mut stream);
+
+  write_h2_frame(
+    &mut stream,
+    H2_FRAME_GOAWAY,
+    0,
+    0,
+    &[0, 0, 0, 0, 0, 0, 0, 0],
+  );
 
   handle.join().expect("server thread");
 }

--- a/rttp_client/src/http2.rs
+++ b/rttp_client/src/http2.rs
@@ -294,7 +294,9 @@ fn read_single_stream_response(stream: &mut TcpStream, url: RoUrl) -> error::Res
         return Err(error::bad_response("HTTP/2 stream received RST_STREAM"));
       }
       (FRAME_GOAWAY, 0) => {
-        return Err(error::bad_response("HTTP/2 connection received GOAWAY"));
+        if goaway_last_stream_id(&frame.payload)? < STREAM_ID {
+          return Err(error::bad_response("HTTP/2 connection received GOAWAY"));
+        }
       }
       (_, STREAM_ID) => {}
       (_, 0) => {}
@@ -308,6 +310,18 @@ fn read_single_stream_response(stream: &mut TcpStream, url: RoUrl) -> error::Res
 
   let status = status.ok_or_else(|| error::bad_response("missing HTTP/2 :status header"))?;
   build_response(url, status, &headers, body)
+}
+
+fn goaway_last_stream_id(payload: &[u8]) -> error::Result<u32> {
+  if payload.len() < 8 {
+    return Err(error::bad_response("invalid HTTP/2 GOAWAY frame"));
+  }
+  Ok(u32::from_be_bytes([
+    payload[0] & 0x7f,
+    payload[1],
+    payload[2],
+    payload[3],
+  ]))
 }
 
 fn build_response(

--- a/rttp_client/src/http2.rs
+++ b/rttp_client/src/http2.rs
@@ -14,7 +14,10 @@ const CLIENT_PREFACE: &[u8; 24] = b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n";
 
 const FRAME_DATA: u8 = 0x0;
 const FRAME_HEADERS: u8 = 0x1;
+const FRAME_RST_STREAM: u8 = 0x3;
 const FRAME_SETTINGS: u8 = 0x4;
+const FRAME_GOAWAY: u8 = 0x7;
+const FRAME_WINDOW_UPDATE: u8 = 0x8;
 const FRAME_CONTINUATION: u8 = 0x9;
 
 const FLAG_END_STREAM: u8 = 0x1;
@@ -276,10 +279,22 @@ fn read_single_stream_response(stream: &mut TcpStream, url: RoUrl) -> error::Res
         }
       }
       (FRAME_DATA, STREAM_ID) => {
+        let end_stream = frame.flags & FLAG_END_STREAM == FLAG_END_STREAM;
         body.extend_from_slice(&frame.payload);
-        if frame.flags & FLAG_END_STREAM == FLAG_END_STREAM {
+        if !frame.payload.is_empty() && !end_stream {
+          write_window_update_best_effort(stream, 0, frame.payload.len())?;
+          write_window_update_best_effort(stream, STREAM_ID, frame.payload.len())?;
+          flush_best_effort(stream)?;
+        }
+        if end_stream {
           break;
         }
+      }
+      (FRAME_RST_STREAM, STREAM_ID) => {
+        return Err(error::bad_response("HTTP/2 stream received RST_STREAM"));
+      }
+      (FRAME_GOAWAY, 0) => {
+        return Err(error::bad_response("HTTP/2 connection received GOAWAY"));
       }
       (_, STREAM_ID) => {}
       (_, 0) => {}
@@ -341,11 +356,21 @@ fn write_frame(
   stream_id: u32,
   payload: &[u8],
 ) -> error::Result<()> {
+  write_frame_io(stream, frame_type, flags, stream_id, payload).map_err(error::request)
+}
+
+fn write_frame_io(
+  stream: &mut TcpStream,
+  frame_type: u8,
+  flags: u8,
+  stream_id: u32,
+  payload: &[u8],
+) -> io::Result<()> {
   if payload.len() > 16_777_215 {
-    return Err(error::request(io::Error::new(
+    return Err(io::Error::new(
       io::ErrorKind::InvalidInput,
       "HTTP/2 frame payload is too large",
-    )));
+    ));
   }
 
   let length = payload.len();
@@ -356,8 +381,61 @@ fn write_frame(
   header[3] = frame_type;
   header[4] = flags;
   header[5..9].copy_from_slice(&(stream_id & 0x7fff_ffff).to_be_bytes());
-  stream.write_all(&header).map_err(error::request)?;
-  stream.write_all(payload).map_err(error::request)
+  stream.write_all(&header)?;
+  stream.write_all(payload)
+}
+
+fn write_window_update_best_effort(
+  stream: &mut TcpStream,
+  stream_id: u32,
+  increment: usize,
+) -> error::Result<()> {
+  match write_window_update_io(stream, stream_id, increment) {
+    Ok(()) => Ok(()),
+    Err(err) if is_connection_closed(&err) => Ok(()),
+    Err(err) => Err(error::request(err)),
+  }
+}
+
+fn write_window_update_io(
+  stream: &mut TcpStream,
+  stream_id: u32,
+  increment: usize,
+) -> io::Result<()> {
+  let increment = u32::try_from(increment).map_err(|_| {
+    io::Error::new(
+      io::ErrorKind::InvalidInput,
+      "HTTP/2 window update increment is too large",
+    )
+  })?;
+  if increment == 0 || increment > 0x7fff_ffff {
+    return Err(io::Error::new(
+      io::ErrorKind::InvalidInput,
+      "invalid HTTP/2 window update increment",
+    ));
+  }
+  write_frame_io(
+    stream,
+    FRAME_WINDOW_UPDATE,
+    0,
+    stream_id,
+    &increment.to_be_bytes(),
+  )
+}
+
+fn flush_best_effort(stream: &mut TcpStream) -> error::Result<()> {
+  match stream.flush() {
+    Ok(()) => Ok(()),
+    Err(err) if is_connection_closed(&err) => Ok(()),
+    Err(err) => Err(error::request(err)),
+  }
+}
+
+fn is_connection_closed(err: &io::Error) -> bool {
+  matches!(
+    err.kind(),
+    io::ErrorKind::BrokenPipe | io::ErrorKind::ConnectionReset | io::ErrorKind::NotConnected
+  )
 }
 
 fn encode_literal_indexed_name_without_indexing(

--- a/rttp_client/tests/http2_prior_knowledge.rs
+++ b/rttp_client/tests/http2_prior_knowledge.rs
@@ -192,6 +192,31 @@ fn prior_knowledge_get_reports_stream_reset_and_goaway() {
 }
 
 #[test]
+fn prior_knowledge_get_continues_after_graceful_goaway_for_active_stream() {
+  let listener = TcpListener::bind("127.0.0.1:0").expect("bind h2 peer");
+  let addr = listener.local_addr().expect("h2 peer addr");
+
+  let handle = thread::spawn(move || {
+    let (mut stream, _) = listener.accept().expect("accept h2 client");
+    complete_h2_request_handshake(&mut stream);
+
+    write_frame(&mut stream, FRAME_GOAWAY, 0, 0, &[0, 0, 0, 1, 0, 0, 0, 0]);
+    write_frame(&mut stream, FRAME_HEADERS, FLAG_END_HEADERS, 1, &[0x88]);
+    write_frame(&mut stream, FRAME_DATA, FLAG_END_STREAM, 1, b"still served");
+  });
+
+  let response = HttpClient::new()
+    .get()
+    .url(format!("http://{}/graceful-goaway", addr))
+    .emit_http2_prior_knowledge()
+    .expect("graceful GOAWAY permits active stream response");
+
+  assert_eq!(200, response.code());
+  assert_eq!("still served", response.body().string().unwrap());
+  handle.join().expect("goaway peer thread");
+}
+
+#[test]
 fn prior_knowledge_sends_window_updates_for_non_final_data_frames() {
   let listener = TcpListener::bind("127.0.0.1:0").expect("bind h2 peer");
   let addr = listener.local_addr().expect("h2 peer addr");
@@ -407,7 +432,7 @@ fn spawn_control_frame_peer(frame_type: u8) -> (SocketAddr, thread::JoinHandle<(
     complete_h2_request_handshake(&mut stream);
     match frame_type {
       FRAME_RST_STREAM => write_frame(&mut stream, FRAME_RST_STREAM, 0, 1, &0u32.to_be_bytes()),
-      FRAME_GOAWAY => write_frame(&mut stream, FRAME_GOAWAY, 0, 0, &[0, 0, 0, 1, 0, 0, 0, 0]),
+      FRAME_GOAWAY => write_frame(&mut stream, FRAME_GOAWAY, 0, 0, &[0, 0, 0, 0, 0, 0, 0, 0]),
       _ => unreachable!("unexpected control frame"),
     }
   });

--- a/rttp_client/tests/http2_prior_knowledge.rs
+++ b/rttp_client/tests/http2_prior_knowledge.rs
@@ -8,7 +8,10 @@ use rttp_client::HttpClient;
 
 const FRAME_DATA: u8 = 0x0;
 const FRAME_HEADERS: u8 = 0x1;
+const FRAME_RST_STREAM: u8 = 0x3;
 const FRAME_SETTINGS: u8 = 0x4;
+const FRAME_GOAWAY: u8 = 0x7;
+const FRAME_WINDOW_UPDATE: u8 = 0x8;
 
 const FLAG_END_STREAM: u8 = 0x1;
 const FLAG_END_HEADERS: u8 = 0x4;
@@ -94,6 +97,108 @@ fn prior_knowledge_get_sends_h2_handshake_and_reads_single_response_stream() {
     .any(|window| window == b"/hello?via=h2"));
 }
 
+#[test]
+fn prior_knowledge_get_ignores_interleaved_data_for_other_streams() {
+  let listener = TcpListener::bind("127.0.0.1:0").expect("bind h2 peer");
+  let addr = listener.local_addr().expect("h2 peer addr");
+
+  let handle = thread::spawn(move || {
+    let (mut stream, _) = listener.accept().expect("accept h2 client");
+    complete_handshake_and_read_request(&mut stream);
+
+    write_frame(
+      &mut stream,
+      FRAME_HEADERS,
+      FLAG_END_HEADERS,
+      1,
+      &[
+        0x88, 0x0f, 16, 10, b't', b'e', b'x', b't', b'/', b'p', b'l', b'a', b'i', b'n',
+      ],
+    );
+    write_frame(&mut stream, FRAME_DATA, 0, 1, b"hel");
+    write_frame(&mut stream, FRAME_HEADERS, FLAG_END_HEADERS, 3, &[0x88]);
+    write_frame(&mut stream, FRAME_DATA, FLAG_END_STREAM, 3, b"ignored");
+    write_frame(&mut stream, FRAME_DATA, FLAG_END_STREAM, 1, b"lo");
+  });
+
+  let response = HttpClient::new()
+    .get()
+    .url(format!("http://{}/interleaved", addr))
+    .emit_http2_prior_knowledge()
+    .expect("interleaved h2 response");
+
+  assert_eq!(200, response.code());
+  assert_eq!("hello", response.body().string().unwrap());
+  handle.join().expect("h2 peer thread");
+}
+
+#[test]
+fn prior_knowledge_get_reports_stream_reset_and_goaway() {
+  let (reset_addr, reset_handle) = spawn_control_frame_peer(FRAME_RST_STREAM);
+  let reset_error = HttpClient::new()
+    .get()
+    .url(format!("http://{}/reset", reset_addr))
+    .emit_http2_prior_knowledge()
+    .expect_err("reset stream must fail the response");
+  assert!(reset_error.to_string().contains("RST_STREAM"));
+  reset_handle.join().expect("reset peer thread");
+
+  let (goaway_addr, goaway_handle) = spawn_control_frame_peer(FRAME_GOAWAY);
+  let goaway_error = HttpClient::new()
+    .get()
+    .url(format!("http://{}/goaway", goaway_addr))
+    .emit_http2_prior_knowledge()
+    .expect_err("goaway must fail the response");
+  assert!(goaway_error.to_string().contains("GOAWAY"));
+  goaway_handle.join().expect("goaway peer thread");
+}
+
+#[test]
+fn prior_knowledge_get_sends_window_updates_while_reading_large_response_body() {
+  let listener = TcpListener::bind("127.0.0.1:0").expect("bind h2 peer");
+  let addr = listener.local_addr().expect("h2 peer addr");
+
+  let handle = thread::spawn(move || {
+    let (mut stream, _) = listener.accept().expect("accept h2 client");
+    stream
+      .set_read_timeout(Some(std::time::Duration::from_secs(2)))
+      .expect("set read timeout");
+    complete_handshake_and_read_request(&mut stream);
+
+    write_frame(&mut stream, FRAME_HEADERS, FLAG_END_HEADERS, 1, &[0x88]);
+    for _ in 0..5 {
+      write_frame(&mut stream, FRAME_DATA, 0, 1, &vec![b'x'; 16 * 1024]);
+    }
+    write_frame(&mut stream, FRAME_DATA, FLAG_END_STREAM, 1, b"done");
+
+    let mut saw_stream_update = false;
+    let mut saw_connection_update = false;
+    for _ in 0..8 {
+      let frame = read_frame(&mut stream);
+      if frame.frame_type == FRAME_WINDOW_UPDATE && frame.stream_id == 0 {
+        saw_connection_update = true;
+      }
+      if frame.frame_type == FRAME_WINDOW_UPDATE && frame.stream_id == 1 {
+        saw_stream_update = true;
+      }
+      if saw_stream_update && saw_connection_update {
+        return;
+      }
+    }
+    panic!("client did not send stream and connection WINDOW_UPDATE frames");
+  });
+
+  let response = HttpClient::new()
+    .get()
+    .url(format!("http://{}/large", addr))
+    .emit_http2_prior_knowledge()
+    .expect("large h2 response");
+
+  assert_eq!(200, response.code());
+  assert_eq!(5 * 16 * 1024 + 4, response.body().binary().len());
+  handle.join().expect("window update peer thread");
+}
+
 struct Frame {
   frame_type: u8,
   flags: u8,
@@ -127,4 +232,44 @@ fn write_frame(stream: &mut impl Write, frame_type: u8, flags: u8, stream_id: u3
   stream.write_all(&header).expect("write frame header");
   stream.write_all(payload).expect("write frame payload");
   stream.flush().expect("flush frame");
+}
+
+fn complete_handshake_and_read_request(stream: &mut (impl Read + Write)) {
+  let mut preface = [0; 24];
+  stream
+    .read_exact(&mut preface)
+    .expect("read client preface");
+  assert_eq!(b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n", &preface);
+
+  let client_settings = read_frame(stream);
+  assert_eq!(FRAME_SETTINGS, client_settings.frame_type);
+  assert_eq!(0, client_settings.stream_id);
+
+  write_frame(stream, FRAME_SETTINGS, 0, 0, &[]);
+
+  let client_settings_ack = read_frame(stream);
+  assert_eq!(FRAME_SETTINGS, client_settings_ack.frame_type);
+  assert_eq!(FLAG_ACK, client_settings_ack.flags);
+
+  let request_headers = read_frame(stream);
+  assert_eq!(FRAME_HEADERS, request_headers.frame_type);
+  assert_eq!(FLAG_END_STREAM | FLAG_END_HEADERS, request_headers.flags);
+  assert_eq!(1, request_headers.stream_id);
+}
+
+fn spawn_control_frame_peer(frame_type: u8) -> (SocketAddr, thread::JoinHandle<()>) {
+  let listener = TcpListener::bind("127.0.0.1:0").expect("bind h2 peer");
+  let addr = listener.local_addr().expect("h2 peer addr");
+
+  let handle = thread::spawn(move || {
+    let (mut stream, _) = listener.accept().expect("accept h2 client");
+    complete_handshake_and_read_request(&mut stream);
+    match frame_type {
+      FRAME_RST_STREAM => write_frame(&mut stream, FRAME_RST_STREAM, 0, 1, &0u32.to_be_bytes()),
+      FRAME_GOAWAY => write_frame(&mut stream, FRAME_GOAWAY, 0, 0, &[0, 0, 0, 1, 0, 0, 0, 0]),
+      _ => unreachable!("unexpected control frame"),
+    }
+  });
+
+  (addr, handle)
 }


### PR DESCRIPTION
Implemented HTTP/2 multiplexing and flow-control regression coverage while preserving existing HTTP/1.1 behavior and public APIs. Full workspace verification passed.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1319/
work_kind: code_work
branch: hbx-1319-rttp-add-http-2-multiplexing
base: main
commit: 9b09d957204f9eae793fda0ee423c345a8da0ac7
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1319/
    url: https://plane.kahub.in/endless/browse/HBX-1319/
    close_policy: link_only
```