### PR TITLE
feat: [rttp_client] Accept valid chunk extensions in chunked responses

### DIFF
--- a/rttp_client/tests/test_http_async.rs
+++ b/rttp_client/tests/test_http_async.rs
@@ -94,6 +94,31 @@ fn test_async_chunked() {
 
 #[test]
 #[cfg(feature = "async")]
+fn test_async_chunked_valid_extension_is_ignored() {
+  let (addr, _handle) = support::spawn_chunked_response_server(concat!(
+    "HTTP/1.1 200 OK\r\n",
+    "Transfer-Encoding: chunked\r\n",
+    "Connection: close\r\n",
+    "\r\n",
+    "4;foo=bar\r\nWiki\r\n",
+    "0\r\n",
+    "\r\n"
+  ));
+
+  block_on(async {
+    let response = client()
+      .get()
+      .url(format!("http://{}/chunked", addr))
+      .rasync()
+      .await
+      .unwrap();
+
+    assert_eq!("Wiki", response.body().string().unwrap());
+  });
+}
+
+#[test]
+#[cfg(feature = "async")]
 fn test_async_streaming_chunked_upload_writes_incremental_framing() {
   let (addr, handle) = spawn_async_chunked_upload_capture_server();
   block_on(async {

--- a/rttp_client/tests/test_http_basic.rs
+++ b/rttp_client/tests/test_http_basic.rs
@@ -210,6 +210,27 @@ fn test_chunked() {
 }
 
 #[test]
+fn test_chunked_valid_extension_is_ignored() {
+  let (addr, _handle) = support::spawn_chunked_response_server(concat!(
+    "HTTP/1.1 200 OK\r\n",
+    "Transfer-Encoding: chunked\r\n",
+    "Connection: close\r\n",
+    "\r\n",
+    "4;foo=bar\r\nWiki\r\n",
+    "0\r\n",
+    "\r\n"
+  ));
+
+  let response = client()
+    .get()
+    .url(format!("http://{}/chunked", addr))
+    .emit()
+    .unwrap();
+
+  assert_eq!("Wiki", response.body().string().unwrap());
+}
+
+#[test]
 fn test_socket2_server_chunked_trailers_are_exposed_case_insensitively() {
   let (addr, _handle) = support::spawn_socket2_chunked_trailer_server();
   let response = client()


### PR DESCRIPTION
Added sync and async rttp_client tests covering valid chunk extensions such as `4;foo=bar`; existing parser behavior already accepts the response shape and full workspace verification passes.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1356/
work_kind: code_work
branch: hbx-1356-rttp-client-accept-valid-chunk
base: main
commit: fb43adcbb7f9bda11f268d8d201b2ace0e6df8eb
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1356/
    url: https://plane.kahub.in/endless/browse/HBX-1356/
    close_policy: link_only
```