### PR TITLE
feat: [rttp_client] Reject malformed chunked response bodies with clear errors

### DIFF
--- a/rttp_client/src/connection/connection_reader.rs
+++ b/rttp_client/src/connection/connection_reader.rs
@@ -264,7 +264,7 @@ where
       let mut body_reader = ResponseBodyReader::new(reader, ResponseBodyKind::Chunked);
       body_reader
         .read_to_end(&mut binary)
-        .map_err(error::request)?;
+        .map_err(response_body_read_error)?;
       trailers = body_reader.trailers().clone();
     }
     ResponseBodyKind::ContentLength(content_length) => {
@@ -272,7 +272,7 @@ where
         ResponseBodyReader::new(reader, ResponseBodyKind::ContentLength(content_length));
       body_reader
         .read_to_end(&mut binary)
-        .map_err(error::request)?;
+        .map_err(response_body_read_error)?;
     }
     ResponseBodyKind::UntilEof => {
       reader.read_to_end(&mut binary).map_err(error::request)?;
@@ -608,8 +608,19 @@ fn to_io_error(err: error::Error) -> io::Error {
     .map(|source| source.kind())
   {
     io::Error::new(kind, err)
+  } else if let Some(source) = std::error::Error::source(&err) {
+    io::Error::new(io::ErrorKind::InvalidData, source.to_string())
   } else {
     io::Error::new(io::ErrorKind::InvalidData, err)
+  }
+}
+
+fn response_body_read_error(err: io::Error) -> error::Error {
+  match err.kind() {
+    io::ErrorKind::InvalidData | io::ErrorKind::UnexpectedEof => {
+      error::bad_response(err.to_string())
+    }
+    _ => error::request(err),
   }
 }
 

--- a/rttp_client/tests/test_http_async.rs
+++ b/rttp_client/tests/test_http_async.rs
@@ -313,6 +313,36 @@ fn test_async_chunked_malformed_extension_is_rejected() {
 
 #[test]
 #[cfg(feature = "async")]
+fn test_async_chunked_malformed_size_is_rejected_as_response_error() {
+  let (addr, _handle) = support::spawn_chunked_response_server(concat!(
+    "HTTP/1.1 200 OK\r\n",
+    "Transfer-Encoding: chunked\r\n",
+    "Connection: close\r\n",
+    "\r\n",
+    "z\r\n",
+    "OK\r\n",
+    "0\r\n",
+    "\r\n"
+  ));
+
+  block_on(async {
+    let error = client()
+      .get()
+      .url(format!("http://{}/chunked", addr))
+      .rasync()
+      .await
+      .expect_err("malformed chunk size should be rejected");
+
+    assert!(
+      error.to_string().starts_with("error receive response")
+        && error.to_string().contains("Invalid chunk size"),
+      "unexpected error: {error}"
+    );
+  });
+}
+
+#[test]
+#[cfg(feature = "async")]
 fn test_async_chunked_missing_crlf_after_chunk_data_is_rejected() {
   let (addr, _handle) = support::spawn_chunked_response_server(concat!(
     "HTTP/1.1 200 OK\r\n",
@@ -334,6 +364,62 @@ fn test_async_chunked_missing_crlf_after_chunk_data_is_rejected() {
 
     assert!(
       error.to_string().contains("Invalid chunk terminator"),
+      "unexpected error: {error}"
+    );
+  });
+}
+
+#[test]
+#[cfg(feature = "async")]
+fn test_async_chunked_missing_final_zero_chunk_is_rejected_as_response_error() {
+  let (addr, _handle) = support::spawn_chunked_response_server(concat!(
+    "HTTP/1.1 200 OK\r\n",
+    "Transfer-Encoding: chunked\r\n",
+    "Connection: close\r\n",
+    "\r\n",
+    "2\r\nOK\r\n"
+  ));
+
+  block_on(async {
+    let error = client()
+      .get()
+      .url(format!("http://{}/chunked", addr))
+      .rasync()
+      .await
+      .expect_err("missing final zero chunk should be rejected");
+
+    assert!(
+      error.to_string().starts_with("error receive response")
+        && error.to_string().contains("Unexpected end of chunked body"),
+      "unexpected error: {error}"
+    );
+  });
+}
+
+#[test]
+#[cfg(feature = "async")]
+fn test_async_chunked_truncated_trailer_block_is_rejected_as_response_error() {
+  let (addr, _handle) = support::spawn_chunked_response_server(concat!(
+    "HTTP/1.1 200 OK\r\n",
+    "Transfer-Encoding: chunked\r\n",
+    "Connection: close\r\n",
+    "\r\n",
+    "2\r\nOK\r\n",
+    "0\r\n",
+    "X-Trace: abc"
+  ));
+
+  block_on(async {
+    let error = client()
+      .get()
+      .url(format!("http://{}/chunked", addr))
+      .rasync()
+      .await
+      .expect_err("truncated chunk trailer block should be rejected");
+
+    assert!(
+      error.to_string().starts_with("error receive response")
+        && error.to_string().contains("Unexpected end of chunked body"),
       "unexpected error: {error}"
     );
   });

--- a/rttp_client/tests/test_http_basic.rs
+++ b/rttp_client/tests/test_http_basic.rs
@@ -401,6 +401,32 @@ fn test_chunked_malformed_extension_is_rejected() {
 }
 
 #[test]
+fn test_chunked_malformed_size_is_rejected_as_response_error() {
+  let (addr, _handle) = support::spawn_chunked_response_server(concat!(
+    "HTTP/1.1 200 OK\r\n",
+    "Transfer-Encoding: chunked\r\n",
+    "Connection: close\r\n",
+    "\r\n",
+    "z\r\n",
+    "OK\r\n",
+    "0\r\n",
+    "\r\n"
+  ));
+
+  let error = client()
+    .get()
+    .url(format!("http://{}/chunked", addr))
+    .emit()
+    .expect_err("malformed chunk size should be rejected");
+
+  assert!(
+    error.to_string().starts_with("error receive response")
+      && error.to_string().contains("Invalid chunk size"),
+    "unexpected error: {error}"
+  );
+}
+
+#[test]
 fn test_chunked_missing_crlf_after_chunk_data_is_rejected() {
   let (addr, _handle) = support::spawn_chunked_response_server(concat!(
     "HTTP/1.1 200 OK\r\n",
@@ -420,6 +446,54 @@ fn test_chunked_missing_crlf_after_chunk_data_is_rejected() {
 
   assert!(
     error.to_string().contains("Invalid chunk terminator"),
+    "unexpected error: {error}"
+  );
+}
+
+#[test]
+fn test_chunked_missing_final_zero_chunk_is_rejected_as_response_error() {
+  let (addr, _handle) = support::spawn_chunked_response_server(concat!(
+    "HTTP/1.1 200 OK\r\n",
+    "Transfer-Encoding: chunked\r\n",
+    "Connection: close\r\n",
+    "\r\n",
+    "2\r\nOK\r\n"
+  ));
+
+  let error = client()
+    .get()
+    .url(format!("http://{}/chunked", addr))
+    .emit()
+    .expect_err("missing final zero chunk should be rejected");
+
+  assert!(
+    error.to_string().starts_with("error receive response")
+      && error.to_string().contains("Unexpected end of chunked body"),
+    "unexpected error: {error}"
+  );
+}
+
+#[test]
+fn test_chunked_truncated_trailer_block_is_rejected_as_response_error() {
+  let (addr, _handle) = support::spawn_chunked_response_server(concat!(
+    "HTTP/1.1 200 OK\r\n",
+    "Transfer-Encoding: chunked\r\n",
+    "Connection: close\r\n",
+    "\r\n",
+    "2\r\nOK\r\n",
+    "0\r\n",
+    "X-Trace: abc"
+  ));
+
+  let error = client()
+    .get()
+    .url(format!("http://{}/chunked", addr))
+    .emit()
+    .expect_err("truncated chunk trailer block should be rejected");
+
+  assert!(
+    error.to_string().starts_with("error receive response")
+      && error.to_string().contains("Unexpected end of chunked body"),
     "unexpected error: {error}"
   );
 }


### PR DESCRIPTION
rttp_client now rejects malformed chunked response bodies consistently across blocking and async paths with response-level errors and regression coverage. Required formatting and test verification passed.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1331/
work_kind: code_work
branch: hbx-1331-rttp-client-reject-malformed-chunked
base: main
commit: a952050542dfaa569092a4e16e48d7e119fd7fa5
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1331/
    url: https://plane.kahub.in/endless/browse/HBX-1331/
    close_policy: link_only
```