### PR TITLE
feat: [rttp_client] Preserve HTTP/2 response trailers on prior-knowledge responses

### DIFF
--- a/rttp_client/src/connection/mod.rs
+++ b/rttp_client/src/connection/mod.rs
@@ -7,6 +7,7 @@ pub use self::async_connection::*;
 pub use self::block_connection::*;
 pub use self::connection::HandoffConnection;
 pub(crate) use self::connection::StreamingRequestBody;
+#[cfg(any(feature = "async", feature = "http2"))]
 pub(crate) use self::connection_reader::validate_response_trailer_header;
 pub use self::connection_reader::{ConnectionReader, ResponseBodyReader, StreamingResponse};
 

--- a/rttp_client/src/connection/mod.rs
+++ b/rttp_client/src/connection/mod.rs
@@ -7,6 +7,7 @@ pub use self::async_connection::*;
 pub use self::block_connection::*;
 pub use self::connection::HandoffConnection;
 pub(crate) use self::connection::StreamingRequestBody;
+pub(crate) use self::connection_reader::validate_response_trailer_header;
 pub use self::connection_reader::{ConnectionReader, ResponseBodyReader, StreamingResponse};
 
 #[cfg(feature = "async")]

--- a/rttp_client/src/http2.rs
+++ b/rttp_client/src/http2.rs
@@ -5,9 +5,10 @@ use std::time::Duration;
 use socket2::{Domain, Protocol, Socket, Type};
 use url::Url;
 
+use crate::connection::validate_response_trailer_header;
 use crate::request::RawRequest;
 use crate::response::Response;
-use crate::types::{RoUrl, ToUrl};
+use crate::types::{Header, RoUrl, ToUrl};
 use crate::{error, Config};
 
 const CLIENT_PREFACE: &[u8; 24] = b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n";
@@ -233,12 +234,19 @@ fn regular_headers(header: &str) -> Vec<(String, String)> {
     .collect()
 }
 
+#[derive(Clone, Copy)]
+enum HeaderBlockKind {
+  ResponseHeaders,
+  Trailers,
+}
+
 fn read_single_stream_response(stream: &mut TcpStream, url: RoUrl) -> error::Result<Response> {
   let mut header_block = Vec::new();
   let mut headers = Vec::new();
+  let mut trailers = Vec::new();
   let mut body = Vec::new();
   let mut status = None;
-  let mut in_header_continuation = false;
+  let mut header_block_kind = None;
 
   loop {
     let frame = read_frame(stream)?;
@@ -254,28 +262,45 @@ fn read_single_stream_response(stream: &mut TcpStream, url: RoUrl) -> error::Res
         }
       }
       (FRAME_HEADERS, STREAM_ID) => {
+        if header_block_kind.is_some() {
+          return Err(error::bad_response("incomplete HTTP/2 header block"));
+        }
+        let kind = if status.is_some() {
+          HeaderBlockKind::Trailers
+        } else {
+          HeaderBlockKind::ResponseHeaders
+        };
         header_block.extend_from_slice(&frame.payload);
         if frame.flags & FLAG_END_HEADERS == FLAG_END_HEADERS {
-          let decoded = decode_header_block(&header_block)?;
-          status = decoded.status;
-          headers = decoded.headers;
+          apply_header_block(
+            kind,
+            &header_block,
+            &mut status,
+            &mut headers,
+            &mut trailers,
+          )?;
           header_block.clear();
-          in_header_continuation = false;
+          header_block_kind = None;
         } else {
-          in_header_continuation = true;
+          header_block_kind = Some(kind);
         }
         if frame.flags & FLAG_END_STREAM == FLAG_END_STREAM {
           break;
         }
       }
-      (FRAME_CONTINUATION, STREAM_ID) if in_header_continuation => {
+      (FRAME_CONTINUATION, STREAM_ID) if header_block_kind.is_some() => {
         header_block.extend_from_slice(&frame.payload);
         if frame.flags & FLAG_END_HEADERS == FLAG_END_HEADERS {
-          let decoded = decode_header_block(&header_block)?;
-          status = decoded.status;
-          headers = decoded.headers;
+          let kind = header_block_kind.expect("checked header block kind");
+          apply_header_block(
+            kind,
+            &header_block,
+            &mut status,
+            &mut headers,
+            &mut trailers,
+          )?;
           header_block.clear();
-          in_header_continuation = false;
+          header_block_kind = None;
         }
       }
       (FRAME_DATA, STREAM_ID) => {
@@ -304,12 +329,32 @@ fn read_single_stream_response(stream: &mut TcpStream, url: RoUrl) -> error::Res
     }
   }
 
-  if in_header_continuation {
+  if header_block_kind.is_some() {
     return Err(error::bad_response("incomplete HTTP/2 header block"));
   }
 
   let status = status.ok_or_else(|| error::bad_response("missing HTTP/2 :status header"))?;
-  build_response(url, status, &headers, body)
+  build_response(url, status, &headers, body, trailers)
+}
+
+fn apply_header_block(
+  kind: HeaderBlockKind,
+  block: &[u8],
+  status: &mut Option<u32>,
+  headers: &mut Vec<(String, String)>,
+  trailers: &mut Vec<Header>,
+) -> error::Result<()> {
+  match kind {
+    HeaderBlockKind::ResponseHeaders => {
+      let decoded = decode_header_block(block)?;
+      *status = decoded.status;
+      *headers = decoded.headers;
+    }
+    HeaderBlockKind::Trailers => {
+      trailers.extend(decode_trailer_block(block)?);
+    }
+  }
+  Ok(())
 }
 
 fn goaway_last_stream_id(payload: &[u8]) -> error::Result<u32> {
@@ -329,6 +374,7 @@ fn build_response(
   status: u32,
   headers: &[(String, String)],
   body: Vec<u8>,
+  trailers: Vec<Header>,
 ) -> error::Result<Response> {
   let mut binary = format!("HTTP/2 {}\r\n", status).into_bytes();
   for (name, value) in headers {
@@ -339,7 +385,7 @@ fn build_response(
   }
   binary.extend_from_slice(b"\r\n");
   binary.extend_from_slice(&body);
-  Response::new(url, binary)
+  Response::with_trailers(url, binary, trailers)
 }
 
 struct Frame {
@@ -511,16 +557,42 @@ struct DecodedHeaders {
 }
 
 fn decode_header_block(block: &[u8]) -> error::Result<DecodedHeaders> {
-  let mut cursor = 0;
+  let entries = decode_header_entries(block)?;
   let mut status = None;
   let mut headers = Vec::new();
+
+  for (name, value) in entries {
+    push_decoded_header(&name, &value, &mut status, &mut headers)?;
+  }
+
+  Ok(DecodedHeaders { status, headers })
+}
+
+fn decode_trailer_block(block: &[u8]) -> error::Result<Vec<Header>> {
+  let entries = decode_header_entries(block)?;
+  let mut trailers = Vec::new();
+
+  for (name, value) in entries {
+    if name.starts_with(':') {
+      return Err(error::bad_response("Invalid trailer header"));
+    }
+    validate_response_trailer_header(&name, &value)?;
+    trailers.push(Header::new(name, value));
+  }
+
+  Ok(trailers)
+}
+
+fn decode_header_entries(block: &[u8]) -> error::Result<Vec<(String, String)>> {
+  let mut cursor = 0;
+  let mut entries = Vec::new();
 
   while cursor < block.len() {
     let byte = block[cursor];
     if byte & 0x80 == 0x80 {
       let index = decode_integer(block, &mut cursor, 7)?;
       let (name, value) = static_header(index)?;
-      push_decoded_header(name, value, &mut status, &mut headers)?;
+      entries.push((name.to_string(), value.to_string()));
       continue;
     }
 
@@ -533,10 +605,10 @@ fn decode_header_block(block: &[u8]) -> error::Result<DecodedHeaders> {
     } else {
       decode_literal(block, &mut cursor, 4)?
     };
-    push_decoded_header(&name, &value, &mut status, &mut headers)?;
+    entries.push((name, value));
   }
 
-  Ok(DecodedHeaders { status, headers })
+  Ok(entries)
 }
 
 fn decode_literal(

--- a/rttp_client/src/http2.rs
+++ b/rttp_client/src/http2.rs
@@ -247,6 +247,8 @@ fn read_single_stream_response(stream: &mut TcpStream, url: RoUrl) -> error::Res
   let mut body = Vec::new();
   let mut status = None;
   let mut header_block_kind = None;
+  let mut final_response_started = false;
+  let mut response_body_started = false;
 
   loop {
     let frame = read_frame(stream)?;
@@ -265,20 +267,22 @@ fn read_single_stream_response(stream: &mut TcpStream, url: RoUrl) -> error::Res
         if header_block_kind.is_some() {
           return Err(error::bad_response("incomplete HTTP/2 header block"));
         }
-        let kind = if status.is_some() {
+        let kind = if final_response_started || response_body_started {
           HeaderBlockKind::Trailers
         } else {
           HeaderBlockKind::ResponseHeaders
         };
         header_block.extend_from_slice(&frame.payload);
         if frame.flags & FLAG_END_HEADERS == FLAG_END_HEADERS {
-          apply_header_block(
+          if apply_header_block(
             kind,
             &header_block,
             &mut status,
             &mut headers,
             &mut trailers,
-          )?;
+          )? {
+            final_response_started = true;
+          }
           header_block.clear();
           header_block_kind = None;
         } else {
@@ -292,19 +296,22 @@ fn read_single_stream_response(stream: &mut TcpStream, url: RoUrl) -> error::Res
         header_block.extend_from_slice(&frame.payload);
         if frame.flags & FLAG_END_HEADERS == FLAG_END_HEADERS {
           let kind = header_block_kind.expect("checked header block kind");
-          apply_header_block(
+          if apply_header_block(
             kind,
             &header_block,
             &mut status,
             &mut headers,
             &mut trailers,
-          )?;
+          )? {
+            final_response_started = true;
+          }
           header_block.clear();
           header_block_kind = None;
         }
       }
       (FRAME_DATA, STREAM_ID) => {
         let end_stream = frame.flags & FLAG_END_STREAM == FLAG_END_STREAM;
+        response_body_started = true;
         body.extend_from_slice(&frame.payload);
         if !frame.payload.is_empty() && !end_stream {
           write_window_update_best_effort(stream, STREAM_ID, frame.payload.len())?;
@@ -343,18 +350,26 @@ fn apply_header_block(
   status: &mut Option<u32>,
   headers: &mut Vec<(String, String)>,
   trailers: &mut Vec<Header>,
-) -> error::Result<()> {
+) -> error::Result<bool> {
   match kind {
     HeaderBlockKind::ResponseHeaders => {
       let decoded = decode_header_block(block)?;
+      if decoded.status.is_some_and(is_informational_status) {
+        return Ok(false);
+      }
       *status = decoded.status;
       *headers = decoded.headers;
+      Ok(status.is_some())
     }
     HeaderBlockKind::Trailers => {
       trailers.extend(decode_trailer_block(block)?);
+      Ok(false)
     }
   }
-  Ok(())
+}
+
+fn is_informational_status(status: u32) -> bool {
+  (100..200).contains(&status)
 }
 
 fn goaway_last_stream_id(payload: &[u8]) -> error::Result<u32> {

--- a/rttp_client/tests/http2_prior_knowledge.rs
+++ b/rttp_client/tests/http2_prior_knowledge.rs
@@ -136,6 +136,85 @@ fn prior_knowledge_decodes_content_length_from_hpack_static_index() {
 }
 
 #[test]
+fn prior_knowledge_exposes_response_trailers_after_data_without_changing_headers() {
+  let listener = TcpListener::bind("127.0.0.1:0").expect("bind h2 peer");
+  let addr = listener.local_addr().expect("h2 peer addr");
+
+  let handle = thread::spawn(move || {
+    let (mut stream, _) = listener.accept().expect("accept h2 client");
+    complete_h2_request_handshake(&mut stream);
+
+    write_frame(
+      &mut stream,
+      FRAME_HEADERS,
+      FLAG_END_HEADERS,
+      1,
+      &[
+        0x88, 0x0f, 16, 10, b't', b'e', b'x', b't', b'/', b'p', b'l', b'a', b'i', b'n',
+      ],
+    );
+    write_frame(&mut stream, FRAME_DATA, 0, 1, b"hello");
+    write_frame(
+      &mut stream,
+      FRAME_HEADERS,
+      FLAG_END_STREAM | FLAG_END_HEADERS,
+      1,
+      &h2_literal_new_name(b"x-trace", b"abc123"),
+    );
+  });
+
+  let response = HttpClient::new()
+    .get()
+    .url(format!("http://{}/trailers", addr))
+    .emit_http2_prior_knowledge()
+    .expect("h2 response with trailers");
+
+  assert_eq!(200, response.code());
+  assert_eq!(
+    Some(&"text/plain".to_string()),
+    response.header_value("content-type")
+  );
+  assert_eq!("hello", response.body().string().unwrap());
+  assert_eq!(1, response.trailers().len());
+  assert_eq!(
+    Some(&"abc123".to_string()),
+    response.trailer_value("X-Trace")
+  );
+  assert!(response.header("x-trace").is_none());
+  handle.join().expect("h2 peer thread");
+}
+
+#[test]
+fn prior_knowledge_rejects_response_trailer_pseudo_headers() {
+  let listener = TcpListener::bind("127.0.0.1:0").expect("bind h2 peer");
+  let addr = listener.local_addr().expect("h2 peer addr");
+
+  let handle = thread::spawn(move || {
+    let (mut stream, _) = listener.accept().expect("accept h2 client");
+    complete_h2_request_handshake(&mut stream);
+
+    write_frame(&mut stream, FRAME_HEADERS, FLAG_END_HEADERS, 1, &[0x88]);
+    write_frame(&mut stream, FRAME_DATA, 0, 1, b"hello");
+    write_frame(
+      &mut stream,
+      FRAME_HEADERS,
+      FLAG_END_STREAM | FLAG_END_HEADERS,
+      1,
+      &[0x88],
+    );
+  });
+
+  let error = HttpClient::new()
+    .get()
+    .url(format!("http://{}/bad-trailers", addr))
+    .emit_http2_prior_knowledge()
+    .expect_err("trailer pseudo-header should be rejected");
+
+  assert!(error.to_string().contains("Invalid trailer header"));
+  handle.join().expect("h2 peer thread");
+}
+
+#[test]
 fn prior_knowledge_get_ignores_interleaved_data_for_other_streams() {
   let listener = TcpListener::bind("127.0.0.1:0").expect("bind h2 peer");
   let addr = listener.local_addr().expect("h2 peer addr");
@@ -407,6 +486,23 @@ fn window_update_increment(frame: &Frame) -> u32 {
     frame.payload[2],
     frame.payload[3],
   ])
+}
+
+fn h2_literal_new_name(name: &[u8], value: &[u8]) -> Vec<u8> {
+  let mut block = Vec::new();
+  block.push(0);
+  h2_string(&mut block, name);
+  h2_string(&mut block, value);
+  block
+}
+
+fn h2_string(block: &mut Vec<u8>, value: &[u8]) {
+  assert!(
+    value.len() < 128,
+    "test HPACK helper only encodes short strings"
+  );
+  block.push(value.len() as u8);
+  block.extend_from_slice(value);
 }
 
 fn write_frame(stream: &mut impl Write, frame_type: u8, flags: u8, stream_id: u32, payload: &[u8]) {

--- a/rttp_client/tests/http2_prior_knowledge.rs
+++ b/rttp_client/tests/http2_prior_knowledge.rs
@@ -136,6 +136,50 @@ fn prior_knowledge_decodes_content_length_from_hpack_static_index() {
 }
 
 #[test]
+fn prior_knowledge_skips_informational_headers_before_final_response() {
+  let listener = TcpListener::bind("127.0.0.1:0").expect("bind h2 peer");
+  let addr = listener.local_addr().expect("h2 peer addr");
+
+  let handle = thread::spawn(move || {
+    let (mut stream, _) = listener.accept().expect("accept h2 client");
+    complete_h2_request_handshake(&mut stream);
+
+    write_frame(
+      &mut stream,
+      FRAME_HEADERS,
+      FLAG_END_HEADERS,
+      1,
+      &h2_literal_new_name(b":status", b"103"),
+    );
+    write_frame(
+      &mut stream,
+      FRAME_HEADERS,
+      FLAG_END_HEADERS,
+      1,
+      &[
+        0x88, 0x0f, 16, 10, b't', b'e', b'x', b't', b'/', b'p', b'l', b'a', b'i', b'n',
+      ],
+    );
+    write_frame(&mut stream, FRAME_DATA, FLAG_END_STREAM, 1, b"final body");
+  });
+
+  let response = HttpClient::new()
+    .get()
+    .url(format!("http://{}/early-hints", addr))
+    .emit_http2_prior_knowledge()
+    .expect("h2 response after informational headers");
+
+  assert_eq!(200, response.code());
+  assert_eq!(
+    Some(&"text/plain".to_string()),
+    response.header_value("content-type")
+  );
+  assert_eq!("final body", response.body().string().unwrap());
+  assert!(response.trailers().is_empty());
+  handle.join().expect("h2 peer thread");
+}
+
+#[test]
 fn prior_knowledge_exposes_response_trailers_after_data_without_changing_headers() {
   let listener = TcpListener::bind("127.0.0.1:0").expect("bind h2 peer");
   let addr = listener.local_addr().expect("h2 peer addr");


### PR DESCRIPTION
Adds prior-knowledge HTTP/2 response trailer preservation for rttp_client, including validation for malformed trailer pseudo-headers and focused regression coverage.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1375/
work_kind: code_work
branch: hbx-1375-rttp-client-preserve-http-2
base: main
commit: 47d7c54934256e6f977e8929618bb74d35bc0094
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1375/
    url: https://plane.kahub.in/endless/browse/HBX-1375/
    close_policy: link_only
```