### PR TITLE
feat: [rttp_client] Treat 204 and 304 responses as bodyless even with framing headers

### DIFF
--- a/rttp_client/src/response/raw_response.rs
+++ b/rttp_client/src/response/raw_response.rs
@@ -232,6 +232,10 @@ impl Parser {
   }
 
   fn parse_body(&self, response: &mut RawResponse, binary: Vec<u8>) -> error::Result<()> {
+    if response_status_has_no_body(response.code_get()) {
+      return Ok(());
+    }
+
     if binary.is_empty() {
       return Ok(());
     }
@@ -260,4 +264,8 @@ impl Parser {
     response.body(body);
     Ok(())
   }
+}
+
+fn response_status_has_no_body(status_code: u32) -> bool {
+  (100..200).contains(&status_code) || status_code == 204 || status_code == 304
 }

--- a/rttp_client/tests/http11_compliance_matrix.rs
+++ b/rttp_client/tests/http11_compliance_matrix.rs
@@ -7,6 +7,98 @@ fn client() -> HttpClient {
   HttpClient::new()
 }
 
+const NO_BODY_STATUS_WITH_FRAMING_CASES: &[(&str, &[u8], u32, &str, &str)] = &[
+  (
+    "204 content-length",
+    concat!(
+      "HTTP/1.1 204 No Content\r\n",
+      "Content-Length: 7\r\n",
+      "X-Trace: kept\r\n",
+      "\r\n",
+      "ignored"
+    )
+    .as_bytes(),
+    204,
+    "Content-Length",
+    "7",
+  ),
+  (
+    "204 chunked",
+    concat!(
+      "HTTP/1.1 204 No Content\r\n",
+      "Transfer-Encoding: chunked\r\n",
+      "X-Trace: kept\r\n",
+      "\r\n",
+      "7\r\nignored\r\n0\r\n\r\n"
+    )
+    .as_bytes(),
+    204,
+    "Transfer-Encoding",
+    "chunked",
+  ),
+  (
+    "304 content-length",
+    concat!(
+      "HTTP/1.1 304 Not Modified\r\n",
+      "Content-Length: 7\r\n",
+      "X-Trace: kept\r\n",
+      "\r\n",
+      "ignored"
+    )
+    .as_bytes(),
+    304,
+    "Content-Length",
+    "7",
+  ),
+  (
+    "304 chunked",
+    concat!(
+      "HTTP/1.1 304 Not Modified\r\n",
+      "Transfer-Encoding: chunked\r\n",
+      "X-Trace: kept\r\n",
+      "\r\n",
+      "7\r\nignored\r\n0\r\n\r\n"
+    )
+    .as_bytes(),
+    304,
+    "Transfer-Encoding",
+    "chunked",
+  ),
+];
+
+const ORDINARY_200_FRAMING_CASES: &[(&str, &[u8], &str, &str, &str)] = &[
+  (
+    "200 content-length",
+    concat!(
+      "HTTP/1.1 200 OK\r\n",
+      "Content-Length: 2\r\n",
+      "X-Trace: kept\r\n",
+      "\r\n",
+      "OK"
+    )
+    .as_bytes(),
+    "Content-Length",
+    "2",
+    "OK",
+  ),
+  (
+    "200 chunked",
+    concat!(
+      "HTTP/1.1 200 OK\r\n",
+      "Transfer-Encoding: chunked\r\n",
+      "X-Trace: kept\r\n",
+      "\r\n",
+      "7\r\nchunked\r\n",
+      "6\r\n body!\r\n",
+      "0\r\n\r\n"
+    )
+    .as_bytes(),
+    "Transfer-Encoding",
+    "chunked",
+    "chunked body!",
+  ),
+];
+
 #[test]
 fn sync_client_decodes_shared_chunk_extensions_and_trailers_fixture() {
   let (addr, handle) = fixtures::spawn_socket2_raw_response_server(
@@ -29,6 +121,56 @@ fn sync_client_decodes_shared_chunk_extensions_and_trailers_fixture() {
 
   let request = handle.join().expect("raw response server thread");
   assert!(String::from_utf8_lossy(&request).starts_with("GET /matrix/chunked HTTP/1.1"));
+}
+
+#[test]
+fn sync_client_treats_204_and_304_as_bodyless_despite_framing_headers() {
+  for (name, raw_response, status, framing_header, framing_value) in
+    NO_BODY_STATUS_WITH_FRAMING_CASES
+  {
+    let (addr, handle) = fixtures::spawn_socket2_raw_response_server(raw_response);
+
+    let response = client()
+      .get()
+      .url(format!("http://{}/matrix/no-body", addr))
+      .emit()
+      .unwrap_or_else(|err| panic!("{name} should parse: {err}"));
+
+    assert_eq!(*status, response.code(), "{name}");
+    assert_eq!(
+      Some(&framing_value.to_string()),
+      response.header_value(framing_header),
+      "{name}"
+    );
+    assert_eq!(Some(&"kept".to_string()), response.header_value("X-Trace"));
+    assert_eq!("", response.body().string().unwrap(), "{name}");
+
+    handle.join().expect("raw response server thread");
+  }
+}
+
+#[test]
+fn sync_client_preserves_ordinary_200_framed_bodies() {
+  for (name, raw_response, framing_header, framing_value, body) in ORDINARY_200_FRAMING_CASES {
+    let (addr, handle) = fixtures::spawn_socket2_raw_response_server(raw_response);
+
+    let response = client()
+      .get()
+      .url(format!("http://{}/matrix/ordinary-body", addr))
+      .emit()
+      .unwrap_or_else(|err| panic!("{name} should parse: {err}"));
+
+    assert_eq!(200, response.code(), "{name}");
+    assert_eq!(
+      Some(&framing_value.to_string()),
+      response.header_value(framing_header),
+      "{name}"
+    );
+    assert_eq!(Some(&"kept".to_string()), response.header_value("X-Trace"));
+    assert_eq!(*body, response.body().string().unwrap(), "{name}");
+
+    handle.join().expect("raw response server thread");
+  }
 }
 
 #[test]
@@ -106,6 +248,64 @@ fn async_client_decodes_shared_chunk_extensions_and_trailers_fixture() {
 
   let request = handle.join().expect("raw response server thread");
   assert!(String::from_utf8_lossy(&request).starts_with("GET /matrix/chunked HTTP/1.1"));
+}
+
+#[test]
+#[cfg(feature = "async")]
+fn async_client_treats_204_and_304_as_bodyless_despite_framing_headers() {
+  for (name, raw_response, status, framing_header, framing_value) in
+    NO_BODY_STATUS_WITH_FRAMING_CASES
+  {
+    let (addr, handle) = fixtures::spawn_socket2_raw_response_server(raw_response);
+
+    block_on(async {
+      let response = client()
+        .get()
+        .url(format!("http://{}/matrix/no-body", addr))
+        .rasync()
+        .await
+        .unwrap_or_else(|err| panic!("{name} should parse: {err}"));
+
+      assert_eq!(*status, response.code(), "{name}");
+      assert_eq!(
+        Some(&framing_value.to_string()),
+        response.header_value(framing_header),
+        "{name}"
+      );
+      assert_eq!(Some(&"kept".to_string()), response.header_value("X-Trace"));
+      assert_eq!("", response.body().string().unwrap(), "{name}");
+    });
+
+    handle.join().expect("raw response server thread");
+  }
+}
+
+#[test]
+#[cfg(feature = "async")]
+fn async_client_preserves_ordinary_200_framed_bodies() {
+  for (name, raw_response, framing_header, framing_value, body) in ORDINARY_200_FRAMING_CASES {
+    let (addr, handle) = fixtures::spawn_socket2_raw_response_server(raw_response);
+
+    block_on(async {
+      let response = client()
+        .get()
+        .url(format!("http://{}/matrix/ordinary-body", addr))
+        .rasync()
+        .await
+        .unwrap_or_else(|err| panic!("{name} should parse: {err}"));
+
+      assert_eq!(200, response.code(), "{name}");
+      assert_eq!(
+        Some(&framing_value.to_string()),
+        response.header_value(framing_header),
+        "{name}"
+      );
+      assert_eq!(Some(&"kept".to_string()), response.header_value("X-Trace"));
+      assert_eq!(*body, response.body().string().unwrap(), "{name}");
+    });
+
+    handle.join().expect("raw response server thread");
+  }
 }
 
 #[test]

--- a/rttp_client/tests/test_response.rs
+++ b/rttp_client/tests/test_response.rs
@@ -104,3 +104,43 @@ fn test_non_chunked_response_exposes_empty_trailers() {
   assert!(response.trailers().is_empty());
   assert!(response.trailer("x-trace").is_none());
 }
+
+#[test]
+fn test_no_body_status_responses_expose_empty_body_with_illegal_framing_bytes() {
+  for raw in [
+    concat!(
+      "HTTP/1.1 204 No Content\r\n",
+      "Content-Length: 7\r\n",
+      "X-Trace: kept\r\n",
+      "\r\n",
+      "ignored"
+    ),
+    concat!(
+      "HTTP/1.1 204 No Content\r\n",
+      "Transfer-Encoding: chunked\r\n",
+      "X-Trace: kept\r\n",
+      "\r\n",
+      "7\r\nignored\r\n0\r\n\r\n"
+    ),
+    concat!(
+      "HTTP/1.1 304 Not Modified\r\n",
+      "Content-Length: 7\r\n",
+      "X-Trace: kept\r\n",
+      "\r\n",
+      "ignored"
+    ),
+    concat!(
+      "HTTP/1.1 304 Not Modified\r\n",
+      "Transfer-Encoding: chunked\r\n",
+      "X-Trace: kept\r\n",
+      "\r\n",
+      "7\r\nignored\r\n0\r\n\r\n"
+    ),
+  ] {
+    let response = Response::new(RoUrl::with("https://example.test"), raw.as_bytes().to_vec())
+      .expect("no-body status response should parse");
+
+    assert_eq!(Some(&"kept".to_string()), response.header_value("X-Trace"));
+    assert_eq!("", response.body().string().unwrap());
+  }
+}


### PR DESCRIPTION
rttp_client now exposes empty bodies for 204 and 304 responses even when peers send illegal framing headers or stray bytes, while preserving headers and normal 200 response framing behavior. Required verification passed.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1330/
work_kind: code_work
branch: hbx-1330-rttp-client-treat-204-and
base: main
commit: 39e30051550ac1758957823400bad829d79be82a
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1330/
    url: https://plane.kahub.in/endless/browse/HBX-1330/
    close_policy: link_only
```