### PR TITLE
feat: [rttp] Decode HTTP/2 request trailers on socket2 prior-knowledge server

### DIFF
--- a/rttp/src/server.rs
+++ b/rttp/src/server.rs
@@ -464,14 +464,22 @@ impl HttpServer {
         }
         (HTTP2_FRAME_HEADERS, id) if id != 0 => {
           let request_stream = http2_request_stream(&mut streams, id);
+          if request_stream.end_stream {
+            return Err(io::Error::new(
+              io::ErrorKind::InvalidData,
+              "HTTP/2 HEADERS frame arrived after END_STREAM",
+            ));
+          }
+          request_stream.header_block_kind = Some(if request_stream.decoded_headers.is_some() {
+            Http2HeaderBlockKind::RequestTrailers
+          } else {
+            Http2HeaderBlockKind::RequestHeaders
+          });
           request_stream
             .header_block
             .extend_from_slice(&frame.payload);
           if frame.flags & HTTP2_FLAG_END_HEADERS == HTTP2_FLAG_END_HEADERS {
-            request_stream.decoded_headers =
-              Some(decode_http2_request_headers(&request_stream.header_block)?);
-            request_stream.header_block.clear();
-            request_stream.in_header_continuation = false;
+            request_stream.finish_header_block()?;
           } else {
             request_stream.in_header_continuation = true;
           }
@@ -499,10 +507,7 @@ impl HttpServer {
             .header_block
             .extend_from_slice(&frame.payload);
           if frame.flags & HTTP2_FLAG_END_HEADERS == HTTP2_FLAG_END_HEADERS {
-            request_stream.decoded_headers =
-              Some(decode_http2_request_headers(&request_stream.header_block)?);
-            request_stream.header_block.clear();
-            request_stream.in_header_continuation = false;
+            request_stream.finish_header_block()?;
           }
         }
         (HTTP2_FRAME_DATA, id) if id != 0 => {
@@ -637,10 +642,18 @@ struct Http2Frame {
 struct Http2RequestStream {
   stream_id: u32,
   header_block: Vec<u8>,
+  header_block_kind: Option<Http2HeaderBlockKind>,
   decoded_headers: Option<DecodedHttp2RequestHeaders>,
+  decoded_trailers: Vec<(String, String)>,
   body: Vec<u8>,
   end_stream: bool,
   in_header_continuation: bool,
+}
+
+#[derive(Clone, Copy)]
+enum Http2HeaderBlockKind {
+  RequestHeaders,
+  RequestTrailers,
 }
 
 impl Http2RequestStream {
@@ -648,7 +661,9 @@ impl Http2RequestStream {
     Self {
       stream_id,
       header_block: Vec::new(),
+      header_block_kind: None,
       decoded_headers: None,
+      decoded_trailers: Vec::new(),
       body: Vec::new(),
       end_stream: false,
       in_header_continuation: false,
@@ -659,11 +674,31 @@ impl Http2RequestStream {
     self.decoded_headers.is_some() && self.end_stream && !self.in_header_continuation
   }
 
+  fn finish_header_block(&mut self) -> io::Result<()> {
+    match self.header_block_kind.take() {
+      Some(Http2HeaderBlockKind::RequestHeaders) => {
+        self.decoded_headers = Some(decode_http2_request_headers(&self.header_block)?);
+      }
+      Some(Http2HeaderBlockKind::RequestTrailers) => {
+        self.decoded_trailers = decode_http2_request_trailers(&self.header_block)?;
+      }
+      None => {
+        return Err(io::Error::new(
+          io::ErrorKind::InvalidData,
+          "HTTP/2 header block completed without HEADERS frame",
+        ));
+      }
+    }
+    self.header_block.clear();
+    self.in_header_continuation = false;
+    Ok(())
+  }
+
   fn into_request(self) -> io::Result<Request> {
     let decoded_headers = self.decoded_headers.ok_or_else(|| {
       io::Error::new(io::ErrorKind::InvalidData, "missing HTTP/2 request headers")
     })?;
-    decoded_headers.into_request(self.body)
+    decoded_headers.into_request(self.body, self.decoded_trailers)
   }
 }
 
@@ -764,7 +799,7 @@ struct DecodedHttp2RequestHeaders {
 }
 
 impl DecodedHttp2RequestHeaders {
-  fn into_request(self, body: Vec<u8>) -> io::Result<Request> {
+  fn into_request(self, body: Vec<u8>, trailers: Vec<(String, String)>) -> io::Result<Request> {
     let method = self
       .method
       .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "missing HTTP/2 :method"))?;
@@ -784,14 +819,13 @@ impl DecodedHttp2RequestHeaders {
       target,
       version: "HTTP/2".to_string(),
       headers,
-      trailers: Vec::new(),
+      trailers,
       body,
     })
   }
 }
 
 fn decode_http2_request_headers(block: &[u8]) -> io::Result<DecodedHttp2RequestHeaders> {
-  let mut cursor = 0;
   let mut decoded = DecodedHttp2RequestHeaders {
     method: None,
     target: None,
@@ -802,23 +836,7 @@ fn decode_http2_request_headers(block: &[u8]) -> io::Result<DecodedHttp2RequestH
   let mut regular_header_seen = false;
   let mut pseudo_headers = Vec::<String>::new();
 
-  while cursor < block.len() {
-    let byte = block[cursor];
-    let (name, value) = if byte & 0x80 == 0x80 {
-      let index = decode_http2_integer(block, &mut cursor, 7)?;
-      let (name, value) = http2_static_header(index)?;
-      (name.to_string(), value.to_string())
-    } else if byte & 0x40 == 0x40 {
-      decode_http2_literal(block, &mut cursor, 6)?
-    } else if byte & 0x20 == 0x20 {
-      return Err(io::Error::new(
-        io::ErrorKind::InvalidData,
-        "HTTP/2 dynamic table size updates are not supported",
-      ));
-    } else {
-      decode_http2_literal(block, &mut cursor, 4)?
-    };
-
+  for (name, value) in decode_http2_header_fields(block)? {
     if name.starts_with(':') {
       if regular_header_seen {
         return Err(io::Error::new(
@@ -852,6 +870,49 @@ fn decode_http2_request_headers(block: &[u8]) -> io::Result<DecodedHttp2RequestH
   }
 
   Ok(decoded)
+}
+
+fn decode_http2_request_trailers(block: &[u8]) -> io::Result<Vec<(String, String)>> {
+  let trailers = decode_http2_header_fields(block)?;
+  for (name, _) in &trailers {
+    if name.starts_with(':') {
+      return Err(io::Error::new(
+        io::ErrorKind::InvalidData,
+        "HTTP/2 request trailer contained pseudo-header",
+      ));
+    }
+    if !is_http_token(name) || is_forbidden_trailer_name(name) {
+      return Err(io::Error::new(
+        io::ErrorKind::InvalidData,
+        "forbidden request trailer",
+      ));
+    }
+  }
+  Ok(trailers)
+}
+
+fn decode_http2_header_fields(block: &[u8]) -> io::Result<Vec<(String, String)>> {
+  let mut cursor = 0;
+  let mut fields = Vec::new();
+  while cursor < block.len() {
+    let byte = block[cursor];
+    let field = if byte & 0x80 == 0x80 {
+      let index = decode_http2_integer(block, &mut cursor, 7)?;
+      let (name, value) = http2_static_header(index)?;
+      (name.to_string(), value.to_string())
+    } else if byte & 0x40 == 0x40 {
+      decode_http2_literal(block, &mut cursor, 6)?
+    } else if byte & 0x20 == 0x20 {
+      return Err(io::Error::new(
+        io::ErrorKind::InvalidData,
+        "HTTP/2 dynamic table size updates are not supported",
+      ));
+    } else {
+      decode_http2_literal(block, &mut cursor, 4)?
+    };
+    fields.push(field);
+  }
+  Ok(fields)
 }
 
 fn decode_http2_literal(

--- a/rttp/src/server.rs
+++ b/rttp/src/server.rs
@@ -470,11 +470,18 @@ impl HttpServer {
               "HTTP/2 HEADERS frame arrived after END_STREAM",
             ));
           }
-          request_stream.header_block_kind = Some(if request_stream.decoded_headers.is_some() {
+          let header_block_kind = if request_stream.decoded_headers.is_some() {
+            if frame.flags & HTTP2_FLAG_END_STREAM != HTTP2_FLAG_END_STREAM {
+              return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "HTTP/2 request trailers must end the stream",
+              ));
+            }
             Http2HeaderBlockKind::RequestTrailers
           } else {
             Http2HeaderBlockKind::RequestHeaders
-          });
+          };
+          request_stream.header_block_kind = Some(header_block_kind);
           request_stream
             .header_block
             .extend_from_slice(&frame.payload);
@@ -874,14 +881,17 @@ fn decode_http2_request_headers(block: &[u8]) -> io::Result<DecodedHttp2RequestH
 
 fn decode_http2_request_trailers(block: &[u8]) -> io::Result<Vec<(String, String)>> {
   let trailers = decode_http2_header_fields(block)?;
-  for (name, _) in &trailers {
+  for (name, value) in &trailers {
     if name.starts_with(':') {
       return Err(io::Error::new(
         io::ErrorKind::InvalidData,
         "HTTP/2 request trailer contained pseudo-header",
       ));
     }
-    if !is_http_token(name) || is_forbidden_trailer_name(name) {
+    if !is_http_token(name)
+      || is_forbidden_trailer_name(name)
+      || !value.bytes().all(is_header_value_byte)
+    {
       return Err(io::Error::new(
         io::ErrorKind::InvalidData,
         "forbidden request trailer",

--- a/rttp/tests/test_server.rs
+++ b/rttp/tests/test_server.rs
@@ -685,6 +685,63 @@ fn server_rejects_http2_prior_knowledge_forbidden_request_trailer_name() {
 }
 
 #[test]
+fn server_rejects_http2_prior_knowledge_request_trailers_without_end_stream() {
+  let server = rttp::Http::server("127.0.0.1:0")
+    .expect("bind server")
+    .with_read_timeout(Some(Duration::from_secs(2)));
+  let addr = server.local_addr().expect("server addr");
+  let (tx, rx) = mpsc::channel();
+
+  let handle = thread::spawn(move || {
+    server.accept_one(|request| {
+      tx.send(request).expect("send unexpected h2 request");
+      HttpResponse::ok("unexpected")
+    })
+  });
+
+  let mut stream = TcpStream::connect(addr).expect("connect h2 server");
+  stream
+    .set_read_timeout(Some(Duration::from_secs(2)))
+    .expect("set h2 read timeout");
+  complete_h2_server_handshake(&mut stream);
+
+  write_h2_frame(
+    &mut stream,
+    H2_FRAME_HEADERS,
+    H2_FLAG_END_HEADERS,
+    1,
+    &h2_post_headers(b"/non-terminal-trailers", addr.to_string().as_bytes()),
+  );
+  write_h2_frame(&mut stream, H2_FRAME_DATA, 0, 1, b"body");
+  write_h2_frame(
+    &mut stream,
+    H2_FRAME_HEADERS,
+    H2_FLAG_END_HEADERS,
+    1,
+    &h2_literal_new_name(b"x-trace", b"not-terminal"),
+  );
+  write_h2_frame(&mut stream, H2_FRAME_DATA, H2_FLAG_END_STREAM, 1, b"after");
+  stream
+    .shutdown(std::net::Shutdown::Write)
+    .expect("shutdown h2 write");
+
+  let error = handle
+    .join()
+    .expect("server thread")
+    .expect_err("non-terminal h2 trailers should reject request");
+  assert_eq!(ErrorKind::InvalidData, error.kind());
+  assert!(rx.try_recv().is_err());
+}
+
+#[test]
+fn server_rejects_http2_prior_knowledge_request_trailer_value_control_bytes() {
+  assert_invalid_h2_request_trailers_without_handler(&h2_literal_new_name(
+    b"x-trace",
+    b"safe\r\nx-evil: true",
+  ));
+}
+
+#[test]
 fn server_acknowledges_http2_prior_knowledge_ping_around_request_frames() {
   let server = rttp::Http::server("127.0.0.1:0").expect("bind server");
   let addr = server.local_addr().expect("server addr");

--- a/rttp/tests/test_server.rs
+++ b/rttp/tests/test_server.rs
@@ -157,6 +157,52 @@ fn assert_invalid_h2_headers_without_handler(header_block: &[u8]) {
   assert!(rx.try_recv().is_err());
 }
 
+fn assert_invalid_h2_request_trailers_without_handler(trailer_block: &[u8]) {
+  let server = rttp::Http::server("127.0.0.1:0")
+    .expect("bind server")
+    .with_read_timeout(Some(Duration::from_secs(2)));
+  let addr = server.local_addr().expect("server addr");
+  let (tx, rx) = mpsc::channel();
+
+  let handle = thread::spawn(move || {
+    server.accept_one(|request| {
+      tx.send(request).expect("send unexpected h2 request");
+      HttpResponse::ok("unexpected")
+    })
+  });
+
+  let mut stream = TcpStream::connect(addr).expect("connect h2 server");
+  stream
+    .set_read_timeout(Some(Duration::from_secs(2)))
+    .expect("set h2 read timeout");
+  complete_h2_server_handshake(&mut stream);
+  write_h2_frame(
+    &mut stream,
+    H2_FRAME_HEADERS,
+    H2_FLAG_END_HEADERS,
+    1,
+    &h2_post_headers(b"/invalid-trailers", addr.to_string().as_bytes()),
+  );
+  write_h2_frame(&mut stream, H2_FRAME_DATA, 0, 1, b"body");
+  write_h2_frame(
+    &mut stream,
+    H2_FRAME_HEADERS,
+    H2_FLAG_END_HEADERS | H2_FLAG_END_STREAM,
+    1,
+    trailer_block,
+  );
+  stream
+    .shutdown(std::net::Shutdown::Write)
+    .expect("shutdown h2 write");
+
+  let error = handle
+    .join()
+    .expect("server thread")
+    .expect_err("invalid h2 trailers should reject request");
+  assert_eq!(ErrorKind::InvalidData, error.kind());
+  assert!(rx.try_recv().is_err());
+}
+
 fn assert_invalid_h2_frame_without_handler(
   frame_type: u8,
   flags: u8,
@@ -484,6 +530,158 @@ fn server_accepts_http2_prior_knowledge_headers_and_data_before_calling_handler(
   assert_eq!(b"stored", response_body.payload.as_slice());
 
   handle.join().expect("server thread");
+}
+
+#[test]
+fn server_decodes_http2_prior_knowledge_request_trailers_after_data() {
+  let server = rttp::Http::server("127.0.0.1:0").expect("bind server");
+  let addr = server.local_addr().expect("server addr");
+  let (tx, rx) = mpsc::channel();
+
+  let handle = thread::spawn(move || {
+    server
+      .accept_one(|request| {
+        tx.send((
+          request.body().to_vec(),
+          request.header("x-trace").map(str::to_string),
+          request.trailer("x-trace").map(str::to_string),
+          request.trailer("X-UPLOAD-STATUS").map(str::to_string),
+          request.trailers().to_vec(),
+        ))
+        .expect("send parsed h2 trailer request");
+        HttpResponse::ok("stored")
+      })
+      .expect("serve one h2 trailer request");
+  });
+
+  let mut stream = TcpStream::connect(addr).expect("connect h2 server");
+  stream
+    .set_read_timeout(Some(Duration::from_secs(2)))
+    .expect("set h2 read timeout");
+  complete_h2_server_handshake(&mut stream);
+
+  write_h2_frame(
+    &mut stream,
+    H2_FRAME_HEADERS,
+    H2_FLAG_END_HEADERS,
+    1,
+    &h2_post_headers(b"/upload-with-trailers", addr.to_string().as_bytes()),
+  );
+  write_h2_frame(&mut stream, H2_FRAME_DATA, 0, 1, b"body before trailers");
+
+  let mut trailers = h2_literal_new_name(b"x-trace", b"from-trailer");
+  trailers.extend(h2_literal_new_name(b"x-upload-status", b"stored"));
+  write_h2_frame(
+    &mut stream,
+    H2_FRAME_HEADERS,
+    H2_FLAG_END_HEADERS | H2_FLAG_END_STREAM,
+    1,
+    &trailers,
+  );
+
+  let response_headers = read_h2_frame_skipping_window_updates(&mut stream);
+  assert_eq!(H2_FRAME_HEADERS, response_headers.frame_type);
+  assert_eq!(H2_FLAG_END_HEADERS, response_headers.flags);
+  assert_eq!(1, response_headers.stream_id);
+
+  let response_body = read_h2_frame_skipping_window_updates(&mut stream);
+  assert_eq!(H2_FRAME_DATA, response_body.frame_type);
+  assert_eq!(H2_FLAG_END_STREAM, response_body.flags);
+  assert_eq!(1, response_body.stream_id);
+  assert_eq!(b"stored", response_body.payload.as_slice());
+
+  assert_eq!(
+    (
+      b"body before trailers".to_vec(),
+      None,
+      Some("from-trailer".to_string()),
+      Some("stored".to_string()),
+      vec![
+        ("x-trace".to_string(), "from-trailer".to_string()),
+        ("x-upload-status".to_string(), "stored".to_string()),
+      ]
+    ),
+    rx.recv().expect("receive parsed h2 trailer request")
+  );
+  handle.join().expect("server thread");
+}
+
+#[test]
+fn server_decodes_http2_prior_knowledge_request_trailers_with_continuation() {
+  let server = rttp::Http::server("127.0.0.1:0").expect("bind server");
+  let addr = server.local_addr().expect("server addr");
+  let (tx, rx) = mpsc::channel();
+
+  let handle = thread::spawn(move || {
+    server
+      .accept_one(|request| {
+        tx.send(request.trailers().to_vec())
+          .expect("send parsed h2 continuation trailers");
+        HttpResponse::ok("stored")
+      })
+      .expect("serve one h2 continuation trailer request");
+  });
+
+  let mut stream = TcpStream::connect(addr).expect("connect h2 server");
+  stream
+    .set_read_timeout(Some(Duration::from_secs(2)))
+    .expect("set h2 read timeout");
+  complete_h2_server_handshake(&mut stream);
+
+  write_h2_frame(
+    &mut stream,
+    H2_FRAME_HEADERS,
+    H2_FLAG_END_HEADERS,
+    1,
+    &h2_post_headers(
+      b"/upload-with-continued-trailers",
+      addr.to_string().as_bytes(),
+    ),
+  );
+  write_h2_frame(&mut stream, H2_FRAME_DATA, 0, 1, b"body");
+
+  write_h2_frame(
+    &mut stream,
+    H2_FRAME_HEADERS,
+    H2_FLAG_END_STREAM,
+    1,
+    &h2_literal_new_name(b"x-first", b"one"),
+  );
+  write_h2_frame(
+    &mut stream,
+    H2_FRAME_CONTINUATION,
+    H2_FLAG_END_HEADERS,
+    1,
+    &h2_literal_new_name(b"x-second", b"two"),
+  );
+
+  let response_headers = read_h2_frame_skipping_window_updates(&mut stream);
+  assert_eq!(H2_FRAME_HEADERS, response_headers.frame_type);
+  assert_eq!(1, response_headers.stream_id);
+
+  let response_body = read_h2_frame_skipping_window_updates(&mut stream);
+  assert_eq!(H2_FRAME_DATA, response_body.frame_type);
+  assert_eq!(H2_FLAG_END_STREAM, response_body.flags);
+  assert_eq!(b"stored", response_body.payload.as_slice());
+
+  assert_eq!(
+    vec![
+      ("x-first".to_string(), "one".to_string()),
+      ("x-second".to_string(), "two".to_string()),
+    ],
+    rx.recv().expect("receive parsed h2 continuation trailers")
+  );
+  handle.join().expect("server thread");
+}
+
+#[test]
+fn server_rejects_http2_prior_knowledge_request_trailer_pseudo_header() {
+  assert_invalid_h2_request_trailers_without_handler(&h2_literal_indexed_name(2, b"GET"));
+}
+
+#[test]
+fn server_rejects_http2_prior_knowledge_forbidden_request_trailer_name() {
+  assert_invalid_h2_request_trailers_without_handler(&h2_literal_new_name(b"content-length", b"4"));
 }
 
 #[test]


### PR DESCRIPTION
Server-side HTTP/2 prior-knowledge requests now decode terminal trailer blocks into Request trailers with validation and regression coverage.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1395/
work_kind: code_work
branch: hbx-1395-rttp-decode-http-2-request
base: main
commit: b3ac9a0bf532c5d64d83b5314ed6661e0b031874
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1395/
    url: https://plane.kahub.in/endless/browse/HBX-1395/
    close_policy: link_only
```