### PR TITLE
feat: [rttp_client] Send HTTP/1.1 chunked request trailers for streaming uploads

### DIFF
--- a/rttp_client/src/client.rs
+++ b/rttp_client/src/client.rs
@@ -150,6 +150,26 @@ impl HttpClient {
     self
   }
 
+  /// Add a request trailer field for chunked streaming uploads.
+  pub fn trailer<P: IntoHeader>(&mut self, trailer: P) -> error::Result<&mut Self> {
+    let trailers = trailer.into_headers();
+    for h in &trailers {
+      validate_request_trailer_header(h.name(), h.value())?;
+    }
+    for h in trailers {
+      let trailers = self.request.trailers_mut();
+      if let Some(existing) = trailers
+        .iter_mut()
+        .find(|d| d.name().eq_ignore_ascii_case(h.name()))
+      {
+        existing.replace(h);
+      } else {
+        trailers.push(h);
+      }
+    }
+    Ok(self)
+  }
+
   /// Add request cookie
   pub fn cookie<S: AsRef<str>>(&mut self, cookie: S) -> &mut Self {
     self.header(("Cookie", cookie.as_ref()))
@@ -258,13 +278,15 @@ impl HttpClient {
       ));
     }
     self.request.prepare_streaming_chunked_body();
+    let trailers = self.request.trailers().clone();
     let result = (|| {
       let request = RawRequest::block_new(&mut self.request)?;
       BlockConnection::new(request).call_streaming_body(StreamingRequestBody::Chunked {
         reader: &mut reader,
+        trailers: &trailers,
       })
     })();
-    self.request.clear_streaming_body_headers();
+    self.request.clear_streaming_chunked_body_headers();
     result
   }
 
@@ -364,16 +386,78 @@ impl HttpClient {
       ));
     }
     self.request.prepare_streaming_chunked_body();
+    let trailers = self.request.trailers().clone();
     let result = async {
       let request = RawRequest::async_new(&mut self.request).await?;
       AsyncConnection::new(request)
         .async_call_streaming_body(AsyncStreamingRequestBody::Chunked {
           reader: &mut reader,
+          trailers: &trailers,
         })
         .await
     }
     .await;
-    self.request.clear_streaming_body_headers();
+    self.request.clear_streaming_chunked_body_headers();
     result
   }
+}
+
+fn validate_request_trailer_header(name: &str, value: &str) -> error::Result<()> {
+  if !is_http_token(name) || !value.bytes().all(is_header_value_byte) {
+    return Err(error::builder_with_message(
+      "Invalid request trailer header",
+    ));
+  }
+  if is_forbidden_request_trailer_name(name) {
+    return Err(error::builder_with_message(
+      "Forbidden request trailer header",
+    ));
+  }
+  Ok(())
+}
+
+fn is_forbidden_request_trailer_name(name: &str) -> bool {
+  matches!(
+    name.trim().to_ascii_lowercase().as_str(),
+    "connection"
+      | "content-length"
+      | "host"
+      | "proxy-authenticate"
+      | "proxy-authorization"
+      | "proxy-connection"
+      | "te"
+      | "trailer"
+      | "transfer-encoding"
+      | "upgrade"
+  )
+}
+
+fn is_http_token(value: &str) -> bool {
+  !value.is_empty() && value.bytes().all(is_http_token_byte)
+}
+
+fn is_http_token_byte(byte: u8) -> bool {
+  byte.is_ascii_alphanumeric()
+    || matches!(
+      byte,
+      b'!'
+        | b'#'
+        | b'$'
+        | b'%'
+        | b'&'
+        | b'\''
+        | b'*'
+        | b'+'
+        | b'-'
+        | b'.'
+        | b'^'
+        | b'_'
+        | b'`'
+        | b'|'
+        | b'~'
+    )
+}
+
+fn is_header_value_byte(byte: u8) -> bool {
+  byte == b'\t' || byte == b' ' || (0x21..=0x7e).contains(&byte) || byte >= 0x80
 }

--- a/rttp_client/src/connection/async_connection.rs
+++ b/rttp_client/src/connection/async_connection.rs
@@ -209,6 +209,7 @@ pub(crate) enum AsyncStreamingRequestBody<'a> {
   },
   Chunked {
     reader: &'a mut (dyn AsyncRead + Unpin),
+    trailers: &'a [Header],
   },
 }
 
@@ -395,8 +396,8 @@ impl<'a> AsyncConnection<'a> {
         reader,
         content_length,
       } => async_write_fixed_streaming_body(stream, *reader, *content_length).await?,
-      AsyncStreamingRequestBody::Chunked { reader } => {
-        async_write_chunked_streaming_body(stream, *reader).await?
+      AsyncStreamingRequestBody::Chunked { reader, trailers } => {
+        async_write_chunked_streaming_body(stream, *reader, trailers).await?
       }
     }
     stream.flush().await.map_err(error::request)
@@ -1008,6 +1009,7 @@ where
 async fn async_write_chunked_streaming_body<S>(
   writer: &mut S,
   reader: &mut (dyn AsyncRead + Unpin),
+  trailers: &[Header],
 ) -> error::Result<()>
 where
   S: AsyncWrite + Unpin,
@@ -1016,10 +1018,7 @@ where
   loop {
     let read = reader.read(&mut buffer).await.map_err(error::request)?;
     if read == 0 {
-      writer
-        .write_all(b"0\r\n\r\n")
-        .await
-        .map_err(error::request)?;
+      async_write_chunked_trailers(writer, trailers).await?;
       return Ok(());
     }
     writer
@@ -1032,6 +1031,20 @@ where
       .map_err(error::request)?;
     writer.write_all(CRLF).await.map_err(error::request)?;
   }
+}
+
+async fn async_write_chunked_trailers<S>(writer: &mut S, trailers: &[Header]) -> error::Result<()>
+where
+  S: AsyncWrite + Unpin,
+{
+  writer.write_all(b"0\r\n").await.map_err(error::request)?;
+  for trailer in trailers {
+    writer
+      .write_all(format!("{}: {}\r\n", trailer.name(), trailer.value()).as_bytes())
+      .await
+      .map_err(error::request)?;
+  }
+  writer.write_all(CRLF).await.map_err(error::request)
 }
 
 // proxy connection

--- a/rttp_client/src/connection/connection.rs
+++ b/rttp_client/src/connection/connection.rs
@@ -15,7 +15,7 @@ use crate::connection::connection_reader::{
 };
 use crate::request::{RawRequest, RequestBody};
 use crate::response::Response;
-use crate::types::{Proxy, RoUrl, ToUrl};
+use crate::types::{Header, Proxy, RoUrl, ToUrl};
 use crate::{error, Config};
 
 #[cfg(feature = "tls-rustls")]
@@ -548,6 +548,7 @@ pub(crate) enum StreamingRequestBody<'a> {
   },
   Chunked {
     reader: &'a mut dyn io::Read,
+    trailers: &'a [Header],
   },
 }
 
@@ -718,7 +719,9 @@ impl<'a> Connection<'a> {
         reader,
         content_length,
       } => write_fixed_streaming_body(stream, *reader, *content_length)?,
-      StreamingRequestBody::Chunked { reader } => write_chunked_streaming_body(stream, *reader)?,
+      StreamingRequestBody::Chunked { reader, trailers } => {
+        write_chunked_streaming_body(stream, *reader, trailers)?
+      }
     }
     stream.flush().map_err(error::request)
   }
@@ -1140,7 +1143,11 @@ where
   Ok(())
 }
 
-fn write_chunked_streaming_body<W>(writer: &mut W, reader: &mut dyn io::Read) -> error::Result<()>
+fn write_chunked_streaming_body<W>(
+  writer: &mut W,
+  reader: &mut dyn io::Read,
+  trailers: &[Header],
+) -> error::Result<()>
 where
   W: io::Write,
 {
@@ -1148,13 +1155,24 @@ where
   loop {
     let read = reader.read(&mut buffer).map_err(error::request)?;
     if read == 0 {
-      writer.write_all(b"0\r\n\r\n").map_err(error::request)?;
+      write_chunked_trailers(writer, trailers)?;
       return Ok(());
     }
     write!(writer, "{:x}\r\n", read).map_err(error::request)?;
     writer.write_all(&buffer[..read]).map_err(error::request)?;
     writer.write_all(b"\r\n").map_err(error::request)?;
   }
+}
+
+fn write_chunked_trailers<W>(writer: &mut W, trailers: &[Header]) -> error::Result<()>
+where
+  W: io::Write,
+{
+  writer.write_all(b"0\r\n").map_err(error::request)?;
+  for trailer in trailers {
+    write!(writer, "{}: {}\r\n", trailer.name(), trailer.value()).map_err(error::request)?;
+  }
+  writer.write_all(b"\r\n").map_err(error::request)
 }
 
 #[cfg(test)]

--- a/rttp_client/src/request/request.rs
+++ b/rttp_client/src/request/request.rs
@@ -20,6 +20,7 @@ pub struct Request {
   paras: Vec<Para>,
   formdatas: Vec<FormData>,
   headers: Vec<Header>,
+  trailers: Vec<Header>,
   traditional: bool,
   encode: bool,
   raw: Option<String>,
@@ -40,6 +41,7 @@ impl Request {
       paras: vec![],
       formdatas: vec![],
       headers: vec![],
+      trailers: vec![],
       traditional: true,
       encode: true,
       raw: None,
@@ -74,6 +76,9 @@ impl Request {
   }
   pub fn headers(&self) -> &Vec<Header> {
     &self.headers
+  }
+  pub fn trailers(&self) -> &Vec<Header> {
+    &self.trailers
   }
   pub fn traditional(&self) -> bool {
     self.traditional
@@ -117,6 +122,9 @@ impl Request {
   }
   pub(crate) fn headers_mut(&mut self) -> &mut Vec<Header> {
     &mut self.headers
+  }
+  pub(crate) fn trailers_mut(&mut self) -> &mut Vec<Header> {
+    &mut self.trailers
   }
   pub(crate) fn traditional_mut(&mut self) -> &mut bool {
     &mut self.traditional
@@ -168,6 +176,10 @@ impl Request {
   }
   pub(crate) fn headers_set(&mut self, headers: Vec<Header>) -> &mut Self {
     self.headers = headers;
+    self
+  }
+  pub(crate) fn trailers_set(&mut self, trailers: Vec<Header>) -> &mut Self {
+    self.trailers = trailers;
     self
   }
   pub(crate) fn traditional_set(&mut self, traditional: bool) -> &mut Self {
@@ -246,13 +258,24 @@ impl Request {
   }
 
   pub(crate) fn prepare_streaming_chunked_body(&mut self) {
+    let has_trailers = !self.trailers.is_empty();
     self.headers.retain(|header| {
       !header.name().eq_ignore_ascii_case("content-length")
         && !header.name().eq_ignore_ascii_case("transfer-encoding")
+        && (!has_trailers || !header.name().eq_ignore_ascii_case("trailer"))
     });
     self
       .headers
       .push(Header::new("Transfer-Encoding", "chunked"));
+    if has_trailers {
+      let names = self
+        .trailers
+        .iter()
+        .map(|header| header.name().as_str())
+        .collect::<Vec<_>>()
+        .join(", ");
+      self.headers.push(Header::new("Trailer", names));
+    }
   }
 
   pub(crate) fn clear_streaming_body_headers(&mut self) {
@@ -260,6 +283,15 @@ impl Request {
       !header.name().eq_ignore_ascii_case("content-length")
         && !header.name().eq_ignore_ascii_case("transfer-encoding")
     });
+  }
+
+  pub(crate) fn clear_streaming_chunked_body_headers(&mut self) {
+    self.clear_streaming_body_headers();
+    if !self.trailers.is_empty() {
+      self
+        .headers
+        .retain(|header| !header.name().eq_ignore_ascii_case("trailer"));
+    }
   }
 }
 

--- a/rttp_client/tests/test_raw_request_capture.rs
+++ b/rttp_client/tests/test_raw_request_capture.rs
@@ -130,6 +130,34 @@ fn spawn_chunked_streaming_then_capture_server() -> (SocketAddr, thread::JoinHan
   (addr, handle)
 }
 
+fn spawn_chunked_trailer_capture_server() -> (SocketAddr, thread::JoinHandle<Vec<u8>>) {
+  let listener = TcpListener::bind("127.0.0.1:0").expect("bind chunked trailer capture server");
+  let addr = listener
+    .local_addr()
+    .expect("chunked trailer capture server addr");
+  let handle = thread::spawn(move || {
+    let (mut stream, _) = listener.accept().expect("accept chunked trailer request");
+    let mut request = read_request_head(&mut stream);
+    let mut body = Vec::new();
+    let mut byte = [0u8; 1];
+    loop {
+      stream.read_exact(&mut byte).expect("read chunked body");
+      body.push(byte[0]);
+      let saw_final_chunk =
+        body.starts_with(b"0\r\n") || body.windows(5).any(|window| window == b"\r\n0\r\n");
+      if saw_final_chunk && body.ends_with(b"\r\n\r\n") {
+        break;
+      }
+    }
+    request.extend_from_slice(&body);
+    stream
+      .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nOK")
+      .expect("write chunked trailer response");
+    request
+  });
+  (addr, handle)
+}
+
 #[test]
 fn get_with_query_parameters_sends_request_target_without_body() {
   let request = capture_request(|base_url| {
@@ -198,6 +226,76 @@ fn streaming_chunked_framing_does_not_leak_into_later_emit() {
   assert!(second.starts_with("GET /second HTTP/1.1\r\n"));
   assert_eq!(None, header_value(&second, "Content-Length"));
   assert_eq!(None, header_value(&second, "Transfer-Encoding"));
+}
+
+#[test]
+fn streaming_chunked_upload_sends_advertised_request_trailers_after_final_chunk() {
+  let (addr, handle) = spawn_chunked_trailer_capture_server();
+
+  client()
+    .post()
+    .url(format!("http://{}/upload", addr))
+    .trailer(("X-Trace", "trace-123"))
+    .expect("request trailer should be accepted")
+    .trailer(("X-Signature", "sha256=abc"))
+    .expect("request trailer should be accepted")
+    .emit_streaming_chunked("hello trailers".as_bytes())
+    .expect("chunked streaming upload should succeed");
+
+  let request = handle.join().expect("chunked trailer capture server");
+  let text = request_text(&request);
+  let body = request_body(&request);
+
+  assert!(text.starts_with("POST /upload HTTP/1.1\r\n"));
+  assert_eq!(Some("chunked"), header_value(&text, "Transfer-Encoding"));
+  assert_eq!(Some("X-Trace, X-Signature"), header_value(&text, "Trailer"));
+  assert_eq!(
+    b"e\r\nhello trailers\r\n0\r\nX-Trace: trace-123\r\nX-Signature: sha256=abc\r\n\r\n",
+    body
+  );
+}
+
+#[test]
+fn streaming_fixed_upload_with_request_trailers_keeps_fixed_length_framing() {
+  let request = capture_request(|base_url| {
+    client()
+      .post()
+      .url(format!("{}/upload", base_url))
+      .trailer(("X-Trace", "trace-123"))
+      .expect("request trailer should be accepted")
+      .emit_streaming_fixed("hello".as_bytes(), 5)
+      .expect("fixed streaming upload should succeed");
+  });
+
+  let text = request_text(&request);
+
+  assert_eq!(Some("5"), header_value(&text, "Content-Length"));
+  assert_eq!(None, header_value(&text, "Transfer-Encoding"));
+  assert_eq!(None, header_value(&text, "Trailer"));
+  assert_eq!(b"hello", request_body(&request));
+}
+
+#[test]
+fn request_trailer_rejects_forbidden_field_names() {
+  for name in [
+    "Host",
+    "Content-Length",
+    "Transfer-Encoding",
+    "Trailer",
+    "Connection",
+    "Upgrade",
+    "Proxy-Authorization",
+    "Proxy-Connection",
+  ] {
+    let error = client()
+      .post()
+      .trailer((name, "blocked"))
+      .expect_err("forbidden request trailer should be rejected");
+    assert!(
+      error.to_string().contains("Forbidden request trailer"),
+      "unexpected error for {name}: {error}"
+    );
+  }
 }
 
 #[test]


### PR DESCRIPTION
Adds validated `rttp_client` request trailers for HTTP/1.1 chunked streaming uploads, including `Trailer` advertisement, final trailer serialization, and focused raw request capture coverage.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1382/
work_kind: code_work
branch: hbx-1382-rttp-client-send-http-1
base: main
commit: 52e66ef7738a0287cf1de305cafb336accfc68eb
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1382/
    url: https://plane.kahub.in/endless/browse/HBX-1382/
    close_policy: link_only
```