### PR TITLE
feat: [rttp_client] Decode padded HTTP/2 response HEADERS and DATA frames

### DIFF
--- a/rttp_client/src/http2.rs
+++ b/rttp_client/src/http2.rs
@@ -24,6 +24,8 @@ const FRAME_CONTINUATION: u8 = 0x9;
 const FLAG_END_STREAM: u8 = 0x1;
 const FLAG_ACK: u8 = 0x1;
 const FLAG_END_HEADERS: u8 = 0x4;
+const FLAG_PADDED: u8 = 0x8;
+const FLAG_PRIORITY: u8 = 0x20;
 
 const STREAM_ID: u32 = 1;
 const SETTING_ENABLE_PUSH: u16 = 0x2;
@@ -445,7 +447,7 @@ fn read_single_stream_response(stream: &mut TcpStream, url: RoUrl) -> error::Res
           HeaderBlockKind::ResponseHeaders
         };
         let end_stream = frame.flags & FLAG_END_STREAM == FLAG_END_STREAM;
-        header_block.extend_from_slice(&frame.payload);
+        header_block.extend_from_slice(header_block_fragment(&frame)?);
         if frame.flags & FLAG_END_HEADERS == FLAG_END_HEADERS {
           if apply_header_block(
             kind,
@@ -489,8 +491,9 @@ fn read_single_stream_response(stream: &mut TcpStream, url: RoUrl) -> error::Res
       }
       (FRAME_DATA, STREAM_ID) => {
         let end_stream = frame.flags & FLAG_END_STREAM == FLAG_END_STREAM;
+        let data = data_payload(&frame)?;
         response_body_started = true;
-        body.extend_from_slice(&frame.payload);
+        body.extend_from_slice(data);
         pending_window_update = pending_window_update
           .checked_add(frame.payload.len())
           .ok_or_else(|| error::bad_response("HTTP/2 response body is too large"))?;
@@ -541,6 +544,50 @@ fn read_single_stream_response(stream: &mut TcpStream, url: RoUrl) -> error::Res
 
   let status = status.ok_or_else(|| error::bad_response("missing HTTP/2 :status header"))?;
   build_response(url, status, &headers, body, trailers)
+}
+
+fn data_payload(frame: &Frame) -> error::Result<&[u8]> {
+  if frame.flags & FLAG_PADDED == 0 {
+    return Ok(&frame.payload);
+  }
+  let (&pad_length, payload) = frame
+    .payload
+    .split_first()
+    .ok_or_else(|| error::bad_response("invalid HTTP/2 DATA padding"))?;
+  strip_padding(payload, pad_length as usize, "DATA")
+}
+
+fn header_block_fragment(frame: &Frame) -> error::Result<&[u8]> {
+  let mut payload = frame.payload.as_slice();
+  let pad_length = if frame.flags & FLAG_PADDED == FLAG_PADDED {
+    let (&pad_length, rest) = payload
+      .split_first()
+      .ok_or_else(|| error::bad_response("invalid HTTP/2 HEADERS padding"))?;
+    payload = rest;
+    pad_length as usize
+  } else {
+    0
+  };
+
+  if frame.flags & FLAG_PRIORITY == FLAG_PRIORITY {
+    payload = payload
+      .get(5..)
+      .ok_or_else(|| error::bad_response("invalid HTTP/2 HEADERS priority"))?;
+  }
+
+  strip_padding(payload, pad_length, "HEADERS")
+}
+
+fn strip_padding<'a>(
+  payload: &'a [u8],
+  pad_length: usize,
+  frame_name: &str,
+) -> error::Result<&'a [u8]> {
+  let data_length = payload
+    .len()
+    .checked_sub(pad_length)
+    .ok_or_else(|| error::bad_response(format!("invalid HTTP/2 {} padding length", frame_name)))?;
+  Ok(&payload[..data_length])
 }
 
 fn is_unexpected_eof(err: &error::Error) -> bool {

--- a/rttp_client/tests/http2_prior_knowledge.rs
+++ b/rttp_client/tests/http2_prior_knowledge.rs
@@ -19,7 +19,9 @@ const FRAME_CONTINUATION: u8 = 0x9;
 
 const FLAG_END_STREAM: u8 = 0x1;
 const FLAG_END_HEADERS: u8 = 0x4;
+const FLAG_PADDED: u8 = 0x8;
 const FLAG_ACK: u8 = 0x1;
+const FLAG_PRIORITY: u8 = 0x20;
 
 const SETTING_ENABLE_PUSH: u16 = 0x2;
 const SETTING_INITIAL_WINDOW_SIZE: u16 = 0x4;
@@ -528,6 +530,179 @@ fn prior_knowledge_exposes_response_trailers_after_data_without_changing_headers
   );
   assert!(response.header("x-trace").is_none());
   handle.join().expect("h2 peer thread");
+}
+
+#[test]
+fn prior_knowledge_decodes_padded_response_headers() {
+  let listener = TcpListener::bind("127.0.0.1:0").expect("bind h2 peer");
+  let addr = listener.local_addr().expect("h2 peer addr");
+
+  let handle = thread::spawn(move || {
+    let (mut stream, _) = listener.accept().expect("accept h2 client");
+    complete_h2_request_handshake(&mut stream);
+
+    let mut payload = vec![3, 0x88];
+    payload.extend_from_slice(&h2_literal_new_name(b"x-padded", b"headers"));
+    payload.extend_from_slice(&[0, 0, 0]);
+
+    write_frame(
+      &mut stream,
+      FRAME_HEADERS,
+      FLAG_PADDED | FLAG_END_HEADERS,
+      1,
+      &payload,
+    );
+    write_frame(&mut stream, FRAME_DATA, FLAG_END_STREAM, 1, b"ok");
+  });
+
+  let response = HttpClient::new()
+    .get()
+    .url(format!("http://{}/padded-headers", addr))
+    .emit_http2_prior_knowledge()
+    .expect("h2 response with padded headers");
+
+  assert_eq!(200, response.code());
+  assert_eq!(
+    Some(&"headers".to_string()),
+    response.header_value("X-Padded")
+  );
+  assert_eq!("ok", response.body().string().unwrap());
+  handle.join().expect("h2 peer thread");
+}
+
+#[test]
+fn prior_knowledge_decodes_padded_data_without_appending_padding() {
+  let listener = TcpListener::bind("127.0.0.1:0").expect("bind h2 peer");
+  let addr = listener.local_addr().expect("h2 peer addr");
+
+  let handle = thread::spawn(move || {
+    let (mut stream, _) = listener.accept().expect("accept h2 client");
+    complete_h2_request_handshake(&mut stream);
+
+    write_frame(&mut stream, FRAME_HEADERS, FLAG_END_HEADERS, 1, &[0x88]);
+    write_frame(
+      &mut stream,
+      FRAME_DATA,
+      FLAG_PADDED | FLAG_END_STREAM,
+      1,
+      &[4, b'b', b'o', b'd', b'y', 0, 0, 0, 0],
+    );
+  });
+
+  let response = HttpClient::new()
+    .get()
+    .url(format!("http://{}/padded-data", addr))
+    .emit_http2_prior_knowledge()
+    .expect("h2 response with padded data");
+
+  assert_eq!(200, response.code());
+  assert_eq!("body", response.body().string().unwrap());
+  handle.join().expect("h2 peer thread");
+}
+
+#[test]
+fn prior_knowledge_decodes_padded_response_trailers() {
+  let listener = TcpListener::bind("127.0.0.1:0").expect("bind h2 peer");
+  let addr = listener.local_addr().expect("h2 peer addr");
+
+  let handle = thread::spawn(move || {
+    let (mut stream, _) = listener.accept().expect("accept h2 client");
+    complete_h2_request_handshake(&mut stream);
+
+    let mut trailer_payload = vec![2];
+    trailer_payload.extend_from_slice(&h2_literal_new_name(b"x-trace", b"padded"));
+    trailer_payload.extend_from_slice(&[0, 0]);
+
+    write_frame(&mut stream, FRAME_HEADERS, FLAG_END_HEADERS, 1, &[0x88]);
+    write_frame(&mut stream, FRAME_DATA, 0, 1, b"trailer body");
+    write_frame(
+      &mut stream,
+      FRAME_HEADERS,
+      FLAG_PADDED | FLAG_END_HEADERS | FLAG_END_STREAM,
+      1,
+      &trailer_payload,
+    );
+  });
+
+  let response = HttpClient::new()
+    .get()
+    .url(format!("http://{}/padded-trailers", addr))
+    .emit_http2_prior_knowledge()
+    .expect("h2 response with padded trailers");
+
+  assert_eq!(200, response.code());
+  assert_eq!("trailer body", response.body().string().unwrap());
+  assert_eq!(
+    Some(&"padded".to_string()),
+    response.trailer_value("X-Trace")
+  );
+  handle.join().expect("h2 peer thread");
+}
+
+#[test]
+fn prior_knowledge_ignores_response_headers_priority_metadata() {
+  let listener = TcpListener::bind("127.0.0.1:0").expect("bind h2 peer");
+  let addr = listener.local_addr().expect("h2 peer addr");
+
+  let handle = thread::spawn(move || {
+    let (mut stream, _) = listener.accept().expect("accept h2 client");
+    complete_h2_request_handshake(&mut stream);
+
+    let mut payload = vec![0, 0, 0, 0, 16, 0x88];
+    payload.extend_from_slice(&h2_literal_new_name(b"x-priority", b"ignored"));
+
+    write_frame(
+      &mut stream,
+      FRAME_HEADERS,
+      FLAG_PRIORITY | FLAG_END_HEADERS,
+      1,
+      &payload,
+    );
+    write_frame(&mut stream, FRAME_DATA, FLAG_END_STREAM, 1, b"priority");
+  });
+
+  let response = HttpClient::new()
+    .get()
+    .url(format!("http://{}/priority-headers", addr))
+    .emit_http2_prior_knowledge()
+    .expect("h2 response with priority headers");
+
+  assert_eq!(200, response.code());
+  assert_eq!(
+    Some(&"ignored".to_string()),
+    response.header_value("X-Priority")
+  );
+  assert_eq!("priority", response.body().string().unwrap());
+  handle.join().expect("h2 peer thread");
+}
+
+#[test]
+fn prior_knowledge_rejects_malformed_padding_lengths() {
+  let (data_addr, data_handle) = spawn_malformed_padding_peer(FRAME_DATA);
+  let data_error = HttpClient::new()
+    .get()
+    .url(format!("http://{}/bad-data-padding", data_addr))
+    .emit_http2_prior_knowledge()
+    .expect_err("DATA padding longer than payload must fail");
+  assert!(
+    data_error.to_string().contains("padding"),
+    "unexpected error: {data_error}"
+  );
+  data_handle.join().expect("bad data padding peer thread");
+
+  let (headers_addr, headers_handle) = spawn_malformed_padding_peer(FRAME_HEADERS);
+  let headers_error = HttpClient::new()
+    .get()
+    .url(format!("http://{}/bad-headers-padding", headers_addr))
+    .emit_http2_prior_knowledge()
+    .expect_err("HEADERS padding longer than payload must fail");
+  assert!(
+    headers_error.to_string().contains("padding"),
+    "unexpected error: {headers_error}"
+  );
+  headers_handle
+    .join()
+    .expect("bad headers padding peer thread");
 }
 
 #[test]
@@ -1365,6 +1540,39 @@ fn spawn_ping_peer(
     let (mut stream, _) = listener.accept().expect("accept h2 client");
     complete_h2_request_handshake(&mut stream);
     write_frame(&mut stream, FRAME_PING, flags, stream_id, payload);
+  });
+
+  (addr, handle)
+}
+
+fn spawn_malformed_padding_peer(frame_type: u8) -> (SocketAddr, thread::JoinHandle<()>) {
+  let listener = TcpListener::bind("127.0.0.1:0").expect("bind h2 peer");
+  let addr = listener.local_addr().expect("h2 peer addr");
+
+  let handle = thread::spawn(move || {
+    let (mut stream, _) = listener.accept().expect("accept h2 client");
+    complete_h2_request_handshake(&mut stream);
+
+    match frame_type {
+      FRAME_DATA => {
+        write_frame(&mut stream, FRAME_HEADERS, FLAG_END_HEADERS, 1, &[0x88]);
+        write_frame(
+          &mut stream,
+          FRAME_DATA,
+          FLAG_PADDED | FLAG_END_STREAM,
+          1,
+          &[2, b'x'],
+        );
+      }
+      FRAME_HEADERS => write_frame(
+        &mut stream,
+        FRAME_HEADERS,
+        FLAG_PADDED | FLAG_END_HEADERS,
+        1,
+        &[2, 0x88],
+      ),
+      _ => unreachable!("unexpected frame type"),
+    }
   });
 
   (addr, handle)


### PR DESCRIPTION
Adds minimal inbound HTTP/2 PADDED response-frame decoding for rttp_client prior-knowledge h2c, including padded DATA, padded response/trailer HEADERS, ignored HEADERS priority metadata, and malformed padding rejection. Verified by the targeted http2_prior_knowledge integration suite.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1402/
work_kind: code_work
branch: hbx-1402-rttp-client-decode-padded-http
base: main
commit: 49ecf0d77e67dd52396f154466de512cf9285e4b
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1402/
    url: https://plane.kahub.in/endless/browse/HBX-1402/
    close_policy: link_only
```