### PR TITLE
feat: [rttp] Validate malformed HTTP/2 request trailers across client and server

### DIFF
--- a/rttp/tests/http2_feature.rs
+++ b/rttp/tests/http2_feature.rs
@@ -261,3 +261,65 @@ fn wrapper_http2_prior_knowledge_post_body_round_trips_between_client_and_server
 
   handle.join().expect("server thread");
 }
+
+#[test]
+fn wrapper_http2_prior_knowledge_post_request_trailers_reach_server_only_as_trailers() {
+  let server = rttp::Http::server("127.0.0.1:0").expect("bind server");
+  let addr = server.local_addr().expect("server addr");
+  let (tx, rx) = mpsc::channel();
+  let request_body = b"body with request trailers".to_vec();
+
+  let handle = thread::spawn(move || {
+    server
+      .accept_one(|request| {
+        tx.send((
+          request.method().to_string(),
+          request.target().to_string(),
+          request.version().to_string(),
+          request.body().to_vec(),
+          request.header("x-trace").map(str::to_string),
+          request.header("x-upload-status").map(str::to_string),
+          request.trailer("x-trace").map(str::to_string),
+          request.trailer("X-UPLOAD-STATUS").map(str::to_string),
+          request.trailers().to_vec(),
+        ))
+        .expect("send parsed h2 request trailers");
+        HttpResponse::ok("stored request trailers")
+      })
+      .expect("serve h2 request trailer request");
+  });
+
+  let response = rttp::Http::client()
+    .post()
+    .url(format!("http://{}/upload-with-request-trailers", addr))
+    .content_type("application/octet-stream")
+    .binary(request_body.clone())
+    .trailer(("X-Trace", "request-trailer-trace"))
+    .expect("configure x-trace request trailer")
+    .trailer(("X-Upload-Status", "stored"))
+    .expect("configure x-upload-status request trailer")
+    .emit_http2_prior_knowledge()
+    .expect("wrapper h2 request trailer response");
+
+  assert_eq!(
+    (
+      "POST".to_string(),
+      "/upload-with-request-trailers".to_string(),
+      "HTTP/2".to_string(),
+      request_body,
+      None,
+      None,
+      Some("request-trailer-trace".to_string()),
+      Some("stored".to_string()),
+      vec![
+        ("x-trace".to_string(), "request-trailer-trace".to_string()),
+        ("x-upload-status".to_string(), "stored".to_string()),
+      ]
+    ),
+    rx.recv().expect("receive parsed h2 request trailers")
+  );
+  assert_eq!("HTTP/2", response.version());
+  assert_eq!("stored request trailers", response.body().string().unwrap());
+
+  handle.join().expect("server thread");
+}

--- a/rttp/tests/test_server.rs
+++ b/rttp/tests/test_server.rs
@@ -203,6 +203,40 @@ fn assert_invalid_h2_request_trailers_without_handler(trailer_block: &[u8]) {
   assert!(rx.try_recv().is_err());
 }
 
+fn assert_invalid_h2_request_trailer_sequence_without_handler(
+  write_sequence: impl FnOnce(&mut TcpStream, SocketAddr),
+) {
+  let server = rttp::Http::server("127.0.0.1:0")
+    .expect("bind server")
+    .with_read_timeout(Some(Duration::from_secs(2)));
+  let addr = server.local_addr().expect("server addr");
+  let (tx, rx) = mpsc::channel();
+
+  let handle = thread::spawn(move || {
+    server.accept_one(|request| {
+      tx.send(request).expect("send unexpected h2 request");
+      HttpResponse::ok("unexpected")
+    })
+  });
+
+  let mut stream = TcpStream::connect(addr).expect("connect h2 server");
+  stream
+    .set_read_timeout(Some(Duration::from_secs(2)))
+    .expect("set h2 read timeout");
+  complete_h2_server_handshake(&mut stream);
+  write_sequence(&mut stream, addr);
+  stream
+    .shutdown(std::net::Shutdown::Write)
+    .expect("shutdown h2 write");
+
+  let error = handle
+    .join()
+    .expect("server thread")
+    .expect_err("invalid h2 trailer sequence should reject request");
+  assert_eq!(ErrorKind::InvalidData, error.kind());
+  assert!(rx.try_recv().is_err());
+}
+
 fn assert_invalid_h2_frame_without_handler(
   frame_type: u8,
   flags: u8,
@@ -681,7 +715,17 @@ fn server_rejects_http2_prior_knowledge_request_trailer_pseudo_header() {
 
 #[test]
 fn server_rejects_http2_prior_knowledge_forbidden_request_trailer_name() {
-  assert_invalid_h2_request_trailers_without_handler(&h2_literal_new_name(b"content-length", b"4"));
+  for name in [
+    b"content-length".as_slice(),
+    b"transfer-encoding",
+    b"connection",
+    b"host",
+    b"te",
+    b"trailer",
+    b"upgrade",
+  ] {
+    assert_invalid_h2_request_trailers_without_handler(&h2_literal_new_name(name, b"blocked"));
+  }
 }
 
 #[test]
@@ -739,6 +783,77 @@ fn server_rejects_http2_prior_knowledge_request_trailer_value_control_bytes() {
     b"x-trace",
     b"safe\r\nx-evil: true",
   ));
+}
+
+#[test]
+fn server_rejects_http2_prior_knowledge_interleaved_frame_during_request_trailers() {
+  assert_invalid_h2_request_trailer_sequence_without_handler(|stream, addr| {
+    write_h2_frame(
+      stream,
+      H2_FRAME_HEADERS,
+      H2_FLAG_END_HEADERS,
+      1,
+      &h2_post_headers(b"/interleaved-trailers", addr.to_string().as_bytes()),
+    );
+    write_h2_frame(stream, H2_FRAME_DATA, 0, 1, b"body");
+    write_h2_frame(
+      stream,
+      H2_FRAME_HEADERS,
+      H2_FLAG_END_STREAM,
+      1,
+      &h2_literal_new_name(b"x-trace", b"partial"),
+    );
+    write_h2_frame(stream, H2_FRAME_DATA, H2_FLAG_END_STREAM, 1, b"interleaved");
+  });
+}
+
+#[test]
+fn server_rejects_http2_prior_knowledge_request_trailer_continuation_on_wrong_stream() {
+  assert_invalid_h2_request_trailer_sequence_without_handler(|stream, addr| {
+    write_h2_frame(
+      stream,
+      H2_FRAME_HEADERS,
+      H2_FLAG_END_HEADERS,
+      1,
+      &h2_post_headers(b"/wrong-stream-trailers", addr.to_string().as_bytes()),
+    );
+    write_h2_frame(stream, H2_FRAME_DATA, 0, 1, b"body");
+    write_h2_frame(
+      stream,
+      H2_FRAME_HEADERS,
+      H2_FLAG_END_STREAM,
+      1,
+      &h2_literal_new_name(b"x-trace", b"partial"),
+    );
+    write_h2_frame(
+      stream,
+      H2_FRAME_CONTINUATION,
+      H2_FLAG_END_HEADERS,
+      3,
+      &h2_literal_new_name(b"x-second", b"wrong-stream"),
+    );
+  });
+}
+
+#[test]
+fn server_rejects_http2_prior_knowledge_eof_during_request_trailers() {
+  assert_invalid_h2_request_trailer_sequence_without_handler(|stream, addr| {
+    write_h2_frame(
+      stream,
+      H2_FRAME_HEADERS,
+      H2_FLAG_END_HEADERS,
+      1,
+      &h2_post_headers(b"/eof-during-trailers", addr.to_string().as_bytes()),
+    );
+    write_h2_frame(stream, H2_FRAME_DATA, 0, 1, b"body");
+    write_h2_frame(
+      stream,
+      H2_FRAME_HEADERS,
+      H2_FLAG_END_STREAM,
+      1,
+      &h2_literal_new_name(b"x-trace", b"partial"),
+    );
+  });
 }
 
 #[test]


### PR DESCRIPTION
Added regression coverage validating HTTP/2 request trailers end to end and malformed trailer rejection across wrapper, server, and client prior-knowledge paths.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1396/
work_kind: code_work
branch: hbx-1396-rttp-validate-malformed-http-2
base: main
commit: 58ad0909f9199a1558afab7bea2bbd7cf262bbf4
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1396/
    url: https://plane.kahub.in/endless/browse/HBX-1396/
    close_policy: link_only
```