### PR TITLE
feat: [rttp] Apply status-specific redirect method and body rewriting

### DIFF
--- a/rttp_client/src/connection/async_connection.rs
+++ b/rttp_client/src/connection/async_connection.rs
@@ -227,7 +227,12 @@ impl<'a> AsyncConnection<'a> {
         Response::with_trailers(self.conn.rourl().clone(), parts.binary, parts.trailers)?;
       let config = self.conn.config().clone();
 
-      if let Some(location) = response.location() {
+      if response.is_redirect() {
+        let Some(location) = response.location() else {
+          self.conn.closed_set(true);
+          return Ok(response);
+        };
+
         if url.as_str() == location {
           return Err(error::loop_detected(url));
         }

--- a/rttp_client/src/connection/block_connection.rs
+++ b/rttp_client/src/connection/block_connection.rs
@@ -37,7 +37,12 @@ impl<'a> BlockConnection<'a> {
         Response::with_trailers(self.conn.rourl().clone(), parts.binary, parts.trailers)?;
       let config = self.conn.config().clone();
 
-      if let Some(location) = response.location() {
+      if response.is_redirect() {
+        let Some(location) = response.location() else {
+          self.conn.closed_set(true);
+          return Ok(response);
+        };
+
         let req_url = url.as_str();
         if req_url == location {
           return Err(error::loop_detected(url));

--- a/rttp_client/src/request/raw_request.rs
+++ b/rttp_client/src/request/raw_request.rs
@@ -57,8 +57,9 @@ impl<'a> RawRequest<'a> {
   }
 
   pub(crate) fn redirect_status_set(&mut self, status_code: u32) {
+    let rewrite_to_get = self.origin.redirect_rewrites_to_get(status_code);
     self.origin.redirect_status_set(status_code);
-    if status_code == 303 && !self.origin.method().eq_ignore_ascii_case("head") {
+    if rewrite_to_get {
       self.body = None;
       self.header = Self::redirect_body_headers_remove(&self.header);
     }

--- a/rttp_client/src/request/request.rs
+++ b/rttp_client/src/request/request.rs
@@ -218,7 +218,7 @@ impl Request {
   pub(crate) fn redirect_rewrites_to_get(&self, status_code: u32) -> bool {
     // Compatibility behavior: like common HTTP clients, 301 and 302
     // rewrite non-HEAD requests to GET. 307 and 308 preserve method/body.
-    matches!(status_code, 301 | 302 | 303) && !self.method.eq_ignore_ascii_case("head")
+    matches!(status_code, 301..=303) && !self.method.eq_ignore_ascii_case("head")
   }
 
   pub(crate) fn remove_sensitive_redirect_headers(&mut self) {

--- a/rttp_client/src/request/request.rs
+++ b/rttp_client/src/request/request.rs
@@ -200,7 +200,7 @@ impl Request {
   }
 
   pub(crate) fn redirect_status_set(&mut self, status_code: u32) -> &mut Self {
-    if status_code == 303 && !self.method.eq_ignore_ascii_case("head") {
+    if self.redirect_rewrites_to_get(status_code) {
       self.method_set("GET");
       self.paras.clear();
       self.formdatas.clear();
@@ -213,6 +213,12 @@ impl Request {
       });
     }
     self
+  }
+
+  pub(crate) fn redirect_rewrites_to_get(&self, status_code: u32) -> bool {
+    // Compatibility behavior: like common HTTP clients, 301 and 302
+    // rewrite non-HEAD requests to GET. 307 and 308 preserve method/body.
+    matches!(status_code, 301 | 302 | 303) && !self.method.eq_ignore_ascii_case("head")
   }
 
   pub(crate) fn remove_sensitive_redirect_headers(&mut self) {

--- a/rttp_client/src/request/request.rs
+++ b/rttp_client/src/request/request.rs
@@ -216,9 +216,13 @@ impl Request {
   }
 
   pub(crate) fn redirect_rewrites_to_get(&self, status_code: u32) -> bool {
-    // Compatibility behavior: like common HTTP clients, 301 and 302
-    // rewrite non-HEAD requests to GET. 307 and 308 preserve method/body.
-    matches!(status_code, 301..=303) && !self.method.eq_ignore_ascii_case("head")
+    // Compatibility behavior: 301/302 rewrite POST requests to GET; 303
+    // rewrites any non-HEAD request. 307 and 308 preserve method/body.
+    match status_code {
+      301 | 302 => self.method.eq_ignore_ascii_case("post"),
+      303 => !self.method.eq_ignore_ascii_case("head"),
+      _ => false,
+    }
   }
 
   pub(crate) fn remove_sensitive_redirect_headers(&mut self) {

--- a/rttp_client/src/response/response.rs
+++ b/rttp_client/src/response/response.rs
@@ -35,11 +35,7 @@ impl Response {
   }
 
   pub fn is_redirect(&self) -> bool {
-    self.code() == 301
-      || self.code() == 302
-      || self.code() == 303
-      || self.code() == 307
-      || self.header_value("Location").is_some()
+    matches!(self.code(), 301 | 302 | 303 | 307 | 308)
   }
 
   pub fn code(&self) -> u32 {

--- a/rttp_client/tests/test_http_async.rs
+++ b/rttp_client/tests/test_http_async.rs
@@ -758,6 +758,36 @@ async fn captured_async_redirected_head(status_code: u16, reason: &'static str) 
 
 #[test]
 #[cfg(feature = "async")]
+fn test_async_auto_redirect_301_post_becomes_get_without_body_or_body_framing() {
+  block_on(async {
+    let request = captured_async_redirected_post(301, "Moved Permanently").await;
+
+    assert_eq!("GET", request.method);
+    assert_eq!("/final?via=redirect", request.target);
+    assert_eq!(b"", request.body.as_slice());
+    assert!(!request.headers.contains_key("content-length"));
+    assert!(!request.headers.contains_key("content-type"));
+    assert!(!request.headers.contains_key("transfer-encoding"));
+  });
+}
+
+#[test]
+#[cfg(feature = "async")]
+fn test_async_auto_redirect_302_post_becomes_get_without_body_or_body_framing() {
+  block_on(async {
+    let request = captured_async_redirected_post(302, "Found").await;
+
+    assert_eq!("GET", request.method);
+    assert_eq!("/final?via=redirect", request.target);
+    assert_eq!(b"", request.body.as_slice());
+    assert!(!request.headers.contains_key("content-length"));
+    assert!(!request.headers.contains_key("content-type"));
+    assert!(!request.headers.contains_key("transfer-encoding"));
+  });
+}
+
+#[test]
+#[cfg(feature = "async")]
 fn test_async_auto_redirect_303_post_becomes_get_without_body_or_body_framing() {
   block_on(async {
     let request = captured_async_redirected_post(303, "See Other").await;

--- a/rttp_client/tests/test_http_async.rs
+++ b/rttp_client/tests/test_http_async.rs
@@ -743,6 +743,21 @@ async fn captured_async_redirected_post(status_code: u16, reason: &'static str) 
 }
 
 #[cfg(feature = "async")]
+async fn captured_async_redirected_put(status_code: u16, reason: &'static str) -> CapturedRequest {
+  let (addr, handle) = support::spawn_status_redirect_request_capture_server(status_code, reason);
+  let response = client()
+    .config(Config::builder().auto_redirect(true))
+    .put()
+    .url(format!("http://{}/redirect", addr))
+    .raw("redirect-body")
+    .rasync()
+    .await;
+
+  assert!(response.is_ok());
+  captured_request(handle.join().expect("redirect capture thread"))
+}
+
+#[cfg(feature = "async")]
 async fn captured_async_redirected_head(status_code: u16, reason: &'static str) -> CapturedRequest {
   let (addr, handle) = support::spawn_status_redirect_request_capture_server(status_code, reason);
   let response = client()
@@ -783,6 +798,46 @@ fn test_async_auto_redirect_302_post_becomes_get_without_body_or_body_framing() 
     assert!(!request.headers.contains_key("content-length"));
     assert!(!request.headers.contains_key("content-type"));
     assert!(!request.headers.contains_key("transfer-encoding"));
+  });
+}
+
+#[test]
+#[cfg(feature = "async")]
+fn test_async_auto_redirect_301_put_preserves_method_body_and_body_framing() {
+  block_on(async {
+    let request = captured_async_redirected_put(301, "Moved Permanently").await;
+
+    assert_eq!("PUT", request.method);
+    assert_eq!("/final?via=redirect", request.target);
+    assert_eq!(b"redirect-body", request.body.as_slice());
+    assert_eq!(
+      Some("13"),
+      request.headers.get("content-length").map(String::as_str)
+    );
+    assert_eq!(
+      Some("text/plain"),
+      request.headers.get("content-type").map(String::as_str)
+    );
+  });
+}
+
+#[test]
+#[cfg(feature = "async")]
+fn test_async_auto_redirect_302_put_preserves_method_body_and_body_framing() {
+  block_on(async {
+    let request = captured_async_redirected_put(302, "Found").await;
+
+    assert_eq!("PUT", request.method);
+    assert_eq!("/final?via=redirect", request.target);
+    assert_eq!(b"redirect-body", request.body.as_slice());
+    assert_eq!(
+      Some("13"),
+      request.headers.get("content-length").map(String::as_str)
+    );
+    assert_eq!(
+      Some("text/plain"),
+      request.headers.get("content-type").map(String::as_str)
+    );
   });
 }
 

--- a/rttp_client/tests/test_http_basic.rs
+++ b/rttp_client/tests/test_http_basic.rs
@@ -860,6 +860,19 @@ fn captured_redirected_post(status_code: u16, reason: &'static str) -> CapturedR
   captured_request(handle.join().expect("redirect capture thread"))
 }
 
+fn captured_redirected_put(status_code: u16, reason: &'static str) -> CapturedRequest {
+  let (addr, handle) = support::spawn_status_redirect_request_capture_server(status_code, reason);
+  let response = client()
+    .config(Config::builder().auto_redirect(true))
+    .put()
+    .url(format!("http://{}/redirect", addr))
+    .raw("redirect-body")
+    .emit();
+
+  assert!(response.is_ok());
+  captured_request(handle.join().expect("redirect capture thread"))
+}
+
 fn captured_redirected_head(status_code: u16, reason: &'static str) -> CapturedRequest {
   let (addr, handle) = support::spawn_status_redirect_request_capture_server(status_code, reason);
   let response = client()
@@ -894,6 +907,40 @@ fn test_auto_redirect_302_post_becomes_get_without_body_or_body_framing() {
   assert!(!request.headers.contains_key("content-length"));
   assert!(!request.headers.contains_key("content-type"));
   assert!(!request.headers.contains_key("transfer-encoding"));
+}
+
+#[test]
+fn test_auto_redirect_301_put_preserves_method_body_and_body_framing() {
+  let request = captured_redirected_put(301, "Moved Permanently");
+
+  assert_eq!("PUT", request.method);
+  assert_eq!("/final?via=redirect", request.target);
+  assert_eq!(b"redirect-body", request.body.as_slice());
+  assert_eq!(
+    Some("13"),
+    request.headers.get("content-length").map(String::as_str)
+  );
+  assert_eq!(
+    Some("text/plain"),
+    request.headers.get("content-type").map(String::as_str)
+  );
+}
+
+#[test]
+fn test_auto_redirect_302_put_preserves_method_body_and_body_framing() {
+  let request = captured_redirected_put(302, "Found");
+
+  assert_eq!("PUT", request.method);
+  assert_eq!("/final?via=redirect", request.target);
+  assert_eq!(b"redirect-body", request.body.as_slice());
+  assert_eq!(
+    Some("13"),
+    request.headers.get("content-length").map(String::as_str)
+  );
+  assert_eq!(
+    Some("text/plain"),
+    request.headers.get("content-type").map(String::as_str)
+  );
 }
 
 #[test]

--- a/rttp_client/tests/test_http_basic.rs
+++ b/rttp_client/tests/test_http_basic.rs
@@ -873,6 +873,30 @@ fn captured_redirected_head(status_code: u16, reason: &'static str) -> CapturedR
 }
 
 #[test]
+fn test_auto_redirect_301_post_becomes_get_without_body_or_body_framing() {
+  let request = captured_redirected_post(301, "Moved Permanently");
+
+  assert_eq!("GET", request.method);
+  assert_eq!("/final?via=redirect", request.target);
+  assert_eq!(b"", request.body.as_slice());
+  assert!(!request.headers.contains_key("content-length"));
+  assert!(!request.headers.contains_key("content-type"));
+  assert!(!request.headers.contains_key("transfer-encoding"));
+}
+
+#[test]
+fn test_auto_redirect_302_post_becomes_get_without_body_or_body_framing() {
+  let request = captured_redirected_post(302, "Found");
+
+  assert_eq!("GET", request.method);
+  assert_eq!("/final?via=redirect", request.target);
+  assert_eq!(b"", request.body.as_slice());
+  assert!(!request.headers.contains_key("content-length"));
+  assert!(!request.headers.contains_key("content-type"));
+  assert!(!request.headers.contains_key("transfer-encoding"));
+}
+
+#[test]
 fn test_auto_redirect_303_post_becomes_get_without_body_or_body_framing() {
   let request = captured_redirected_post(303, "See Other");
 


### PR DESCRIPTION
Implemented status-specific redirect rewriting in rttp_client with sync and async coverage for 301, 302, 303, 307, and 308 POST redirect chains. Formatting, workspace tests, and async-feature client tests pass.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1326/
work_kind: code_work
branch: hbx-1326-rttp-apply-status-specific-redirect
base: main
commit: 7ba079ba2a4651e272f4e93ee43d9832ffc1af53
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1326/
    url: https://plane.kahub.in/endless/browse/HBX-1326/
    close_policy: link_only
```