### PR TITLE
feat: [rttp_client] Decode HTTP/2 response CONTINUATION header blocks

### DIFF
--- a/rttp_client/src/http2.rs
+++ b/rttp_client/src/http2.rs
@@ -313,19 +313,32 @@ enum HeaderBlockKind {
   Trailers,
 }
 
+#[derive(Clone, Copy)]
+struct PendingHeaderBlock {
+  kind: HeaderBlockKind,
+  end_stream: bool,
+}
+
 fn read_single_stream_response(stream: &mut TcpStream, url: RoUrl) -> error::Result<Response> {
   let mut header_block = Vec::new();
   let mut headers = Vec::new();
   let mut trailers = Vec::new();
   let mut body = Vec::new();
   let mut status = None;
-  let mut header_block_kind = None;
+  let mut pending_header_block = None;
   let mut final_response_started = false;
   let mut response_body_started = false;
   let mut pending_window_update = 0usize;
 
   loop {
     let frame = read_frame(stream)?;
+    if pending_header_block.is_some()
+      && (frame.frame_type != FRAME_CONTINUATION || frame.stream_id != STREAM_ID)
+    {
+      return Err(error::bad_response(
+        "expected HTTP/2 CONTINUATION frame for incomplete header block",
+      ));
+    }
     match (frame.frame_type, frame.stream_id) {
       (FRAME_SETTINGS, 0) => {
         if frame.flags & FLAG_ACK == 0 {
@@ -338,14 +351,12 @@ fn read_single_stream_response(stream: &mut TcpStream, url: RoUrl) -> error::Res
         }
       }
       (FRAME_HEADERS, STREAM_ID) => {
-        if header_block_kind.is_some() {
-          return Err(error::bad_response("incomplete HTTP/2 header block"));
-        }
         let kind = if final_response_started || response_body_started {
           HeaderBlockKind::Trailers
         } else {
           HeaderBlockKind::ResponseHeaders
         };
+        let end_stream = frame.flags & FLAG_END_STREAM == FLAG_END_STREAM;
         header_block.extend_from_slice(&frame.payload);
         if frame.flags & FLAG_END_HEADERS == FLAG_END_HEADERS {
           if apply_header_block(
@@ -358,20 +369,22 @@ fn read_single_stream_response(stream: &mut TcpStream, url: RoUrl) -> error::Res
             final_response_started = true;
           }
           header_block.clear();
-          header_block_kind = None;
+          pending_header_block = None;
         } else {
-          header_block_kind = Some(kind);
+          pending_header_block = Some(PendingHeaderBlock { kind, end_stream });
         }
-        if frame.flags & FLAG_END_STREAM == FLAG_END_STREAM {
+        if frame.flags & FLAG_END_HEADERS == FLAG_END_HEADERS && end_stream {
           break;
         }
       }
-      (FRAME_CONTINUATION, STREAM_ID) if header_block_kind.is_some() => {
+      (FRAME_CONTINUATION, STREAM_ID) => {
+        let pending = pending_header_block.ok_or_else(|| {
+          error::bad_response("unexpected HTTP/2 CONTINUATION frame without header block")
+        })?;
         header_block.extend_from_slice(&frame.payload);
         if frame.flags & FLAG_END_HEADERS == FLAG_END_HEADERS {
-          let kind = header_block_kind.expect("checked header block kind");
           if apply_header_block(
-            kind,
+            pending.kind,
             &header_block,
             &mut status,
             &mut headers,
@@ -380,7 +393,10 @@ fn read_single_stream_response(stream: &mut TcpStream, url: RoUrl) -> error::Res
             final_response_started = true;
           }
           header_block.clear();
-          header_block_kind = None;
+          pending_header_block = None;
+          if pending.end_stream {
+            break;
+          }
         }
       }
       (FRAME_DATA, STREAM_ID) => {
@@ -409,12 +425,17 @@ fn read_single_stream_response(stream: &mut TcpStream, url: RoUrl) -> error::Res
         }
       }
       (_, STREAM_ID) => {}
+      (FRAME_CONTINUATION, _) => {
+        return Err(error::bad_response(
+          "unexpected HTTP/2 CONTINUATION frame without header block",
+        ));
+      }
       (_, 0) => {}
       _ => {}
     }
   }
 
-  if header_block_kind.is_some() {
+  if pending_header_block.is_some() {
     return Err(error::bad_response("incomplete HTTP/2 header block"));
   }
 

--- a/rttp_client/tests/http2_prior_knowledge.rs
+++ b/rttp_client/tests/http2_prior_knowledge.rs
@@ -14,6 +14,7 @@ const FRAME_RST_STREAM: u8 = 0x3;
 const FRAME_SETTINGS: u8 = 0x4;
 const FRAME_GOAWAY: u8 = 0x7;
 const FRAME_WINDOW_UPDATE: u8 = 0x8;
+const FRAME_CONTINUATION: u8 = 0x9;
 
 const FLAG_END_STREAM: u8 = 0x1;
 const FLAG_END_HEADERS: u8 = 0x4;
@@ -353,6 +354,141 @@ fn prior_knowledge_exposes_response_trailers_after_data_without_changing_headers
     response.trailer_value("X-Trace")
   );
   assert!(response.header("x-trace").is_none());
+  handle.join().expect("h2 peer thread");
+}
+
+#[test]
+fn prior_knowledge_decodes_response_headers_split_across_continuation_frames() {
+  let listener = TcpListener::bind("127.0.0.1:0").expect("bind h2 peer");
+  let addr = listener.local_addr().expect("h2 peer addr");
+
+  let handle = thread::spawn(move || {
+    let (mut stream, _) = listener.accept().expect("accept h2 client");
+    complete_h2_request_handshake(&mut stream);
+
+    write_frame(&mut stream, FRAME_HEADERS, 0, 1, &[0x88]);
+    write_frame(
+      &mut stream,
+      FRAME_CONTINUATION,
+      FLAG_END_HEADERS,
+      1,
+      &h2_literal_new_name(b"x-split", b"headers"),
+    );
+    write_frame(
+      &mut stream,
+      FRAME_DATA,
+      FLAG_END_STREAM,
+      1,
+      b"split header body",
+    );
+  });
+
+  let response = HttpClient::new()
+    .get()
+    .url(format!("http://{}/split-headers", addr))
+    .emit_http2_prior_knowledge()
+    .expect("h2 response with continued headers");
+
+  assert_eq!(200, response.code());
+  assert_eq!(
+    Some(&"headers".to_string()),
+    response.header_value("X-Split")
+  );
+  assert_eq!("split header body", response.body().string().unwrap());
+  handle.join().expect("h2 peer thread");
+}
+
+#[test]
+fn prior_knowledge_decodes_response_trailers_split_across_continuation_frames() {
+  let listener = TcpListener::bind("127.0.0.1:0").expect("bind h2 peer");
+  let addr = listener.local_addr().expect("h2 peer addr");
+
+  let handle = thread::spawn(move || {
+    let (mut stream, _) = listener.accept().expect("accept h2 client");
+    complete_h2_request_handshake(&mut stream);
+
+    write_frame(&mut stream, FRAME_HEADERS, FLAG_END_HEADERS, 1, &[0x88]);
+    write_frame(&mut stream, FRAME_DATA, 0, 1, b"split trailer body");
+    write_frame(&mut stream, FRAME_HEADERS, FLAG_END_STREAM, 1, &[]);
+    write_frame(
+      &mut stream,
+      FRAME_CONTINUATION,
+      FLAG_END_HEADERS,
+      1,
+      &h2_literal_new_name(b"x-trace", b"continued"),
+    );
+  });
+
+  let response = HttpClient::new()
+    .get()
+    .url(format!("http://{}/split-trailers", addr))
+    .emit_http2_prior_knowledge()
+    .expect("h2 response with continued trailers");
+
+  assert_eq!(200, response.code());
+  assert_eq!("split trailer body", response.body().string().unwrap());
+  assert_eq!(
+    Some(&"continued".to_string()),
+    response.trailer_value("X-Trace")
+  );
+  assert!(response.header("x-trace").is_none());
+  handle.join().expect("h2 peer thread");
+}
+
+#[test]
+fn prior_knowledge_rejects_continuation_without_pending_header_block() {
+  let listener = TcpListener::bind("127.0.0.1:0").expect("bind h2 peer");
+  let addr = listener.local_addr().expect("h2 peer addr");
+
+  let handle = thread::spawn(move || {
+    let (mut stream, _) = listener.accept().expect("accept h2 client");
+    complete_h2_request_handshake(&mut stream);
+
+    write_frame(
+      &mut stream,
+      FRAME_CONTINUATION,
+      FLAG_END_HEADERS,
+      1,
+      &[0x88],
+    );
+  });
+
+  let error = HttpClient::new()
+    .get()
+    .url(format!("http://{}/orphan-continuation", addr))
+    .emit_http2_prior_knowledge()
+    .expect_err("orphan CONTINUATION frame should be rejected");
+
+  assert!(
+    error.to_string().contains("unexpected HTTP/2 CONTINUATION"),
+    "unexpected error: {error}"
+  );
+  handle.join().expect("h2 peer thread");
+}
+
+#[test]
+fn prior_knowledge_rejects_interrupted_continuation_sequence() {
+  let listener = TcpListener::bind("127.0.0.1:0").expect("bind h2 peer");
+  let addr = listener.local_addr().expect("h2 peer addr");
+
+  let handle = thread::spawn(move || {
+    let (mut stream, _) = listener.accept().expect("accept h2 client");
+    complete_h2_request_handshake(&mut stream);
+
+    write_frame(&mut stream, FRAME_HEADERS, 0, 1, &[0x88]);
+    write_frame(&mut stream, FRAME_DATA, 0, 1, b"not allowed here");
+  });
+
+  let error = HttpClient::new()
+    .get()
+    .url(format!("http://{}/interrupted-continuation", addr))
+    .emit_http2_prior_knowledge()
+    .expect_err("interrupted CONTINUATION sequence should be rejected");
+
+  assert!(
+    error.to_string().contains("expected HTTP/2 CONTINUATION"),
+    "unexpected error: {error}"
+  );
   handle.join().expect("h2 peer thread");
 }
 


### PR DESCRIPTION
Added HTTP/2 prior-knowledge client support for continued response headers and trailers, with explicit rejection of invalid CONTINUATION sequencing.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1386/
work_kind: code_work
branch: hbx-1386-rttp-client-decode-http-2
base: main
commit: ff852c27fb98ad2d2c1c29bf14cc7a64d55aed47
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1386/
    url: https://plane.kahub.in/endless/browse/HBX-1386/
    close_policy: link_only
```