### PR TITLE
feat: [rttp] Enforce HTTP/1.1 Host header requirements on server requests

### DIFF
--- a/rttp/tests/test_server.rs
+++ b/rttp/tests/test_server.rs
@@ -1268,6 +1268,11 @@ fn server_returns_bad_request_for_http_11_request_with_multiple_host_headers_bef
 }
 
 #[test]
+fn server_returns_bad_request_for_http_11_request_with_empty_host_before_handler() {
+  assert_bad_request_without_handler(b"GET / HTTP/1.1\r\nHost: \r\n\r\n");
+}
+
+#[test]
 fn server_accepts_http_10_request_without_host() {
   let (response, handler_called) = send_raw_request(b"GET /legacy HTTP/1.0\r\n\r\n");
 


### PR DESCRIPTION
Added live-server regression coverage for empty HTTP/1.1 Host header rejection before handler dispatch; workspace formatting and tests pass.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1344/
work_kind: code_work
branch: hbx-1344-rttp-enforce-http-1-1
base: main
commit: 88a6da3deed811ed7559cf3e36fef1d347538d07
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1344/
    url: https://plane.kahub.in/endless/browse/HBX-1344/
    close_policy: link_only
```