### PR TITLE
feat: [rttp] Read HTTP/2 prior-knowledge request bodies before invoking handlers

### DIFF
--- a/rttp/src/server.rs
+++ b/rttp/src/server.rs
@@ -455,26 +455,37 @@ impl HttpServer {
           }
         }
         (HTTP2_FRAME_DATA, id) if id != 0 => {
-          if let Some(request_stream) = streams
+          let request_stream = streams
             .iter_mut()
             .find(|request_stream| request_stream.stream_id == id)
-          {
-            let new_len = request_stream
-              .body
-              .len()
-              .checked_add(frame.payload.len())
-              .ok_or_else(|| {
-                io::Error::new(io::ErrorKind::InvalidData, "request body is too large")
-              })?;
-            reject_oversized_request_body(new_len)?;
-            request_stream.body.extend_from_slice(&frame.payload);
-            if !frame.payload.is_empty() {
-              write_http2_window_update(&mut stream, 0, frame.payload.len())?;
-              write_http2_window_update(&mut stream, id, frame.payload.len())?;
-            }
-            if frame.flags & HTTP2_FLAG_END_STREAM == HTTP2_FLAG_END_STREAM {
-              request_stream.end_stream = true;
-            }
+            .ok_or_else(|| {
+              io::Error::new(
+                io::ErrorKind::InvalidData,
+                "HTTP/2 DATA frame arrived before request headers",
+              )
+            })?;
+          if request_stream.decoded_headers.is_none() || request_stream.in_header_continuation {
+            return Err(io::Error::new(
+              io::ErrorKind::InvalidData,
+              "HTTP/2 DATA frame arrived before request headers",
+            ));
+          }
+
+          let new_len = request_stream
+            .body
+            .len()
+            .checked_add(frame.payload.len())
+            .ok_or_else(|| {
+              io::Error::new(io::ErrorKind::InvalidData, "request body is too large")
+            })?;
+          reject_oversized_request_body(new_len)?;
+          request_stream.body.extend_from_slice(&frame.payload);
+          if !frame.payload.is_empty() {
+            write_http2_window_update(&mut stream, 0, frame.payload.len())?;
+            write_http2_window_update(&mut stream, id, frame.payload.len())?;
+          }
+          if frame.flags & HTTP2_FLAG_END_STREAM == HTTP2_FLAG_END_STREAM {
+            request_stream.end_stream = true;
           }
         }
         (HTTP2_FRAME_RST_STREAM, id) if id != 0 => {

--- a/rttp/src/server.rs
+++ b/rttp/src/server.rs
@@ -382,6 +382,7 @@ impl HttpServer {
     self.normalize_connection_error(stream.flush())?;
 
     let mut streams = Vec::<Http2RequestStream>::new();
+    let mut reset_streams = Vec::<u32>::new();
     let mut served = 0;
 
     while served < request_limit {
@@ -455,15 +456,18 @@ impl HttpServer {
           }
         }
         (HTTP2_FRAME_DATA, id) if id != 0 => {
-          let request_stream = streams
+          let Some(request_stream) = streams
             .iter_mut()
             .find(|request_stream| request_stream.stream_id == id)
-            .ok_or_else(|| {
-              io::Error::new(
-                io::ErrorKind::InvalidData,
-                "HTTP/2 DATA frame arrived before request headers",
-              )
-            })?;
+          else {
+            if reset_streams.contains(&id) {
+              continue;
+            }
+            return Err(io::Error::new(
+              io::ErrorKind::InvalidData,
+              "HTTP/2 DATA frame arrived before request headers",
+            ));
+          };
           if request_stream.decoded_headers.is_none() || request_stream.in_header_continuation {
             return Err(io::Error::new(
               io::ErrorKind::InvalidData,
@@ -490,6 +494,9 @@ impl HttpServer {
         }
         (HTTP2_FRAME_RST_STREAM, id) if id != 0 => {
           streams.retain(|request_stream| request_stream.stream_id != id);
+          if !reset_streams.contains(&id) {
+            reset_streams.push(id);
+          }
         }
         (HTTP2_FRAME_GOAWAY, 0) => break,
         (HTTP2_FRAME_WINDOW_UPDATE, _) => {}

--- a/rttp/tests/test_server.rs
+++ b/rttp/tests/test_server.rs
@@ -659,6 +659,7 @@ fn server_ignores_reset_stream_and_serves_surviving_http2_stream() {
   );
   write_h2_frame(&mut stream, H2_FRAME_DATA, 0, 1, b"partial");
   write_h2_frame(&mut stream, H2_FRAME_RST_STREAM, 0, 1, &0u32.to_be_bytes());
+  write_h2_frame(&mut stream, H2_FRAME_DATA, 0, 1, b"after-reset");
 
   write_h2_frame(
     &mut stream,

--- a/rttp/tests/test_server.rs
+++ b/rttp/tests/test_server.rs
@@ -448,6 +448,42 @@ fn server_accepts_http2_prior_knowledge_headers_and_data_before_calling_handler(
 }
 
 #[test]
+fn server_rejects_http2_prior_knowledge_data_before_headers_without_handler() {
+  let server = rttp::Http::server("127.0.0.1:0")
+    .expect("bind server")
+    .with_read_timeout(Some(Duration::from_secs(2)));
+  let addr = server.local_addr().expect("server addr");
+  let (tx, rx) = mpsc::channel();
+
+  let handle = thread::spawn(move || {
+    server.accept_one(|request| {
+      tx.send(request).expect("send unexpected h2 request");
+      HttpResponse::ok("unexpected")
+    })
+  });
+
+  let mut stream = TcpStream::connect(addr).expect("connect h2 server");
+  complete_h2_server_handshake(&mut stream);
+  write_h2_frame(
+    &mut stream,
+    H2_FRAME_DATA,
+    H2_FLAG_END_STREAM,
+    1,
+    b"body before headers",
+  );
+  stream
+    .shutdown(std::net::Shutdown::Write)
+    .expect("shutdown h2 write");
+
+  let error = handle
+    .join()
+    .expect("server thread")
+    .expect_err("DATA before HEADERS should reject request");
+  assert_eq!(ErrorKind::InvalidData, error.kind());
+  assert!(rx.try_recv().is_err());
+}
+
+#[test]
 fn server_rejects_http2_prior_knowledge_request_missing_scheme() {
   let mut headers = vec![0x82];
   headers.extend(h2_literal_indexed_name(4, b"/missing-scheme"));


### PR DESCRIPTION
Implemented HTTP/2 prior-knowledge request-body framing validation: valid DATA after HEADERS remains exposed through Request::body(), while DATA before headers is rejected before handler invocation. Verified with formatting and workspace tests.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1379/
work_kind: code_work
branch: hbx-1379-rttp-read-http-2-prior
base: main
commit: 81a84820ca98cba2c5e84594c6e92f4439e78000
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1379/
    url: https://plane.kahub.in/endless/browse/HBX-1379/
    close_policy: link_only
```