### PR TITLE
feat: [rttp_client] Preserve explicit absolute-form request targets for proxy-style requests

### DIFF
--- a/rttp_client/tests/test_raw_request_capture.rs
+++ b/rttp_client/tests/test_raw_request_capture.rs
@@ -2,6 +2,7 @@ mod support;
 
 #[cfg(feature = "async")]
 use futures::executor::block_on;
+use rttp_client::types::Proxy;
 use rttp_client::HttpClient;
 use std::time::Duration;
 
@@ -19,6 +20,12 @@ fn capture_optional_request(request: impl FnOnce(String)) -> Vec<u8> {
   let (addr, handle) = support::capture_optional_raw_http_request(Duration::from_millis(250));
   request(format!("http://{}", addr));
   handle.join().expect("optional raw request capture server")
+}
+
+fn capture_proxy_request(request: impl FnOnce(Proxy)) -> Vec<u8> {
+  let (addr, handle) = support::capture_raw_http_request();
+  request(Proxy::http("127.0.0.1", u32::from(addr.port())));
+  handle.join().expect("raw proxy request capture server")
 }
 
 fn request_text(request: &[u8]) -> String {
@@ -63,6 +70,39 @@ fn get_with_query_parameters_sends_request_target_without_body() {
   assert_eq!(None, header_value(&text, "Content-Type"));
   assert_eq!(None, header_value(&text, "Content-Length"));
   assert_eq!(b"", request_body(&request));
+}
+
+#[test]
+fn http_proxy_request_sends_absolute_form_request_target() {
+  let request = capture_proxy_request(|proxy| {
+    client()
+      .get()
+      .url("http://example.test/path?x=1")
+      .proxy(proxy)
+      .emit()
+      .expect("request should succeed");
+  });
+
+  let text = request_text(&request);
+  let request_line = text.lines().next().expect("request line");
+
+  assert_eq!("GET http://example.test/path?x=1 HTTP/1.1", request_line);
+}
+
+#[test]
+fn direct_http_request_sends_origin_form_request_target() {
+  let request = capture_request(|base_url| {
+    client()
+      .get()
+      .url(format!("{}/path?x=1", base_url))
+      .emit()
+      .expect("request should succeed");
+  });
+
+  let text = request_text(&request);
+  let request_line = text.lines().next().expect("request line");
+
+  assert_eq!("GET /path?x=1 HTTP/1.1", request_line);
 }
 
 #[test]


### PR DESCRIPTION
Added sync client regression coverage for absolute-form HTTP proxy request targets while preserving direct origin-form emission.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1367/
work_kind: code_work
branch: hbx-1367-rttp-client-preserve-explicit-absolute
base: main
commit: 316755c019af99040413073c2b1a2699ab8242ca
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1367/
    url: https://plane.kahub.in/endless/browse/HBX-1367/
    close_policy: link_only
  - kind: other_url
    canonical: http://example.test/path?x=1
    url: http://example.test/path?x=1
    close_policy: link_only
```