### PR TITLE
feat: [rttp] Preserve server-side chunked request trailers for handlers

### DIFF
--- a/rttp/tests/test_server.rs
+++ b/rttp/tests/test_server.rs
@@ -1757,6 +1757,8 @@ fn server_preserves_chunked_request_trailers() {
         "6\r\n body!\r\n",
         "0\r\n",
         "X-Trace: abc\r\n",
+        "x-trace: duplicate\r\n",
+        "MiXeD-Trailer: Case Preserved\r\n",
         "X-Signature: signed\r\n",
         "\r\n"
       )
@@ -1772,11 +1774,16 @@ fn server_preserves_chunked_request_trailers() {
 
   let request: Request = rx.recv().expect("receive parsed request");
   assert_eq!(b"chunked body!", request.body());
+  assert_eq!(Some("chunked"), request.header("Transfer-Encoding"));
+  assert_eq!(None, request.header("X-Trace"));
   assert_eq!(Some("abc"), request.trailer("x-trace"));
+  assert_eq!(Some("Case Preserved"), request.trailer("mixed-trailer"));
   assert_eq!(Some("signed"), request.trailer("X-SIGNATURE"));
   assert_eq!(
     &[
       ("X-Trace".to_string(), "abc".to_string()),
+      ("x-trace".to_string(), "duplicate".to_string()),
+      ("MiXeD-Trailer".to_string(), "Case Preserved".to_string()),
       ("X-Signature".to_string(), "signed".to_string())
     ],
     request.trailers()


### PR DESCRIPTION
Added regression coverage for preserving chunked request trailers separately from headers, including duplicate and mixed-case trailer fields.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1341/
work_kind: code_work
branch: hbx-1341-rttp-preserve-server-side-chunked
base: main
commit: 4fb4c9f1dec5ae9f7e0045f9d05521e31d648dbd
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1341/
    url: https://plane.kahub.in/endless/browse/HBX-1341/
    close_policy: link_only
```