### PR TITLE
feat: [rttp] Enforce required HTTP/2 pseudo-headers on prior-knowledge server requests

### DIFF
--- a/rttp/src/server.rs
+++ b/rttp/src/server.rs
@@ -683,6 +683,7 @@ fn write_http2_window_update(
 struct DecodedHttp2RequestHeaders {
   method: Option<String>,
   target: Option<String>,
+  scheme: Option<String>,
   authority: Option<String>,
   headers: Vec<(String, String)>,
 }
@@ -695,10 +696,14 @@ impl DecodedHttp2RequestHeaders {
     let target = self
       .target
       .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "missing HTTP/2 :path"))?;
+    let _scheme = self
+      .scheme
+      .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "missing HTTP/2 :scheme"))?;
+    let authority = self
+      .authority
+      .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "missing HTTP/2 :authority"))?;
     let mut headers = self.headers;
-    if let Some(authority) = self.authority {
-      headers.push(("host".to_string(), authority));
-    }
+    headers.push(("host".to_string(), authority));
 
     Ok(Request {
       method,
@@ -716,9 +721,12 @@ fn decode_http2_request_headers(block: &[u8]) -> io::Result<DecodedHttp2RequestH
   let mut decoded = DecodedHttp2RequestHeaders {
     method: None,
     target: None,
+    scheme: None,
     authority: None,
     headers: Vec::new(),
   };
+  let mut regular_header_seen = false;
+  let mut pseudo_headers = Vec::<String>::new();
 
   while cursor < block.len() {
     let byte = block[cursor];
@@ -737,9 +745,31 @@ fn decode_http2_request_headers(block: &[u8]) -> io::Result<DecodedHttp2RequestH
       decode_http2_literal(block, &mut cursor, 4)?
     };
 
+    if name.starts_with(':') {
+      if regular_header_seen {
+        return Err(io::Error::new(
+          io::ErrorKind::InvalidData,
+          "HTTP/2 pseudo-header appeared after a regular header",
+        ));
+      }
+      if pseudo_headers
+        .iter()
+        .any(|pseudo_header| pseudo_header == &name)
+      {
+        return Err(io::Error::new(
+          io::ErrorKind::InvalidData,
+          "duplicate HTTP/2 pseudo-header",
+        ));
+      }
+      pseudo_headers.push(name.clone());
+    } else {
+      regular_header_seen = true;
+    }
+
     match name.as_str() {
       ":method" => decoded.method = Some(value),
       ":path" => decoded.target = Some(value),
+      ":scheme" => decoded.scheme = Some(value),
       ":authority" => decoded.authority = Some(value),
       name if name.starts_with(':') => {}
       "connection" | "keep-alive" | "proxy-connection" | "transfer-encoding" | "upgrade" => {}

--- a/rttp/src/server.rs
+++ b/rttp/src/server.rs
@@ -699,11 +699,10 @@ impl DecodedHttp2RequestHeaders {
     let _scheme = self
       .scheme
       .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "missing HTTP/2 :scheme"))?;
-    let authority = self
-      .authority
-      .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "missing HTTP/2 :authority"))?;
     let mut headers = self.headers;
-    headers.push(("host".to_string(), authority));
+    if let Some(authority) = self.authority {
+      headers.push(("host".to_string(), authority));
+    }
 
     Ok(Request {
       method,

--- a/rttp/tests/test_server.rs
+++ b/rttp/tests/test_server.rs
@@ -457,11 +457,52 @@ fn server_rejects_http2_prior_knowledge_request_missing_scheme() {
 }
 
 #[test]
-fn server_rejects_http2_prior_knowledge_request_missing_authority() {
-  let mut headers = vec![0x82, 0x86];
-  headers.extend(h2_literal_indexed_name(4, b"/missing-authority"));
+fn server_accepts_http2_prior_knowledge_options_asterisk_without_authority() {
+  let server = rttp::Http::server("127.0.0.1:0").expect("bind server");
+  let addr = server.local_addr().expect("server addr");
+  let (tx, rx) = mpsc::channel();
 
-  assert_invalid_h2_headers_without_handler(&headers);
+  let handle = thread::spawn(move || {
+    server
+      .accept_one(|request| {
+        tx.send((
+          request.method().to_string(),
+          request.target().to_string(),
+          request.header("host").map(str::to_string),
+        ))
+        .expect("send h2 options request");
+        HttpResponse::ok("options")
+      })
+      .expect("serve h2 options request");
+  });
+
+  let mut stream = TcpStream::connect(addr).expect("connect h2 server");
+  complete_h2_server_handshake(&mut stream);
+  let mut headers = h2_literal_indexed_name(2, b"OPTIONS");
+  headers.push(0x86);
+  headers.extend(h2_literal_indexed_name(4, b"*"));
+  write_h2_frame(
+    &mut stream,
+    H2_FRAME_HEADERS,
+    H2_FLAG_END_HEADERS | H2_FLAG_END_STREAM,
+    1,
+    &headers,
+  );
+
+  let response_headers = read_h2_frame(&mut stream);
+  assert_eq!(H2_FRAME_HEADERS, response_headers.frame_type);
+  assert_eq!(H2_FLAG_END_HEADERS, response_headers.flags);
+  assert_eq!(1, response_headers.stream_id);
+
+  let response_body = read_h2_frame(&mut stream);
+  assert_eq!(H2_FRAME_DATA, response_body.frame_type);
+  assert_eq!(H2_FLAG_END_STREAM, response_body.flags);
+  assert_eq!(1, response_body.stream_id);
+  assert_eq!(b"options", response_body.payload.as_slice());
+
+  let request = rx.recv().expect("receive h2 options request");
+  assert_eq!(("OPTIONS".to_string(), "*".to_string(), None), request);
+  handle.join().expect("server thread");
 }
 
 #[test]

--- a/rttp/tests/test_server.rs
+++ b/rttp/tests/test_server.rs
@@ -76,6 +76,16 @@ fn h2_literal_indexed_name(name_index: u8, value: &[u8]) -> Vec<u8> {
   encoded
 }
 
+fn h2_literal_new_name(name: &[u8], value: &[u8]) -> Vec<u8> {
+  assert!(name.len() < 128);
+  assert!(value.len() < 128);
+  let mut encoded = vec![0, name.len() as u8];
+  encoded.extend_from_slice(name);
+  encoded.push(value.len() as u8);
+  encoded.extend_from_slice(value);
+  encoded
+}
+
 fn h2_get_headers(path: &[u8], authority: &[u8]) -> Vec<u8> {
   let mut headers = vec![0x82, 0x86];
   headers.extend(h2_literal_indexed_name(4, path));
@@ -105,6 +115,44 @@ fn complete_h2_server_handshake(stream: &mut TcpStream) {
   assert_eq!(0, settings_ack.stream_id);
 
   write_h2_frame(stream, H2_FRAME_SETTINGS, H2_FLAG_ACK, 0, &[]);
+}
+
+fn assert_invalid_h2_headers_without_handler(header_block: &[u8]) {
+  let server = rttp::Http::server("127.0.0.1:0")
+    .expect("bind server")
+    .with_read_timeout(Some(Duration::from_secs(2)));
+  let addr = server.local_addr().expect("server addr");
+  let (tx, rx) = mpsc::channel();
+
+  let handle = thread::spawn(move || {
+    server.accept_one(|request| {
+      tx.send(request).expect("send unexpected h2 request");
+      HttpResponse::ok("unexpected")
+    })
+  });
+
+  let mut stream = TcpStream::connect(addr).expect("connect h2 server");
+  stream
+    .set_read_timeout(Some(Duration::from_secs(2)))
+    .expect("set h2 read timeout");
+  complete_h2_server_handshake(&mut stream);
+  write_h2_frame(
+    &mut stream,
+    H2_FRAME_HEADERS,
+    H2_FLAG_END_HEADERS | H2_FLAG_END_STREAM,
+    1,
+    header_block,
+  );
+  stream
+    .shutdown(std::net::Shutdown::Write)
+    .expect("shutdown h2 write");
+
+  let error = handle
+    .join()
+    .expect("server thread")
+    .expect_err("invalid h2 headers should reject request");
+  assert_eq!(ErrorKind::InvalidData, error.kind());
+  assert!(rx.try_recv().is_err());
 }
 
 fn send_raw_request_capture(raw: &[u8]) -> (String, Option<Request>) {
@@ -397,6 +445,42 @@ fn server_accepts_http2_prior_knowledge_headers_and_data_before_calling_handler(
   assert_eq!(b"stored", response_body.payload.as_slice());
 
   handle.join().expect("server thread");
+}
+
+#[test]
+fn server_rejects_http2_prior_knowledge_request_missing_scheme() {
+  let mut headers = vec![0x82];
+  headers.extend(h2_literal_indexed_name(4, b"/missing-scheme"));
+  headers.extend(h2_literal_indexed_name(1, b"localhost"));
+
+  assert_invalid_h2_headers_without_handler(&headers);
+}
+
+#[test]
+fn server_rejects_http2_prior_knowledge_request_missing_authority() {
+  let mut headers = vec![0x82, 0x86];
+  headers.extend(h2_literal_indexed_name(4, b"/missing-authority"));
+
+  assert_invalid_h2_headers_without_handler(&headers);
+}
+
+#[test]
+fn server_rejects_http2_prior_knowledge_request_duplicate_pseudo_header() {
+  let mut headers = vec![0x82, 0x82, 0x86];
+  headers.extend(h2_literal_indexed_name(4, b"/duplicate-method"));
+  headers.extend(h2_literal_indexed_name(1, b"localhost"));
+
+  assert_invalid_h2_headers_without_handler(&headers);
+}
+
+#[test]
+fn server_rejects_http2_prior_knowledge_pseudo_header_after_regular_header() {
+  let mut headers = vec![0x82, 0x86];
+  headers.extend(h2_literal_new_name(b"x-before-pseudo", b"present"));
+  headers.extend(h2_literal_indexed_name(4, b"/late-path"));
+  headers.extend(h2_literal_indexed_name(1, b"localhost"));
+
+  assert_invalid_h2_headers_without_handler(&headers);
 }
 
 #[test]


### PR DESCRIPTION
HTTP/2 prior-knowledge server request validation now enforces required pseudo-headers, duplicate pseudo-header rejection, and pseudo-header ordering with focused live coverage. Formatting and workspace tests pass.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1374/
work_kind: code_work
branch: hbx-1374-rttp-enforce-required-http-2
base: main
commit: 1f99307057275b99c0dada98de2dbaeb38875256
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1374/
    url: https://plane.kahub.in/endless/browse/HBX-1374/
    close_policy: link_only
```