### PR TITLE
feat: [rttp] Reject authority-form request targets except CONNECT

### DIFF
--- a/rttp/tests/http11_compliance_matrix.rs
+++ b/rttp/tests/http11_compliance_matrix.rs
@@ -89,6 +89,85 @@ fn live_socket2_server_accepts_shared_chunk_extensions_and_trailers_fixture() {
 }
 
 #[test]
+fn live_socket2_server_accepts_shared_origin_and_absolute_form_fixtures() {
+  for fixture in fixtures::request::valid_origin_and_absolute_form_cases() {
+    let server = rttp::Http::server("127.0.0.1:0").expect("bind server");
+    let addr = server.local_addr().expect("server addr");
+    let (tx, rx) = mpsc::channel();
+
+    let handle = thread::spawn(move || {
+      server
+        .accept_one(|request| {
+          tx.send((request.method().to_string(), request.target().to_string()))
+            .expect("send parsed request");
+          HttpResponse::ok(format!("served {}", request.target()))
+        })
+        .expect("serve one request");
+    });
+
+    let mut stream = TcpStream::connect(addr).expect("connect server");
+    stream.write_all(fixture.raw).expect(fixture.name);
+    stream.shutdown(Shutdown::Write).expect("shutdown write");
+
+    let mut response = String::new();
+    stream.read_to_string(&mut response).expect("read response");
+
+    assert_eq!(
+      (fixture.method.to_string(), fixture.target.to_string()),
+      rx.recv().expect("parsed request"),
+      "{}",
+      fixture.name
+    );
+    assert!(
+      response.starts_with("HTTP/1.1 200 OK"),
+      "{} returned {response:?}",
+      fixture.name
+    );
+
+    handle.join().expect("server thread");
+  }
+}
+
+#[test]
+fn live_socket2_server_rejects_shared_invalid_host_and_target_fixtures_before_handler() {
+  for fixture in fixtures::request::invalid_host_and_target_cases() {
+    let server = rttp::Http::server("127.0.0.1:0").expect("bind server");
+    let addr = server.local_addr().expect("server addr");
+    let (tx, rx) = mpsc::channel();
+
+    let handle = thread::spawn(move || {
+      server
+        .accept_one(|request| {
+          tx.send(request.target().to_string())
+            .expect("send unexpected request");
+          HttpResponse::ok("unexpected")
+        })
+        .expect("serve invalid request");
+    });
+
+    let mut stream = TcpStream::connect(addr).expect("connect server");
+    stream.write_all(fixture.raw).expect(fixture.name);
+    stream.shutdown(Shutdown::Write).expect("shutdown write");
+
+    let mut response = String::new();
+    stream.read_to_string(&mut response).expect("read response");
+
+    assert!(
+      rx.try_recv().is_err(),
+      "{} should not dispatch to the handler",
+      fixture.name
+    );
+    assert!(
+      response.starts_with("HTTP/1.1 400 Bad Request"),
+      "{} returned {response:?}",
+      fixture.name
+    );
+
+    handle.join().expect("server thread");
+  }
+}
+
+#[test]
 fn live_socket2_server_preserves_connection_lifetime_boundaries() {
   let server = rttp::Http::server("127.0.0.1:0").expect("bind server");
   let addr = server.local_addr().expect("server addr");

--- a/rttp_http11_test_fixtures/src/lib.rs
+++ b/rttp_http11_test_fixtures/src/lib.rs
@@ -22,6 +22,13 @@ pub mod request {
     pub error: &'static str,
   }
 
+  pub struct TargetFormRequest {
+    pub name: &'static str,
+    pub raw: &'static [u8],
+    pub method: &'static str,
+    pub target: &'static str,
+  }
+
   pub struct ChunkedRequest {
     pub raw: &'static [u8],
     pub method: &'static str,
@@ -66,9 +73,31 @@ pub mod request {
         error: "invalid request target",
       },
       InvalidRequest {
+        name: "non-CONNECT authority-form target",
+        raw: b"GET example.test:443 HTTP/1.1\r\nHost: example.test\r\n\r\n",
+        error: "invalid request target",
+      },
+      InvalidRequest {
         name: "connect authority host mismatch",
         raw: b"CONNECT example.test:443 HTTP/1.1\r\nHost: other.test:443\r\n\r\n",
         error: "invalid Host header",
+      },
+    ]
+  }
+
+  pub fn valid_origin_and_absolute_form_cases() -> &'static [TargetFormRequest] {
+    &[
+      TargetFormRequest {
+        name: "origin-form target",
+        raw: b"GET /matrix/origin?case=shared HTTP/1.1\r\nHost: example.test\r\n\r\n",
+        method: "GET",
+        target: "/matrix/origin?case=shared",
+      },
+      TargetFormRequest {
+        name: "absolute-form target",
+        raw: b"GET http://example.test/matrix/absolute?case=shared HTTP/1.1\r\nHost: proxy.local\r\n\r\n",
+        method: "GET",
+        target: "http://example.test/matrix/absolute?case=shared",
       },
     ]
   }


### PR DESCRIPTION
Added shared HTTP/1.1 fixtures and live socket compliance tests for authority-form rejection outside `CONNECT`, with origin-form and absolute-form regression coverage. Verified with formatter check and full workspace tests.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1364/
work_kind: code_work
branch: hbx-1364-rttp-reject-authority-form-request
base: main
commit: 5e5904cef0f80af5020be6ac553586f129f2d9ad
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1364/
    url: https://plane.kahub.in/endless/browse/HBX-1364/
    close_policy: link_only
```