### PR TITLE
feat: [rttp] Reject obsolete folded request headers in the server parser

### DIFF
--- a/rttp/tests/http11_compliance_matrix.rs
+++ b/rttp/tests/http11_compliance_matrix.rs
@@ -40,6 +40,15 @@ fn model_parser_rejects_shared_framing_ambiguity_fixtures() {
 }
 
 #[test]
+fn model_parser_rejects_shared_obsolete_line_folding_fixtures() {
+  for fixture in fixtures::request::obsolete_line_folding_cases() {
+    let error = HttpRequest::parse(fixture.raw).expect_err(fixture.name);
+
+    assert_eq!(fixture.error, error.to_string(), "{}", fixture.name);
+  }
+}
+
+#[test]
 fn live_socket2_server_accepts_shared_chunk_extensions_and_trailers_fixture() {
   let fixture = fixtures::request::chunked_with_extensions_and_trailers();
   let server = rttp::Http::server("127.0.0.1:0").expect("bind server");

--- a/rttp/tests/test_server.rs
+++ b/rttp/tests/test_server.rs
@@ -1345,7 +1345,7 @@ fn server_returns_bad_request_for_header_name_with_whitespace() {
 #[test]
 fn server_returns_bad_request_for_obsolete_folded_header() {
   assert_bad_request_without_handler(
-    b"GET / HTTP/1.1\r\nHost: localhost\r\n folded: value\r\n\r\n",
+    b"GET / HTTP/1.1\r\nHost: localhost\r\nX-Test: one\r\n two\r\n\r\n",
   );
 }
 

--- a/rttp_http11_test_fixtures/src/lib.rs
+++ b/rttp_http11_test_fixtures/src/lib.rs
@@ -88,6 +88,21 @@ pub mod request {
     ]
   }
 
+  pub fn obsolete_line_folding_cases() -> &'static [InvalidRequest] {
+    &[
+      InvalidRequest {
+        name: "space-prefixed folded request header",
+        raw: b"GET /matrix HTTP/1.1\r\nHost: example.test\r\nX-Test: one\r\n two\r\n\r\n",
+        error: "invalid request header",
+      },
+      InvalidRequest {
+        name: "tab-prefixed folded request header",
+        raw: b"GET /matrix HTTP/1.1\r\nHost: example.test\r\nX-Test: one\r\n\ttwo\r\n\r\n",
+        error: "invalid request header",
+      },
+    ]
+  }
+
   pub fn chunked_with_extensions_and_trailers() -> ChunkedRequest {
     ChunkedRequest {
       raw: concat!(


### PR DESCRIPTION
Adds explicit parser and live-server coverage ensuring obsolete folded HTTP/1.1 request headers are rejected with `400 Bad Request` before application handlers run.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1346/
work_kind: code_work
branch: hbx-1346-rttp-reject-obsolete-folded-request
base: main
commit: caf4ad20118f1af990be8a4a4a223e296ccea271
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1346/
    url: https://plane.kahub.in/endless/browse/HBX-1346/
    close_policy: link_only
```