### PR TITLE
feat: [rttp_client] Treat response Connection close as a terminal socket signal

### DIFF
--- a/rttp_client/src/client.rs
+++ b/rttp_client/src/client.rs
@@ -234,11 +234,15 @@ impl HttpClient {
       ));
     }
     self.request.prepare_streaming_fixed_body(content_length);
-    let request = RawRequest::block_new(&mut self.request)?;
-    BlockConnection::new(request).call_streaming_body(StreamingRequestBody::Fixed {
-      reader: &mut reader,
-      content_length,
-    })
+    let result = (|| {
+      let request = RawRequest::block_new(&mut self.request)?;
+      BlockConnection::new(request).call_streaming_body(StreamingRequestBody::Fixed {
+        reader: &mut reader,
+        content_length,
+      })
+    })();
+    self.request.clear_streaming_body_headers();
+    result
   }
 
   pub fn emit_streaming_chunked<R>(&mut self, mut reader: R) -> error::Result<Response>
@@ -254,10 +258,14 @@ impl HttpClient {
       ));
     }
     self.request.prepare_streaming_chunked_body();
-    let request = RawRequest::block_new(&mut self.request)?;
-    BlockConnection::new(request).call_streaming_body(StreamingRequestBody::Chunked {
-      reader: &mut reader,
-    })
+    let result = (|| {
+      let request = RawRequest::block_new(&mut self.request)?;
+      BlockConnection::new(request).call_streaming_body(StreamingRequestBody::Chunked {
+        reader: &mut reader,
+      })
+    })();
+    self.request.clear_streaming_body_headers();
+    result
   }
 
   pub fn connect(&mut self) -> error::Result<HandoffConnection> {
@@ -328,13 +336,18 @@ impl HttpClient {
       ));
     }
     self.request.prepare_streaming_fixed_body(content_length);
-    let request = RawRequest::async_new(&mut self.request).await?;
-    AsyncConnection::new(request)
-      .async_call_streaming_body(AsyncStreamingRequestBody::Fixed {
-        reader: &mut reader,
-        content_length,
-      })
-      .await
+    let result = async {
+      let request = RawRequest::async_new(&mut self.request).await?;
+      AsyncConnection::new(request)
+        .async_call_streaming_body(AsyncStreamingRequestBody::Fixed {
+          reader: &mut reader,
+          content_length,
+        })
+        .await
+    }
+    .await;
+    self.request.clear_streaming_body_headers();
+    result
   }
 
   #[cfg(feature = "async")]
@@ -351,11 +364,16 @@ impl HttpClient {
       ));
     }
     self.request.prepare_streaming_chunked_body();
-    let request = RawRequest::async_new(&mut self.request).await?;
-    AsyncConnection::new(request)
-      .async_call_streaming_body(AsyncStreamingRequestBody::Chunked {
-        reader: &mut reader,
-      })
-      .await
+    let result = async {
+      let request = RawRequest::async_new(&mut self.request).await?;
+      AsyncConnection::new(request)
+        .async_call_streaming_body(AsyncStreamingRequestBody::Chunked {
+          reader: &mut reader,
+        })
+        .await
+    }
+    .await;
+    self.request.clear_streaming_body_headers();
+    result
   }
 }

--- a/rttp_client/src/connection/async_connection.rs
+++ b/rttp_client/src/connection/async_connection.rs
@@ -14,9 +14,9 @@ use crate::connection::connection::{
   ExpectContinueResult,
 };
 use crate::connection::connection_reader::{
-  is_skippable_informational_status, response_body_kind, response_headers, response_status_code,
-  validate_response_trailer_header, ResponseBodyKind, ResponseParts,
-  MAX_CHUNKED_RESPONSE_LINE_BYTES,
+  is_skippable_informational_status, response_body_kind, response_connection_should_close,
+  response_headers, response_status_code, validate_response_trailer_header, ResponseBodyKind,
+  ResponseParts, MAX_CHUNKED_RESPONSE_LINE_BYTES,
 };
 use crate::error;
 use crate::request::RawRequest;
@@ -62,11 +62,13 @@ impl<'a, S: AsyncRead + Unpin + ?Sized> AsyncStreamingResponse<'a, S> {
   }
 
   async fn read_to_parts(mut self) -> error::Result<ResponseParts> {
+    let close_connection = response_connection_should_close(&self.head)?;
     let mut binary = self.head;
     self.body.read_to_end(&mut binary).await?;
     Ok(ResponseParts {
       binary,
       trailers: self.body.trailers().clone(),
+      close_connection,
     })
   }
 }
@@ -230,13 +232,14 @@ impl<'a> AsyncConnection<'a> {
         self.async_send_parts(&url).await?
       };
 
+      let close_connection = parts.close_connection;
       let response =
         Response::with_trailers(self.conn.rourl().clone(), parts.binary, parts.trailers)?;
       let config = self.conn.config().clone();
 
       if response.is_redirect() {
         let Some(location) = response.location() else {
-          self.conn.closed_set(true);
+          self.conn.closed_set(close_connection);
           return Ok(response);
         };
         if config.auto_redirect() {
@@ -265,7 +268,7 @@ impl<'a> AsyncConnection<'a> {
         }
       }
 
-      self.conn.closed_set(true);
+      self.conn.closed_set(close_connection);
       return Ok(response);
     }
   }
@@ -282,9 +285,10 @@ impl<'a> AsyncConnection<'a> {
 
     let url = self.conn.url().map_err(error::builder)?;
     let parts = self.async_send_streaming_parts(&url, body).await?;
+    let close_connection = parts.close_connection;
     let response =
       Response::with_trailers(self.conn.rourl().clone(), parts.binary, parts.trailers)?;
-    self.conn.closed_set(true);
+    self.conn.closed_set(close_connection);
     Ok(response)
   }
 }

--- a/rttp_client/src/connection/block_connection.rs
+++ b/rttp_client/src/connection/block_connection.rs
@@ -40,17 +40,18 @@ impl<'a> BlockConnection<'a> {
         self.conn.block_send_parts(&url)?
       };
 
+      let close_connection = parts.close_connection;
       let response =
         Response::with_trailers(self.conn.rourl().clone(), parts.binary, parts.trailers)?;
       let config = self.conn.config().clone();
 
       if response.is_redirect() {
         let Some(location) = response.location() else {
-          self.conn.closed_set(true);
+          self.conn.closed_set(close_connection);
           return Ok(response);
         };
         if !config.auto_redirect() {
-          self.conn.closed_set(true);
+          self.conn.closed_set(close_connection);
           return Ok(response);
         }
         let count = self.conn.count();
@@ -77,7 +78,7 @@ impl<'a> BlockConnection<'a> {
         continue;
       }
 
-      self.conn.closed_set(true);
+      self.conn.closed_set(close_connection);
       return Ok(response);
     }
   }
@@ -91,9 +92,10 @@ impl<'a> BlockConnection<'a> {
 
     let url = self.conn.url().map_err(error::builder)?;
     let parts = self.conn.block_send_streaming_parts(&url, body)?;
+    let close_connection = parts.close_connection;
     let response =
       Response::with_trailers(self.conn.rourl().clone(), parts.binary, parts.trailers)?;
-    self.conn.closed_set(true);
+    self.conn.closed_set(close_connection);
     Ok(response)
   }
 

--- a/rttp_client/src/connection/connection_reader.rs
+++ b/rttp_client/src/connection/connection_reader.rs
@@ -22,6 +22,7 @@ pub(crate) enum ResponseBodyKind {
 pub(crate) struct ResponseParts {
   pub(crate) binary: Vec<u8>,
   pub(crate) trailers: Vec<Header>,
+  pub(crate) close_connection: bool,
 }
 
 pub struct StreamingResponse<'a, R: Read + ?Sized> {
@@ -257,6 +258,7 @@ pub(crate) fn read_response_parts_after_header<R>(
 where
   R: Read + ?Sized,
 {
+  let close_connection = response_connection_should_close(&binary)?;
   let mut trailers = Vec::new();
   match response_body_kind(&binary, expect_no_body)? {
     ResponseBodyKind::NoBody => {}
@@ -278,7 +280,11 @@ where
       reader.read_to_end(&mut binary).map_err(error::request)?;
     }
   }
-  Ok(ResponseParts { binary, trailers })
+  Ok(ResponseParts {
+    binary,
+    trailers,
+    close_connection,
+  })
 }
 
 pub(crate) fn response_headers(header: &[u8]) -> error::Result<Vec<Header>> {
@@ -291,6 +297,36 @@ pub(crate) fn response_headers(header: &[u8]) -> error::Result<Vec<Header>> {
       .flat_map(|line| line.into_headers())
       .collect(),
   )
+}
+
+pub(crate) fn response_connection_should_close(header: &[u8]) -> error::Result<bool> {
+  let header = String::from_utf8(header.to_vec()).map_err(error::response)?;
+  let version = header
+    .lines()
+    .next()
+    .and_then(|line| line.split_whitespace().next())
+    .unwrap_or_default();
+  let mut has_keep_alive = false;
+
+  for line in header.lines().skip(1) {
+    let Some((name, value)) = line.split_once(':') else {
+      continue;
+    };
+    if !name.eq_ignore_ascii_case("Connection") {
+      continue;
+    }
+
+    for token in value.split(',').map(str::trim) {
+      if token.eq_ignore_ascii_case("close") {
+        return Ok(true);
+      }
+      if token.eq_ignore_ascii_case("keep-alive") {
+        has_keep_alive = true;
+      }
+    }
+  }
+
+  Ok(version.eq_ignore_ascii_case("HTTP/1.0") && !has_keep_alive)
 }
 
 pub(crate) fn read_response_header<R>(reader: &mut R) -> error::Result<Vec<u8>>

--- a/rttp_client/src/request/request.rs
+++ b/rttp_client/src/request/request.rs
@@ -254,6 +254,13 @@ impl Request {
       .headers
       .push(Header::new("Transfer-Encoding", "chunked"));
   }
+
+  pub(crate) fn clear_streaming_body_headers(&mut self) {
+    self.headers.retain(|header| {
+      !header.name().eq_ignore_ascii_case("content-length")
+        && !header.name().eq_ignore_ascii_case("transfer-encoding")
+    });
+  }
 }
 
 #[derive(Clone)]

--- a/rttp_client/tests/support/mod.rs
+++ b/rttp_client/tests/support/mod.rs
@@ -500,13 +500,22 @@ fn echoed_redirect_request_target_and_headers(request: &[u8]) -> String {
 }
 
 pub fn spawn_keep_alive_server() -> (SocketAddr, JoinHandle<()>) {
+  spawn_keep_alive_server_count(1)
+}
+
+pub fn spawn_keep_alive_server_count(count: usize) -> (SocketAddr, JoinHandle<()>) {
   let (listener, addr) = bind_local_http_listener("keep-alive server");
   let handle = thread::spawn(move || {
-    if let Ok((mut stream, _)) = listener.accept() {
+    for _ in 0..count {
+      let Ok((mut stream, _)) = listener.accept() else {
+        break;
+      };
       let _ = read_http_request(&mut stream);
       let response = b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: keep-alive\r\n\r\nOK";
       let _ = stream.write_all(response);
-      thread::sleep(Duration::from_millis(300));
+      if count == 1 {
+        thread::sleep(Duration::from_millis(300));
+      }
     }
   });
   (addr, handle)

--- a/rttp_client/tests/test_http_async.rs
+++ b/rttp_client/tests/test_http_async.rs
@@ -666,6 +666,32 @@ fn test_async_content_length_response_does_not_wait_for_eof() {
 
 #[test]
 #[cfg(feature = "async")]
+fn test_async_keep_alive_content_length_response_leaves_client_reusable() {
+  let (addr, _handle) = support::spawn_keep_alive_server_count(2);
+  block_on(async {
+    let mut client = client();
+
+    let first = client
+      .get()
+      .config(Config::builder().read_timeout(100))
+      .url(format!("http://{}/keep-alive", addr))
+      .rasync()
+      .await
+      .unwrap();
+    assert_eq!("OK", first.body().string().unwrap());
+
+    let second = client
+      .get()
+      .url(format!("http://{}/keep-alive", addr))
+      .rasync()
+      .await
+      .unwrap();
+    assert_eq!("OK", second.body().string().unwrap());
+  });
+}
+
+#[test]
+#[cfg(feature = "async")]
 fn test_async_client_skips_100_continue_before_final_response() {
   let (addr, _handle) = support::spawn_continue_then_ok_server();
   block_on(async {

--- a/rttp_client/tests/test_http_basic.rs
+++ b/rttp_client/tests/test_http_basic.rs
@@ -684,6 +684,27 @@ fn test_content_length_response_does_not_wait_for_eof() {
 }
 
 #[test]
+fn test_keep_alive_content_length_response_leaves_client_reusable() {
+  let (addr, _handle) = support::spawn_keep_alive_server_count(2);
+  let mut client = client();
+
+  let first = client
+    .get()
+    .config(Config::builder().read_timeout(100))
+    .url(format!("http://{}/keep-alive", addr))
+    .emit()
+    .unwrap();
+  assert_eq!("OK", first.body().string().unwrap());
+
+  let second = client
+    .get()
+    .url(format!("http://{}/keep-alive", addr))
+    .emit()
+    .unwrap();
+  assert_eq!("OK", second.body().string().unwrap());
+}
+
+#[test]
 fn test_sync_client_skips_100_continue_before_final_response() {
   let (addr, _handle) = support::spawn_continue_then_ok_server();
   let response = client()

--- a/rttp_client/tests/test_raw_request_capture.rs
+++ b/rttp_client/tests/test_raw_request_capture.rs
@@ -4,6 +4,9 @@ mod support;
 use futures::executor::block_on;
 use rttp_client::types::Proxy;
 use rttp_client::HttpClient;
+use std::io::{Read, Write};
+use std::net::{SocketAddr, TcpListener, TcpStream};
+use std::thread;
 use std::time::Duration;
 
 fn client() -> HttpClient {
@@ -52,6 +55,81 @@ fn request_body(request: &[u8]) -> &[u8] {
   &request[body_start..]
 }
 
+fn read_request_head(stream: &mut TcpStream) -> Vec<u8> {
+  let mut request = Vec::new();
+  let mut byte = [0u8; 1];
+  while !request.ends_with(b"\r\n\r\n") {
+    stream.read_exact(&mut byte).expect("read request head");
+    request.push(byte[0]);
+  }
+  request
+}
+
+fn content_length(request: &[u8]) -> usize {
+  request
+    .split(|byte| *byte == b'\n')
+    .find_map(|line| {
+      let line = String::from_utf8_lossy(line);
+      let (name, value) = line.split_once(':')?;
+      if name.eq_ignore_ascii_case("Content-Length") {
+        Some(value.trim().parse().expect("valid content length"))
+      } else {
+        None
+      }
+    })
+    .unwrap_or(0)
+}
+
+fn spawn_streaming_then_capture_server() -> (SocketAddr, thread::JoinHandle<Vec<u8>>) {
+  let listener = TcpListener::bind("127.0.0.1:0").expect("bind streaming reuse server");
+  let addr = listener.local_addr().expect("streaming reuse server addr");
+  let handle = thread::spawn(move || {
+    let (mut stream, _) = listener.accept().expect("accept streaming request");
+    let first_head = read_request_head(&mut stream);
+    let mut body = vec![0u8; content_length(&first_head)];
+    stream.read_exact(&mut body).expect("read streaming body");
+    stream
+      .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 8\r\nConnection: keep-alive\r\n\r\nuploaded")
+      .expect("write streaming response");
+
+    let (mut stream, _) = listener.accept().expect("accept follow-up request");
+    let second_head = read_request_head(&mut stream);
+    stream
+      .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 6\r\nConnection: close\r\n\r\nsecond")
+      .expect("write follow-up response");
+    second_head
+  });
+  (addr, handle)
+}
+
+fn spawn_chunked_streaming_then_capture_server() -> (SocketAddr, thread::JoinHandle<Vec<u8>>) {
+  let listener = TcpListener::bind("127.0.0.1:0").expect("bind chunked streaming reuse server");
+  let addr = listener
+    .local_addr()
+    .expect("chunked streaming reuse server addr");
+  let handle = thread::spawn(move || {
+    let (mut stream, _) = listener.accept().expect("accept chunked streaming request");
+    let _first_head = read_request_head(&mut stream);
+    let mut body = Vec::new();
+    let mut byte = [0u8; 1];
+    while !body.ends_with(b"\r\n0\r\n\r\n") {
+      stream.read_exact(&mut byte).expect("read chunked body");
+      body.push(byte[0]);
+    }
+    stream
+      .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 8\r\nConnection: keep-alive\r\n\r\nuploaded")
+      .expect("write chunked streaming response");
+
+    let (mut stream, _) = listener.accept().expect("accept follow-up request");
+    let second_head = read_request_head(&mut stream);
+    stream
+      .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 6\r\nConnection: close\r\n\r\nsecond")
+      .expect("write follow-up response");
+    second_head
+  });
+  (addr, handle)
+}
+
 #[test]
 fn get_with_query_parameters_sends_request_target_without_body() {
   let request = capture_request(|base_url| {
@@ -70,6 +148,56 @@ fn get_with_query_parameters_sends_request_target_without_body() {
   assert_eq!(None, header_value(&text, "Content-Type"));
   assert_eq!(None, header_value(&text, "Content-Length"));
   assert_eq!(b"", request_body(&request));
+}
+
+#[test]
+fn streaming_fixed_framing_does_not_leak_into_later_emit() {
+  let (addr, handle) = spawn_streaming_then_capture_server();
+  let mut client = client();
+
+  client
+    .post()
+    .url(format!("http://{}/upload", addr))
+    .emit_streaming_fixed("hello".as_bytes(), 5)
+    .expect("streaming upload should succeed");
+
+  client
+    .get()
+    .url(format!("http://{}/second", addr))
+    .emit()
+    .expect("follow-up request should succeed");
+
+  let second = handle.join().expect("streaming reuse server");
+  let second = request_text(&second);
+
+  assert!(second.starts_with("GET /second HTTP/1.1\r\n"));
+  assert_eq!(None, header_value(&second, "Content-Length"));
+  assert_eq!(None, header_value(&second, "Transfer-Encoding"));
+}
+
+#[test]
+fn streaming_chunked_framing_does_not_leak_into_later_emit() {
+  let (addr, handle) = spawn_chunked_streaming_then_capture_server();
+  let mut client = client();
+
+  client
+    .post()
+    .url(format!("http://{}/upload", addr))
+    .emit_streaming_chunked("hello".as_bytes())
+    .expect("chunked streaming upload should succeed");
+
+  client
+    .get()
+    .url(format!("http://{}/second", addr))
+    .emit()
+    .expect("follow-up request should succeed");
+
+  let second = handle.join().expect("chunked streaming reuse server");
+  let second = request_text(&second);
+
+  assert!(second.starts_with("GET /second HTTP/1.1\r\n"));
+  assert_eq!(None, header_value(&second, "Content-Length"));
+  assert_eq!(None, header_value(&second, "Transfer-Encoding"));
 }
 
 #[test]


### PR DESCRIPTION
rttp_client now bases client reuse state on response connection semantics, preserving terminal handling for `Connection: close` and allowing complete keep-alive `Content-Length` responses to be reused. Verified with formatting and full workspace tests.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1371/
work_kind: code_work
branch: hbx-1371-rttp-client-treat-response-connection
base: main
commit: e2a56ea17e8e5bfbe95d8181efcb4653faf3325b
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1371/
    url: https://plane.kahub.in/endless/browse/HBX-1371/
    close_policy: link_only
```