### PR TITLE
feat: [rttp] Accept valid chunk extensions in chunked request bodies

### DIFF
--- a/rttp/tests/test_server.rs
+++ b/rttp/tests/test_server.rs
@@ -1688,6 +1688,58 @@ fn server_accepts_small_chunked_request_body() {
 }
 
 #[test]
+fn server_accepts_chunk_extension_without_exposing_extension_metadata() {
+  let server = rttp::Http::server("127.0.0.1:0").expect("bind server");
+  let addr = server.local_addr().expect("server addr");
+  let (tx, rx) = mpsc::channel();
+
+  let handle = thread::spawn(move || {
+    server
+      .accept_one(|request| {
+        tx.send(request).expect("send parsed request");
+        HttpResponse::ok("accepted")
+      })
+      .expect("serve one request");
+  });
+
+  let mut stream = TcpStream::connect(addr).expect("connect server");
+  stream
+    .write_all(
+      concat!(
+        "POST /upload HTTP/1.1\r\n",
+        "Host: localhost\r\n",
+        "Transfer-Encoding: chunked\r\n",
+        "\r\n",
+        "4;foo=bar\r\n",
+        "body\r\n",
+        "0\r\n\r\n"
+      )
+      .as_bytes(),
+    )
+    .expect("write request");
+  stream
+    .shutdown(std::net::Shutdown::Write)
+    .expect("shutdown write");
+
+  let mut response = String::new();
+  stream.read_to_string(&mut response).expect("read response");
+
+  let request: Request = rx.recv().expect("receive parsed request");
+  assert_eq!("POST", request.method());
+  assert_eq!("/upload", request.target());
+  assert_eq!(b"body", request.body());
+  assert_eq!(None, request.header("foo"));
+  assert_eq!(None, request.trailer("foo"));
+  assert!(request.trailers().is_empty());
+  assert_eq!(
+    "HTTP/1.1 200 OK\r\nContent-Length: 8\r\nConnection: close\r\n\r\naccepted",
+    response
+  );
+
+  handle.join().expect("server thread");
+}
+
+#[test]
 fn server_returns_bad_request_for_oversized_chunked_request_body() {
   let server = rttp::Http::server("127.0.0.1:0").expect("bind server");
   let addr = server.local_addr().expect("server addr");


### PR DESCRIPTION
Live HTTP/1.1 server coverage now verifies valid chunk extensions are accepted and discarded from handler-visible metadata while decoded request bodies remain intact.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1357/
work_kind: code_work
branch: hbx-1357-rttp-accept-valid-chunk-extensions
base: main
commit: 4951e0c8e5eb959286baf037a60b5ef5446b9cd7
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1357/
    url: https://plane.kahub.in/endless/browse/HBX-1357/
    close_policy: link_only
```