### PR TITLE
feat: [rttp] Add server-side request framing guards for conflicting length headers

### DIFF
--- a/rttp/src/server.rs
+++ b/rttp/src/server.rs
@@ -2294,8 +2294,14 @@ fn optional_header_content_length(headers: &[(String, String)]) -> io::Result<Op
     .filter(|(name, _)| name.eq_ignore_ascii_case("Content-Length"))
   {
     for token in value.split(',') {
+      let token = token.trim();
+      if token.is_empty() || !token.bytes().all(|byte| byte.is_ascii_digit()) {
+        return Err(io::Error::new(
+          io::ErrorKind::InvalidData,
+          "invalid Content-Length header",
+        ));
+      }
       let parsed = token
-        .trim()
         .parse::<usize>()
         .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "invalid Content-Length header"))?;
       if length

--- a/rttp/tests/test_server.rs
+++ b/rttp/tests/test_server.rs
@@ -1653,6 +1653,20 @@ fn server_returns_bad_request_for_malformed_content_length() {
 }
 
 #[test]
+fn server_returns_bad_request_for_signed_content_length() {
+  assert_bad_request_without_handler(
+    concat!(
+      "POST /upload HTTP/1.1\r\n",
+      "Host: localhost\r\n",
+      "Content-Length: +5\r\n",
+      "\r\n",
+      "hello"
+    )
+    .as_bytes(),
+  );
+}
+
+#[test]
 fn server_accepts_small_chunked_request_body() {
   let (response, handler_called) = send_raw_request(
     concat!(


### PR DESCRIPTION
Server request framing now rejects invalid signed `Content-Length` syntax before handler dispatch, with socket-level regression coverage and full workspace verification passing.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1333/
work_kind: code_work
branch: hbx-1333-rttp-add-server-side-request
base: main
commit: 17975f064091d7929e0c7f074414cf25abc1970f
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1333/
    url: https://plane.kahub.in/endless/browse/HBX-1333/
    close_policy: link_only
```