### PR TITLE
feat: [rttp] Handle Expect 100-continue before reading request bodies

### DIFF
--- a/rttp/src/server.rs
+++ b/rttp/src/server.rs
@@ -141,17 +141,24 @@ impl HttpServer {
     let mut served = 0;
 
     while served < request_limit {
-      let request =
-        match self.normalize_connection_error(Request::read_next_from_with_continue(&mut reader)) {
-          Ok(Some(request)) => request,
-          Ok(None) => break,
-          Err(err) if is_bad_request_error(&err) => {
-            self.normalize_connection_error(bad_request_response().write_to(reader.get_mut()))?;
-            served += 1;
-            break;
-          }
-          Err(err) => return Err(err),
-        };
+      let request = match self
+        .normalize_connection_error(Request::read_next_from_with_continue(&mut reader))
+      {
+        Ok(Some(request)) => request,
+        Ok(None) => break,
+        Err(err) if is_expectation_failed_error(&err) => {
+          self
+            .normalize_connection_error(expectation_failed_response().write_to(reader.get_mut()))?;
+          served += 1;
+          break;
+        }
+        Err(err) if is_bad_request_error(&err) => {
+          self.normalize_connection_error(bad_request_response().write_to(reader.get_mut()))?;
+          served += 1;
+          break;
+        }
+        Err(err) => return Err(err),
+      };
       let request_closes_connection = request.closes_connection();
       let request_uses_http10_defaults = request.version() == "HTTP/1.0";
       let request_is_head = request.method() == "HEAD";
@@ -206,6 +213,10 @@ impl HttpServer {
       }),
     ) {
       Ok(request) => request,
+      Err(err) if is_expectation_failed_error(&err) => {
+        return self
+          .normalize_connection_error(expectation_failed_response().write_to(reader.get_mut()));
+      }
       Err(err) if is_bad_request_error(&err) => {
         return self.normalize_connection_error(bad_request_response().write_to(reader.get_mut()));
       }
@@ -233,6 +244,10 @@ impl HttpServer {
       }),
     ) {
       Ok(request) => request,
+      Err(err) if is_expectation_failed_error(&err) => {
+        return self
+          .normalize_connection_error(expectation_failed_response().write_to(reader.get_mut()));
+      }
       Err(err) if is_bad_request_error(&err) => {
         return self.normalize_connection_error(bad_request_response().write_to(reader.get_mut()));
       }
@@ -263,6 +278,10 @@ impl HttpServer {
       }),
     ) {
       Ok(request) => request,
+      Err(err) if is_expectation_failed_error(&err) => {
+        return self
+          .normalize_connection_error(expectation_failed_response().write_to(reader.get_mut()));
+      }
       Err(err) if is_bad_request_error(&err) => {
         return self.normalize_connection_error(bad_request_response().write_to(reader.get_mut()));
       }
@@ -2379,7 +2398,7 @@ fn request_needs_continue(
     if !value.eq_ignore_ascii_case("100-continue") {
       return Err(io::Error::new(
         io::ErrorKind::InvalidData,
-        "unsupported Expect header",
+        UnsupportedExpectation,
       ));
     }
   }
@@ -2718,9 +2737,30 @@ fn is_bad_request_error(err: &io::Error) -> bool {
   )
 }
 
+fn is_expectation_failed_error(err: &io::Error) -> bool {
+  err
+    .get_ref()
+    .is_some_and(|source| source.is::<UnsupportedExpectation>())
+}
+
 fn bad_request_response() -> HttpResponse {
   HttpResponse::new(400, "Bad Request").body("Bad Request")
 }
+
+fn expectation_failed_response() -> HttpResponse {
+  HttpResponse::new(417, "Expectation Failed").body("Expectation Failed")
+}
+
+#[derive(Debug)]
+struct UnsupportedExpectation;
+
+impl fmt::Display for UnsupportedExpectation {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    f.write_str("unsupported Expect header")
+  }
+}
+
+impl Error for UnsupportedExpectation {}
 
 #[cfg(test)]
 mod tests {

--- a/rttp/tests/http11_compliance_matrix.rs
+++ b/rttp/tests/http11_compliance_matrix.rs
@@ -178,3 +178,50 @@ fn live_socket2_server_sends_continue_before_reading_shared_body_fixture() {
 
   handle.join().expect("server thread");
 }
+
+#[test]
+fn live_socket2_server_rejects_unsupported_expectation_without_reading_body() {
+  let server = rttp::Http::server("127.0.0.1:0").expect("bind server");
+  let addr = server.local_addr().expect("server addr");
+  let (tx, rx) = mpsc::channel();
+
+  let handle = thread::spawn(move || {
+    server
+      .accept_one(|request| {
+        tx.send(request.target().to_string())
+          .expect("send unexpected request");
+        HttpResponse::ok("unexpected")
+      })
+      .expect("serve one request");
+  });
+
+  let mut stream = TcpStream::connect(addr).expect("connect server");
+  stream
+    .set_read_timeout(Some(Duration::from_millis(250)))
+    .expect("set read timeout");
+  stream
+    .write_all(
+      concat!(
+        "POST /matrix/unsupported-expect HTTP/1.1\r\n",
+        "Host: example.test\r\n",
+        "Expect: tea-time\r\n",
+        "Content-Length: 12\r\n",
+        "\r\n"
+      )
+      .as_bytes(),
+    )
+    .expect("write unsupported expectation head");
+
+  let mut response = String::new();
+  stream
+    .read_to_string(&mut response)
+    .expect("read expectation failure");
+
+  assert!(response.starts_with("HTTP/1.1 417 Expectation Failed"));
+  assert!(
+    rx.try_recv().is_err(),
+    "unsupported expectation reached the request handler"
+  );
+
+  handle.join().expect("server thread");
+}

--- a/rttp/tests/test_server.rs
+++ b/rttp/tests/test_server.rs
@@ -1097,10 +1097,11 @@ fn server_does_not_send_continue_for_expect_with_zero_content_length() {
 }
 
 #[test]
-fn server_returns_bad_request_for_unsupported_expectation_without_calling_handler() {
+fn server_returns_expectation_failed_for_unsupported_expectation_without_calling_handler() {
   let (response, handler_called) = send_raw_request(
     concat!(
       "POST /submit HTTP/1.1\r\n",
+      "Host: localhost\r\n",
       "Expect: magic\r\n",
       "Content-Length: 5\r\n",
       "\r\n",
@@ -1111,7 +1112,7 @@ fn server_returns_bad_request_for_unsupported_expectation_without_calling_handle
 
   assert!(!handler_called);
   assert_eq!(
-    "HTTP/1.1 400 Bad Request\r\nContent-Length: 11\r\nConnection: close\r\n\r\nBad Request",
+    "HTTP/1.1 417 Expectation Failed\r\nContent-Length: 18\r\nConnection: close\r\n\r\nExpectation Failed",
     response
   );
 }
@@ -1148,8 +1149,7 @@ fn server_rejects_unsupported_expectation_before_body_is_sent() {
     )
     .expect("write request head");
 
-  let expected =
-    b"HTTP/1.1 400 Bad Request\r\nContent-Length: 11\r\nConnection: close\r\n\r\nBad Request";
+  let expected = b"HTTP/1.1 417 Expectation Failed\r\nContent-Length: 18\r\nConnection: close\r\n\r\nExpectation Failed";
   let mut response = vec![0; expected.len()];
   stream
     .read_exact(&mut response)


### PR DESCRIPTION
HTTP/1.1 server Expect handling now sends interim continue for acceptable body requests and returns `417 Expectation Failed` for unsupported expectations without reading the body.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1342/
work_kind: code_work
branch: hbx-1342-rttp-handle-expect-100-continue
base: main
commit: 3bf2974b681d18f54445c17315bcfbb56d1bbeee
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1342/
    url: https://plane.kahub.in/endless/browse/HBX-1342/
    close_policy: link_only
```