### PR TITLE
feat: [rttp_client] Send HTTP/2 request trailers from prior-knowledge requests

### DIFF
--- a/rttp_client/src/http2.rs
+++ b/rttp_client/src/http2.rs
@@ -190,7 +190,8 @@ fn write_request(
     .as_ref()
     .map(|body| body.bytes())
     .unwrap_or(&[]);
-  let header_flags = if body.is_empty() {
+  let has_trailers = !request.origin().trailers().is_empty();
+  let header_flags = if body.is_empty() && !has_trailers {
     FLAG_END_STREAM | FLAG_END_HEADERS
   } else {
     FLAG_END_HEADERS
@@ -203,7 +204,17 @@ fn write_request(
     &header_block,
   )?;
   if !body.is_empty() {
-    write_data_frames(stream, body, peer_max_frame_size)?;
+    write_data_frames(stream, body, peer_max_frame_size, has_trailers)?;
+  }
+  if has_trailers {
+    let trailer_block = encode_request_trailers(request)?;
+    write_frame(
+      stream,
+      FRAME_HEADERS,
+      FLAG_END_HEADERS | FLAG_END_STREAM,
+      STREAM_ID,
+      &trailer_block,
+    )?;
   }
   stream.flush().map_err(error::request)
 }
@@ -212,12 +223,13 @@ fn write_data_frames(
   stream: &mut TcpStream,
   body: &[u8],
   peer_max_frame_size: usize,
+  has_trailers: bool,
 ) -> error::Result<()> {
   for (index, chunk) in body.chunks(peer_max_frame_size).enumerate() {
     let sent = index
       .checked_mul(peer_max_frame_size)
       .ok_or_else(|| error::request(io::Error::other("HTTP/2 request body is too large")))?;
-    let flags = if sent + chunk.len() == body.len() {
+    let flags = if sent + chunk.len() == body.len() && !has_trailers {
       FLAG_END_STREAM
     } else {
       0
@@ -248,6 +260,18 @@ fn encode_request_headers(request: &RawRequest<'_>, url: &Url) -> error::Result<
     encode_literal_new_name_without_indexing(&mut block, name.as_bytes(), value.as_bytes())?;
   }
 
+  Ok(block)
+}
+
+fn encode_request_trailers(request: &RawRequest<'_>) -> error::Result<Vec<u8>> {
+  let mut block = Vec::new();
+  for header in request.origin().trailers() {
+    encode_literal_new_name_without_indexing(
+      &mut block,
+      header.name().to_ascii_lowercase().as_bytes(),
+      header.value().as_bytes(),
+    )?;
+  }
   Ok(block)
 }
 
@@ -301,6 +325,7 @@ fn regular_headers(header: &str) -> Vec<(String, String)> {
           | "keep-alive"
           | "proxy-connection"
           | "te"
+          | "trailer"
           | "transfer-encoding"
           | "upgrade"
       )

--- a/rttp_client/src/http2.rs
+++ b/rttp_client/src/http2.rs
@@ -260,7 +260,25 @@ fn encode_request_headers(request: &RawRequest<'_>, url: &Url) -> error::Result<
     encode_literal_new_name_without_indexing(&mut block, name.as_bytes(), value.as_bytes())?;
   }
 
+  if !request.origin().trailers().is_empty() {
+    encode_literal_new_name_without_indexing(
+      &mut block,
+      b"trailer",
+      request_trailer_field_value(request).as_bytes(),
+    )?;
+  }
+
   Ok(block)
+}
+
+fn request_trailer_field_value(request: &RawRequest<'_>) -> String {
+  request
+    .origin()
+    .trailers()
+    .iter()
+    .map(|header| header.name().as_str())
+    .collect::<Vec<_>>()
+    .join(", ")
 }
 
 fn encode_request_trailers(request: &RawRequest<'_>) -> error::Result<Vec<u8>> {

--- a/rttp_client/tests/http2_prior_knowledge.rs
+++ b/rttp_client/tests/http2_prior_knowledge.rs
@@ -167,6 +167,65 @@ fn prior_knowledge_post_sends_headers_then_body_data_frame() {
 }
 
 #[test]
+fn prior_knowledge_post_sends_request_trailers_after_body_data_frame() {
+  let listener = TcpListener::bind("127.0.0.1:0").expect("bind h2 peer");
+  let addr = listener.local_addr().expect("h2 peer addr");
+
+  let handle = thread::spawn(move || {
+    let (mut stream, _) = listener.accept().expect("accept h2 client");
+    complete_h2_handshake_without_request(&mut stream);
+
+    let request_headers = read_frame(&mut stream);
+    assert_eq!(FRAME_HEADERS, request_headers.frame_type);
+    assert_eq!(FLAG_END_HEADERS, request_headers.flags);
+    assert_eq!(1, request_headers.stream_id);
+
+    let request_body = read_frame(&mut stream);
+    assert_eq!(FRAME_DATA, request_body.frame_type);
+    assert_eq!(0, request_body.flags);
+    assert_eq!(1, request_body.stream_id);
+    assert_eq!(b"trace body", request_body.payload.as_slice());
+
+    let request_trailers = read_frame(&mut stream);
+    assert_eq!(FRAME_HEADERS, request_trailers.frame_type);
+    assert_eq!(FLAG_END_HEADERS | FLAG_END_STREAM, request_trailers.flags);
+    assert_eq!(1, request_trailers.stream_id);
+
+    write_frame(&mut stream, FRAME_SETTINGS, FLAG_ACK, 0, &[]);
+    write_frame(&mut stream, FRAME_HEADERS, FLAG_END_HEADERS, 1, &[0x88]);
+    write_frame(&mut stream, FRAME_DATA, FLAG_END_STREAM, 1, b"created");
+
+    (request_headers.payload, request_trailers.payload)
+  });
+
+  let response = HttpClient::new()
+    .post()
+    .url(format!("http://{}/submit-with-tail", addr))
+    .trailer(("X-Trace", "abc"))
+    .expect("configure request trailer")
+    .raw("trace body")
+    .emit_http2_prior_knowledge()
+    .expect("h2 POST response");
+
+  assert_eq!(200, response.code());
+  assert_eq!("created", response.body().string().unwrap());
+
+  let (request_header_block, request_trailer_block) = handle.join().expect("h2 peer thread");
+  assert!(request_header_block
+    .windows(b"/submit-with-tail".len())
+    .any(|window| window == b"/submit-with-tail"));
+  assert!(!request_header_block
+    .windows(b"trailer".len())
+    .any(|window| window == b"trailer"));
+  assert!(request_trailer_block
+    .windows(b"x-trace".len())
+    .any(|window| window == b"x-trace"));
+  assert!(request_trailer_block
+    .windows(b"abc".len())
+    .any(|window| window == b"abc"));
+}
+
+#[test]
 fn prior_knowledge_post_splits_body_data_frames_at_default_peer_max_frame_size() {
   let listener = TcpListener::bind("127.0.0.1:0").expect("bind h2 peer");
   let addr = listener.local_addr().expect("h2 peer addr");

--- a/rttp_client/tests/http2_prior_knowledge.rs
+++ b/rttp_client/tests/http2_prior_knowledge.rs
@@ -201,6 +201,7 @@ fn prior_knowledge_post_sends_request_trailers_after_body_data_frame() {
   let response = HttpClient::new()
     .post()
     .url(format!("http://{}/submit-with-tail", addr))
+    .header(("Trailer", "X-Trace"))
     .trailer(("X-Trace", "abc"))
     .expect("configure request trailer")
     .raw("trace body")
@@ -214,9 +215,12 @@ fn prior_knowledge_post_sends_request_trailers_after_body_data_frame() {
   assert!(request_header_block
     .windows(b"/submit-with-tail".len())
     .any(|window| window == b"/submit-with-tail"));
-  assert!(!request_header_block
+  assert!(request_header_block
     .windows(b"trailer".len())
     .any(|window| window == b"trailer"));
+  assert!(request_header_block
+    .windows(b"X-Trace".len())
+    .any(|window| window == b"X-Trace"));
   assert!(request_trailer_block
     .windows(b"x-trace".len())
     .any(|window| window == b"x-trace"));


### PR DESCRIPTION
rttp_client HTTP/2 prior-knowledge requests now send validated request trailers in a terminal trailer HEADERS frame while preserving existing no-trailer stream-ending behavior. Added focused integration coverage and verified the rttp_client package with the http2 feature enabled.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1394/
work_kind: code_work
branch: hbx-1394-rttp-client-send-http-2
base: main
commit: 1663fc690997518a3718cdd0421eecd798ce5cef
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1394/
    url: https://plane.kahub.in/endless/browse/HBX-1394/
    close_policy: link_only
```