### PR TITLE
feat: [rttp] Enforce redirect loop and max-hop boundaries

### DIFF
--- a/rttp_client/src/connection/async_connection.rs
+++ b/rttp_client/src/connection/async_connection.rs
@@ -219,7 +219,10 @@ impl<'a> AsyncConnection<'a> {
 
     loop {
       let url = self.conn.url().map_err(error::builder)?;
-      visited_urls.insert(url.clone());
+      visited_urls.insert((
+        self.conn.request().origin().method().to_uppercase(),
+        url.clone(),
+      ));
       let proxy = self.conn.proxy().clone();
       let parts = if let Some(proxy) = proxy.as_ref() {
         self.call_with_proxy(&url, proxy).await?
@@ -232,10 +235,6 @@ impl<'a> AsyncConnection<'a> {
       let config = self.conn.config().clone();
 
       if let Some(location) = response.location() {
-        if url.as_str() == location {
-          return Err(error::loop_detected(url));
-        }
-
         if config.auto_redirect() {
           let count = self.conn.count();
           if count > config.max_redirect() {
@@ -243,11 +242,15 @@ impl<'a> AsyncConnection<'a> {
           }
 
           let redirect_url = self.conn.resolve_redirect_url(&url, location)?;
-          if visited_urls.contains(&redirect_url.url) {
-            return Err(error::loop_detected(url));
-          }
           let strip_sensitive_headers = !self.conn.is_same_origin_url(&url, &redirect_url.url);
           self.conn.request_mut().redirect_status_set(response.code());
+          let next_visit = (
+            self.conn.request().origin().method().to_uppercase(),
+            redirect_url.url.clone(),
+          );
+          if visited_urls.contains(&next_visit) {
+            return Err(error::loop_detected(url));
+          }
           self.conn.request_mut().redirect_url_set(
             redirect_url.url.to_string(),
             strip_sensitive_headers,

--- a/rttp_client/src/connection/async_connection.rs
+++ b/rttp_client/src/connection/async_connection.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::net::TcpStream;
 
 use futures::io::{AllowStdIo, AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
@@ -214,8 +215,11 @@ impl<'a> AsyncConnection<'a> {
   }
 
   pub async fn async_call(mut self) -> error::Result<Response> {
+    let mut visited_urls = HashSet::new();
+
     loop {
       let url = self.conn.url().map_err(error::builder)?;
+      visited_urls.insert(url.clone());
       let proxy = self.conn.proxy().clone();
       let parts = if let Some(proxy) = proxy.as_ref() {
         self.call_with_proxy(&url, proxy).await?
@@ -239,7 +243,7 @@ impl<'a> AsyncConnection<'a> {
           }
 
           let redirect_url = self.conn.resolve_redirect_url(&url, location)?;
-          if url == redirect_url.url {
+          if visited_urls.contains(&redirect_url.url) {
             return Err(error::loop_detected(url));
           }
           let strip_sensitive_headers = !self.conn.is_same_origin_url(&url, &redirect_url.url);

--- a/rttp_client/src/connection/block_connection.rs
+++ b/rttp_client/src/connection/block_connection.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::io::Write;
 
 use socks::{Socks4Stream, Socks5Stream};
@@ -24,8 +25,11 @@ impl<'a> BlockConnection<'a> {
   }
 
   pub fn call(mut self) -> error::Result<Response> {
+    let mut visited_urls = HashSet::new();
+
     loop {
       let url = self.conn.url().map_err(error::builder)?;
+      visited_urls.insert(url.clone());
       let proxy = self.conn.proxy().clone();
       let parts = if let Some(proxy) = proxy.as_ref() {
         self.call_with_proxy(&url, proxy)?
@@ -52,7 +56,7 @@ impl<'a> BlockConnection<'a> {
         }
 
         let redirect_url = self.conn.resolve_redirect_url(&url, location)?;
-        if url == redirect_url.url {
+        if visited_urls.contains(&redirect_url.url) {
           return Err(error::loop_detected(url));
         }
         let strip_sensitive_headers = !self.conn.is_same_origin_url(&url, &redirect_url.url);

--- a/rttp_client/src/connection/block_connection.rs
+++ b/rttp_client/src/connection/block_connection.rs
@@ -29,7 +29,10 @@ impl<'a> BlockConnection<'a> {
 
     loop {
       let url = self.conn.url().map_err(error::builder)?;
-      visited_urls.insert(url.clone());
+      visited_urls.insert((
+        self.conn.request().origin().method().to_uppercase(),
+        url.clone(),
+      ));
       let proxy = self.conn.proxy().clone();
       let parts = if let Some(proxy) = proxy.as_ref() {
         self.call_with_proxy(&url, proxy)?
@@ -42,10 +45,6 @@ impl<'a> BlockConnection<'a> {
       let config = self.conn.config().clone();
 
       if let Some(location) = response.location() {
-        let req_url = url.as_str();
-        if req_url == location {
-          return Err(error::loop_detected(url));
-        }
         if !config.auto_redirect() {
           self.conn.closed_set(true);
           return Ok(response);
@@ -56,11 +55,15 @@ impl<'a> BlockConnection<'a> {
         }
 
         let redirect_url = self.conn.resolve_redirect_url(&url, location)?;
-        if visited_urls.contains(&redirect_url.url) {
-          return Err(error::loop_detected(url));
-        }
         let strip_sensitive_headers = !self.conn.is_same_origin_url(&url, &redirect_url.url);
         self.conn.request_mut().redirect_status_set(response.code());
+        let next_visit = (
+          self.conn.request().origin().method().to_uppercase(),
+          redirect_url.url.clone(),
+        );
+        if visited_urls.contains(&next_visit) {
+          return Err(error::loop_detected(url));
+        }
         self.conn.request_mut().redirect_url_set(
           redirect_url.url.to_string(),
           strip_sensitive_headers,

--- a/rttp_client/tests/support/mod.rs
+++ b/rttp_client/tests/support/mod.rs
@@ -329,6 +329,34 @@ pub fn spawn_status_redirect_request_capture_server(
   (addr, handle)
 }
 
+pub fn spawn_same_url_303_redirect_method_echo_server() -> (SocketAddr, JoinHandle<()>) {
+  let (listener, addr) = bind_local_http_listener("same url 303 redirect method echo server");
+  let handle = thread::spawn(move || {
+    if let Ok((mut stream, _)) = listener.accept() {
+      let _ = read_http_request(&mut stream);
+      let response =
+        "HTTP/1.1 303 See Other\r\nLocation: /submit\r\nContent-Length: 0\r\nConnection: close\r\n\r\n";
+      let _ = stream.write_all(response.as_bytes());
+    }
+
+    if let Ok((mut stream, _)) = listener.accept() {
+      let request = read_http_request(&mut stream);
+      let request_line = String::from_utf8_lossy(&request)
+        .lines()
+        .next()
+        .unwrap_or("")
+        .to_string();
+      let response = format!(
+        "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+        request_line.len(),
+        request_line
+      );
+      let _ = stream.write_all(response.as_bytes());
+    }
+  });
+  (addr, handle)
+}
+
 pub fn spawn_cross_authority_redirect_host_echo_server() -> (SocketAddr, SocketAddr, JoinHandle<()>)
 {
   let (origin_listener, origin_addr) = bind_local_http_listener("cross authority redirect origin");

--- a/rttp_client/tests/test_http_async.rs
+++ b/rttp_client/tests/test_http_async.rs
@@ -796,6 +796,25 @@ fn test_async_auto_redirect_303_post_becomes_get_without_body_or_body_framing() 
 
 #[test]
 #[cfg(feature = "async")]
+fn test_async_auto_redirect_303_post_allows_same_url_after_method_changes() {
+  let (addr, _handle) = support::spawn_same_url_303_redirect_method_echo_server();
+  block_on(async {
+    let response = client()
+      .config(Config::builder().auto_redirect(true).max_redirect(1))
+      .post()
+      .url(format!("http://{}/submit", addr))
+      .raw("redirect-body")
+      .rasync()
+      .await;
+
+    assert!(response.is_ok());
+    let response = response.unwrap();
+    assert_eq!("GET /submit HTTP/1.1", response.body().string().unwrap());
+  });
+}
+
+#[test]
+#[cfg(feature = "async")]
 fn test_async_auto_redirect_303_head_preserves_method() {
   block_on(async {
     let request = captured_async_redirected_head(303, "See Other").await;

--- a/rttp_client/tests/test_http_async.rs
+++ b/rttp_client/tests/test_http_async.rs
@@ -686,6 +686,29 @@ where
 }
 
 #[cfg(feature = "async")]
+fn assert_redirect_error_has_url_context(
+  error: &rttp_client::error::Error,
+  message: &str,
+  expected_path: &str,
+) {
+  assert!(error.is_redirect());
+  let error_message = error.to_string();
+  assert!(error_message.contains(message));
+  assert!(error_message.contains(" for url (http://"));
+  assert!(error_message.contains(expected_path));
+  assert!(!error_message.contains("Authorization"));
+  assert!(!error_message.contains("Bearer secret"));
+  assert!(!error_message.contains("Cookie"));
+  assert!(!error_message.contains("session=secret"));
+  assert!(!error_message.contains("Proxy-Authorization"));
+  assert!(!error_message.contains("proxy-secret"));
+  assert_eq!(
+    expected_path,
+    error.url().expect("redirect error url").path()
+  );
+}
+
+#[cfg(feature = "async")]
 struct CapturedRequest {
   method: String,
   target: String,
@@ -936,8 +959,111 @@ fn test_async_auto_redirect_enforces_max_redirect_bound() {
       .await
       .expect_err("redirect chain should exceed max_redirect");
 
-    assert!(error.is_redirect());
-    assert!(error.to_string().contains("too many redirects"));
+    assert_redirect_error_has_url_context(&error, "too many redirects", "/hop-two");
+  });
+}
+
+#[test]
+#[cfg(feature = "async")]
+fn test_async_auto_redirect_with_zero_max_redirect_fails_before_first_hop() {
+  let (addr, _handle) = support::spawn_redirect_chain_server(vec![("/start", "/final?done=1")], 1);
+  block_on(async {
+    let error = client()
+      .config(Config::builder().auto_redirect(true).max_redirect(0))
+      .get()
+      .url(format!("http://{}/start", addr))
+      .header(("Authorization", "Bearer secret"))
+      .header(("Cookie", "session=secret"))
+      .header(("Proxy-Authorization", "Basic proxy-secret"))
+      .rasync()
+      .await
+      .expect_err("max_redirect=0 should reject the first redirect");
+
+    assert_redirect_error_has_url_context(&error, "too many redirects", "/start");
+  });
+}
+
+#[test]
+#[cfg(feature = "async")]
+fn test_async_auto_redirect_with_one_max_redirect_fails_on_second_hop() {
+  let (addr, _handle) = support::spawn_redirect_chain_server(
+    vec![("/start", "/hop-one"), ("/hop-one", "/final?done=1")],
+    2,
+  );
+  block_on(async {
+    let error = client()
+      .config(Config::builder().auto_redirect(true).max_redirect(1))
+      .get()
+      .url(format!("http://{}/start", addr))
+      .rasync()
+      .await
+      .expect_err("max_redirect=1 should allow one redirect and reject the second");
+
+    assert_redirect_error_has_url_context(&error, "too many redirects", "/hop-one");
+  });
+}
+
+#[test]
+#[cfg(feature = "async")]
+fn test_async_auto_redirect_uses_default_max_redirect_when_enabled() {
+  let (addr, _handle) = support::spawn_redirect_chain_server(
+    vec![
+      ("/start", "/hop-one"),
+      ("/hop-one", "/hop-two"),
+      ("/hop-two", "/hop-three"),
+      ("/hop-three", "/hop-four"),
+      ("/hop-four", "/hop-five"),
+      ("/hop-five", "/final"),
+    ],
+    6,
+  );
+  block_on(async {
+    let error = client()
+      .config(Config::builder().auto_redirect(true))
+      .get()
+      .url(format!("http://{}/start", addr))
+      .rasync()
+      .await
+      .expect_err("auto_redirect default max should reject the sixth redirect");
+
+    assert_redirect_error_has_url_context(&error, "too many redirects", "/hop-five");
+  });
+}
+
+#[test]
+#[cfg(feature = "async")]
+fn test_async_auto_redirect_detects_a_b_a_loop() {
+  let (addr, _handle) = support::spawn_redirect_chain_server(vec![("/a", "/b"), ("/b", "/a")], 3);
+  block_on(async {
+    let error = client()
+      .config(Config::builder().auto_redirect(true).max_redirect(10))
+      .get()
+      .url(format!("http://{}/a", addr))
+      .header(("Authorization", "Bearer secret"))
+      .header(("Cookie", "session=secret"))
+      .header(("Proxy-Authorization", "Basic proxy-secret"))
+      .rasync()
+      .await
+      .expect_err("A -> B -> A should be detected as a loop");
+
+    assert_redirect_error_has_url_context(&error, "infinite redirect loop detected", "/b");
+  });
+}
+
+#[test]
+#[cfg(feature = "async")]
+fn test_async_auto_redirect_detects_self_redirect() {
+  let (addr, _handle) = support::spawn_redirect_chain_server(vec![("/self", "/self")], 1);
+  block_on(async {
+    let error = client()
+      .config(Config::builder().auto_redirect(true))
+      .get()
+      .url(format!("http://{}/self", addr))
+      .rasync()
+      .await
+      .expect_err("self redirect should be detected as a loop");
+
+    assert_redirect_error_has_url_context(&error, "infinite redirect loop detected", "/self");
   });
 }
 

--- a/rttp_client/tests/test_http_basic.rs
+++ b/rttp_client/tests/test_http_basic.rs
@@ -907,6 +907,21 @@ fn test_auto_redirect_303_post_becomes_get_without_body_or_body_framing() {
 }
 
 #[test]
+fn test_auto_redirect_303_post_allows_same_url_after_method_changes() {
+  let (addr, _handle) = support::spawn_same_url_303_redirect_method_echo_server();
+  let response = client()
+    .config(Config::builder().auto_redirect(true).max_redirect(1))
+    .post()
+    .url(format!("http://{}/submit", addr))
+    .raw("redirect-body")
+    .emit();
+
+  assert!(response.is_ok());
+  let response = response.unwrap();
+  assert_eq!("GET /submit HTTP/1.1", response.body().string().unwrap());
+}
+
+#[test]
 fn test_auto_redirect_303_head_preserves_method() {
   let request = captured_redirected_head(303, "See Other");
 

--- a/rttp_client/tests/test_http_basic.rs
+++ b/rttp_client/tests/test_http_basic.rs
@@ -807,6 +807,28 @@ where
   assert_eq!(expected_target, response.body().string().unwrap());
 }
 
+fn assert_redirect_error_has_url_context(
+  error: &rttp_client::error::Error,
+  message: &str,
+  expected_path: &str,
+) {
+  assert!(error.is_redirect());
+  let error_message = error.to_string();
+  assert!(error_message.contains(message));
+  assert!(error_message.contains(" for url (http://"));
+  assert!(error_message.contains(expected_path));
+  assert!(!error_message.contains("Authorization"));
+  assert!(!error_message.contains("Bearer secret"));
+  assert!(!error_message.contains("Cookie"));
+  assert!(!error_message.contains("session=secret"));
+  assert!(!error_message.contains("Proxy-Authorization"));
+  assert!(!error_message.contains("proxy-secret"));
+  assert_eq!(
+    expected_path,
+    error.url().expect("redirect error url").path()
+  );
+}
+
 struct CapturedRequest {
   method: String,
   target: String,
@@ -1021,8 +1043,91 @@ fn test_auto_redirect_enforces_max_redirect_bound() {
     .emit()
     .expect_err("redirect chain should exceed max_redirect");
 
-  assert!(error.is_redirect());
-  assert!(error.to_string().contains("too many redirects"));
+  assert_redirect_error_has_url_context(&error, "too many redirects", "/hop-two");
+}
+
+#[test]
+fn test_auto_redirect_with_zero_max_redirect_fails_before_first_hop() {
+  let (addr, _handle) = support::spawn_redirect_chain_server(vec![("/start", "/final?done=1")], 1);
+  let error = client()
+    .config(Config::builder().auto_redirect(true).max_redirect(0))
+    .get()
+    .url(format!("http://{}/start", addr))
+    .header(("Authorization", "Bearer secret"))
+    .header(("Cookie", "session=secret"))
+    .header(("Proxy-Authorization", "Basic proxy-secret"))
+    .emit()
+    .expect_err("max_redirect=0 should reject the first redirect");
+
+  assert_redirect_error_has_url_context(&error, "too many redirects", "/start");
+}
+
+#[test]
+fn test_auto_redirect_with_one_max_redirect_fails_on_second_hop() {
+  let (addr, _handle) = support::spawn_redirect_chain_server(
+    vec![("/start", "/hop-one"), ("/hop-one", "/final?done=1")],
+    2,
+  );
+  let error = client()
+    .config(Config::builder().auto_redirect(true).max_redirect(1))
+    .get()
+    .url(format!("http://{}/start", addr))
+    .emit()
+    .expect_err("max_redirect=1 should allow one redirect and reject the second");
+
+  assert_redirect_error_has_url_context(&error, "too many redirects", "/hop-one");
+}
+
+#[test]
+fn test_auto_redirect_uses_default_max_redirect_when_enabled() {
+  let (addr, _handle) = support::spawn_redirect_chain_server(
+    vec![
+      ("/start", "/hop-one"),
+      ("/hop-one", "/hop-two"),
+      ("/hop-two", "/hop-three"),
+      ("/hop-three", "/hop-four"),
+      ("/hop-four", "/hop-five"),
+      ("/hop-five", "/final"),
+    ],
+    6,
+  );
+  let error = client()
+    .config(Config::builder().auto_redirect(true))
+    .get()
+    .url(format!("http://{}/start", addr))
+    .emit()
+    .expect_err("auto_redirect default max should reject the sixth redirect");
+
+  assert_redirect_error_has_url_context(&error, "too many redirects", "/hop-five");
+}
+
+#[test]
+fn test_auto_redirect_detects_a_b_a_loop() {
+  let (addr, _handle) = support::spawn_redirect_chain_server(vec![("/a", "/b"), ("/b", "/a")], 3);
+  let error = client()
+    .config(Config::builder().auto_redirect(true).max_redirect(10))
+    .get()
+    .url(format!("http://{}/a", addr))
+    .header(("Authorization", "Bearer secret"))
+    .header(("Cookie", "session=secret"))
+    .header(("Proxy-Authorization", "Basic proxy-secret"))
+    .emit()
+    .expect_err("A -> B -> A should be detected as a loop");
+
+  assert_redirect_error_has_url_context(&error, "infinite redirect loop detected", "/b");
+}
+
+#[test]
+fn test_auto_redirect_detects_self_redirect() {
+  let (addr, _handle) = support::spawn_redirect_chain_server(vec![("/self", "/self")], 1);
+  let error = client()
+    .config(Config::builder().auto_redirect(true))
+    .get()
+    .url(format!("http://{}/self", addr))
+    .emit()
+    .expect_err("self redirect should be detected as a loop");
+
+  assert_redirect_error_has_url_context(&error, "infinite redirect loop detected", "/self");
 }
 
 #[test]


### PR DESCRIPTION
Implemented and verified deterministic redirect loop detection and max_redirect boundary enforcement for rttp_client sync and async redirect handling.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1328/
work_kind: code_work
branch: hbx-1328-rttp-enforce-redirect-loop-and
base: main
commit: 03bc83d7a909b37da73972c4195064489e9a7097
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1328/
    url: https://plane.kahub.in/endless/browse/HBX-1328/
    close_policy: link_only
```