### PR TITLE
feat: [rttp_client] Preserve chunked response trailers when chunks use extensions

### DIFF
--- a/rttp_client/tests/test_http_async.rs
+++ b/rttp_client/tests/test_http_async.rs
@@ -94,7 +94,7 @@ fn test_async_chunked() {
 
 #[test]
 #[cfg(feature = "async")]
-fn test_async_chunked_valid_extension_is_ignored() {
+fn test_async_chunked_valid_extension_preserves_trailers_without_leaking_extension() {
   let (addr, _handle) = support::spawn_chunked_response_server(concat!(
     "HTTP/1.1 200 OK\r\n",
     "Transfer-Encoding: chunked\r\n",
@@ -102,6 +102,8 @@ fn test_async_chunked_valid_extension_is_ignored() {
     "\r\n",
     "4;foo=bar\r\nWiki\r\n",
     "0\r\n",
+    "X-Trace: abc\r\n",
+    "X-Signature: signed\r\n",
     "\r\n"
   ));
 
@@ -114,6 +116,17 @@ fn test_async_chunked_valid_extension_is_ignored() {
       .unwrap();
 
     assert_eq!("Wiki", response.body().string().unwrap());
+    assert_eq!(2, response.trailers().len());
+    assert_eq!(
+      Some("abc"),
+      response.trailer("X-TRACE").map(|h| h.value().as_str())
+    );
+    assert_eq!(
+      Some("signed"),
+      response.trailer_value("x-signature").map(String::as_str)
+    );
+    assert!(response.trailer("foo").is_none());
+    assert!(response.trailer_value("foo").is_none());
   });
 }
 

--- a/rttp_client/tests/test_http_basic.rs
+++ b/rttp_client/tests/test_http_basic.rs
@@ -210,7 +210,7 @@ fn test_chunked() {
 }
 
 #[test]
-fn test_chunked_valid_extension_is_ignored() {
+fn test_chunked_valid_extension_preserves_trailers_without_leaking_extension() {
   let (addr, _handle) = support::spawn_chunked_response_server(concat!(
     "HTTP/1.1 200 OK\r\n",
     "Transfer-Encoding: chunked\r\n",
@@ -218,6 +218,8 @@ fn test_chunked_valid_extension_is_ignored() {
     "\r\n",
     "4;foo=bar\r\nWiki\r\n",
     "0\r\n",
+    "X-Trace: abc\r\n",
+    "X-Signature: signed\r\n",
     "\r\n"
   ));
 
@@ -228,6 +230,17 @@ fn test_chunked_valid_extension_is_ignored() {
     .unwrap();
 
   assert_eq!("Wiki", response.body().string().unwrap());
+  assert_eq!(2, response.trailers().len());
+  assert_eq!(
+    Some("abc"),
+    response.trailer("x-trace").map(|h| h.value().as_str())
+  );
+  assert_eq!(
+    Some("signed"),
+    response.trailer_value("X-SIGNATURE").map(String::as_str)
+  );
+  assert!(response.trailer("foo").is_none());
+  assert!(response.trailer_value("foo").is_none());
 }
 
 #[test]


### PR DESCRIPTION
Added explicit sync and async client regression coverage ensuring chunked response trailers are preserved when chunks include valid extensions, without exposing extension metadata.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1360/
work_kind: code_work
branch: hbx-1360-rttp-client-preserve-chunked-response
base: main
commit: d33f6eee0e16ec1aef865b5a95046051028a185f
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1360/
    url: https://plane.kahub.in/endless/browse/HBX-1360/
    close_policy: link_only
```