### PR TITLE
feat: [rttp] Resolve relative redirect Location values consistently

### DIFF
--- a/rttp_client/tests/test_http_async.rs
+++ b/rttp_client/tests/test_http_async.rs
@@ -835,15 +835,28 @@ fn test_async_auto_redirect_resolves_absolute_location() {
 #[cfg(feature = "async")]
 fn test_async_auto_redirect_resolves_absolute_path_location() {
   block_on(async {
-    assert_async_redirect_resolves_to_target(|_| "/final?x=1".to_string(), "/final?x=1").await;
+    assert_async_redirect_resolves_to_target(|_| "/absolute-path".to_string(), "/absolute-path")
+      .await;
   });
 }
 
 #[test]
 #[cfg(feature = "async")]
-fn test_async_auto_redirect_resolves_relative_path_location() {
+fn test_async_auto_redirect_resolves_relative_child_location() {
   block_on(async {
-    assert_async_redirect_resolves_to_target(|_| "../final".to_string(), "/final").await;
+    assert_async_redirect_resolves_to_target(
+      |_| "relative-child".to_string(),
+      "/redirect/relative-child",
+    )
+    .await;
+  });
+}
+
+#[test]
+#[cfg(feature = "async")]
+fn test_async_auto_redirect_resolves_parent_relative_location() {
+  block_on(async {
+    assert_async_redirect_resolves_to_target(|_| "../sibling".to_string(), "/sibling").await;
   });
 }
 
@@ -851,8 +864,35 @@ fn test_async_auto_redirect_resolves_relative_path_location() {
 #[cfg(feature = "async")]
 fn test_async_auto_redirect_resolves_query_only_location() {
   block_on(async {
-    assert_async_redirect_resolves_to_target(|_| "?page=2".to_string(), "/redirect/from?page=2")
-      .await;
+    assert_async_redirect_resolves_to_target(
+      |_| "?query-only".to_string(),
+      "/redirect/from?query-only",
+    )
+    .await;
+  });
+}
+
+#[test]
+#[cfg(feature = "async")]
+fn test_async_auto_redirect_resolves_location_with_fragment_without_sending_fragment() {
+  block_on(async {
+    assert_async_redirect_resolves_to_target(
+      |_| "fragment-child#section".to_string(),
+      "/redirect/fragment-child",
+    )
+    .await;
+  });
+}
+
+#[test]
+#[cfg(feature = "async")]
+fn test_async_auto_redirect_resolves_absolute_location_with_fragment_without_sending_fragment() {
+  block_on(async {
+    assert_async_redirect_resolves_to_target(
+      |addr| format!("http://{}/absolute-fragment#section", addr),
+      "/absolute-fragment",
+    )
+    .await;
   });
 }
 

--- a/rttp_client/tests/test_http_basic.rs
+++ b/rttp_client/tests/test_http_basic.rs
@@ -933,12 +933,17 @@ fn test_auto_redirect_resolves_absolute_location() {
 
 #[test]
 fn test_auto_redirect_resolves_absolute_path_location() {
-  assert_redirect_resolves_to_target(|_| "/final?x=1".to_string(), "/final?x=1");
+  assert_redirect_resolves_to_target(|_| "/absolute-path".to_string(), "/absolute-path");
 }
 
 #[test]
-fn test_auto_redirect_resolves_relative_path_location() {
-  assert_redirect_resolves_to_target(|_| "../final".to_string(), "/final");
+fn test_auto_redirect_resolves_relative_child_location() {
+  assert_redirect_resolves_to_target(|_| "relative-child".to_string(), "/redirect/relative-child");
+}
+
+#[test]
+fn test_auto_redirect_resolves_parent_relative_location() {
+  assert_redirect_resolves_to_target(|_| "../sibling".to_string(), "/sibling");
 }
 
 #[test]
@@ -953,7 +958,23 @@ fn test_auto_redirect_preserves_trailing_slash_for_parent_dot_segment_location()
 
 #[test]
 fn test_auto_redirect_resolves_query_only_location() {
-  assert_redirect_resolves_to_target(|_| "?page=2".to_string(), "/redirect/from?page=2");
+  assert_redirect_resolves_to_target(|_| "?query-only".to_string(), "/redirect/from?query-only");
+}
+
+#[test]
+fn test_auto_redirect_resolves_location_with_fragment_without_sending_fragment() {
+  assert_redirect_resolves_to_target(
+    |_| "fragment-child#section".to_string(),
+    "/redirect/fragment-child",
+  );
+}
+
+#[test]
+fn test_auto_redirect_resolves_absolute_location_with_fragment_without_sending_fragment() {
+  assert_redirect_resolves_to_target(
+    |addr| format!("http://{}/absolute-fragment#section", addr),
+    "/absolute-fragment",
+  );
 }
 
 #[test]


### PR DESCRIPTION
Added rttp_client sync and async socket coverage proving relative redirect Location values resolve to the expected request path/query without sending fragments.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1325/
work_kind: code_work
branch: hbx-1325-rttp-resolve-relative-redirect-location
base: main
commit: 39008418bb0544442b4f614a1f6046f7dbb774d7
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1325/
    url: https://plane.kahub.in/endless/browse/HBX-1325/
    close_policy: link_only
```