### PR TITLE
feat: [rttp] Reject divergent duplicate Content-Length request headers

### DIFF
--- a/rttp/src/server.rs
+++ b/rttp/src/server.rs
@@ -2760,6 +2760,46 @@ mod tests {
   }
 
   #[test]
+  fn read_next_from_rejects_conflicting_duplicate_content_length() {
+    let raw = concat!(
+      "POST /upload HTTP/1.1\r\n",
+      "Host: example.test\r\n",
+      "Content-Length: 5\r\n",
+      "Content-Length: 6\r\n",
+      "\r\n",
+      "hello!"
+    );
+    let mut reader = BufReader::new(Cursor::new(raw.as_bytes()));
+
+    let error =
+      Request::read_next_from(&mut reader).expect_err("conflicting Content-Length should fail");
+
+    assert_eq!(io::ErrorKind::InvalidData, error.kind());
+    assert_eq!("conflicting Content-Length headers", error.to_string());
+  }
+
+  #[test]
+  fn read_next_from_accepts_duplicate_matching_content_length() {
+    let raw = concat!(
+      "POST /upload HTTP/1.1\r\n",
+      "Host: example.test\r\n",
+      "Content-Length: 5\r\n",
+      "Content-Length: 5\r\n",
+      "\r\n",
+      "hello"
+    );
+    let mut reader = BufReader::new(Cursor::new(raw.as_bytes()));
+
+    let request = Request::read_next_from(&mut reader)
+      .expect("matching duplicate Content-Length should parse")
+      .expect("request should be present");
+
+    assert_eq!("POST", request.method());
+    assert_eq!("/upload", request.target());
+    assert_eq!(b"hello", request.body());
+  }
+
+  #[test]
   fn read_next_from_consumes_one_chunked_request_at_a_time() {
     let raw = concat!(
       "POST /first HTTP/1.1\r\n",


### PR DESCRIPTION
Parser-level duplicate `Content-Length` coverage was added for divergent rejection and matching-value acceptance. Live socket behavior and valid single-length request handling were verified by the existing server tests. Formatting and full workspace tests passed.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1352/
work_kind: code_work
branch: hbx-1352-rttp-reject-divergent-duplicate-content
base: main
commit: 70afbbafe2c4037f08a4f5a7fc3abb4b93c128ec
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1352/
    url: https://plane.kahub.in/endless/browse/HBX-1352/
    close_policy: link_only
```