### PR TITLE
feat: [rttp] Accept absolute-form request targets in the HTTP/1.1 server parser

### DIFF
--- a/rttp/src/server.rs
+++ b/rttp/src/server.rs
@@ -2029,10 +2029,11 @@ fn parse_request_head(raw: &[u8]) -> io::Result<RequestHead> {
 
   let headers = parse_header_lines(lines)?;
   validate_host_header(version, target, &headers)?;
+  let target = normalize_request_target(target);
 
   Ok(RequestHead {
     method: method.to_string(),
-    target: target.to_string(),
+    target,
     version: version.to_string(),
     headers,
   })
@@ -2114,6 +2115,26 @@ fn is_absolute_form_target(target: &str) -> bool {
 
   let authority_end = rest.find(['/', '?']).unwrap_or(rest.len());
   is_valid_host_authority(&rest[..authority_end], false)
+}
+
+fn normalize_request_target(target: &str) -> String {
+  if request_target_form(target) != Some(RequestTargetForm::Absolute) {
+    return target.to_string();
+  }
+
+  let (_, rest) = target
+    .split_once("://")
+    .expect("absolute-form target must include a scheme separator");
+  let path_start = rest.find(['/', '?']).unwrap_or(rest.len());
+  let origin = &rest[path_start..];
+
+  if origin.is_empty() {
+    "/".to_string()
+  } else if origin.starts_with('?') {
+    format!("/{origin}")
+  } else {
+    origin.to_string()
+  }
 }
 
 fn is_uri_scheme(scheme: &str) -> bool {

--- a/rttp/tests/test_server.rs
+++ b/rttp/tests/test_server.rs
@@ -191,6 +191,46 @@ fn server_accepts_get_request_and_writes_response() {
 }
 
 #[test]
+fn server_accepts_absolute_form_get_request_as_origin_target() {
+  let server = rttp::Http::server("127.0.0.1:0").expect("bind server");
+  let addr = server.local_addr().expect("server addr");
+  let (tx, rx) = mpsc::channel();
+
+  let handle = thread::spawn(move || {
+    server
+      .accept_one(|request| {
+        tx.send(request).expect("send parsed request");
+        HttpResponse::ok("hello")
+      })
+      .expect("serve one request");
+  });
+
+  let mut stream = TcpStream::connect(addr).expect("connect server");
+  stream
+    .write_all(b"GET http://example.com/a/b?x=1 HTTP/1.1\r\nHost: localhost\r\n\r\n")
+    .expect("write request");
+  stream
+    .shutdown(std::net::Shutdown::Write)
+    .expect("shutdown write");
+
+  let mut response = String::new();
+  stream.read_to_string(&mut response).expect("read response");
+
+  let request: Request = rx.recv().expect("receive parsed request");
+  assert_eq!("GET", request.method());
+  assert_eq!("/a/b?x=1", request.target());
+  assert_eq!("HTTP/1.1", request.version());
+  assert_eq!(Some("localhost"), request.header("host"));
+
+  assert_eq!(
+    "HTTP/1.1 200 OK\r\nContent-Length: 5\r\nConnection: close\r\n\r\nhello",
+    response
+  );
+
+  handle.join().expect("server thread");
+}
+
+#[test]
 fn server_accepts_http2_prior_knowledge_get_and_writes_single_stream_response() {
   let server = rttp::Http::server("127.0.0.1:0").expect("bind server");
   let addr = server.local_addr().expect("server addr");
@@ -2380,7 +2420,7 @@ fn server_rejects_invalid_second_request_target_on_kept_alive_connection() {
         "Connection: keep-alive\r\n",
         "\r\n"
       ),
-      "http://example.test/first",
+      "/first",
     ),
   ] {
     let server = rttp::Http::server("127.0.0.1:0").expect("bind server");

--- a/rttp/tests/test_server_models.rs
+++ b/rttp/tests/test_server_models.rs
@@ -25,6 +25,22 @@ fn parses_http_request_target_headers_and_body() {
 }
 
 #[test]
+fn parses_absolute_form_request_target_as_origin_path_and_query() {
+  let raw = concat!(
+    "GET http://example.com/a/b?x=1 HTTP/1.1\r\n",
+    "Host: proxy.local\r\n",
+    "\r\n"
+  );
+
+  let request = HttpRequest::parse(raw.as_bytes()).expect("request should parse");
+
+  assert_eq!("GET", request.method());
+  assert_eq!("/a/b", request.path());
+  assert_eq!(Some("x=1"), request.query());
+  assert_eq!(Some("proxy.local"), request.header("host"));
+}
+
+#[test]
 fn parses_body_only_when_content_length_matches() {
   let raw = concat!(
     "POST /submit HTTP/1.1\r\n",
@@ -128,6 +144,16 @@ fn rejects_malformed_request_line_and_request_metadata() {
   ] {
     let _error = HttpRequest::parse(raw).expect_err("request should be rejected");
   }
+}
+
+#[test]
+fn rejects_malformed_absolute_form_request_target() {
+  let error = HttpRequest::parse(
+    b"GET http://example.test:port/a/b?x=1 HTTP/1.1\r\nHost: proxy.local\r\n\r\n",
+  )
+  .expect_err("request should be rejected");
+
+  assert_eq!("invalid request target", error.to_string());
 }
 
 #[test]


### PR DESCRIPTION
HTTP/1.1 server parsing now normalizes valid absolute-form targets to origin-form path/query and rejects malformed absolute-form input. Formatter and full workspace tests pass.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1343/
work_kind: code_work
branch: hbx-1343-rttp-accept-absolute-form-request
base: main
commit: 88c321064c3547042de2a6096c4bcdae275d3ec0
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1343/
    url: https://plane.kahub.in/endless/browse/HBX-1343/
    close_policy: link_only
  - kind: other_url
    canonical: http://example.com/a/b?x=1
    url: http://example.com/a/b?x=1
    close_policy: link_only
```