### PR TITLE
feat: [rttp_client] Parse interim 1xx responses before the final response

### DIFF
--- a/rttp_client/src/connection/connection.rs
+++ b/rttp_client/src/connection/connection.rs
@@ -10,8 +10,8 @@ use std::sync::Arc;
 use url::Url;
 
 use crate::connection::connection_reader::{
-  is_skippable_informational_status, read_response_header, read_response_parts_after_header,
-  response_status_code, ConnectionReader, ResponseParts,
+  is_skippable_informational_status, read_response_head, read_response_header,
+  read_response_parts_after_header, response_status_code, ConnectionReader, ResponseParts,
 };
 use crate::request::{RawRequest, RequestBody};
 use crate::response::Response;
@@ -593,9 +593,26 @@ where
 
     header.push(byte[0]);
     if header.ends_with(b"\r\n\r\n") {
+      let status_code = proxy_connect_response_status_code(&header)?;
+      if is_skippable_informational_status(status_code) {
+        header.clear();
+        continue;
+      }
       return parse_proxy_connect_response(&header);
     }
   }
+}
+
+fn proxy_connect_response_status_code(header: &[u8]) -> error::Result<u16> {
+  let header = String::from_utf8(header.to_vec())
+    .map_err(|_| error::bad_proxy("parse proxy server response error."))?;
+  header
+    .lines()
+    .next()
+    .and_then(|line| line.split_whitespace().nth(1))
+    .ok_or_else(|| error::bad_proxy("Proxy server response error."))?
+    .parse::<u16>()
+    .map_err(|_| error::bad_proxy("parse proxy server response error."))
 }
 
 pub(crate) fn connect_tcp_stream<A>(addr: A, config: &Config) -> error::Result<std::net::TcpStream>
@@ -777,7 +794,7 @@ impl<'a> Connection<'a> {
     let mut stream = self.block_tcp_stream(&addr)?;
     self.block_write_stream(&mut stream)?;
 
-    let header = read_response_header(&mut stream)?;
+    let header = read_response_head(&mut stream)?;
     let status_code = response_status_code(&header)?;
     match kind {
       HandoffKind::Connect if (200..300).contains(&status_code) => {
@@ -1222,6 +1239,22 @@ mod tests {
     let mut reader = Cursor::new(header);
 
     read_proxy_connect_response(&mut reader).unwrap();
+  }
+
+  #[test]
+  fn test_read_proxy_connect_response_skips_interim_headers() {
+    let raw = concat!(
+      "HTTP/1.1 103 Early Hints\r\n",
+      "Link: </proxy.css>; rel=preload\r\n",
+      "\r\n",
+      "HTTP/1.1 200 Connection Established\r\n",
+      "Proxy-Agent: test\r\n",
+      "\r\n"
+    );
+    let mut reader = Cursor::new(raw.as_bytes());
+
+    read_proxy_connect_response(&mut reader).unwrap();
+    assert_eq!(raw.len() as u64, reader.position());
   }
 
   #[test]

--- a/rttp_client/src/connection/connection_reader.rs
+++ b/rttp_client/src/connection/connection_reader.rs
@@ -235,7 +235,7 @@ where
   read_response_parts_after_header(reader, expect_no_body, binary)
 }
 
-fn read_response_head<R>(reader: &mut R) -> error::Result<Vec<u8>>
+pub(crate) fn read_response_head<R>(reader: &mut R) -> error::Result<Vec<u8>>
 where
   R: Read + ?Sized,
 {

--- a/rttp_client/tests/test_connect_upgrade_handoff.rs
+++ b/rttp_client/tests/test_connect_upgrade_handoff.rs
@@ -100,6 +100,50 @@ fn upgrade_returns_socket_after_101_and_does_not_parse_upgraded_bytes() {
 }
 
 #[test]
+fn upgrade_skips_interim_responses_before_101() {
+  let listener = TcpListener::bind("127.0.0.1:0").expect("bind upgrade server");
+  let addr = listener.local_addr().expect("upgrade server addr");
+
+  let handle = thread::spawn(move || {
+    let (mut stream, _) = listener.accept().expect("accept upgrade");
+    let request = String::from_utf8(read_request_head(&mut stream)).expect("request utf8");
+    assert!(request.starts_with("GET /chat HTTP/1.1\r\n"));
+    stream
+      .write_all(
+        concat!(
+          "HTTP/1.1 103 Early Hints\r\n",
+          "Link: </style.css>; rel=preload\r\n",
+          "\r\n",
+          "HTTP/1.1 101 Switching Protocols\r\n",
+          "Connection: Upgrade\r\n",
+          "Upgrade: websocket\r\n",
+          "\r\n",
+          "server-bytes"
+        )
+        .as_bytes(),
+      )
+      .expect("write interim and final upgrade responses");
+  });
+
+  let mut upgraded = HttpClient::new()
+    .url(format!("http://{}/chat", addr))
+    .header(("Connection", "Upgrade"))
+    .header(("Upgrade", "websocket"))
+    .upgrade()
+    .expect("upgrade connection");
+
+  assert_eq!(101, upgraded.response().code());
+  let mut server_bytes = [0u8; 12];
+  upgraded
+    .stream_mut()
+    .read_exact(&mut server_bytes)
+    .expect("read upgraded server bytes");
+  assert_eq!(b"server-bytes", &server_bytes);
+
+  handle.join().expect("server thread");
+}
+
+#[test]
 fn failed_upgrade_reads_http_response_and_closes_socket() {
   let listener = TcpListener::bind("127.0.0.1:0").expect("bind failed upgrade server");
   let addr = listener.local_addr().expect("failed upgrade server addr");


### PR DESCRIPTION
`rttp_client` now skips interim `1xx` responses before final responses across normal, handoff, and proxy CONNECT response parsing paths, with regression coverage for Upgrade handoff and proxy CONNECT.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1337/
work_kind: code_work
branch: hbx-1337-rttp-client-parse-interim-1xx
base: main
commit: 7cefe88b0722da008c22fa0547a0e96a5a11ecfd
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1337/
    url: https://plane.kahub.in/endless/browse/HBX-1337/
    close_policy: link_only
```