### PR TITLE
feat: [rttp] Reject invalid HTTP/2 CONTINUATION sequencing consistently

### DIFF
--- a/rttp/src/server.rs
+++ b/rttp/src/server.rs
@@ -389,6 +389,15 @@ impl HttpServer {
       let frame = match self.normalize_connection_error(read_http2_frame(&mut stream)) {
         Ok(frame) => frame,
         Err(err)
+          if err.kind() == io::ErrorKind::UnexpectedEof
+            && active_http2_header_continuation_stream(&streams).is_some() =>
+        {
+          return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "incomplete HTTP/2 header block",
+          ));
+        }
+        Err(err)
           if err.kind() == io::ErrorKind::UnexpectedEof && served > 0 && streams.is_empty() =>
         {
           break;

--- a/rttp/tests/test_server.rs
+++ b/rttp/tests/test_server.rs
@@ -555,6 +555,113 @@ fn server_rejects_http2_prior_knowledge_interleaved_frame_before_end_headers() {
 }
 
 #[test]
+fn server_rejects_http2_prior_knowledge_continuation_without_open_header_block() {
+  let server = rttp::Http::server("127.0.0.1:0")
+    .expect("bind server")
+    .with_read_timeout(Some(Duration::from_secs(2)));
+  let addr = server.local_addr().expect("server addr");
+  let (tx, rx) = mpsc::channel();
+
+  let handle = thread::spawn(move || {
+    server.accept_one(|request| {
+      tx.send(request).expect("send unexpected h2 request");
+      HttpResponse::ok("unexpected")
+    })
+  });
+
+  let mut stream = TcpStream::connect(addr).expect("connect h2 server");
+  complete_h2_server_handshake(&mut stream);
+  write_h2_frame(
+    &mut stream,
+    H2_FRAME_CONTINUATION,
+    H2_FLAG_END_HEADERS,
+    1,
+    &[0x82],
+  );
+  stream
+    .shutdown(std::net::Shutdown::Write)
+    .expect("shutdown h2 write");
+
+  let error = handle
+    .join()
+    .expect("server thread")
+    .expect_err("orphan CONTINUATION should reject request");
+  assert_eq!(ErrorKind::InvalidData, error.kind());
+  assert!(rx.try_recv().is_err());
+}
+
+#[test]
+fn server_rejects_http2_prior_knowledge_continuation_on_wrong_stream() {
+  let server = rttp::Http::server("127.0.0.1:0")
+    .expect("bind server")
+    .with_read_timeout(Some(Duration::from_secs(2)));
+  let addr = server.local_addr().expect("server addr");
+  let (tx, rx) = mpsc::channel();
+
+  let handle = thread::spawn(move || {
+    server.accept_one(|request| {
+      tx.send(request).expect("send unexpected h2 request");
+      HttpResponse::ok("unexpected")
+    })
+  });
+
+  let mut stream = TcpStream::connect(addr).expect("connect h2 server");
+  complete_h2_server_handshake(&mut stream);
+  write_h2_frame(&mut stream, H2_FRAME_HEADERS, 0, 1, &[0x83, 0x86]);
+  write_h2_frame(
+    &mut stream,
+    H2_FRAME_CONTINUATION,
+    H2_FLAG_END_HEADERS,
+    3,
+    &h2_get_headers(b"/wrong-continuation", addr.to_string().as_bytes()),
+  );
+  stream
+    .shutdown(std::net::Shutdown::Write)
+    .expect("shutdown h2 write");
+
+  let error = handle
+    .join()
+    .expect("server thread")
+    .expect_err("wrong-stream CONTINUATION should reject request");
+  assert_eq!(ErrorKind::InvalidData, error.kind());
+  assert!(rx.try_recv().is_err());
+}
+
+#[test]
+fn server_rejects_http2_prior_knowledge_eof_before_end_headers() {
+  let server = rttp::Http::server("127.0.0.1:0")
+    .expect("bind server")
+    .with_read_timeout(Some(Duration::from_secs(2)));
+  let addr = server.local_addr().expect("server addr");
+  let (tx, rx) = mpsc::channel();
+
+  let handle = thread::spawn(move || {
+    server.accept_one(|request| {
+      tx.send(request).expect("send unexpected h2 request");
+      HttpResponse::ok("unexpected")
+    })
+  });
+
+  let mut stream = TcpStream::connect(addr).expect("connect h2 server");
+  complete_h2_server_handshake(&mut stream);
+  write_h2_frame(&mut stream, H2_FRAME_HEADERS, 0, 1, &[0x83, 0x86]);
+  stream
+    .shutdown(std::net::Shutdown::Write)
+    .expect("shutdown h2 write");
+
+  let error = handle
+    .join()
+    .expect("server thread")
+    .expect_err("EOF before END_HEADERS should reject request");
+  assert_eq!(ErrorKind::InvalidData, error.kind());
+  assert!(
+    error.to_string().contains("incomplete HTTP/2 header block"),
+    "unexpected error: {error}"
+  );
+  assert!(rx.try_recv().is_err());
+}
+
+#[test]
 fn server_rejects_http2_prior_knowledge_data_before_headers_without_handler() {
   let server = rttp::Http::server("127.0.0.1:0")
     .expect("bind server")

--- a/rttp_client/src/http2.rs
+++ b/rttp_client/src/http2.rs
@@ -331,7 +331,13 @@ fn read_single_stream_response(stream: &mut TcpStream, url: RoUrl) -> error::Res
   let mut pending_window_update = 0usize;
 
   loop {
-    let frame = read_frame(stream)?;
+    let frame = match read_frame(stream) {
+      Ok(frame) => frame,
+      Err(err) if pending_header_block.is_some() && is_unexpected_eof(&err) => {
+        return Err(error::bad_response("incomplete HTTP/2 header block"));
+      }
+      Err(err) => return Err(err),
+    };
     if pending_header_block.is_some()
       && (frame.frame_type != FRAME_CONTINUATION || frame.stream_id != STREAM_ID)
     {
@@ -441,6 +447,12 @@ fn read_single_stream_response(stream: &mut TcpStream, url: RoUrl) -> error::Res
 
   let status = status.ok_or_else(|| error::bad_response("missing HTTP/2 :status header"))?;
   build_response(url, status, &headers, body, trailers)
+}
+
+fn is_unexpected_eof(err: &error::Error) -> bool {
+  std::error::Error::source(err)
+    .and_then(|source| source.downcast_ref::<io::Error>())
+    .is_some_and(|source| source.kind() == io::ErrorKind::UnexpectedEof)
 }
 
 fn apply_header_block(

--- a/rttp_client/tests/http2_prior_knowledge.rs
+++ b/rttp_client/tests/http2_prior_knowledge.rs
@@ -493,6 +493,65 @@ fn prior_knowledge_rejects_interrupted_continuation_sequence() {
 }
 
 #[test]
+fn prior_knowledge_rejects_continuation_on_wrong_stream_during_header_block() {
+  let listener = TcpListener::bind("127.0.0.1:0").expect("bind h2 peer");
+  let addr = listener.local_addr().expect("h2 peer addr");
+
+  let handle = thread::spawn(move || {
+    let (mut stream, _) = listener.accept().expect("accept h2 client");
+    complete_h2_request_handshake(&mut stream);
+
+    write_frame(&mut stream, FRAME_HEADERS, 0, 1, &[0x88]);
+    write_frame(
+      &mut stream,
+      FRAME_CONTINUATION,
+      FLAG_END_HEADERS,
+      3,
+      &[
+        0x0f, 16, 10, b't', b'e', b'x', b't', b'/', b'p', b'l', b'a', b'i', b'n',
+      ],
+    );
+  });
+
+  let error = HttpClient::new()
+    .get()
+    .url(format!("http://{}/wrong-stream-continuation", addr))
+    .emit_http2_prior_knowledge()
+    .expect_err("wrong-stream CONTINUATION sequence should be rejected");
+
+  assert!(
+    error.to_string().contains("expected HTTP/2 CONTINUATION"),
+    "unexpected error: {error}"
+  );
+  handle.join().expect("h2 peer thread");
+}
+
+#[test]
+fn prior_knowledge_rejects_eof_before_end_headers() {
+  let listener = TcpListener::bind("127.0.0.1:0").expect("bind h2 peer");
+  let addr = listener.local_addr().expect("h2 peer addr");
+
+  let handle = thread::spawn(move || {
+    let (mut stream, _) = listener.accept().expect("accept h2 client");
+    complete_h2_request_handshake(&mut stream);
+
+    write_frame(&mut stream, FRAME_HEADERS, 0, 1, &[0x88]);
+  });
+
+  let error = HttpClient::new()
+    .get()
+    .url(format!("http://{}/eof-before-end-headers", addr))
+    .emit_http2_prior_knowledge()
+    .expect_err("EOF before END_HEADERS should be rejected");
+
+  assert!(
+    error.to_string().contains("incomplete HTTP/2 header block"),
+    "unexpected error: {error}"
+  );
+  handle.join().expect("h2 peer thread");
+}
+
+#[test]
 fn prior_knowledge_rejects_response_trailer_pseudo_headers() {
   let listener = TcpListener::bind("127.0.0.1:0").expect("bind h2 peer");
   let addr = listener.local_addr().expect("h2 peer addr");


### PR DESCRIPTION
Reject invalid HTTP/2 CONTINUATION sequencing consistently across rttp client and server, with regression coverage for orphan, wrong-stream, interleaved, and EOF-before-END_HEADERS cases.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1388/
work_kind: code_work
branch: hbx-1388-rttp-reject-invalid-http-2
base: main
commit: f2d02bf0c956b1ac6e03471ce675a56da88f7156
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1388/
    url: https://plane.kahub.in/endless/browse/HBX-1388/
    close_policy: link_only
```