### PR TITLE
feat: [rttp_client] Treat HEAD responses as bodyless while preserving headers

### DIFF
--- a/rttp_client/tests/support/mod.rs
+++ b/rttp_client/tests/support/mod.rs
@@ -12,7 +12,8 @@ use socket2::{Domain, Protocol, Socket, Type};
 #[path = "local_http.rs"]
 mod local_http;
 
-use local_http::{bind_local_http_listener, read_http_request, HTTP_OK_RESPONSE};
+pub use local_http::read_http_request;
+use local_http::{bind_local_http_listener, HTTP_OK_RESPONSE};
 
 fn read_exact_bytes<R: Read>(stream: &mut R, len: usize) -> io::Result<Vec<u8>> {
   let mut bytes = vec![0u8; len];

--- a/rttp_client/tests/test_http_async.rs
+++ b/rttp_client/tests/test_http_async.rs
@@ -48,6 +48,36 @@ fn spawn_async_chunked_upload_capture_server() -> (std::net::SocketAddr, thread:
   (addr, handle)
 }
 
+#[cfg(feature = "async")]
+fn spawn_async_head_metadata_server() -> (std::net::SocketAddr, thread::JoinHandle<Vec<u8>>) {
+  let listener = TcpListener::bind("127.0.0.1:0").expect("bind async HEAD metadata server");
+  let addr = listener
+    .local_addr()
+    .expect("async HEAD metadata server addr");
+  let handle = thread::spawn(move || {
+    let (mut stream, _) = listener
+      .accept()
+      .expect("accept async HEAD metadata request");
+    let request = support::read_http_request(&mut stream);
+    stream
+      .write_all(
+        concat!(
+          "HTTP/1.1 200 OK\r\n",
+          "Content-Length: 7\r\n",
+          "Transfer-Encoding: chunked\r\n",
+          "X-Object-Size: 7\r\n",
+          "Connection: close\r\n",
+          "\r\n",
+          "ignored"
+        )
+        .as_bytes(),
+      )
+      .expect("write async HEAD metadata response");
+    request
+  });
+  (addr, handle)
+}
+
 #[test]
 #[cfg(feature = "async")]
 fn test_async_http() {
@@ -64,6 +94,39 @@ fn test_async_http() {
     assert_eq!("127.0.0.1", response.host());
     println!("{}", response);
   });
+}
+
+#[test]
+#[cfg(feature = "async")]
+fn test_async_head_response_is_bodyless_and_preserves_headers() {
+  let (addr, handle) = spawn_async_head_metadata_server();
+  block_on(async {
+    let response = client()
+      .head()
+      .url(format!("http://{}/metadata", addr))
+      .rasync()
+      .await
+      .expect("async HEAD metadata response");
+
+    assert_eq!("", response.body().string().unwrap());
+    assert_eq!(
+      Some("7"),
+      response.header_value("Content-Length").map(String::as_str)
+    );
+    assert_eq!(
+      Some("chunked"),
+      response
+        .header_value("Transfer-Encoding")
+        .map(String::as_str)
+    );
+    assert_eq!(
+      Some("7"),
+      response.header_value("X-Object-Size").map(String::as_str)
+    );
+  });
+
+  let request = handle.join().expect("async HEAD metadata server thread");
+  assert!(String::from_utf8_lossy(&request).starts_with("HEAD /metadata HTTP/1.1\r\n"));
 }
 
 #[test]

--- a/rttp_client/tests/test_http_basic.rs
+++ b/rttp_client/tests/test_http_basic.rs
@@ -59,6 +59,31 @@ fn spawn_fixed_upload_capture_server() -> (std::net::SocketAddr, thread::JoinHan
   (addr, handle)
 }
 
+fn spawn_head_metadata_server() -> (std::net::SocketAddr, thread::JoinHandle<Vec<u8>>) {
+  let listener = TcpListener::bind("127.0.0.1:0").expect("bind HEAD metadata server");
+  let addr = listener.local_addr().expect("HEAD metadata server addr");
+  let handle = thread::spawn(move || {
+    let (mut stream, _) = listener.accept().expect("accept HEAD metadata request");
+    let request = support::read_http_request(&mut stream);
+    stream
+      .write_all(
+        concat!(
+          "HTTP/1.1 200 OK\r\n",
+          "Content-Length: 7\r\n",
+          "Transfer-Encoding: chunked\r\n",
+          "X-Object-Size: 7\r\n",
+          "Connection: close\r\n",
+          "\r\n",
+          "ignored"
+        )
+        .as_bytes(),
+      )
+      .expect("write HEAD metadata response");
+    request
+  });
+  (addr, handle)
+}
+
 struct FailingReader {
   sent: bool,
 }
@@ -85,6 +110,35 @@ fn test_http() {
   let response = response.unwrap();
   assert_eq!("127.0.0.1", response.host());
   println!("{}", response);
+}
+
+#[test]
+fn test_head_response_is_bodyless_and_preserves_headers() {
+  let (addr, handle) = spawn_head_metadata_server();
+  let response = client()
+    .head()
+    .url(format!("http://{}/metadata", addr))
+    .emit()
+    .expect("HEAD metadata response");
+
+  assert_eq!("", response.body().string().unwrap());
+  assert_eq!(
+    Some("7"),
+    response.header_value("Content-Length").map(String::as_str)
+  );
+  assert_eq!(
+    Some("chunked"),
+    response
+      .header_value("Transfer-Encoding")
+      .map(String::as_str)
+  );
+  assert_eq!(
+    Some("7"),
+    response.header_value("X-Object-Size").map(String::as_str)
+  );
+
+  let request = handle.join().expect("HEAD metadata server thread");
+  assert!(String::from_utf8_lossy(&request).starts_with("HEAD /metadata HTTP/1.1\r\n"));
 }
 
 #[test]


### PR DESCRIPTION
Adds sync and async regression tests ensuring rttp_client treats HEAD responses as bodyless while preserving response headers.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1336/
work_kind: code_work
branch: hbx-1336-rttp-client-treat-head-responses
base: main
commit: ce18adbbe53c3bba4f3e5e9c14a2e0bea5879ce8
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1336/
    url: https://plane.kahub.in/endless/browse/HBX-1336/
    close_policy: link_only
```