### PR TITLE
feat: [rttp_client] Reject malformed response header lines without a colon

### DIFF
--- a/rttp_client/src/connection/async_connection.rs
+++ b/rttp_client/src/connection/async_connection.rs
@@ -1166,4 +1166,34 @@ mod tests {
       );
     });
   }
+
+  #[test]
+  fn async_streaming_response_rejects_malformed_header_without_colon() {
+    block_on(async {
+      let raw = concat!(
+        "HTTP/1.1 200 OK\r\n",
+        "BrokenHeader\r\n",
+        "Content-Length: 2\r\n",
+        "\r\n",
+        "OK"
+      );
+      let mut cursor = AllowStdIo::new(Cursor::new(raw.as_bytes()));
+      let head = async_read_response_head(&mut cursor).await.unwrap();
+
+      let error = match async_streaming_response_after_header(&mut cursor, false, head).await {
+        Ok(_) => panic!("malformed response header should be rejected"),
+        Err(error) => error,
+      };
+
+      assert!(
+        error.to_string().contains("Invalid response header"),
+        "unexpected error: {error}"
+      );
+      assert_eq!(
+        (raw.len() - "OK".len()) as u64,
+        cursor.get_ref().position(),
+        "malformed response headers must be rejected before body bytes are consumed"
+      );
+    });
+  }
 }

--- a/rttp_client/src/connection/connection_reader.rs
+++ b/rttp_client/src/connection/connection_reader.rs
@@ -282,6 +282,7 @@ where
 }
 
 pub(crate) fn response_headers(header: &[u8]) -> error::Result<Vec<Header>> {
+  validate_response_header_lines(header)?;
   let header = String::from_utf8(header.to_vec()).map_err(error::response)?;
   Ok(
     header
@@ -338,6 +339,8 @@ pub(crate) fn response_body_kind(
   header: &[u8],
   expect_no_body: bool,
 ) -> error::Result<ResponseBodyKind> {
+  validate_response_header_lines(header)?;
+
   if expect_no_body {
     return Ok(ResponseBodyKind::NoBody);
   }
@@ -412,6 +415,23 @@ pub(crate) fn response_body_kind(
   } else {
     Ok(ResponseBodyKind::UntilEof)
   }
+}
+
+fn validate_response_header_lines(header: &[u8]) -> error::Result<()> {
+  let header = match header
+    .windows(HEADER_END.len())
+    .position(|w| w == HEADER_END)
+  {
+    Some(header_end) => &header[..header_end],
+    None => header,
+  };
+  let header = String::from_utf8_lossy(header);
+  for line in header.lines().skip(1).filter(|line| !line.is_empty()) {
+    if !line.contains(':') {
+      return Err(error::bad_response("Invalid response header"));
+    }
+  }
+  Ok(())
 }
 
 fn read_bounded_crlf_line<R>(reader: &mut R, max_len: usize) -> error::Result<Vec<u8>>
@@ -870,6 +890,34 @@ mod tests {
     assert!(
       error.to_string().contains("Invalid trailer header"),
       "unexpected error: {error}"
+    );
+  }
+
+  #[test]
+  fn test_malformed_response_header_without_colon_is_rejected_before_body() {
+    let raw = concat!(
+      "HTTP/1.1 200 OK\r\n",
+      "BrokenHeader\r\n",
+      "Content-Length: 2\r\n",
+      "\r\n",
+      "OK"
+    );
+    let url = url::Url::parse("http://localhost").unwrap();
+    let mut cursor = Cursor::new(raw.as_bytes());
+    let mut reader = ConnectionReader::new(&url, &mut cursor, false);
+
+    let error = reader
+      .response()
+      .expect_err("malformed response header should be rejected");
+
+    assert!(
+      error.to_string().contains("Invalid response header"),
+      "unexpected error: {error}"
+    );
+    assert_eq!(
+      (raw.len() - "OK".len()) as u64,
+      cursor.position(),
+      "malformed response headers must be rejected before body bytes are consumed"
     );
   }
 

--- a/rttp_client/src/response/raw_response.rs
+++ b/rttp_client/src/response/raw_response.rs
@@ -210,6 +210,17 @@ impl Parser {
       .code(status_code)
       .reason(reason);
 
+    for header_line in parts
+      .iter()
+      .skip(1)
+      .map(|part| part.trim_end_matches('\r'))
+      .filter(|part| !part.is_empty())
+    {
+      if !header_line.contains(':') {
+        return Err(error::bad_response("Invalid response header"));
+      }
+    }
+
     let headers = parts
       .iter()
       .enumerate()

--- a/rttp_client/tests/test_http_async.rs
+++ b/rttp_client/tests/test_http_async.rs
@@ -554,6 +554,33 @@ fn test_async_malformed_chunked_response_trailer_is_rejected() {
 
 #[test]
 #[cfg(feature = "async")]
+fn test_async_malformed_response_header_without_colon_is_rejected() {
+  let response = concat!(
+    "HTTP/1.1 200 OK\r\n",
+    "BrokenHeader\r\n",
+    "Content-Length: 2\r\n",
+    "Connection: close\r\n",
+    "\r\n",
+    "OK"
+  );
+  let (addr, _handle) = support::spawn_chunked_response_server(response);
+  block_on(async {
+    let error = client()
+      .get()
+      .url(format!("http://{}/broken", addr))
+      .rasync()
+      .await
+      .expect_err("malformed response header should be rejected");
+
+    assert!(
+      error.to_string().contains("Invalid response header"),
+      "unexpected error: {error}"
+    );
+  });
+}
+
+#[test]
+#[cfg(feature = "async")]
 fn test_async_duplicate_set_cookie_headers_are_preserved() {
   let (addr, _handle) = support::spawn_duplicate_set_cookie_server();
   block_on(async {

--- a/rttp_client/tests/test_http_basic.rs
+++ b/rttp_client/tests/test_http_basic.rs
@@ -584,6 +584,30 @@ fn test_forbidden_chunked_response_trailer_is_rejected() {
 }
 
 #[test]
+fn test_malformed_response_header_without_colon_is_rejected() {
+  let response = concat!(
+    "HTTP/1.1 200 OK\r\n",
+    "BrokenHeader\r\n",
+    "Content-Length: 2\r\n",
+    "Connection: close\r\n",
+    "\r\n",
+    "OK"
+  );
+  let (addr, _handle) = support::spawn_chunked_response_server(response);
+
+  let error = client()
+    .get()
+    .url(format!("http://{}/broken", addr))
+    .emit()
+    .expect_err("malformed response header should be rejected");
+
+  assert!(
+    error.to_string().contains("Invalid response header"),
+    "unexpected error: {error}"
+  );
+}
+
+#[test]
 fn test_duplicate_set_cookie_headers_are_preserved() {
   let (addr, _handle) = support::spawn_duplicate_set_cookie_server();
   let response = client()

--- a/rttp_client/tests/test_response.rs
+++ b/rttp_client/tests/test_response.rs
@@ -107,6 +107,25 @@ fn test_parse_response_preserves_duplicate_headers_with_case_insensitive_lookup(
 }
 
 #[test]
+fn test_parse_response_rejects_header_without_colon() {
+  let s = concat!(
+    "HTTP/1.1 200 OK\r\n",
+    "BrokenHeader\r\n",
+    "Content-Length: 2\r\n",
+    "\r\n",
+    "OK"
+  );
+
+  let error = Response::new(RoUrl::with("https://example.test"), s.as_bytes().to_vec())
+    .expect_err("malformed response header should be rejected");
+
+  assert!(
+    error.to_string().contains("Invalid response header"),
+    "unexpected error: {error}"
+  );
+}
+
+#[test]
 fn test_parse_response_1() {
   let s = "HTTP/1.1 200 OK\r\n\
   Access-Control-Allow-Credentials: true\r\n\


### PR DESCRIPTION
Hardened `rttp_client` HTTP/1.1 response parsing to reject colonless malformed header lines before body decoding, with sync, async, streaming, and raw parser coverage.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1349/
work_kind: code_work
branch: hbx-1349-rttp-client-reject-malformed-response
base: main
commit: 9d93e3d5299feb8e800a8a34bcf7d7389f26be3f
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1349/
    url: https://plane.kahub.in/endless/browse/HBX-1349/
    close_policy: link_only
```