### PR TITLE
feat: [rttp_client] Send HTTP/2 prior-knowledge request bodies with DATA frames

### DIFF
--- a/rttp/README.md
+++ b/rttp/README.md
@@ -65,7 +65,7 @@ loops.
 Enable the `client` feature to access `rttp::Http::client`, or enable `async`,
 `http2`, `tls-native`, `tls-rustls`, or `all` for the corresponding
 `rttp_client` capabilities. The `http2` feature exposes the minimal
-prior-knowledge h2c GET client path; TLS ALPN remains a later integration point.
+prior-knowledge h2c client path; TLS ALPN remains a later integration point.
 
 Direct TCP client connections use `socket2`. SOCKS proxy handshakes remain
 delegated to the `socks` crate.

--- a/rttp_client/README.md
+++ b/rttp_client/README.md
@@ -7,7 +7,7 @@ optional features add async request APIs and TLS implementations.
 | name | comment |
 |------|---------|
 | async | Async request APIs |
-| http2 | Prior-knowledge h2c GET over direct `socket2` TCP connections |
+| http2 | Prior-knowledge h2c over direct `socket2` TCP connections |
 | tls-native | HTTPS with `native-tls` |
 | tls-rustls | HTTPS with `rustls` |
 
@@ -27,9 +27,9 @@ HTTP/1.x chunked responses are decoded, and response trailers are exposed
 through `Response::trailers`, `Response::trailer`, and
 `Response::trailer_value` for both blocking and async request APIs.
 With the `http2` feature enabled, `emit_http2_prior_knowledge` sends a minimal
-prior-knowledge h2c GET request over a direct socket2 TCP connection. TLS ALPN,
-proxy tunneling, request bodies, and general HTTP/2 multiplexing are not part of
-that initial client path.
+prior-knowledge h2c request over a direct socket2 TCP connection. Non-empty
+buffered request bodies are sent as DATA frames. TLS ALPN, proxy tunneling, and
+general HTTP/2 multiplexing are not part of that client path.
 
 ## Examples
 

--- a/rttp_client/src/http2.rs
+++ b/rttp_client/src/http2.rs
@@ -37,14 +37,15 @@ impl<'a> PriorKnowledgeClient<'a> {
   }
 
   pub fn get(mut self) -> error::Result<Response> {
-    if !self.request.origin().method().eq_ignore_ascii_case("GET") {
-      return Err(error::builder_with_message(
-        "HTTP/2 prior-knowledge client currently supports GET only",
-      ));
-    }
-    if self.request.body().is_some() {
+    let method = self.request.origin().method();
+    if method.eq_ignore_ascii_case("GET") && self.request.body().is_some() {
       return Err(error::builder_with_message(
         "HTTP/2 prior-knowledge GET cannot send a request body",
+      ));
+    }
+    if !is_supported_request_method(method) {
+      return Err(error::builder_with_message(
+        "HTTP/2 prior-knowledge client supports GET and buffered POST, PUT, or PATCH",
       ));
     }
 
@@ -56,11 +57,18 @@ impl<'a> PriorKnowledgeClient<'a> {
     let mut stream = connect_tcp_stream(addr(&url)?, self.request.origin().config())?;
     write_connection_preface(&mut stream)?;
     read_settings_and_ack(&mut stream)?;
-    write_get_headers(&mut stream, &self.request, &url)?;
+    write_request(&mut stream, &self.request, &url)?;
     let response = read_single_stream_response(&mut stream, self.request.url().clone())?;
     self.request.origin_mut().closed_set(true);
     Ok(response)
   }
+}
+
+fn is_supported_request_method(method: &str) -> bool {
+  method.eq_ignore_ascii_case("GET")
+    || method.eq_ignore_ascii_case("POST")
+    || method.eq_ignore_ascii_case("PUT")
+    || method.eq_ignore_ascii_case("PATCH")
 }
 
 fn addr(url: &Url) -> error::Result<String> {
@@ -148,25 +156,34 @@ fn read_settings_and_ack(stream: &mut TcpStream) -> error::Result<()> {
   }
 }
 
-fn write_get_headers(
-  stream: &mut TcpStream,
-  request: &RawRequest<'_>,
-  url: &Url,
-) -> error::Result<()> {
+fn write_request(stream: &mut TcpStream, request: &RawRequest<'_>, url: &Url) -> error::Result<()> {
   let header_block = encode_request_headers(request, url)?;
+  let body = request
+    .body()
+    .as_ref()
+    .map(|body| body.bytes())
+    .unwrap_or(&[]);
+  let header_flags = if body.is_empty() {
+    FLAG_END_STREAM | FLAG_END_HEADERS
+  } else {
+    FLAG_END_HEADERS
+  };
   write_frame(
     stream,
     FRAME_HEADERS,
-    FLAG_END_STREAM | FLAG_END_HEADERS,
+    header_flags,
     STREAM_ID,
     &header_block,
   )?;
+  if !body.is_empty() {
+    write_frame(stream, FRAME_DATA, FLAG_END_STREAM, STREAM_ID, body)?;
+  }
   stream.flush().map_err(error::request)
 }
 
 fn encode_request_headers(request: &RawRequest<'_>, url: &Url) -> error::Result<Vec<u8>> {
   let mut block = Vec::new();
-  block.push(0x82);
+  encode_method(&mut block, request.origin().method())?;
   if url.scheme() == "http" {
     block.push(0x86);
   } else {
@@ -186,6 +203,17 @@ fn encode_request_headers(request: &RawRequest<'_>, url: &Url) -> error::Result<
   }
 
   Ok(block)
+}
+
+fn encode_method(block: &mut Vec<u8>, method: &str) -> error::Result<()> {
+  if method.eq_ignore_ascii_case("GET") {
+    block.push(0x82);
+  } else if method.eq_ignore_ascii_case("POST") {
+    block.push(0x83);
+  } else {
+    encode_literal_indexed_name_without_indexing(block, 2, method.to_uppercase().as_bytes())?;
+  }
+  Ok(())
 }
 
 fn request_target(url: &Url) -> String {

--- a/rttp_client/src/http2.rs
+++ b/rttp_client/src/http2.rs
@@ -25,6 +25,9 @@ const FLAG_ACK: u8 = 0x1;
 const FLAG_END_HEADERS: u8 = 0x4;
 
 const STREAM_ID: u32 = 1;
+const SETTING_MAX_FRAME_SIZE: u16 = 0x5;
+const DEFAULT_MAX_FRAME_SIZE: usize = 16 * 1024;
+const MAX_FRAME_SIZE_LIMIT: usize = 16_777_215;
 const WINDOW_UPDATE_THRESHOLD: usize = 32 * 1024;
 
 pub struct PriorKnowledgeClient<'a> {
@@ -56,8 +59,8 @@ impl<'a> PriorKnowledgeClient<'a> {
 
     let mut stream = connect_tcp_stream(addr(&url)?, self.request.origin().config())?;
     write_connection_preface(&mut stream)?;
-    read_settings_and_ack(&mut stream)?;
-    write_request(&mut stream, &self.request, &url)?;
+    let peer_max_frame_size = read_settings_and_ack(&mut stream)?;
+    write_request(&mut stream, &self.request, &url, peer_max_frame_size)?;
     let response = read_single_stream_response(&mut stream, self.request.url().clone())?;
     self.request.origin_mut().closed_set(true);
     Ok(response)
@@ -131,7 +134,7 @@ fn write_connection_preface(stream: &mut TcpStream) -> error::Result<()> {
   stream.flush().map_err(error::request)
 }
 
-fn read_settings_and_ack(stream: &mut TcpStream) -> error::Result<()> {
+fn read_settings_and_ack(stream: &mut TcpStream) -> error::Result<usize> {
   loop {
     let frame = read_frame(stream)?;
     if frame.frame_type != FRAME_SETTINGS {
@@ -150,13 +153,36 @@ fn read_settings_and_ack(stream: &mut TcpStream) -> error::Result<()> {
     if frame.stream_id != 0 || frame.payload.len() % 6 != 0 {
       return Err(error::bad_response("invalid HTTP/2 SETTINGS frame"));
     }
+    let peer_max_frame_size = peer_max_frame_size(&frame.payload)?;
     write_frame(stream, FRAME_SETTINGS, FLAG_ACK, 0, &[])?;
     stream.flush().map_err(error::request)?;
-    return Ok(());
+    return Ok(peer_max_frame_size);
   }
 }
 
-fn write_request(stream: &mut TcpStream, request: &RawRequest<'_>, url: &Url) -> error::Result<()> {
+fn peer_max_frame_size(payload: &[u8]) -> error::Result<usize> {
+  let mut max_frame_size = DEFAULT_MAX_FRAME_SIZE;
+  for setting in payload.chunks_exact(6) {
+    let identifier = u16::from_be_bytes([setting[0], setting[1]]);
+    let value = u32::from_be_bytes([setting[2], setting[3], setting[4], setting[5]]) as usize;
+    if identifier == SETTING_MAX_FRAME_SIZE {
+      if !(DEFAULT_MAX_FRAME_SIZE..=MAX_FRAME_SIZE_LIMIT).contains(&value) {
+        return Err(error::bad_response(
+          "invalid HTTP/2 SETTINGS_MAX_FRAME_SIZE value",
+        ));
+      }
+      max_frame_size = value;
+    }
+  }
+  Ok(max_frame_size)
+}
+
+fn write_request(
+  stream: &mut TcpStream,
+  request: &RawRequest<'_>,
+  url: &Url,
+  peer_max_frame_size: usize,
+) -> error::Result<()> {
   let header_block = encode_request_headers(request, url)?;
   let body = request
     .body()
@@ -176,9 +202,28 @@ fn write_request(stream: &mut TcpStream, request: &RawRequest<'_>, url: &Url) ->
     &header_block,
   )?;
   if !body.is_empty() {
-    write_frame(stream, FRAME_DATA, FLAG_END_STREAM, STREAM_ID, body)?;
+    write_data_frames(stream, body, peer_max_frame_size)?;
   }
   stream.flush().map_err(error::request)
+}
+
+fn write_data_frames(
+  stream: &mut TcpStream,
+  body: &[u8],
+  peer_max_frame_size: usize,
+) -> error::Result<()> {
+  for (index, chunk) in body.chunks(peer_max_frame_size).enumerate() {
+    let sent = index
+      .checked_mul(peer_max_frame_size)
+      .ok_or_else(|| error::request(io::Error::other("HTTP/2 request body is too large")))?;
+    let flags = if sent + chunk.len() == body.len() {
+      FLAG_END_STREAM
+    } else {
+      0
+    };
+    write_frame(stream, FRAME_DATA, flags, STREAM_ID, chunk)?;
+  }
+  Ok(())
 }
 
 fn encode_request_headers(request: &RawRequest<'_>, url: &Url) -> error::Result<Vec<u8>> {
@@ -474,7 +519,7 @@ fn write_frame_io(
   stream_id: u32,
   payload: &[u8],
 ) -> io::Result<()> {
-  if payload.len() > 16_777_215 {
+  if payload.len() > MAX_FRAME_SIZE_LIMIT {
     return Err(io::Error::new(
       io::ErrorKind::InvalidInput,
       "HTTP/2 frame payload is too large",

--- a/rttp_client/src/lib.rs
+++ b/rttp_client/src/lib.rs
@@ -4,15 +4,15 @@
 //! | name | comment |
 //! |------|---------|
 //! | async | Async request APIs |
-//! | http2 | Prior-knowledge h2c GET over direct `socket2` TCP connections |
+//! | http2 | Prior-knowledge h2c over direct `socket2` TCP connections |
 //! | tls-native | HTTPS with `native-tls` |
 //! | tls-rustls | HTTPS with `rustls` |
 //!
 //! Direct TCP connections use `socket2`. SOCKS proxy handshakes remain delegated
 //! to the `socks` crate.
 //! With the `http2` feature enabled, `emit_http2_prior_knowledge` sends a
-//! minimal prior-knowledge h2c GET request over a direct socket2 TCP connection.
-//! TLS ALPN and full HTTP/2 multiplexing are not part of that initial path.
+//! minimal prior-knowledge h2c request over a direct socket2 TCP connection.
+//! TLS ALPN and full HTTP/2 multiplexing are not part of that path.
 //!
 //! ```rust,no_run
 //! use rttp_client::HttpClient;

--- a/rttp_client/tests/http2_prior_knowledge.rs
+++ b/rttp_client/tests/http2_prior_knowledge.rs
@@ -100,6 +100,85 @@ fn prior_knowledge_get_sends_h2_handshake_and_reads_single_response_stream() {
 }
 
 #[test]
+fn prior_knowledge_post_sends_headers_then_body_data_frame() {
+  let listener = TcpListener::bind("127.0.0.1:0").expect("bind h2 peer");
+  let addr = listener.local_addr().expect("h2 peer addr");
+
+  let handle = thread::spawn(move || {
+    let (mut stream, _) = listener.accept().expect("accept h2 client");
+    complete_h2_handshake_without_request(&mut stream);
+
+    let request_headers = read_frame(&mut stream);
+    assert_eq!(FRAME_HEADERS, request_headers.frame_type);
+    assert_eq!(FLAG_END_HEADERS, request_headers.flags);
+    assert_eq!(1, request_headers.stream_id);
+
+    let request_body = read_frame(&mut stream);
+    assert_eq!(FRAME_DATA, request_body.frame_type);
+    assert_eq!(FLAG_END_STREAM, request_body.flags);
+    assert_eq!(1, request_body.stream_id);
+    assert_eq!(b"{\"ok\":true}", request_body.payload.as_slice());
+
+    write_frame(&mut stream, FRAME_SETTINGS, FLAG_ACK, 0, &[]);
+    write_frame(&mut stream, FRAME_HEADERS, FLAG_END_HEADERS, 1, &[0x88]);
+    write_frame(&mut stream, FRAME_DATA, FLAG_END_STREAM, 1, b"created");
+
+    request_headers.payload
+  });
+
+  let response = HttpClient::new()
+    .post()
+    .url(format!("http://{}/submit", addr))
+    .content_type("application/json")
+    .header(("X-Trace", "abc123"))
+    .raw("{\"ok\":true}")
+    .emit_http2_prior_knowledge()
+    .expect("h2 POST response");
+
+  assert_eq!(200, response.code());
+  assert_eq!("HTTP/2", response.version());
+  assert_eq!("created", response.body().string().unwrap());
+
+  let request_header_block = handle.join().expect("h2 peer thread");
+  assert!(request_header_block.contains(&0x83));
+  assert!(request_header_block
+    .windows(b"/submit".len())
+    .any(|window| window == b"/submit"));
+  assert!(request_header_block
+    .windows(b"content-type".len())
+    .any(|window| window == b"content-type"));
+  assert!(request_header_block
+    .windows(b"application/json".len())
+    .any(|window| window == b"application/json"));
+  assert!(request_header_block
+    .windows(b"content-length".len())
+    .any(|window| window == b"content-length"));
+  assert!(request_header_block
+    .windows(b"11".len())
+    .any(|window| window == b"11"));
+  assert!(request_header_block
+    .windows(b"x-trace".len())
+    .any(|window| window == b"x-trace"));
+  assert!(request_header_block
+    .windows(b"abc123".len())
+    .any(|window| window == b"abc123"));
+}
+
+#[test]
+fn prior_knowledge_put_and_patch_send_body_data_frames() {
+  for method in ["PUT", "PATCH"] {
+    let request_header_block = emit_prior_knowledge_body_request(method);
+
+    assert!(request_header_block
+      .windows(method.len())
+      .any(|window| window == method.as_bytes()));
+    assert!(request_header_block
+      .windows(b"/resource".len())
+      .any(|window| window == b"/resource"));
+  }
+}
+
+#[test]
 fn prior_knowledge_rejects_configured_proxy_before_connecting() {
   let err = HttpClient::new()
     .get()
@@ -595,6 +674,15 @@ fn spawn_h2_prior_knowledge_peer_with_response(
 }
 
 fn complete_h2_request_handshake(stream: &mut impl ReadWrite) {
+  complete_h2_handshake_without_request(stream);
+
+  let request_headers = read_frame(stream);
+  assert_eq!(FRAME_HEADERS, request_headers.frame_type);
+  assert_eq!(FLAG_END_STREAM | FLAG_END_HEADERS, request_headers.flags);
+  assert_eq!(1, request_headers.stream_id);
+}
+
+fn complete_h2_handshake_without_request(stream: &mut impl ReadWrite) {
   let mut preface = [0; 24];
   stream
     .read_exact(&mut preface)
@@ -613,11 +701,44 @@ fn complete_h2_request_handshake(stream: &mut impl ReadWrite) {
   assert_eq!(FLAG_ACK, client_settings_ack.flags);
   assert_eq!(0, client_settings_ack.stream_id);
   assert_eq!(0, client_settings_ack.payload.len());
+}
 
-  let request_headers = read_frame(stream);
-  assert_eq!(FRAME_HEADERS, request_headers.frame_type);
-  assert_eq!(FLAG_END_STREAM | FLAG_END_HEADERS, request_headers.flags);
-  assert_eq!(1, request_headers.stream_id);
+fn emit_prior_knowledge_body_request(method: &str) -> Vec<u8> {
+  let listener = TcpListener::bind("127.0.0.1:0").expect("bind h2 peer");
+  let addr = listener.local_addr().expect("h2 peer addr");
+
+  let handle = thread::spawn(move || {
+    let (mut stream, _) = listener.accept().expect("accept h2 client");
+    complete_h2_handshake_without_request(&mut stream);
+
+    let request_headers = read_frame(&mut stream);
+    assert_eq!(FRAME_HEADERS, request_headers.frame_type);
+    assert_eq!(FLAG_END_HEADERS, request_headers.flags);
+    assert_eq!(1, request_headers.stream_id);
+
+    let request_body = read_frame(&mut stream);
+    assert_eq!(FRAME_DATA, request_body.frame_type);
+    assert_eq!(FLAG_END_STREAM, request_body.flags);
+    assert_eq!(1, request_body.stream_id);
+    assert_eq!(b"update-body", request_body.payload.as_slice());
+
+    write_frame(&mut stream, FRAME_SETTINGS, FLAG_ACK, 0, &[]);
+    write_frame(&mut stream, FRAME_HEADERS, FLAG_END_HEADERS, 1, &[0x88]);
+    write_frame(&mut stream, FRAME_DATA, FLAG_END_STREAM, 1, b"updated");
+
+    request_headers.payload
+  });
+
+  let response = HttpClient::new()
+    .method(method)
+    .url(format!("http://{}/resource", addr))
+    .raw("update-body")
+    .emit_http2_prior_knowledge()
+    .expect("h2 request body response");
+
+  assert_eq!(200, response.code());
+  assert_eq!("updated", response.body().string().unwrap());
+  handle.join().expect("h2 peer thread")
 }
 
 trait ReadWrite: Read + Write {}

--- a/rttp_client/tests/http2_prior_knowledge.rs
+++ b/rttp_client/tests/http2_prior_knowledge.rs
@@ -165,6 +165,55 @@ fn prior_knowledge_post_sends_headers_then_body_data_frame() {
 }
 
 #[test]
+fn prior_knowledge_post_splits_body_data_frames_at_default_peer_max_frame_size() {
+  let listener = TcpListener::bind("127.0.0.1:0").expect("bind h2 peer");
+  let addr = listener.local_addr().expect("h2 peer addr");
+  let body = "x".repeat(16 * 1024 + 7);
+  let expected_body = body.clone();
+
+  let handle = thread::spawn(move || {
+    let (mut stream, _) = listener.accept().expect("accept h2 client");
+    complete_h2_handshake_without_request(&mut stream);
+
+    let request_headers = read_frame(&mut stream);
+    assert_eq!(FRAME_HEADERS, request_headers.frame_type);
+    assert_eq!(FLAG_END_HEADERS, request_headers.flags);
+    assert_eq!(1, request_headers.stream_id);
+
+    let first_body = read_frame(&mut stream);
+    assert_eq!(FRAME_DATA, first_body.frame_type);
+    assert_eq!(0, first_body.flags);
+    assert_eq!(1, first_body.stream_id);
+    assert_eq!(16 * 1024, first_body.payload.len());
+
+    let second_body = read_frame(&mut stream);
+    assert_eq!(FRAME_DATA, second_body.frame_type);
+    assert_eq!(FLAG_END_STREAM, second_body.flags);
+    assert_eq!(1, second_body.stream_id);
+    assert_eq!(7, second_body.payload.len());
+
+    let mut full_body = first_body.payload;
+    full_body.extend_from_slice(&second_body.payload);
+    assert_eq!(expected_body.as_bytes(), full_body.as_slice());
+
+    write_frame(&mut stream, FRAME_SETTINGS, FLAG_ACK, 0, &[]);
+    write_frame(&mut stream, FRAME_HEADERS, FLAG_END_HEADERS, 1, &[0x88]);
+    write_frame(&mut stream, FRAME_DATA, FLAG_END_STREAM, 1, b"created");
+  });
+
+  let response = HttpClient::new()
+    .post()
+    .url(format!("http://{}/upload", addr))
+    .raw(&body)
+    .emit_http2_prior_knowledge()
+    .expect("h2 POST response");
+
+  assert_eq!(200, response.code());
+  assert_eq!("created", response.body().string().unwrap());
+  handle.join().expect("h2 peer thread");
+}
+
+#[test]
 fn prior_knowledge_put_and_patch_send_body_data_frames() {
   for method in ["PUT", "PATCH"] {
     let request_header_block = emit_prior_knowledge_body_request(method);


### PR DESCRIPTION
rttp_client prior-knowledge h2c now supports buffered POST/PUT/PATCH request bodies via DATA frames while preserving existing GET/header-only behavior and HTTP/1.x-style content metadata.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1378/
work_kind: code_work
branch: hbx-1378-rttp-client-send-http-2
base: main
commit: 4b25d920a0c731c96bda360ecd4710ab4a87c147
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1378/
    url: https://plane.kahub.in/endless/browse/HBX-1378/
    close_policy: link_only
```