### PR TITLE
feat: [rttp] Strip sensitive headers across cross-origin redirects

### DIFF
--- a/rttp_client/src/connection/connection.rs
+++ b/rttp_client/src/connection/connection.rs
@@ -283,6 +283,7 @@ impl<'a> Connection<'a> {
     let mut redirect = url
       .join(location)
       .map_err(|_| error::bad_url(url.clone(), "Bad redirect location"))?;
+    strip_userinfo_for_cross_origin_redirect(url, &mut redirect);
     let (path, query) = raw_redirect_path_and_query(url, self.request.request_target(), location)
       .unwrap_or_else(|| {
         (
@@ -446,6 +447,15 @@ fn is_same_origin(left: &Url, right: &Url) -> bool {
   left.scheme() == right.scheme()
     && left.host_str() == right.host_str()
     && left.port_or_known_default() == right.port_or_known_default()
+}
+
+fn strip_userinfo_for_cross_origin_redirect(base: &Url, redirect: &mut Url) {
+  if is_same_origin(base, redirect) {
+    return;
+  }
+
+  let _ = redirect.set_username("");
+  let _ = redirect.set_password(None);
 }
 
 fn proxy_authorization_value(proxy: &Proxy) -> Option<String> {
@@ -1139,10 +1149,11 @@ mod tests {
   use crate::request::RequestBody;
   use crate::types::Proxy;
   use crate::Config;
+  use url::Url;
 
   use super::{
     connect_tcp_stream, parse_proxy_connect_response, proxy_authorization_value,
-    read_proxy_connect_response, write_http_request,
+    read_proxy_connect_response, strip_userinfo_for_cross_origin_redirect, write_http_request,
   };
 
   struct PartialWriter {
@@ -1211,6 +1222,28 @@ mod tests {
     let mut reader = Cursor::new(header);
 
     read_proxy_connect_response(&mut reader).unwrap();
+  }
+
+  #[test]
+  fn test_strip_userinfo_for_cross_origin_redirect_removes_redirect_credentials() {
+    let base = Url::parse("http://user:secret@example.test/start").unwrap();
+    let mut cross_origin = Url::parse("http://next:secret@other.test/final").unwrap();
+
+    strip_userinfo_for_cross_origin_redirect(&base, &mut cross_origin);
+
+    assert_eq!("", cross_origin.username());
+    assert_eq!(None, cross_origin.password());
+  }
+
+  #[test]
+  fn test_strip_userinfo_for_cross_origin_redirect_preserves_same_origin_credentials() {
+    let base = Url::parse("http://user:secret@example.test/start").unwrap();
+    let mut same_origin = Url::parse("http://next:secret@example.test/final").unwrap();
+
+    strip_userinfo_for_cross_origin_redirect(&base, &mut same_origin);
+
+    assert_eq!("next", same_origin.username());
+    assert_eq!(Some("secret"), same_origin.password());
   }
 
   #[test]

--- a/rttp_client/tests/support/mod.rs
+++ b/rttp_client/tests/support/mod.rs
@@ -389,6 +389,36 @@ pub fn spawn_cross_authority_redirect_header_echo_server(
   (origin_addr, target_addr, handle)
 }
 
+pub fn spawn_cross_authority_redirect_userinfo_echo_server(
+) -> (SocketAddr, SocketAddr, JoinHandle<()>) {
+  let (origin_listener, origin_addr) = bind_local_http_listener("cross authority redirect origin");
+  let (target_listener, target_addr) = bind_local_http_listener("cross authority redirect target");
+
+  let handle = thread::spawn(move || {
+    if let Ok((mut stream, _)) = origin_listener.accept() {
+      let _ = read_http_request(&mut stream);
+      let response = format!(
+        "HTTP/1.1 302 Found\r\nLocation: http://user:secret@{}/final\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+        target_addr
+      );
+      let _ = stream.write_all(response.as_bytes());
+    }
+
+    if let Ok((mut stream, _)) = target_listener.accept() {
+      let request = read_http_request(&mut stream);
+      let body = echoed_redirect_request_target_and_headers(&request);
+      let response = format!(
+        "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+        body.len(),
+        body
+      );
+      let _ = stream.write_all(response.as_bytes());
+    }
+  });
+
+  (origin_addr, target_addr, handle)
+}
+
 pub fn spawn_same_authority_redirect_header_echo_server() -> (SocketAddr, JoinHandle<()>) {
   let (listener, addr) = bind_local_http_listener("same authority redirect");
 
@@ -422,6 +452,20 @@ fn echoed_redirect_headers(request: &[u8]) -> String {
     header_value(request, "Cookie").unwrap_or_default(),
     header_value(request, "Proxy-Authorization").unwrap_or_default(),
     header_value(request, "X-Trace").unwrap_or_default()
+  )
+}
+
+fn echoed_redirect_request_target_and_headers(request: &[u8]) -> String {
+  let request_text = String::from_utf8_lossy(request);
+  let request_target = request_text
+    .lines()
+    .next()
+    .and_then(|line| line.split_whitespace().nth(1))
+    .unwrap_or_default();
+  format!(
+    "request-target={}\n{}",
+    request_target,
+    echoed_redirect_headers(request)
   )
 }
 

--- a/rttp_client/tests/test_http_async.rs
+++ b/rttp_client/tests/test_http_async.rs
@@ -1155,6 +1155,32 @@ fn test_async_auto_redirect_strips_sensitive_headers_for_cross_authority_locatio
 
 #[test]
 #[cfg(feature = "async")]
+fn test_async_auto_redirect_strips_sensitive_headers_and_userinfo_for_cross_authority_location() {
+  let (origin_addr, _target_addr, _handle) =
+    support::spawn_cross_authority_redirect_userinfo_echo_server();
+  block_on(async {
+    let response = client()
+      .config(Config::builder().auto_redirect(true))
+      .get()
+      .url(format!("http://{}/redirect", origin_addr))
+      .header(("Authorization", "Bearer secret"))
+      .header(("Cookie", "session=secret"))
+      .header(("Proxy-Authorization", "Basic proxy-secret"))
+      .header(("X-Trace", "trace-123"))
+      .rasync()
+      .await;
+
+    assert!(response.is_ok());
+    let response = response.unwrap();
+    assert_eq!(
+      "request-target=/final\nauthorization=\ncookie=\nproxy-authorization=\nx-trace=trace-123",
+      response.body().string().unwrap()
+    );
+  });
+}
+
+#[test]
+#[cfg(feature = "async")]
 fn test_async_auto_redirect_preserves_sensitive_headers_for_same_authority_location() {
   let (addr, _handle) = support::spawn_same_authority_redirect_header_echo_server();
   block_on(async {

--- a/rttp_client/tests/test_http_basic.rs
+++ b/rttp_client/tests/test_http_basic.rs
@@ -1174,6 +1174,28 @@ fn test_auto_redirect_strips_sensitive_headers_for_cross_authority_location() {
 }
 
 #[test]
+fn test_auto_redirect_strips_sensitive_headers_and_userinfo_for_cross_authority_location() {
+  let (origin_addr, _target_addr, _handle) =
+    support::spawn_cross_authority_redirect_userinfo_echo_server();
+  let response = client()
+    .config(Config::builder().auto_redirect(true))
+    .get()
+    .url(format!("http://{}/redirect", origin_addr))
+    .header(("Authorization", "Bearer secret"))
+    .header(("Cookie", "session=secret"))
+    .header(("Proxy-Authorization", "Basic proxy-secret"))
+    .header(("X-Trace", "trace-123"))
+    .emit();
+
+  assert!(response.is_ok());
+  let response = response.unwrap();
+  assert_eq!(
+    "request-target=/final\nauthorization=\ncookie=\nproxy-authorization=\nx-trace=trace-123",
+    response.body().string().unwrap()
+  );
+}
+
+#[test]
 fn test_auto_redirect_preserves_sensitive_headers_for_same_authority_location() {
   let (addr, _handle) = support::spawn_same_authority_redirect_header_echo_server();
   let response = client()


### PR DESCRIPTION
Cross-origin redirects in rttp_client now remove redirect URL user-info and retain the existing sensitive-header stripping behavior, with sync and async local-server regression coverage. Formatting and workspace tests pass.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1327/
work_kind: code_work
branch: hbx-1327-rttp-strip-sensitive-headers-across
base: main
commit: 33b8a4dbfd09ec4b3fa0c4dcf7a32bed84b0c528
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1327/
    url: https://plane.kahub.in/endless/browse/HBX-1327/
    close_policy: link_only
```