### PR TITLE
feat: [rttp_client] Respect Connection: close when deciding whether to reuse sockets

### DIFF
--- a/rttp_client/src/connection/async_connection.rs
+++ b/rttp_client/src/connection/async_connection.rs
@@ -14,9 +14,9 @@ use crate::connection::connection::{
   ExpectContinueResult,
 };
 use crate::connection::connection_reader::{
-  is_skippable_informational_status, response_body_kind, response_headers, response_status_code,
-  validate_response_trailer_header, ResponseBodyKind, ResponseParts,
-  MAX_CHUNKED_RESPONSE_LINE_BYTES,
+  is_skippable_informational_status, response_body_kind, response_connection_reusable,
+  response_headers, response_status_code, validate_response_trailer_header, ResponseBodyKind,
+  ResponseParts, MAX_CHUNKED_RESPONSE_LINE_BYTES,
 };
 use crate::error;
 use crate::request::RawRequest;
@@ -62,11 +62,13 @@ impl<'a, S: AsyncRead + Unpin + ?Sized> AsyncStreamingResponse<'a, S> {
   }
 
   async fn read_to_parts(mut self) -> error::Result<ResponseParts> {
+    let connection_reusable = response_connection_reusable(&self.head, &self.body.kind);
     let mut binary = self.head;
     self.body.read_to_end(&mut binary).await?;
     Ok(ResponseParts {
       binary,
       trailers: self.body.trailers().clone(),
+      connection_reusable,
     })
   }
 }
@@ -216,6 +218,7 @@ impl<'a> AsyncConnection<'a> {
 
   pub async fn async_call(mut self) -> error::Result<Response> {
     let mut visited_urls = HashSet::new();
+    let mut reusable_stream: Option<AllowStdIo<TcpStream>> = None;
 
     loop {
       let url = self.conn.url().map_err(error::builder)?;
@@ -225,8 +228,23 @@ impl<'a> AsyncConnection<'a> {
       ));
       let proxy = self.conn.proxy().clone();
       let parts = if let Some(proxy) = proxy.as_ref() {
+        reusable_stream = None;
         self.call_with_proxy(&url, proxy).await?
+      } else if url.scheme() == "http" {
+        let mut stream = match reusable_stream.take() {
+          Some(stream) => stream,
+          None => {
+            let addr = self.conn.addr(&url)?;
+            AllowStdIo::new(self.async_tcp_stream(&addr).await?)
+          }
+        };
+        let parts = self.async_send_http_parts(&url, &mut stream).await?;
+        if parts.connection_reusable {
+          reusable_stream = Some(stream);
+        }
+        parts
       } else {
+        reusable_stream = None;
         self.async_send_parts(&url).await?
       };
 
@@ -247,6 +265,11 @@ impl<'a> AsyncConnection<'a> {
 
           let redirect_url = self.conn.resolve_redirect_url(&url, location)?;
           let strip_sensitive_headers = !self.conn.is_same_origin_url(&url, &redirect_url.url);
+          if !self.conn.is_same_origin_url(&url, &redirect_url.url)
+            || redirect_url.url.scheme() != "http"
+          {
+            reusable_stream = None;
+          }
           self.conn.request_mut().redirect_status_set(response.code());
           let next_visit = (
             self.conn.request().origin().method().to_uppercase(),

--- a/rttp_client/src/connection/block_connection.rs
+++ b/rttp_client/src/connection/block_connection.rs
@@ -1,5 +1,6 @@
 use std::collections::HashSet;
 use std::io::Write;
+use std::net::TcpStream;
 
 use socks::{Socks4Stream, Socks5Stream};
 use url::Url;
@@ -26,6 +27,7 @@ impl<'a> BlockConnection<'a> {
 
   pub fn call(mut self) -> error::Result<Response> {
     let mut visited_urls = HashSet::new();
+    let mut reusable_stream: Option<TcpStream> = None;
 
     loop {
       let url = self.conn.url().map_err(error::builder)?;
@@ -35,8 +37,23 @@ impl<'a> BlockConnection<'a> {
       ));
       let proxy = self.conn.proxy().clone();
       let parts = if let Some(proxy) = proxy.as_ref() {
+        reusable_stream = None;
         self.call_with_proxy(&url, proxy)?
+      } else if url.scheme() == "http" {
+        let mut stream = match reusable_stream.take() {
+          Some(stream) => stream,
+          None => {
+            let addr = self.conn.addr(&url)?;
+            self.conn.block_tcp_stream(&addr)?
+          }
+        };
+        let parts = self.conn.block_send_with_stream_parts(&url, &mut stream)?;
+        if parts.connection_reusable {
+          reusable_stream = Some(stream);
+        }
+        parts
       } else {
+        reusable_stream = None;
         self.conn.block_send_parts(&url)?
       };
 
@@ -60,6 +77,11 @@ impl<'a> BlockConnection<'a> {
 
         let redirect_url = self.conn.resolve_redirect_url(&url, location)?;
         let strip_sensitive_headers = !self.conn.is_same_origin_url(&url, &redirect_url.url);
+        if !self.conn.is_same_origin_url(&url, &redirect_url.url)
+          || redirect_url.url.scheme() != "http"
+        {
+          reusable_stream = None;
+        }
         self.conn.request_mut().redirect_status_set(response.code());
         let next_visit = (
           self.conn.request().origin().method().to_uppercase(),

--- a/rttp_client/src/connection/connection_reader.rs
+++ b/rttp_client/src/connection/connection_reader.rs
@@ -22,6 +22,7 @@ pub(crate) enum ResponseBodyKind {
 pub(crate) struct ResponseParts {
   pub(crate) binary: Vec<u8>,
   pub(crate) trailers: Vec<Header>,
+  pub(crate) connection_reusable: bool,
 }
 
 pub struct StreamingResponse<'a, R: Read + ?Sized> {
@@ -258,7 +259,9 @@ where
   R: Read + ?Sized,
 {
   let mut trailers = Vec::new();
-  match response_body_kind(&binary, expect_no_body)? {
+  let body_kind = response_body_kind(&binary, expect_no_body)?;
+  let connection_reusable = response_connection_reusable(&binary, &body_kind);
+  match body_kind {
     ResponseBodyKind::NoBody => {}
     ResponseBodyKind::Chunked => {
       let mut body_reader = ResponseBodyReader::new(reader, ResponseBodyKind::Chunked);
@@ -278,7 +281,29 @@ where
       reader.read_to_end(&mut binary).map_err(error::request)?;
     }
   }
-  Ok(ResponseParts { binary, trailers })
+  Ok(ResponseParts {
+    binary,
+    trailers,
+    connection_reusable,
+  })
+}
+
+pub(crate) fn response_connection_reusable(header: &[u8], body_kind: &ResponseBodyKind) -> bool {
+  !matches!(body_kind, ResponseBodyKind::UntilEof) && !response_header_has_connection_close(header)
+}
+
+pub(crate) fn response_header_has_connection_close(header: &[u8]) -> bool {
+  response_headers(header)
+    .map(|headers| {
+      headers.iter().any(|header| {
+        header.name().eq_ignore_ascii_case("Connection")
+          && header
+            .value()
+            .split(',')
+            .any(|token| token.trim().eq_ignore_ascii_case("close"))
+      })
+    })
+    .unwrap_or(false)
 }
 
 pub(crate) fn response_headers(header: &[u8]) -> error::Result<Vec<Header>> {

--- a/rttp_client/tests/support/mod.rs
+++ b/rttp_client/tests/support/mod.rs
@@ -512,6 +512,57 @@ pub fn spawn_keep_alive_server() -> (SocketAddr, JoinHandle<()>) {
   (addr, handle)
 }
 
+pub fn spawn_redirect_connection_lifecycle_server(
+  first_response_connection_close: bool,
+) -> (SocketAddr, JoinHandle<Vec<usize>>) {
+  let (listener, addr) = bind_local_http_listener("redirect connection lifecycle server");
+  let handle = thread::spawn(move || {
+    let Ok((mut first_stream, _)) = listener.accept() else {
+      return Vec::new();
+    };
+
+    let mut requests_per_connection = vec![1];
+    let _ = read_http_request(&mut first_stream);
+    let connection_header = if first_response_connection_close {
+      "Connection: close\r\n"
+    } else {
+      ""
+    };
+    let redirect = format!(
+      "HTTP/1.1 302 Found\r\nLocation: /final\r\nContent-Length: 0\r\n{}\r\n",
+      connection_header
+    );
+    let _ = first_stream.write_all(redirect.as_bytes());
+
+    if first_response_connection_close {
+      drop(first_stream);
+    } else {
+      first_stream
+        .set_read_timeout(Some(Duration::from_millis(300)))
+        .expect("set redirect lifecycle read timeout");
+      match read_http_request(&mut first_stream) {
+        request if !request.is_empty() => {
+          requests_per_connection[0] += 1;
+          let _ = first_stream
+            .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 5\r\nConnection: close\r\n\r\nfinal");
+          return requests_per_connection;
+        }
+        _ => {}
+      }
+    }
+
+    let Ok((mut second_stream, _)) = listener.accept() else {
+      return requests_per_connection;
+    };
+    requests_per_connection.push(1);
+    let _ = read_http_request(&mut second_stream);
+    let _ = second_stream
+      .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 5\r\nConnection: close\r\n\r\nfinal");
+    requests_per_connection
+  });
+  (addr, handle)
+}
+
 pub fn spawn_eof_delimited_response_server(body: &'static str) -> (SocketAddr, JoinHandle<()>) {
   let (listener, addr) = bind_local_http_listener("eof delimited response server");
   let handle = thread::spawn(move || {

--- a/rttp_client/tests/test_http_async.rs
+++ b/rttp_client/tests/test_http_async.rs
@@ -628,6 +628,44 @@ fn test_async_content_length_response_does_not_wait_for_eof() {
 
 #[test]
 #[cfg(feature = "async")]
+fn test_async_redirect_reuses_socket_when_connection_close_is_absent() {
+  let (addr, handle) = support::spawn_redirect_connection_lifecycle_server(false);
+  block_on(async {
+    let response = client()
+      .get()
+      .config(Config::builder().auto_redirect(true))
+      .url(format!("http://{}/start", addr))
+      .rasync()
+      .await
+      .unwrap();
+
+    assert_eq!(200, response.code());
+    assert_eq!("final", response.body().string().unwrap());
+  });
+  assert_eq!(vec![2], handle.join().unwrap());
+}
+
+#[test]
+#[cfg(feature = "async")]
+fn test_async_redirect_uses_fresh_socket_after_connection_close() {
+  let (addr, handle) = support::spawn_redirect_connection_lifecycle_server(true);
+  block_on(async {
+    let response = client()
+      .get()
+      .config(Config::builder().auto_redirect(true))
+      .url(format!("http://{}/start", addr))
+      .rasync()
+      .await
+      .unwrap();
+
+    assert_eq!(200, response.code());
+    assert_eq!("final", response.body().string().unwrap());
+  });
+  assert_eq!(vec![1, 1], handle.join().unwrap());
+}
+
+#[test]
+#[cfg(feature = "async")]
 fn test_async_client_skips_100_continue_before_final_response() {
   let (addr, _handle) = support::spawn_continue_then_ok_server();
   block_on(async {

--- a/rttp_client/tests/test_http_basic.rs
+++ b/rttp_client/tests/test_http_basic.rs
@@ -650,6 +650,36 @@ fn test_content_length_response_does_not_wait_for_eof() {
 }
 
 #[test]
+fn test_sync_redirect_reuses_socket_when_connection_close_is_absent() {
+  let (addr, handle) = support::spawn_redirect_connection_lifecycle_server(false);
+  let response = client()
+    .get()
+    .config(Config::builder().auto_redirect(true))
+    .url(format!("http://{}/start", addr))
+    .emit()
+    .unwrap();
+
+  assert_eq!(200, response.code());
+  assert_eq!("final", response.body().string().unwrap());
+  assert_eq!(vec![2], handle.join().unwrap());
+}
+
+#[test]
+fn test_sync_redirect_uses_fresh_socket_after_connection_close() {
+  let (addr, handle) = support::spawn_redirect_connection_lifecycle_server(true);
+  let response = client()
+    .get()
+    .config(Config::builder().auto_redirect(true))
+    .url(format!("http://{}/start", addr))
+    .emit()
+    .unwrap();
+
+  assert_eq!(200, response.code());
+  assert_eq!("final", response.body().string().unwrap());
+  assert_eq!(vec![1, 1], handle.join().unwrap());
+}
+
+#[test]
 fn test_sync_client_skips_100_continue_before_final_response() {
   let (addr, _handle) = support::spawn_continue_then_ok_server();
   let response = client()


### PR DESCRIPTION
Implemented `Connection: close` aware socket lifecycle handling for sync and async rttp_client redirect follow-ups, with regression coverage for fresh-socket and keep-alive reuse behavior.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1348/
work_kind: code_work
branch: hbx-1348-rttp-client-respect-connection-close
base: main
commit: 6a105fce966c91b1f64e3cd88bf6091641a86cfc
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1348/
    url: https://plane.kahub.in/endless/browse/HBX-1348/
    close_policy: link_only
```