### PR TITLE
feat: [rttp] Validate malformed HTTP/2 PING frames across client and server

### DIFF
--- a/rttp/tests/http2_feature.rs
+++ b/rttp/tests/http2_feature.rs
@@ -1,9 +1,126 @@
 #![cfg(feature = "http2")]
 
+use std::io::{Read, Write};
+use std::net::{SocketAddr, TcpListener};
 use std::sync::mpsc;
 use std::thread;
+use std::time::Duration;
 
 use rttp::server::HttpResponse;
+
+const H2_FRAME_DATA: u8 = 0x0;
+const H2_FRAME_HEADERS: u8 = 0x1;
+const H2_FRAME_SETTINGS: u8 = 0x4;
+const H2_FRAME_PING: u8 = 0x6;
+const H2_FLAG_END_STREAM: u8 = 0x1;
+const H2_FLAG_ACK: u8 = 0x1;
+const H2_FLAG_END_HEADERS: u8 = 0x4;
+
+struct H2Frame {
+  frame_type: u8,
+  flags: u8,
+  stream_id: u32,
+  payload: Vec<u8>,
+}
+
+fn write_h2_frame(
+  stream: &mut impl Write,
+  frame_type: u8,
+  flags: u8,
+  stream_id: u32,
+  payload: &[u8],
+) {
+  let length = payload.len();
+  let mut header = [0; 9];
+  header[0] = ((length >> 16) & 0xff) as u8;
+  header[1] = ((length >> 8) & 0xff) as u8;
+  header[2] = (length & 0xff) as u8;
+  header[3] = frame_type;
+  header[4] = flags;
+  header[5..9].copy_from_slice(&(stream_id & 0x7fff_ffff).to_be_bytes());
+  stream.write_all(&header).expect("write h2 frame head");
+  stream.write_all(payload).expect("write h2 frame payload");
+}
+
+fn read_h2_frame(stream: &mut impl Read) -> H2Frame {
+  let mut header = [0; 9];
+  stream.read_exact(&mut header).expect("read h2 frame head");
+  let length = ((header[0] as usize) << 16) | ((header[1] as usize) << 8) | header[2] as usize;
+  let mut payload = vec![0; length];
+  stream
+    .read_exact(&mut payload)
+    .expect("read h2 frame payload");
+  H2Frame {
+    frame_type: header[3],
+    flags: header[4],
+    stream_id: u32::from_be_bytes([header[5] & 0x7f, header[6], header[7], header[8]]),
+    payload,
+  }
+}
+
+fn spawn_h2_peer_sending_ping_before_response() -> (SocketAddr, thread::JoinHandle<()>) {
+  let listener = TcpListener::bind("127.0.0.1:0").expect("bind h2 peer");
+  let addr = listener.local_addr().expect("h2 peer addr");
+
+  let handle = thread::spawn(move || {
+    let (mut stream, _) = listener.accept().expect("accept h2 client");
+    stream
+      .set_read_timeout(Some(Duration::from_secs(2)))
+      .expect("set h2 peer read timeout");
+
+    let mut preface = [0; 24];
+    stream
+      .read_exact(&mut preface)
+      .expect("read client preface");
+    assert_eq!(b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n", &preface);
+
+    let client_settings = read_h2_frame(&mut stream);
+    assert_eq!(H2_FRAME_SETTINGS, client_settings.frame_type);
+    assert_eq!(0, client_settings.flags);
+    assert_eq!(0, client_settings.stream_id);
+
+    write_h2_frame(&mut stream, H2_FRAME_SETTINGS, 0, 0, &[]);
+
+    let client_settings_ack = read_h2_frame(&mut stream);
+    assert_eq!(H2_FRAME_SETTINGS, client_settings_ack.frame_type);
+    assert_eq!(H2_FLAG_ACK, client_settings_ack.flags);
+    assert_eq!(0, client_settings_ack.stream_id);
+
+    let request_headers = read_h2_frame(&mut stream);
+    assert_eq!(H2_FRAME_HEADERS, request_headers.frame_type);
+    assert_eq!(
+      H2_FLAG_END_STREAM | H2_FLAG_END_HEADERS,
+      request_headers.flags
+    );
+    assert_eq!(1, request_headers.stream_id);
+
+    write_h2_frame(&mut stream, H2_FRAME_SETTINGS, H2_FLAG_ACK, 0, &[]);
+    write_h2_frame(&mut stream, H2_FRAME_PING, 0, 0, b"rttp-png");
+
+    let ping_ack = read_h2_frame(&mut stream);
+    assert_eq!(H2_FRAME_PING, ping_ack.frame_type);
+    assert_eq!(H2_FLAG_ACK, ping_ack.flags);
+    assert_eq!(0, ping_ack.stream_id);
+    assert_eq!(b"rttp-png", ping_ack.payload.as_slice());
+
+    write_h2_frame(
+      &mut stream,
+      H2_FRAME_HEADERS,
+      H2_FLAG_END_HEADERS,
+      1,
+      &[0x88],
+    );
+    write_h2_frame(
+      &mut stream,
+      H2_FRAME_DATA,
+      H2_FLAG_END_STREAM,
+      1,
+      b"wrapper pong",
+    );
+  });
+
+  (addr, handle)
+}
 
 #[test]
 fn wrapper_http2_feature_exposes_prior_knowledge_client_path() {
@@ -33,6 +150,22 @@ fn wrapper_http2_feature_exposes_prior_knowledge_client_path() {
   assert_eq!("wrapper h2", response.body().string().unwrap());
 
   handle.join().expect("server thread");
+}
+
+#[test]
+fn wrapper_http2_prior_knowledge_client_acks_peer_ping_before_response() {
+  let (addr, handle) = spawn_h2_peer_sending_ping_before_response();
+
+  let response = rttp::Http::client()
+    .url(format!("http://{}/wrapper-ping", addr))
+    .emit_http2_prior_knowledge()
+    .expect("wrapper h2 response after ping");
+
+  assert_eq!("HTTP/2", response.version());
+  assert_eq!(200, response.code());
+  assert_eq!("wrapper pong", response.body().string().unwrap());
+
+  handle.join().expect("h2 ping peer thread");
 }
 
 #[test]

--- a/rttp/tests/test_server.rs
+++ b/rttp/tests/test_server.rs
@@ -562,6 +562,11 @@ fn server_rejects_http2_prior_knowledge_ping_with_invalid_payload_length() {
 }
 
 #[test]
+fn server_rejects_http2_prior_knowledge_ping_ack_with_invalid_payload_length() {
+  assert_invalid_h2_frame_without_handler(H2_FRAME_PING, H2_FLAG_ACK, 0, b"short");
+}
+
+#[test]
 fn server_accepts_http2_prior_knowledge_continuation_headers_before_data() {
   let server = rttp::Http::server("127.0.0.1:0").expect("bind server");
   let addr = server.local_addr().expect("server addr");

--- a/rttp_client/tests/http2_prior_knowledge.rs
+++ b/rttp_client/tests/http2_prior_knowledge.rs
@@ -726,7 +726,7 @@ fn prior_knowledge_ignores_ping_ack_and_consumes_final_response() {
 
 #[test]
 fn prior_knowledge_rejects_malformed_ping_frames() {
-  let (stream_addr, stream_handle) = spawn_ping_peer(1, b"rttp-png");
+  let (stream_addr, stream_handle) = spawn_ping_peer(0, 1, b"rttp-png");
   let stream_error = HttpClient::new()
     .get()
     .url(format!("http://{}/bad-ping-stream", stream_addr))
@@ -735,7 +735,7 @@ fn prior_knowledge_rejects_malformed_ping_frames() {
   assert!(stream_error.to_string().contains("PING"));
   stream_handle.join().expect("bad ping stream peer thread");
 
-  let (length_addr, length_handle) = spawn_ping_peer(0, b"short");
+  let (length_addr, length_handle) = spawn_ping_peer(0, 0, b"short");
   let length_error = HttpClient::new()
     .get()
     .url(format!("http://{}/bad-ping-length", length_addr))
@@ -743,6 +743,22 @@ fn prior_knowledge_rejects_malformed_ping_frames() {
     .expect_err("ping with invalid payload length must fail");
   assert!(length_error.to_string().contains("PING"));
   length_handle.join().expect("bad ping length peer thread");
+
+  let (ack_length_addr, ack_length_handle) = spawn_ping_peer(FLAG_ACK, 0, b"short");
+  let ack_length_error = HttpClient::new()
+    .get()
+    .url(format!("http://{}/bad-ping-ack-length", ack_length_addr))
+    .emit_http2_prior_knowledge()
+    .expect_err("ping ack with invalid payload length must fail");
+  assert!(
+    ack_length_error
+      .to_string()
+      .contains("invalid HTTP/2 PING frame"),
+    "unexpected error: {ack_length_error}"
+  );
+  ack_length_handle
+    .join()
+    .expect("bad ping ack length peer thread");
 }
 
 #[test]
@@ -1130,14 +1146,18 @@ fn spawn_control_frame_peer(frame_type: u8) -> (SocketAddr, thread::JoinHandle<(
   (addr, handle)
 }
 
-fn spawn_ping_peer(stream_id: u32, payload: &'static [u8]) -> (SocketAddr, thread::JoinHandle<()>) {
+fn spawn_ping_peer(
+  flags: u8,
+  stream_id: u32,
+  payload: &'static [u8],
+) -> (SocketAddr, thread::JoinHandle<()>) {
   let listener = TcpListener::bind("127.0.0.1:0").expect("bind h2 peer");
   let addr = listener.local_addr().expect("h2 peer addr");
 
   let handle = thread::spawn(move || {
     let (mut stream, _) = listener.accept().expect("accept h2 client");
     complete_h2_request_handshake(&mut stream);
-    write_frame(&mut stream, FRAME_PING, 0, stream_id, payload);
+    write_frame(&mut stream, FRAME_PING, flags, stream_id, payload);
   });
 
   (addr, handle)


### PR DESCRIPTION
Added HTTP/2 PING wrapper and malformed ACK regression coverage for rttp client/server behavior. Verification passes with formatting, workspace tests, and HTTP/2 feature-enabled package tests.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1392/
work_kind: code_work
branch: hbx-1392-rttp-validate-malformed-http-2
base: main
commit: cd265e0a3cd5a18fb241f7f2a93d89bd2856fc43
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1392/
    url: https://plane.kahub.in/endless/browse/HBX-1392/
    close_policy: link_only
```