### PR TITLE
feat: [rttp_client] Expose HTTP chunked response trailers after body decoding

### DIFF
--- a/rttp_client/src/response/response.rs
+++ b/rttp_client/src/response/response.rs
@@ -106,11 +106,28 @@ impl Response {
     self.header(name).map(|header| header.value())
   }
 
+  pub fn trailers_of_name<S: AsRef<str>>(&self, name: S) -> Vec<&Header> {
+    self
+      .trailers()
+      .iter()
+      .filter(|header| header.name().eq_ignore_ascii_case(name.as_ref()))
+      .collect()
+  }
+
   pub fn trailer<S: AsRef<str>>(&self, name: S) -> Option<&Header> {
     self
       .trailers()
       .iter()
       .find(|header| header.name().eq_ignore_ascii_case(name.as_ref()))
+  }
+
+  pub fn trailer_values<S: AsRef<str>>(&self, name: S) -> Vec<&String> {
+    self
+      .trailers()
+      .iter()
+      .filter(|header| header.name().eq_ignore_ascii_case(name.as_ref()))
+      .map(|header| header.value())
+      .collect()
   }
 
   pub fn trailer_value<S: AsRef<str>>(&self, name: S) -> Option<&String> {

--- a/rttp_client/tests/test_http_async.rs
+++ b/rttp_client/tests/test_http_async.rs
@@ -170,6 +170,66 @@ fn test_async_socket2_server_chunked_trailers_match_sync_accessors() {
 
 #[test]
 #[cfg(feature = "async")]
+fn test_async_chunked_duplicate_trailers_are_exposed_in_wire_order() {
+  let (addr, _handle) = support::spawn_chunked_response_server(concat!(
+    "HTTP/1.1 200 OK\r\n",
+    "Transfer-Encoding: chunked\r\n",
+    "Connection: close\r\n",
+    "\r\n",
+    "7;foo=bar\r\nchunked\r\n",
+    "6\r\n body!\r\n",
+    "0\r\n",
+    "X-Trace: first\r\n",
+    "x-trace: second\r\n",
+    "X-Signature: signed\r\n",
+    "\r\n"
+  ));
+
+  block_on(async {
+    let response = client()
+      .get()
+      .url(format!("http://{}/chunked", addr))
+      .rasync()
+      .await
+      .unwrap();
+
+    assert_eq!("chunked body!", response.body().string().unwrap());
+    assert_eq!(3, response.trailers().len());
+    assert_eq!("X-Trace", response.trailers()[0].name());
+    assert_eq!("first", response.trailers()[0].value());
+    assert_eq!("x-trace", response.trailers()[1].name());
+    assert_eq!("second", response.trailers()[1].value());
+    assert_eq!("X-Signature", response.trailers()[2].name());
+    assert_eq!("signed", response.trailers()[2].value());
+    assert_eq!(
+      Some("first"),
+      response.trailer("X-TRACE").map(|h| h.value().as_str())
+    );
+    assert_eq!(
+      Some("first"),
+      response.trailer_value("x-trace").map(String::as_str)
+    );
+    assert_eq!(
+      vec!["first", "second"],
+      response
+        .trailers_of_name("x-trace")
+        .iter()
+        .map(|header| header.value().as_str())
+        .collect::<Vec<_>>()
+    );
+    assert_eq!(
+      vec!["first", "second"],
+      response
+        .trailer_values("X-TRACE")
+        .iter()
+        .map(|value| value.as_str())
+        .collect::<Vec<_>>()
+    );
+  });
+}
+
+#[test]
+#[cfg(feature = "async")]
 fn test_async_chunked_quoted_extensions_are_accepted() {
   let (addr, _handle) = support::spawn_chunked_response_server(concat!(
     "HTTP/1.1 200 OK\r\n",

--- a/rttp_client/tests/test_http_basic.rs
+++ b/rttp_client/tests/test_http_basic.rs
@@ -239,6 +239,62 @@ fn test_socket2_server_chunked_trailers_are_exposed_case_insensitively() {
 }
 
 #[test]
+fn test_chunked_duplicate_trailers_are_exposed_in_wire_order() {
+  let (addr, _handle) = support::spawn_chunked_response_server(concat!(
+    "HTTP/1.1 200 OK\r\n",
+    "Transfer-Encoding: chunked\r\n",
+    "Connection: close\r\n",
+    "\r\n",
+    "7;foo=bar\r\nchunked\r\n",
+    "6\r\n body!\r\n",
+    "0\r\n",
+    "X-Trace: first\r\n",
+    "x-trace: second\r\n",
+    "X-Signature: signed\r\n",
+    "\r\n"
+  ));
+
+  let response = client()
+    .get()
+    .url(format!("http://{}/chunked", addr))
+    .emit()
+    .unwrap();
+
+  assert_eq!("chunked body!", response.body().string().unwrap());
+  assert_eq!(3, response.trailers().len());
+  assert_eq!("X-Trace", response.trailers()[0].name());
+  assert_eq!("first", response.trailers()[0].value());
+  assert_eq!("x-trace", response.trailers()[1].name());
+  assert_eq!("second", response.trailers()[1].value());
+  assert_eq!("X-Signature", response.trailers()[2].name());
+  assert_eq!("signed", response.trailers()[2].value());
+  assert_eq!(
+    Some("first"),
+    response.trailer("x-trace").map(|h| h.value().as_str())
+  );
+  assert_eq!(
+    Some("first"),
+    response.trailer_value("X-TRACE").map(String::as_str)
+  );
+  assert_eq!(
+    vec!["first", "second"],
+    response
+      .trailers_of_name("X-TRACE")
+      .iter()
+      .map(|header| header.value().as_str())
+      .collect::<Vec<_>>()
+  );
+  assert_eq!(
+    vec!["first", "second"],
+    response
+      .trailer_values("x-trace")
+      .iter()
+      .map(|value| value.as_str())
+      .collect::<Vec<_>>()
+  );
+}
+
+#[test]
 fn test_chunked_without_trailers_exposes_empty_trailers() {
   let (addr, _handle) = support::spawn_chunked_server_without_trailers();
   let response = client()


### PR DESCRIPTION
Adds duplicate-aware `rttp_client::Response` trailer lookup APIs with sync and async HTTP/1.1 chunked response coverage for duplicate, case-varied trailers. Formatting and workspace tests pass.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1340/
work_kind: code_work
branch: hbx-1340-rttp-client-expose-http-chunked
base: main
commit: 0f9a60173242feb9e6aba3a6f38219d59c70727a
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1340/
    url: https://plane.kahub.in/endless/browse/HBX-1340/
    close_policy: link_only
```