### PR TITLE
feat: [rttp] Reject Transfer-Encoding plus Content-Length on server requests

### DIFF
--- a/rttp/tests/test_server.rs
+++ b/rttp/tests/test_server.rs
@@ -585,6 +585,51 @@ fn streaming_handler_can_reject_before_reading_request_body() {
 }
 
 #[test]
+fn streaming_handler_is_not_invoked_for_transfer_encoding_with_content_length() {
+  let server = rttp::Http::server("127.0.0.1:0").expect("bind server");
+  let addr = server.local_addr().expect("server addr");
+  let (tx, rx) = mpsc::channel();
+
+  let handle = thread::spawn(move || {
+    server
+      .accept_one_streaming(|_request, _body| {
+        tx.send(()).expect("send unexpected handler invocation");
+        HttpResponse::ok("unexpected")
+      })
+      .expect("serve streaming request");
+  });
+
+  let mut stream = TcpStream::connect(addr).expect("connect server");
+  stream
+    .write_all(
+      concat!(
+        "POST /upload HTTP/1.1\r\n",
+        "Host: localhost\r\n",
+        "Transfer-Encoding: chunked\r\n",
+        "Content-Length: 0\r\n",
+        "\r\n",
+        "0\r\n\r\n"
+      )
+      .as_bytes(),
+    )
+    .expect("write request");
+  stream
+    .shutdown(std::net::Shutdown::Write)
+    .expect("shutdown write");
+
+  let mut response = String::new();
+  stream.read_to_string(&mut response).expect("read response");
+
+  assert!(rx.try_recv().is_err());
+  assert_eq!(
+    "HTTP/1.1 400 Bad Request\r\nContent-Length: 11\r\nConnection: close\r\n\r\nBad Request",
+    response
+  );
+
+  handle.join().expect("server thread");
+}
+
+#[test]
 fn server_bind_falls_back_to_later_candidate_when_first_addr_is_occupied() {
   let (_occupied_listener, occupied_addr) = reserve_local_addr();
   let (available_listener, available_addr) = reserve_local_addr();


### PR DESCRIPTION
Added live socket regression coverage proving ambiguous HTTP/1.1 request framing is rejected before the streaming handler is invoked. Formatting and workspace tests pass.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1353/
work_kind: code_work
branch: hbx-1353-rttp-reject-transfer-encoding-plus
base: main
commit: ad6a5c71e96034e26acd592655a8d0b67a4453cf
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1353/
    url: https://plane.kahub.in/endless/browse/HBX-1353/
    close_policy: link_only
```