### PR TITLE
feat: [rttp] Reject malformed chunked trailer header lines before exposing trailers

### DIFF
--- a/rttp/src/server.rs
+++ b/rttp/src/server.rs
@@ -2196,6 +2196,13 @@ fn is_valid_port(port: &str) -> bool {
 fn parse_header_lines<'a>(
   lines: impl Iterator<Item = &'a str>,
 ) -> io::Result<Vec<(String, String)>> {
+  parse_header_lines_with_error(lines, "invalid request header")
+}
+
+fn parse_header_lines_with_error<'a>(
+  lines: impl Iterator<Item = &'a str>,
+  invalid_line_error: &'static str,
+) -> io::Result<Vec<(String, String)>> {
   let mut headers = Vec::new();
 
   for line in lines {
@@ -2205,16 +2212,16 @@ fn parse_header_lines<'a>(
     if line.starts_with(' ') || line.starts_with('\t') {
       return Err(io::Error::new(
         io::ErrorKind::InvalidData,
-        "invalid request header",
+        invalid_line_error,
       ));
     }
     let (name, value) = line
       .split_once(':')
-      .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "invalid request header"))?;
+      .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, invalid_line_error))?;
     if !is_http_token(name) || !value.bytes().all(is_header_value_byte) {
       return Err(io::Error::new(
         io::ErrorKind::InvalidData,
-        "invalid request header",
+        invalid_line_error,
       ));
     }
     headers.push((name.trim().to_string(), value.trim().to_string()));
@@ -2658,7 +2665,7 @@ where
 fn parse_trailer_lines<'a>(
   lines: impl Iterator<Item = &'a str>,
 ) -> io::Result<Vec<(String, String)>> {
-  let trailers = parse_header_lines(lines)?;
+  let trailers = parse_header_lines_with_error(lines, "invalid request trailer")?;
   if trailers
     .iter()
     .any(|(name, _)| is_forbidden_trailer_name(name))

--- a/rttp/tests/test_server.rs
+++ b/rttp/tests/test_server.rs
@@ -674,6 +674,59 @@ fn streaming_body_reader_rejects_malformed_chunk_size_on_read() {
 }
 
 #[test]
+fn streaming_body_reader_rejects_malformed_chunked_trailer_before_exposing_trailers() {
+  let server = rttp::Http::server("127.0.0.1:0").expect("bind server");
+  let addr = server.local_addr().expect("server addr");
+
+  let handle = thread::spawn(move || {
+    server
+      .accept_one_streaming(|_request, mut body| {
+        let mut buffer = Vec::new();
+        let error = body
+          .read_to_end(&mut buffer)
+          .expect_err("malformed chunk trailer should fail on read");
+        assert_eq!(ErrorKind::InvalidData, error.kind());
+        assert_eq!("invalid request trailer", error.to_string());
+        assert!(body.trailers().is_empty());
+        assert_eq!(b"hello", buffer.as_slice());
+        HttpResponse::new(400, "Bad Request").body("Bad Request")
+      })
+      .expect("serve malformed streaming request");
+  });
+
+  let mut stream = TcpStream::connect(addr).expect("connect server");
+  stream
+    .write_all(
+      concat!(
+        "POST /upload HTTP/1.1\r\n",
+        "Host: localhost\r\n",
+        "Transfer-Encoding: chunked\r\n",
+        "\r\n",
+        "5\r\n",
+        "hello\r\n",
+        "0\r\n",
+        "X-Trace abc\r\n",
+        "\r\n"
+      )
+      .as_bytes(),
+    )
+    .expect("write malformed chunked request");
+  stream
+    .shutdown(std::net::Shutdown::Write)
+    .expect("shutdown write");
+
+  let mut response = String::new();
+  stream.read_to_string(&mut response).expect("read response");
+
+  assert_eq!(
+    "HTTP/1.1 400 Bad Request\r\nContent-Length: 11\r\nConnection: close\r\n\r\nBad Request",
+    response
+  );
+
+  handle.join().expect("server thread");
+}
+
+#[test]
 fn server_bind_falls_back_to_later_candidate_when_first_addr_is_occupied() {
   let (_occupied_listener, occupied_addr) = reserve_local_addr();
   let (available_listener, available_addr) = reserve_local_addr();


### PR DESCRIPTION
rttp now rejects malformed chunked request trailer lines before exposing trailers, including the streaming body-reader path, while preserving valid trailer handling. Workspace formatting and tests passed.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1362/
work_kind: code_work
branch: hbx-1362-rttp-reject-malformed-chunked-trailer
base: main
commit: 9a4a8898b9360d0dae8ab54d9c728b5ddeca3f61
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1362/
    url: https://plane.kahub.in/endless/browse/HBX-1362/
    close_policy: link_only
```