### PR TITLE
feat: [rttp] Validate and expose HTTP/1.1 chunked request trailers consistently

### DIFF
--- a/rttp/src/server.rs
+++ b/rttp/src/server.rs
@@ -2861,7 +2861,10 @@ fn is_forbidden_trailer_name(name: &str) -> bool {
     name.to_ascii_lowercase().as_str(),
     "authorization"
       | "connection"
+      | "content-encoding"
       | "content-length"
+      | "content-range"
+      | "content-type"
       | "cookie"
       | "host"
       | "proxy-authenticate"

--- a/rttp/tests/test_server.rs
+++ b/rttp/tests/test_server.rs
@@ -2497,6 +2497,42 @@ fn server_returns_bad_request_for_forbidden_chunked_request_trailer() {
 }
 
 #[test]
+fn server_returns_bad_request_for_payload_processing_chunked_request_trailer() {
+  assert_bad_request_without_handler(
+    concat!(
+      "POST /upload HTTP/1.1\r\n",
+      "Host: localhost\r\n",
+      "Transfer-Encoding: chunked\r\n",
+      "\r\n",
+      "2\r\n",
+      "OK\r\n",
+      "0\r\n",
+      "Content-Type: text/plain\r\n",
+      "\r\n"
+    )
+    .as_bytes(),
+  );
+}
+
+#[test]
+fn server_returns_bad_request_for_pseudo_header_chunked_request_trailer() {
+  assert_bad_request_without_handler(
+    concat!(
+      "POST /upload HTTP/1.1\r\n",
+      "Host: localhost\r\n",
+      "Transfer-Encoding: chunked\r\n",
+      "\r\n",
+      "2\r\n",
+      "OK\r\n",
+      "0\r\n",
+      ":method: POST\r\n",
+      "\r\n"
+    )
+    .as_bytes(),
+  );
+}
+
+#[test]
 fn server_exposes_empty_trailers_for_chunked_request_without_trailers() {
   let server = rttp::Http::server("127.0.0.1:0").expect("bind server");
   let addr = server.local_addr().expect("server addr");


### PR DESCRIPTION
Hardened rttp HTTP/1.1 chunked request trailer validation so handlers do not receive forbidden payload-processing trailer fields, with regressions for accepted trailers, pseudo-header rejection, and chunk-extension trailer behavior.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1383/
work_kind: code_work
branch: hbx-1383-rttp-validate-and-expose-http
base: main
commit: 695f5b19d0041717b235027df1f4c904b281b8dc
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1383/
    url: https://plane.kahub.in/endless/browse/HBX-1383/
    close_policy: link_only
```