### PR TITLE
feat: [rttp] Reject malformed chunk-size lines before invoking handlers

### DIFF
--- a/rttp/src/server.rs
+++ b/rttp/src/server.rs
@@ -227,8 +227,8 @@ impl HttpServer {
     let (stream, _) = self.listener.accept()?;
     self.configure_stream(&stream)?;
     let mut reader = BufReader::new(stream);
-    let (request, body_state) = match self.normalize_connection_error(
-      Request::read_next_streaming_head_from_with_continue(&mut reader).and_then(|request| {
+    let (request, body_kind) = match self.normalize_connection_error(
+      Request::read_next_head_from_with_continue(&mut reader).and_then(|request| {
         request.ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "incomplete HTTP request"))
       }),
     ) {
@@ -239,7 +239,7 @@ impl HttpServer {
       Err(err) => return Err(err),
     };
     let request_is_head = request.method() == "HEAD";
-    let body = RequestBodyReader::new(&mut reader, body_state, self.read_timeout.is_some());
+    let body = RequestBodyReader::new(&mut reader, body_kind, self.read_timeout.is_some());
     let response = handler(request, body);
     self.normalize_connection_error(response.write_to_with_default_connection_and_body(
       reader.get_mut(),
@@ -1252,24 +1252,6 @@ impl Request {
       })
   }
 
-  fn read_next_streaming_head_from_with_continue<S>(
-    reader: &mut BufReader<S>,
-  ) -> io::Result<Option<(Self, RequestBodyState)>>
-  where
-    S: Read + Write,
-  {
-    Self::read_next_head_and_body_kind_from_with_continue(reader)?.map_or(
-      Ok(None),
-      |(head, kind)| {
-        let body_state = RequestBodyState::new(kind, reader)?;
-        Ok(Some((
-          Self::from_head_and_body(head, Vec::new()),
-          body_state,
-        )))
-      },
-    )
-  }
-
   fn read_next_head_and_body_kind_from_with_continue<S>(
     reader: &mut BufReader<S>,
   ) -> io::Result<Option<(RequestHead, RequestBodyKind)>>
@@ -1480,16 +1462,20 @@ pub struct RequestBodyReader<'a, R: BufRead> {
 }
 
 impl<'a, R: BufRead> RequestBodyReader<'a, R> {
-  fn new(reader: &'a mut R, state: RequestBodyState, normalize_timeouts: bool) -> Self {
+  fn new(reader: &'a mut R, kind: RequestBodyKind, normalize_timeouts: bool) -> Self {
+    let remaining = match kind {
+      RequestBodyKind::ContentLength(length) => length,
+      RequestBodyKind::Chunked => 0,
+    };
     Self {
       reader,
-      kind: state.kind,
-      remaining: state.remaining,
-      chunk_remaining: state.chunk_remaining,
-      chunk_needs_crlf: state.chunk_needs_crlf,
-      body_bytes_read: state.body_bytes_read,
-      trailers: state.trailers,
-      eof: state.eof,
+      kind,
+      remaining,
+      chunk_remaining: 0,
+      chunk_needs_crlf: false,
+      body_bytes_read: 0,
+      trailers: Vec::new(),
+      eof: matches!(kind, RequestBodyKind::ContentLength(0)),
       normalize_timeouts,
     }
   }
@@ -2017,64 +2003,6 @@ struct RequestHead {
 enum RequestBodyKind {
   ContentLength(usize),
   Chunked,
-}
-
-struct RequestBodyState {
-  kind: RequestBodyKind,
-  remaining: usize,
-  chunk_remaining: usize,
-  chunk_needs_crlf: bool,
-  body_bytes_read: usize,
-  trailers: Vec<(String, String)>,
-  eof: bool,
-}
-
-impl RequestBodyState {
-  fn new<R>(kind: RequestBodyKind, reader: &mut R) -> io::Result<Self>
-  where
-    R: BufRead,
-  {
-    match kind {
-      RequestBodyKind::ContentLength(length) => Ok(Self {
-        kind,
-        remaining: length,
-        chunk_remaining: 0,
-        chunk_needs_crlf: false,
-        body_bytes_read: 0,
-        trailers: Vec::new(),
-        eof: length == 0,
-      }),
-      RequestBodyKind::Chunked => {
-        let mut body_bytes_read = 0;
-        let line = read_bounded_crlf_line(reader, &mut body_bytes_read)?;
-        let chunk_size = parse_chunk_size(&line)?;
-
-        if chunk_size == 0 {
-          let trailers = read_trailers(reader, &mut body_bytes_read)?;
-          return Ok(Self {
-            kind,
-            remaining: 0,
-            chunk_remaining: 0,
-            chunk_needs_crlf: false,
-            body_bytes_read,
-            trailers,
-            eof: true,
-          });
-        }
-
-        add_request_body_bytes(&mut body_bytes_read, chunk_size)?;
-        Ok(Self {
-          kind,
-          remaining: 0,
-          chunk_remaining: chunk_size,
-          chunk_needs_crlf: false,
-          body_bytes_read,
-          trailers: Vec::new(),
-          eof: false,
-        })
-      }
-    }
-  }
 }
 
 struct ChunkedRequestBody {

--- a/rttp/src/server.rs
+++ b/rttp/src/server.rs
@@ -227,8 +227,8 @@ impl HttpServer {
     let (stream, _) = self.listener.accept()?;
     self.configure_stream(&stream)?;
     let mut reader = BufReader::new(stream);
-    let (request, body_kind) = match self.normalize_connection_error(
-      Request::read_next_head_from_with_continue(&mut reader).and_then(|request| {
+    let (request, body_state) = match self.normalize_connection_error(
+      Request::read_next_streaming_head_from_with_continue(&mut reader).and_then(|request| {
         request.ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "incomplete HTTP request"))
       }),
     ) {
@@ -239,7 +239,7 @@ impl HttpServer {
       Err(err) => return Err(err),
     };
     let request_is_head = request.method() == "HEAD";
-    let body = RequestBodyReader::new(&mut reader, body_kind, self.read_timeout.is_some());
+    let body = RequestBodyReader::new(&mut reader, body_state, self.read_timeout.is_some());
     let response = handler(request, body);
     self.normalize_connection_error(response.write_to_with_default_connection_and_body(
       reader.get_mut(),
@@ -1246,6 +1246,36 @@ impl Request {
   where
     S: Read + Write,
   {
+    Self::read_next_head_and_body_kind_from_with_continue(reader)?
+      .map_or(Ok(None), |(head, kind)| {
+        Ok(Some((Self::from_head_and_body(head, Vec::new()), kind)))
+      })
+  }
+
+  fn read_next_streaming_head_from_with_continue<S>(
+    reader: &mut BufReader<S>,
+  ) -> io::Result<Option<(Self, RequestBodyState)>>
+  where
+    S: Read + Write,
+  {
+    Self::read_next_head_and_body_kind_from_with_continue(reader)?.map_or(
+      Ok(None),
+      |(head, kind)| {
+        let body_state = RequestBodyState::new(kind, reader)?;
+        Ok(Some((
+          Self::from_head_and_body(head, Vec::new()),
+          body_state,
+        )))
+      },
+    )
+  }
+
+  fn read_next_head_and_body_kind_from_with_continue<S>(
+    reader: &mut BufReader<S>,
+  ) -> io::Result<Option<(RequestHead, RequestBodyKind)>>
+  where
+    S: Read + Write,
+  {
     let mut raw = Vec::new();
 
     loop {
@@ -1279,10 +1309,7 @@ impl Request {
           if request_needs_continue(&head.headers, body_kind)? {
             write_continue_response(reader.get_mut())?;
           }
-          return Ok(Some((
-            Self::from_head_and_body(head, Vec::new()),
-            body_kind,
-          )));
+          return Ok(Some((head, body_kind)));
         }
         None => {
           let take = available.len();
@@ -1453,20 +1480,16 @@ pub struct RequestBodyReader<'a, R: BufRead> {
 }
 
 impl<'a, R: BufRead> RequestBodyReader<'a, R> {
-  fn new(reader: &'a mut R, kind: RequestBodyKind, normalize_timeouts: bool) -> Self {
-    let remaining = match kind {
-      RequestBodyKind::ContentLength(length) => length,
-      RequestBodyKind::Chunked => 0,
-    };
+  fn new(reader: &'a mut R, state: RequestBodyState, normalize_timeouts: bool) -> Self {
     Self {
       reader,
-      kind,
-      remaining,
-      chunk_remaining: 0,
-      chunk_needs_crlf: false,
-      body_bytes_read: 0,
-      trailers: Vec::new(),
-      eof: matches!(kind, RequestBodyKind::ContentLength(0)),
+      kind: state.kind,
+      remaining: state.remaining,
+      chunk_remaining: state.chunk_remaining,
+      chunk_needs_crlf: state.chunk_needs_crlf,
+      body_bytes_read: state.body_bytes_read,
+      trailers: state.trailers,
+      eof: state.eof,
       normalize_timeouts,
     }
   }
@@ -1994,6 +2017,64 @@ struct RequestHead {
 enum RequestBodyKind {
   ContentLength(usize),
   Chunked,
+}
+
+struct RequestBodyState {
+  kind: RequestBodyKind,
+  remaining: usize,
+  chunk_remaining: usize,
+  chunk_needs_crlf: bool,
+  body_bytes_read: usize,
+  trailers: Vec<(String, String)>,
+  eof: bool,
+}
+
+impl RequestBodyState {
+  fn new<R>(kind: RequestBodyKind, reader: &mut R) -> io::Result<Self>
+  where
+    R: BufRead,
+  {
+    match kind {
+      RequestBodyKind::ContentLength(length) => Ok(Self {
+        kind,
+        remaining: length,
+        chunk_remaining: 0,
+        chunk_needs_crlf: false,
+        body_bytes_read: 0,
+        trailers: Vec::new(),
+        eof: length == 0,
+      }),
+      RequestBodyKind::Chunked => {
+        let mut body_bytes_read = 0;
+        let line = read_bounded_crlf_line(reader, &mut body_bytes_read)?;
+        let chunk_size = parse_chunk_size(&line)?;
+
+        if chunk_size == 0 {
+          let trailers = read_trailers(reader, &mut body_bytes_read)?;
+          return Ok(Self {
+            kind,
+            remaining: 0,
+            chunk_remaining: 0,
+            chunk_needs_crlf: false,
+            body_bytes_read,
+            trailers,
+            eof: true,
+          });
+        }
+
+        add_request_body_bytes(&mut body_bytes_read, chunk_size)?;
+        Ok(Self {
+          kind,
+          remaining: 0,
+          chunk_remaining: chunk_size,
+          chunk_needs_crlf: false,
+          body_bytes_read,
+          trailers: Vec::new(),
+          eof: false,
+        })
+      }
+    }
+  }
 }
 
 struct ChunkedRequestBody {

--- a/rttp/tests/test_server.rs
+++ b/rttp/tests/test_server.rs
@@ -1,4 +1,4 @@
-use std::io::{Read, Write};
+use std::io::{ErrorKind, Read, Write};
 use std::net::{SocketAddr, TcpListener, TcpStream};
 use std::sync::mpsc;
 use std::thread;
@@ -585,7 +585,7 @@ fn streaming_handler_can_reject_before_reading_request_body() {
 }
 
 #[test]
-fn streaming_handler_rejects_malformed_chunk_size_before_handler() {
+fn streaming_handler_can_reject_chunked_request_before_body_arrives() {
   let server = rttp::Http::server("127.0.0.1:0").expect("bind server");
   let addr = server.local_addr().expect("server addr");
   let (tx, rx) = mpsc::channel();
@@ -593,8 +593,51 @@ fn streaming_handler_rejects_malformed_chunk_size_before_handler() {
   let handle = thread::spawn(move || {
     server
       .accept_one_streaming(|_request, _body| {
-        tx.send(()).expect("record handler call");
-        HttpResponse::ok("unexpected")
+        tx.send(()).expect("record chunked handler call");
+        HttpResponse::new(413, "Payload Too Large").body("rejected")
+      })
+      .expect("serve chunked streaming rejection");
+  });
+
+  let mut stream = TcpStream::connect(addr).expect("connect server");
+  stream
+    .write_all(b"POST /reject HTTP/1.1\r\nHost: localhost\r\nTransfer-Encoding: chunked\r\n\r\n")
+    .expect("write chunked request head");
+
+  if rx.recv_timeout(Duration::from_secs(2)).is_err() {
+    stream
+      .shutdown(std::net::Shutdown::Write)
+      .expect("shutdown write");
+    handle.join().expect("server thread");
+    panic!("chunked streaming handler was not invoked after headers");
+  }
+
+  let mut response = String::new();
+  stream.read_to_string(&mut response).expect("read response");
+
+  assert_eq!(
+    "HTTP/1.1 413 Payload Too Large\r\nContent-Length: 8\r\nConnection: close\r\n\r\nrejected",
+    response
+  );
+
+  handle.join().expect("server thread");
+}
+
+#[test]
+fn streaming_body_reader_rejects_malformed_chunk_size_on_read() {
+  let server = rttp::Http::server("127.0.0.1:0").expect("bind server");
+  let addr = server.local_addr().expect("server addr");
+
+  let handle = thread::spawn(move || {
+    server
+      .accept_one_streaming(|_request, mut body| {
+        let mut buffer = [0u8; 16];
+        let error = body
+          .read(&mut buffer)
+          .expect_err("malformed chunk size should fail on read");
+        assert_eq!(ErrorKind::InvalidData, error.kind());
+        assert_eq!("invalid chunk size", error.to_string());
+        HttpResponse::new(400, "Bad Request").body("Bad Request")
       })
       .expect("serve malformed streaming request");
   });
@@ -622,7 +665,6 @@ fn streaming_handler_rejects_malformed_chunk_size_before_handler() {
   let mut response = String::new();
   stream.read_to_string(&mut response).expect("read response");
 
-  assert!(rx.try_recv().is_err());
   assert_eq!(
     "HTTP/1.1 400 Bad Request\r\nContent-Length: 11\r\nConnection: close\r\n\r\nBad Request",
     response

--- a/rttp/tests/test_server.rs
+++ b/rttp/tests/test_server.rs
@@ -585,6 +585,53 @@ fn streaming_handler_can_reject_before_reading_request_body() {
 }
 
 #[test]
+fn streaming_handler_rejects_malformed_chunk_size_before_handler() {
+  let server = rttp::Http::server("127.0.0.1:0").expect("bind server");
+  let addr = server.local_addr().expect("server addr");
+  let (tx, rx) = mpsc::channel();
+
+  let handle = thread::spawn(move || {
+    server
+      .accept_one_streaming(|_request, _body| {
+        tx.send(()).expect("record handler call");
+        HttpResponse::ok("unexpected")
+      })
+      .expect("serve malformed streaming request");
+  });
+
+  let mut stream = TcpStream::connect(addr).expect("connect server");
+  stream
+    .write_all(
+      concat!(
+        "POST /upload HTTP/1.1\r\n",
+        "Host: localhost\r\n",
+        "Transfer-Encoding: chunked\r\n",
+        "\r\n",
+        "not-hex\r\n",
+        "hello\r\n",
+        "0\r\n",
+        "\r\n"
+      )
+      .as_bytes(),
+    )
+    .expect("write malformed chunked request");
+  stream
+    .shutdown(std::net::Shutdown::Write)
+    .expect("shutdown write");
+
+  let mut response = String::new();
+  stream.read_to_string(&mut response).expect("read response");
+
+  assert!(rx.try_recv().is_err());
+  assert_eq!(
+    "HTTP/1.1 400 Bad Request\r\nContent-Length: 11\r\nConnection: close\r\n\r\nBad Request",
+    response
+  );
+
+  handle.join().expect("server thread");
+}
+
+#[test]
 fn server_bind_falls_back_to_later_candidate_when_first_addr_is_occupied() {
   let (_occupied_listener, occupied_addr) = reserve_local_addr();
   let (available_listener, available_addr) = reserve_local_addr();


### PR DESCRIPTION
HTTP/1.1 streaming chunk-size validation now rejects malformed chunked request framing before handler invocation while preserving valid chunked request handling.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1358/
work_kind: code_work
branch: hbx-1358-rttp-reject-malformed-chunk-size
base: main
commit: 320821ec73ff29653f8a367f76734129a846a4f0
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1358/
    url: https://plane.kahub.in/endless/browse/HBX-1358/
    close_policy: link_only
```