### PR TITLE
feat: [rttp] Verify HTTP/2 prior-knowledge request body client/server parity

### DIFF
--- a/rttp/tests/http2_feature.rs
+++ b/rttp/tests/http2_feature.rs
@@ -14,7 +14,7 @@ fn wrapper_http2_feature_exposes_prior_knowledge_client_path() {
   let handle = thread::spawn(move || {
     server
       .accept_one(|request| {
-        tx.send(request.version().to_string())
+        tx.send((request.version().to_string(), request.body().to_vec()))
           .expect("send request version");
         HttpResponse::ok("wrapper h2")
       })
@@ -26,7 +26,9 @@ fn wrapper_http2_feature_exposes_prior_knowledge_client_path() {
     .emit_http2_prior_knowledge()
     .expect("wrapper h2 response");
 
-  assert_eq!("HTTP/2", rx.recv().expect("receive request version"));
+  let (request_version, request_body) = rx.recv().expect("receive request version");
+  assert_eq!("HTTP/2", request_version);
+  assert!(request_body.is_empty());
   assert_eq!("HTTP/2", response.version());
   assert_eq!("wrapper h2", response.body().string().unwrap());
 
@@ -61,6 +63,66 @@ fn wrapper_http2_feature_exposes_response_trailers_from_prior_knowledge_server()
   assert_eq!(
     Some(&"signed".to_string()),
     response.trailer_value("X-SIGNATURE")
+  );
+  assert!(response.header_value("Trailer").is_none());
+
+  handle.join().expect("server thread");
+}
+
+#[test]
+fn wrapper_http2_prior_knowledge_post_body_round_trips_between_client_and_server() {
+  let server = rttp::Http::server("127.0.0.1:0").expect("bind server");
+  let addr = server.local_addr().expect("server addr");
+  let (tx, rx) = mpsc::channel();
+  let request_body = b"body over h2 from rttp_client".to_vec();
+
+  let handle = thread::spawn(move || {
+    server
+      .accept_one(|request| {
+        tx.send((
+          request.method().to_string(),
+          request.target().to_string(),
+          request.version().to_string(),
+          request.header("content-type").map(str::to_string),
+          request.body().to_vec(),
+        ))
+        .expect("send parsed h2 request");
+        HttpResponse::new(201, "Created")
+          .header("Trailer", "X-Trace, X-Upload-Status")
+          .body("stored over h2")
+          .trailer("X-Trace", "post-body-parity")
+          .trailer("X-Upload-Status", "stored")
+      })
+      .expect("serve h2 POST request");
+  });
+
+  let response = rttp::Http::client()
+    .post()
+    .url(format!("http://{}/upload", addr))
+    .content_type("application/octet-stream")
+    .binary(request_body.clone())
+    .emit_http2_prior_knowledge()
+    .expect("wrapper h2 POST response");
+
+  let (method, target, version, content_type, observed_body) =
+    rx.recv().expect("receive parsed h2 request");
+  assert_eq!("POST", method);
+  assert_eq!("/upload", target);
+  assert_eq!("HTTP/2", version);
+  assert_eq!(Some("application/octet-stream".to_string()), content_type);
+  assert_eq!(request_body, observed_body);
+
+  assert_eq!("HTTP/2", response.version());
+  assert_eq!(201, response.code());
+  assert_eq!("stored over h2", response.body().string().unwrap());
+  assert_eq!(2, response.trailers().len());
+  assert_eq!(
+    Some(&"post-body-parity".to_string()),
+    response.trailer_value("x-trace")
+  );
+  assert_eq!(
+    Some(&"stored".to_string()),
+    response.trailer_value("X-UPLOAD-STATUS")
   );
   assert!(response.header_value("Trailer").is_none());
 

--- a/rttp_client/src/http2.rs
+++ b/rttp_client/src/http2.rs
@@ -37,12 +37,7 @@ impl<'a> PriorKnowledgeClient<'a> {
   }
 
   pub fn get(mut self) -> error::Result<Response> {
-    if !self.request.origin().method().eq_ignore_ascii_case("GET") {
-      return Err(error::builder_with_message(
-        "HTTP/2 prior-knowledge client currently supports GET only",
-      ));
-    }
-    if self.request.body().is_some() {
+    if self.request.origin().method().eq_ignore_ascii_case("GET") && self.request.body().is_some() {
       return Err(error::builder_with_message(
         "HTTP/2 prior-knowledge GET cannot send a request body",
       ));
@@ -56,7 +51,7 @@ impl<'a> PriorKnowledgeClient<'a> {
     let mut stream = connect_tcp_stream(addr(&url)?, self.request.origin().config())?;
     write_connection_preface(&mut stream)?;
     read_settings_and_ack(&mut stream)?;
-    write_get_headers(&mut stream, &self.request, &url)?;
+    write_request(&mut stream, &self.request, &url)?;
     let response = read_single_stream_response(&mut stream, self.request.url().clone())?;
     self.request.origin_mut().closed_set(true);
     Ok(response)
@@ -148,25 +143,29 @@ fn read_settings_and_ack(stream: &mut TcpStream) -> error::Result<()> {
   }
 }
 
-fn write_get_headers(
-  stream: &mut TcpStream,
-  request: &RawRequest<'_>,
-  url: &Url,
-) -> error::Result<()> {
+fn write_request(stream: &mut TcpStream, request: &RawRequest<'_>, url: &Url) -> error::Result<()> {
   let header_block = encode_request_headers(request, url)?;
+  let body = request.body().as_ref().map(|body| body.bytes());
   write_frame(
     stream,
     FRAME_HEADERS,
-    FLAG_END_STREAM | FLAG_END_HEADERS,
+    if body.is_some() {
+      FLAG_END_HEADERS
+    } else {
+      FLAG_END_STREAM | FLAG_END_HEADERS
+    },
     STREAM_ID,
     &header_block,
   )?;
+  if let Some(body) = body {
+    write_frame(stream, FRAME_DATA, FLAG_END_STREAM, STREAM_ID, body)?;
+  }
   stream.flush().map_err(error::request)
 }
 
 fn encode_request_headers(request: &RawRequest<'_>, url: &Url) -> error::Result<Vec<u8>> {
   let mut block = Vec::new();
-  block.push(0x82);
+  encode_request_method(&mut block, request.origin().method())?;
   if url.scheme() == "http" {
     block.push(0x86);
   } else {
@@ -186,6 +185,17 @@ fn encode_request_headers(request: &RawRequest<'_>, url: &Url) -> error::Result<
   }
 
   Ok(block)
+}
+
+fn encode_request_method(block: &mut Vec<u8>, method: &str) -> error::Result<()> {
+  if method.eq_ignore_ascii_case("GET") {
+    block.push(0x82);
+  } else if method.eq_ignore_ascii_case("POST") {
+    block.push(0x83);
+  } else {
+    encode_literal_indexed_name_without_indexing(block, 2, method.to_uppercase().as_bytes())?;
+  }
+  Ok(())
 }
 
 fn request_target(url: &Url) -> String {

--- a/rttp_client/src/lib.rs
+++ b/rttp_client/src/lib.rs
@@ -11,8 +11,9 @@
 //! Direct TCP connections use `socket2`. SOCKS proxy handshakes remain delegated
 //! to the `socks` crate.
 //! With the `http2` feature enabled, `emit_http2_prior_knowledge` sends a
-//! minimal prior-knowledge h2c GET request over a direct socket2 TCP connection.
-//! TLS ALPN and full HTTP/2 multiplexing are not part of that initial path.
+//! minimal prior-knowledge h2c request over a direct socket2 TCP connection.
+//! TLS ALPN and full HTTP/2 multiplexing are not part of that single-stream
+//! path.
 //!
 //! ```rust,no_run
 //! use rttp_client::HttpClient;


### PR DESCRIPTION
Enables rttp_client buffered HTTP/2 prior-knowledge request bodies and verifies rttp server parity with POST body/trailer coverage plus header-only GET regression.

## Metadata
```yaml
version: 1
issue: default:1db42efd-a529-4a00-9d1f-6c9622b1b550
work_kind: code_work
branch: hbx-1380-rttp-verify-http-2-prior
base: main
commit: ce9b5391fe51f53ab514f92481f4296aa76b1281
```