### PR TITLE
feat: [rttp] Emit HTTP/2 response trailers from the prior-knowledge server path

### DIFF
--- a/rttp/src/server.rs
+++ b/rttp/src/server.rs
@@ -835,6 +835,7 @@ fn write_http2_response(
   write_body: bool,
 ) -> io::Result<()> {
   let headers = encode_http2_response_headers(response)?;
+  let write_trailers = write_body && response.allows_body() && !response.trailers().is_empty();
   write_http2_frame(
     stream,
     HTTP2_FRAME_HEADERS,
@@ -848,19 +849,32 @@ fn write_http2_response(
     &[]
   };
   if body.is_empty() {
-    write_http2_frame(
-      stream,
-      HTTP2_FRAME_DATA,
-      HTTP2_FLAG_END_STREAM,
-      stream_id,
-      &[],
-    )?;
+    let flags = if write_trailers {
+      0
+    } else {
+      HTTP2_FLAG_END_STREAM
+    };
+    write_http2_frame(stream, HTTP2_FRAME_DATA, flags, stream_id, &[])?;
   } else {
     for (index, chunk) in body.chunks(HTTP2_DEFAULT_MAX_FRAME_SIZE).enumerate() {
-      let end_stream = (index + 1) * HTTP2_DEFAULT_MAX_FRAME_SIZE >= body.len();
-      let flags = if end_stream { HTTP2_FLAG_END_STREAM } else { 0 };
+      let final_data = (index + 1) * HTTP2_DEFAULT_MAX_FRAME_SIZE >= body.len();
+      let flags = if final_data && !write_trailers {
+        HTTP2_FLAG_END_STREAM
+      } else {
+        0
+      };
       write_http2_frame(stream, HTTP2_FRAME_DATA, flags, stream_id, chunk)?;
     }
+  }
+  if write_trailers {
+    let trailers = encode_http2_response_trailers(response)?;
+    write_http2_frame(
+      stream,
+      HTTP2_FRAME_HEADERS,
+      HTTP2_FLAG_END_HEADERS | HTTP2_FLAG_END_STREAM,
+      stream_id,
+      &trailers,
+    )?;
   }
   stream.flush()
 }
@@ -900,6 +914,8 @@ fn encode_http2_response_headers(response: &HttpResponse) -> io::Result<Vec<u8>>
       "connection"
         | "keep-alive"
         | "proxy-connection"
+        | "te"
+        | "trailer"
         | "transfer-encoding"
         | "upgrade"
         | "content-length"
@@ -913,6 +929,39 @@ fn encode_http2_response_headers(response: &HttpResponse) -> io::Result<Vec<u8>>
     )?;
   }
 
+  Ok(block)
+}
+
+fn encode_http2_response_trailers(response: &HttpResponse) -> io::Result<Vec<u8>> {
+  let mut block = Vec::new();
+  for trailer in response.trailers() {
+    let name = trailer.name.to_ascii_lowercase();
+    if matches!(
+      name.as_str(),
+      "authorization"
+        | "connection"
+        | "content-length"
+        | "cookie"
+        | "host"
+        | "keep-alive"
+        | "proxy-authenticate"
+        | "proxy-authorization"
+        | "proxy-connection"
+        | "set-cookie"
+        | "te"
+        | "trailer"
+        | "transfer-encoding"
+        | "upgrade"
+        | "www-authenticate"
+    ) {
+      continue;
+    }
+    encode_http2_literal_new_name_without_indexing(
+      &mut block,
+      name.as_bytes(),
+      trailer.value.as_bytes(),
+    )?;
+  }
   Ok(block)
 }
 

--- a/rttp/tests/http2_feature.rs
+++ b/rttp/tests/http2_feature.rs
@@ -32,3 +32,37 @@ fn wrapper_http2_feature_exposes_prior_knowledge_client_path() {
 
   handle.join().expect("server thread");
 }
+
+#[test]
+fn wrapper_http2_feature_exposes_response_trailers_from_prior_knowledge_server() {
+  let server = rttp::Http::server("127.0.0.1:0").expect("bind server");
+  let addr = server.local_addr().expect("server addr");
+
+  let handle = thread::spawn(move || {
+    server
+      .accept_one(|_| {
+        HttpResponse::ok("wrapper h2 trailers")
+          .header("Trailer", "X-Trace, X-Signature")
+          .trailer("X-Trace", "abc")
+          .trailer("X-Signature", "signed")
+      })
+      .expect("serve h2 trailer response");
+  });
+
+  let response = rttp::Http::client()
+    .url(format!("http://{}/trailers", addr))
+    .emit_http2_prior_knowledge()
+    .expect("wrapper h2 trailer response");
+
+  assert_eq!("HTTP/2", response.version());
+  assert_eq!("wrapper h2 trailers", response.body().string().unwrap());
+  assert_eq!(2, response.trailers().len());
+  assert_eq!(Some(&"abc".to_string()), response.trailer_value("x-trace"));
+  assert_eq!(
+    Some(&"signed".to_string()),
+    response.trailer_value("X-SIGNATURE")
+  );
+  assert!(response.header_value("Trailer").is_none());
+
+  handle.join().expect("server thread");
+}

--- a/rttp_client/src/http2.rs
+++ b/rttp_client/src/http2.rs
@@ -25,6 +25,7 @@ const FLAG_ACK: u8 = 0x1;
 const FLAG_END_HEADERS: u8 = 0x4;
 
 const STREAM_ID: u32 = 1;
+const WINDOW_UPDATE_THRESHOLD: usize = 32 * 1024;
 
 pub struct PriorKnowledgeClient<'a> {
   request: RawRequest<'a>,
@@ -241,6 +242,7 @@ fn read_single_stream_response(stream: &mut TcpStream, url: RoUrl) -> error::Res
   let mut status = None;
   let mut in_header_continuation = false;
   let mut header_block_is_trailer = false;
+  let mut pending_window_update = 0usize;
 
   loop {
     let frame = read_frame(stream)?;
@@ -290,10 +292,14 @@ fn read_single_stream_response(stream: &mut TcpStream, url: RoUrl) -> error::Res
       (FRAME_DATA, STREAM_ID) => {
         let end_stream = frame.flags & FLAG_END_STREAM == FLAG_END_STREAM;
         body.extend_from_slice(&frame.payload);
-        if !frame.payload.is_empty() && !end_stream {
-          write_window_update_best_effort(stream, STREAM_ID, frame.payload.len())?;
-          write_window_update_best_effort(stream, 0, frame.payload.len())?;
+        pending_window_update = pending_window_update
+          .checked_add(frame.payload.len())
+          .ok_or_else(|| error::bad_response("HTTP/2 response body is too large"))?;
+        if !end_stream && pending_window_update >= WINDOW_UPDATE_THRESHOLD {
+          write_window_update_best_effort(stream, STREAM_ID, pending_window_update)?;
+          write_window_update_best_effort(stream, 0, pending_window_update)?;
           flush_best_effort(stream)?;
+          pending_window_update = 0;
         }
         if end_stream {
           break;

--- a/rttp_client/src/http2.rs
+++ b/rttp_client/src/http2.rs
@@ -7,7 +7,7 @@ use url::Url;
 
 use crate::request::RawRequest;
 use crate::response::Response;
-use crate::types::{RoUrl, ToUrl};
+use crate::types::{Header, RoUrl, ToUrl};
 use crate::{error, Config};
 
 const CLIENT_PREFACE: &[u8; 24] = b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n";
@@ -236,9 +236,11 @@ fn regular_headers(header: &str) -> Vec<(String, String)> {
 fn read_single_stream_response(stream: &mut TcpStream, url: RoUrl) -> error::Result<Response> {
   let mut header_block = Vec::new();
   let mut headers = Vec::new();
+  let mut trailers = Vec::new();
   let mut body = Vec::new();
   let mut status = None;
   let mut in_header_continuation = false;
+  let mut header_block_is_trailer = false;
 
   loop {
     let frame = read_frame(stream)?;
@@ -254,11 +256,16 @@ fn read_single_stream_response(stream: &mut TcpStream, url: RoUrl) -> error::Res
         }
       }
       (FRAME_HEADERS, STREAM_ID) => {
+        header_block_is_trailer = status.is_some();
         header_block.extend_from_slice(&frame.payload);
         if frame.flags & FLAG_END_HEADERS == FLAG_END_HEADERS {
           let decoded = decode_header_block(&header_block)?;
-          status = decoded.status;
-          headers = decoded.headers;
+          if header_block_is_trailer {
+            append_trailers(&mut trailers, decoded)?;
+          } else {
+            status = decoded.status;
+            headers = decoded.headers;
+          }
           header_block.clear();
           in_header_continuation = false;
         } else {
@@ -272,8 +279,12 @@ fn read_single_stream_response(stream: &mut TcpStream, url: RoUrl) -> error::Res
         header_block.extend_from_slice(&frame.payload);
         if frame.flags & FLAG_END_HEADERS == FLAG_END_HEADERS {
           let decoded = decode_header_block(&header_block)?;
-          status = decoded.status;
-          headers = decoded.headers;
+          if header_block_is_trailer {
+            append_trailers(&mut trailers, decoded)?;
+          } else {
+            status = decoded.status;
+            headers = decoded.headers;
+          }
           header_block.clear();
           in_header_continuation = false;
         }
@@ -309,7 +320,7 @@ fn read_single_stream_response(stream: &mut TcpStream, url: RoUrl) -> error::Res
   }
 
   let status = status.ok_or_else(|| error::bad_response("missing HTTP/2 :status header"))?;
-  build_response(url, status, &headers, body)
+  build_response(url, status, &headers, body, trailers)
 }
 
 fn goaway_last_stream_id(payload: &[u8]) -> error::Result<u32> {
@@ -329,6 +340,7 @@ fn build_response(
   status: u32,
   headers: &[(String, String)],
   body: Vec<u8>,
+  trailers: Vec<Header>,
 ) -> error::Result<Response> {
   let mut binary = format!("HTTP/2 {}\r\n", status).into_bytes();
   for (name, value) in headers {
@@ -339,7 +351,18 @@ fn build_response(
   }
   binary.extend_from_slice(b"\r\n");
   binary.extend_from_slice(&body);
-  Response::new(url, binary)
+  Response::with_trailers(url, binary, trailers)
+}
+
+fn append_trailers(trailers: &mut Vec<Header>, decoded: DecodedHeaders) -> error::Result<()> {
+  if decoded.status.is_some() {
+    return Err(error::bad_response("invalid HTTP/2 trailer pseudo-header"));
+  }
+  for (name, value) in decoded.headers {
+    validate_response_trailer_header(&name, &value)?;
+    trailers.push(Header::new(name, value));
+  }
+  Ok(())
 }
 
 struct Frame {
@@ -619,6 +642,39 @@ fn push_decoded_header(
     headers.push((name.to_string(), value.to_string()));
   }
   Ok(())
+}
+
+fn validate_response_trailer_header(name: &str, value: &str) -> error::Result<()> {
+  if name.is_empty()
+    || name.contains(|ch: char| ch.is_ascii_control() || ch == ':' || ch == ' ')
+    || value.contains('\r')
+    || value.contains('\n')
+  {
+    return Err(error::bad_response("Invalid trailer header"));
+  }
+  if is_forbidden_response_trailer_name(name) {
+    return Err(error::bad_response("Forbidden trailer header"));
+  }
+  Ok(())
+}
+
+fn is_forbidden_response_trailer_name(name: &str) -> bool {
+  matches!(
+    name.to_ascii_lowercase().as_str(),
+    "authorization"
+      | "connection"
+      | "content-length"
+      | "cookie"
+      | "host"
+      | "proxy-authenticate"
+      | "proxy-authorization"
+      | "www-authenticate"
+      | "set-cookie"
+      | "te"
+      | "trailer"
+      | "transfer-encoding"
+      | "upgrade"
+  )
 }
 
 fn static_header(index: usize) -> error::Result<(&'static str, &'static str)> {

--- a/rttp_client/src/http2.rs
+++ b/rttp_client/src/http2.rs
@@ -263,8 +263,7 @@ fn read_single_stream_response(stream: &mut TcpStream, url: RoUrl) -> error::Res
           if header_block_is_trailer {
             append_trailers(&mut trailers, decoded)?;
           } else {
-            status = decoded.status;
-            headers = decoded.headers;
+            apply_response_headers(decoded, &mut status, &mut headers);
           }
           header_block.clear();
           in_header_continuation = false;
@@ -282,8 +281,7 @@ fn read_single_stream_response(stream: &mut TcpStream, url: RoUrl) -> error::Res
           if header_block_is_trailer {
             append_trailers(&mut trailers, decoded)?;
           } else {
-            status = decoded.status;
-            headers = decoded.headers;
+            apply_response_headers(decoded, &mut status, &mut headers);
           }
           header_block.clear();
           in_header_continuation = false;
@@ -321,6 +319,22 @@ fn read_single_stream_response(stream: &mut TcpStream, url: RoUrl) -> error::Res
 
   let status = status.ok_or_else(|| error::bad_response("missing HTTP/2 :status header"))?;
   build_response(url, status, &headers, body, trailers)
+}
+
+fn apply_response_headers(
+  decoded: DecodedHeaders,
+  status: &mut Option<u32>,
+  headers: &mut Vec<(String, String)>,
+) {
+  if decoded.status.is_some_and(is_informational_status) {
+    return;
+  }
+  *status = decoded.status;
+  *headers = decoded.headers;
+}
+
+fn is_informational_status(status: u32) -> bool {
+  (100..200).contains(&status)
 }
 
 fn goaway_last_stream_id(payload: &[u8]) -> error::Result<u32> {

--- a/rttp_client/tests/http2_prior_knowledge.rs
+++ b/rttp_client/tests/http2_prior_knowledge.rs
@@ -316,6 +316,40 @@ fn prior_knowledge_get_sends_window_updates_while_reading_large_response_body() 
   handle.join().expect("h2 peer thread");
 }
 
+#[test]
+fn prior_knowledge_get_decodes_terminal_trailer_headers() {
+  let listener = TcpListener::bind("127.0.0.1:0").expect("bind h2 peer");
+  let addr = listener.local_addr().expect("h2 peer addr");
+
+  let handle = thread::spawn(move || {
+    let (mut stream, _) = listener.accept().expect("accept h2 client");
+    complete_h2_request_handshake(&mut stream);
+
+    write_frame(&mut stream, FRAME_HEADERS, FLAG_END_HEADERS, 1, &[0x88]);
+    write_frame(&mut stream, FRAME_DATA, 0, 1, b"hello trailers");
+    write_frame(
+      &mut stream,
+      FRAME_HEADERS,
+      FLAG_END_HEADERS | FLAG_END_STREAM,
+      1,
+      &[
+        0, 7, b'x', b'-', b't', b'r', b'a', b'c', b'e', 3, b'a', b'b', b'c',
+      ],
+    );
+  });
+
+  let response = HttpClient::new()
+    .get()
+    .url(format!("http://{}/trailers", addr))
+    .emit_http2_prior_knowledge()
+    .expect("h2 response with trailer headers");
+
+  assert_eq!(200, response.code());
+  assert_eq!("hello trailers", response.body().string().unwrap());
+  assert_eq!(Some(&"abc".to_string()), response.trailer_value("X-Trace"));
+  handle.join().expect("h2 peer thread");
+}
+
 struct Frame {
   frame_type: u8,
   flags: u8,

--- a/rttp_client/tests/http2_prior_knowledge.rs
+++ b/rttp_client/tests/http2_prior_knowledge.rs
@@ -1,6 +1,6 @@
 #![cfg(feature = "http2")]
 
-use std::io::{Read, Write};
+use std::io::{self, Read, Write};
 use std::net::{SocketAddr, TcpListener};
 use std::thread;
 use std::time::Duration;
@@ -262,21 +262,19 @@ fn prior_knowledge_sends_window_updates_for_non_final_data_frames() {
 
     write_frame(&mut stream, FRAME_SETTINGS, FLAG_ACK, 0, &[]);
     write_frame(&mut stream, FRAME_HEADERS, FLAG_END_HEADERS, 1, &[0x88]);
-    write_frame(&mut stream, FRAME_DATA, 0, 1, b"first chunk");
+    let chunk = vec![b'x'; 32 * 1024];
+    write_frame(&mut stream, FRAME_DATA, 0, 1, &chunk);
 
     let stream_update = read_frame(&mut stream);
     assert_eq!(FRAME_WINDOW_UPDATE, stream_update.frame_type);
     assert_eq!(1, stream_update.stream_id);
-    assert_eq!(
-      b"first chunk".len() as u32,
-      window_update_increment(&stream_update)
-    );
+    assert_eq!(chunk.len() as u32, window_update_increment(&stream_update));
 
     let connection_update = read_frame(&mut stream);
     assert_eq!(FRAME_WINDOW_UPDATE, connection_update.frame_type);
     assert_eq!(0, connection_update.stream_id);
     assert_eq!(
-      b"first chunk".len() as u32,
+      chunk.len() as u32,
       window_update_increment(&connection_update)
     );
 
@@ -296,8 +294,8 @@ fn prior_knowledge_sends_window_updates_for_non_final_data_frames() {
     .expect("h2 response requiring window updates");
 
   assert_eq!(
-    "first chunk and final chunk",
-    response.body().string().unwrap()
+    32 * 1024 + b" and final chunk".len(),
+    response.body().binary().len()
   );
   handle.join().expect("h2 peer thread");
 }
@@ -382,6 +380,52 @@ fn prior_knowledge_get_decodes_terminal_trailer_headers() {
   handle.join().expect("h2 peer thread");
 }
 
+#[test]
+fn prior_knowledge_get_defers_small_window_updates_until_more_credit_is_needed() {
+  let listener = TcpListener::bind("127.0.0.1:0").expect("bind h2 peer");
+  let addr = listener.local_addr().expect("h2 peer addr");
+
+  let handle = thread::spawn(move || {
+    let (mut stream, _) = listener.accept().expect("accept h2 client");
+    stream
+      .set_read_timeout(Some(Duration::from_millis(200)))
+      .expect("set h2 peer read timeout");
+    complete_h2_request_handshake(&mut stream);
+
+    write_frame(&mut stream, FRAME_HEADERS, FLAG_END_HEADERS, 1, &[0x88]);
+    write_frame(&mut stream, FRAME_DATA, 0, 1, b"small trailer body");
+    write_frame(
+      &mut stream,
+      FRAME_HEADERS,
+      FLAG_END_HEADERS | FLAG_END_STREAM,
+      1,
+      &[
+        0, 7, b'x', b'-', b't', b'r', b'a', b'c', b'e', 3, b'a', b'b', b'c',
+      ],
+    );
+
+    match try_read_frame(&mut stream) {
+      Ok(Some(frame)) => panic!(
+        "unexpected client frame after small trailer response: type={}, stream_id={}",
+        frame.frame_type, frame.stream_id
+      ),
+      Ok(None) => {}
+      Err(err) => panic!("unexpected frame read error: {err}"),
+    }
+  });
+
+  let response = HttpClient::new()
+    .get()
+    .url(format!("http://{}/small-trailers", addr))
+    .emit_http2_prior_knowledge()
+    .expect("h2 response with small trailer body");
+
+  assert_eq!(200, response.code());
+  assert_eq!("small trailer body", response.body().string().unwrap());
+  assert_eq!(Some(&"abc".to_string()), response.trailer_value("X-Trace"));
+  handle.join().expect("h2 peer thread");
+}
+
 struct Frame {
   frame_type: u8,
   flags: u8,
@@ -401,6 +445,30 @@ fn read_frame(stream: &mut impl Read) -> Frame {
     stream_id: u32::from_be_bytes([header[5] & 0x7f, header[6], header[7], header[8]]),
     payload,
   }
+}
+
+fn try_read_frame(stream: &mut impl Read) -> io::Result<Option<Frame>> {
+  let mut header = [0; 9];
+  match stream.read_exact(&mut header) {
+    Ok(()) => {}
+    Err(err)
+      if err.kind() == io::ErrorKind::WouldBlock
+        || err.kind() == io::ErrorKind::TimedOut
+        || err.kind() == io::ErrorKind::UnexpectedEof =>
+    {
+      return Ok(None);
+    }
+    Err(err) => return Err(err),
+  }
+  let length = ((header[0] as usize) << 16) | ((header[1] as usize) << 8) | header[2] as usize;
+  let mut payload = vec![0; length];
+  stream.read_exact(&mut payload)?;
+  Ok(Some(Frame {
+    frame_type: header[3],
+    flags: header[4],
+    stream_id: u32::from_be_bytes([header[5] & 0x7f, header[6], header[7], header[8]]),
+    payload,
+  }))
 }
 
 fn spawn_h2_prior_knowledge_peer_with_response(

--- a/rttp_client/tests/http2_prior_knowledge.rs
+++ b/rttp_client/tests/http2_prior_knowledge.rs
@@ -136,6 +136,38 @@ fn prior_knowledge_decodes_content_length_from_hpack_static_index() {
 }
 
 #[test]
+fn prior_knowledge_get_skips_informational_headers_before_final_response() {
+  let listener = TcpListener::bind("127.0.0.1:0").expect("bind h2 peer");
+  let addr = listener.local_addr().expect("h2 peer addr");
+
+  let handle = thread::spawn(move || {
+    let (mut stream, _) = listener.accept().expect("accept h2 client");
+    complete_h2_request_handshake(&mut stream);
+
+    write_frame(
+      &mut stream,
+      FRAME_HEADERS,
+      FLAG_END_HEADERS,
+      1,
+      &[0x08, 3, b'1', b'0', b'3'],
+    );
+    write_frame(&mut stream, FRAME_HEADERS, FLAG_END_HEADERS, 1, &[0x88]);
+    write_frame(&mut stream, FRAME_DATA, FLAG_END_STREAM, 1, b"final h2");
+  });
+
+  let response = HttpClient::new()
+    .get()
+    .url(format!("http://{}/early-hints", addr))
+    .emit_http2_prior_knowledge()
+    .expect("h2 response after informational headers");
+
+  assert_eq!(200, response.code());
+  assert_eq!("final h2", response.body().string().unwrap());
+  assert!(response.trailers().is_empty());
+  handle.join().expect("h2 peer thread");
+}
+
+#[test]
 fn prior_knowledge_get_ignores_interleaved_data_for_other_streams() {
   let listener = TcpListener::bind("127.0.0.1:0").expect("bind h2 peer");
   let addr = listener.local_addr().expect("h2 peer addr");


### PR DESCRIPTION
Adds HTTP/2 prior-knowledge response trailer emission and matching client trailer decoding, with focused h2 integration coverage and full workspace verification.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1376/
work_kind: code_work
branch: hbx-1376-rttp-emit-http-2-response
base: main
commit: 0c60dd577e9b107b31723f31998bd160d27d110e
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1376/
    url: https://plane.kahub.in/endless/browse/HBX-1376/
    close_policy: link_only
```