### PR TITLE
feat: [rttp] Reject unsupported HTTP versions in server request lines

### DIFF
--- a/rttp/tests/test_server.rs
+++ b/rttp/tests/test_server.rs
@@ -1246,8 +1246,14 @@ fn server_returns_bad_request_for_malformed_request_line() {
 }
 
 #[test]
-fn server_returns_bad_request_for_invalid_http_version() {
-  assert_bad_request_without_handler(b"GET / HTTP/2.0\r\nHost: localhost\r\n\r\n");
+fn server_returns_bad_request_for_unsupported_and_malformed_http_versions() {
+  for raw in [
+    b"GET / HTTP/0.9\r\nHost: localhost\r\n\r\n".as_slice(),
+    b"GET / HTTP/2.0\r\nHost: localhost\r\n\r\n",
+    b"GET / HTP/1.1\r\nHost: localhost\r\n\r\n",
+  ] {
+    assert_bad_request_without_handler(raw);
+  }
 }
 
 #[test]

--- a/rttp/tests/test_server_models.rs
+++ b/rttp/tests/test_server_models.rs
@@ -118,7 +118,6 @@ fn rejects_request_body_longer_than_content_length() {
 fn rejects_malformed_request_line_and_request_metadata() {
   for raw in [
     b"GET  HTTP/1.1\r\nHost: example.test\r\n\r\n".as_slice(),
-    b"GET / HTTP/2.0\r\nHost: example.test\r\n\r\n",
     b"GE(T / HTTP/1.1\r\nHost: example.test\r\n\r\n",
     b"GET /bad path HTTP/1.1\r\nHost: example.test\r\n\r\n",
     b"GET http://:80/path HTTP/1.1\r\nHost: example.test\r\n\r\n",
@@ -127,6 +126,19 @@ fn rejects_malformed_request_line_and_request_metadata() {
     b"CONNECT example.test:port HTTP/1.1\r\nHost: example.test\r\n\r\n",
   ] {
     let _error = HttpRequest::parse(raw).expect_err("request should be rejected");
+  }
+}
+
+#[test]
+fn rejects_unsupported_and_malformed_http_version_tokens() {
+  for raw in [
+    b"GET / HTTP/0.9\r\nHost: example.test\r\n\r\n".as_slice(),
+    b"GET / HTTP/2.0\r\nHost: example.test\r\n\r\n",
+    b"GET / HTP/1.1\r\nHost: example.test\r\n\r\n",
+  ] {
+    let error = HttpRequest::parse(raw).expect_err("request should be rejected");
+
+    assert_eq!("invalid request version", error.to_string());
   }
 }
 


### PR DESCRIPTION
Added explicit parser and live-server regression coverage for rejecting unsupported HTTP request-line versions before handler dispatch.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1350/
work_kind: code_work
branch: hbx-1350-rttp-reject-unsupported-http-versions
base: main
commit: 1d480082582f0d773bee089fb88b6185c9cc68e6
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1350/
    url: https://plane.kahub.in/endless/browse/HBX-1350/
    close_policy: link_only
```