### PR TITLE
feat: [rttp] Add server request body support for chunked transfer coding

### DIFF
--- a/rttp/src/server.rs
+++ b/rttp/src/server.rs
@@ -1594,9 +1594,15 @@ impl HttpRequest {
         body_bytes.to_vec()
       }
       RequestBodyKind::Chunked => {
-        return Err(HttpParseError::new(
-          "chunked request body requires streaming reader",
-        ));
+        let mut reader = Cursor::new(body_bytes);
+        let chunked =
+          read_chunked_request_body(&mut reader).map_err(HttpParseError::from_io_error)?;
+        if reader.position() as usize != body_bytes.len() {
+          return Err(HttpParseError::new(
+            "request body length does not match Transfer-Encoding",
+          ));
+        }
+        chunked.body
       }
     };
     let headers = head

--- a/rttp/tests/test_server_models.rs
+++ b/rttp/tests/test_server_models.rs
@@ -40,6 +40,29 @@ fn parses_body_only_when_content_length_matches() {
 }
 
 #[test]
+fn parses_chunked_transfer_coded_request_body() {
+  let raw = concat!(
+    "POST /submit HTTP/1.1\r\n",
+    "Host: example.test\r\n",
+    "Transfer-Encoding: chunked\r\n",
+    "\r\n",
+    "5;foo=bar\r\n",
+    "hello\r\n",
+    "6\r\n",
+    " world\r\n",
+    "0\r\n",
+    "X-Trace: abc\r\n",
+    "\r\n"
+  );
+
+  let request = HttpRequest::parse(raw.as_bytes()).expect("request should parse");
+
+  assert_eq!("POST", request.method());
+  assert_eq!("/submit", request.path());
+  assert_eq!(b"hello world", request.body());
+}
+
+#[test]
 fn parses_fixed_length_request_with_duplicate_matching_content_length() {
   let raw = concat!(
     "POST /submit HTTP/1.1\r\n",


### PR DESCRIPTION
Raw server request parsing now supports chunked transfer-coded bodies using the existing chunk decoder, with regression coverage and full `rttp` package verification passing.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1338/
work_kind: code_work
branch: hbx-1338-rttp-add-server-request-body
base: main
commit: 4100b948996589d4b3058ffde6d5fae028590899
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1338/
    url: https://plane.kahub.in/endless/browse/HBX-1338/
    close_policy: link_only
```