### PR TITLE
feat: [rttp] Parse padded HTTP/2 request HEADERS and DATA on socket2 server

### DIFF
--- a/rttp/src/server.rs
+++ b/rttp/src/server.rs
@@ -20,6 +20,8 @@ const HTTP2_FRAME_CONTINUATION: u8 = 0x9;
 const HTTP2_FLAG_END_STREAM: u8 = 0x1;
 const HTTP2_FLAG_ACK: u8 = 0x1;
 const HTTP2_FLAG_END_HEADERS: u8 = 0x4;
+const HTTP2_FLAG_PADDED: u8 = 0x8;
+const HTTP2_FLAG_PRIORITY: u8 = 0x20;
 const HTTP2_DEFAULT_MAX_FRAME_SIZE: usize = 16 * 1024;
 const HTTP2_SETTINGS_ENABLE_PUSH: u16 = 0x2;
 const HTTP2_SETTINGS_INITIAL_WINDOW_SIZE: u16 = 0x4;
@@ -462,6 +464,8 @@ impl HttpServer {
           ));
         }
         (HTTP2_FRAME_HEADERS, id) if id != 0 => {
+          let header_block_fragment =
+            http2_headers_payload_to_header_block_fragment(&frame.payload, frame.flags)?;
           let request_stream = http2_request_stream(&mut streams, id);
           if request_stream.end_stream {
             return Err(io::Error::new(
@@ -483,7 +487,7 @@ impl HttpServer {
           request_stream.header_block_kind = Some(header_block_kind);
           request_stream
             .header_block
-            .extend_from_slice(&frame.payload);
+            .extend_from_slice(header_block_fragment);
           if frame.flags & HTTP2_FLAG_END_HEADERS == HTTP2_FLAG_END_HEADERS {
             request_stream.finish_header_block()?;
           } else {
@@ -536,15 +540,16 @@ impl HttpServer {
             ));
           }
 
+          let data_payload = http2_data_payload_to_data(&frame.payload, frame.flags)?;
           let new_len = request_stream
             .body
             .len()
-            .checked_add(frame.payload.len())
+            .checked_add(data_payload.len())
             .ok_or_else(|| {
               io::Error::new(io::ErrorKind::InvalidData, "request body is too large")
             })?;
           reject_oversized_request_body(new_len)?;
-          request_stream.body.extend_from_slice(&frame.payload);
+          request_stream.body.extend_from_slice(data_payload);
           if !frame.payload.is_empty() {
             write_http2_window_update(&mut stream, 0, frame.payload.len())?;
             write_http2_window_update(&mut stream, id, frame.payload.len())?;
@@ -728,6 +733,61 @@ fn active_http2_header_continuation_stream(streams: &[Http2RequestStream]) -> Op
     .iter()
     .find(|request_stream| request_stream.in_header_continuation)
     .map(|request_stream| request_stream.stream_id)
+}
+
+fn http2_headers_payload_to_header_block_fragment(payload: &[u8], flags: u8) -> io::Result<&[u8]> {
+  let mut start = 0;
+  let pad_len = if flags & HTTP2_FLAG_PADDED == HTTP2_FLAG_PADDED {
+    let Some((&pad_len, rest)) = payload.split_first() else {
+      return Err(io::Error::new(
+        io::ErrorKind::InvalidData,
+        "invalid padded HTTP/2 HEADERS frame",
+      ));
+    };
+    start = payload.len() - rest.len();
+    pad_len as usize
+  } else {
+    0
+  };
+
+  if flags & HTTP2_FLAG_PRIORITY == HTTP2_FLAG_PRIORITY {
+    if payload.len().saturating_sub(start) < 5 {
+      return Err(io::Error::new(
+        io::ErrorKind::InvalidData,
+        "invalid priority HTTP/2 HEADERS frame",
+      ));
+    }
+    start += 5;
+  }
+
+  let available = payload.len().saturating_sub(start);
+  if pad_len > available {
+    return Err(io::Error::new(
+      io::ErrorKind::InvalidData,
+      "invalid padded HTTP/2 HEADERS frame",
+    ));
+  }
+  Ok(&payload[start..payload.len() - pad_len])
+}
+
+fn http2_data_payload_to_data(payload: &[u8], flags: u8) -> io::Result<&[u8]> {
+  if flags & HTTP2_FLAG_PADDED != HTTP2_FLAG_PADDED {
+    return Ok(payload);
+  }
+  let Some((&pad_len, data_and_padding)) = payload.split_first() else {
+    return Err(io::Error::new(
+      io::ErrorKind::InvalidData,
+      "invalid padded HTTP/2 DATA frame",
+    ));
+  };
+  let pad_len = pad_len as usize;
+  if pad_len > data_and_padding.len() {
+    return Err(io::Error::new(
+      io::ErrorKind::InvalidData,
+      "invalid padded HTTP/2 DATA frame",
+    ));
+  }
+  Ok(&data_and_padding[..data_and_padding.len() - pad_len])
 }
 
 fn read_http2_frame(stream: &mut TcpStream) -> io::Result<Http2Frame> {

--- a/rttp/tests/http2_feature.rs
+++ b/rttp/tests/http2_feature.rs
@@ -12,9 +12,12 @@ const H2_FRAME_DATA: u8 = 0x0;
 const H2_FRAME_HEADERS: u8 = 0x1;
 const H2_FRAME_SETTINGS: u8 = 0x4;
 const H2_FRAME_PING: u8 = 0x6;
+const H2_FRAME_WINDOW_UPDATE: u8 = 0x8;
 const H2_FLAG_END_STREAM: u8 = 0x1;
 const H2_FLAG_ACK: u8 = 0x1;
 const H2_FLAG_END_HEADERS: u8 = 0x4;
+const H2_FLAG_PADDED: u8 = 0x8;
+const H2_FLAG_PRIORITY: u8 = 0x20;
 const H2_PREFACE: &[u8; 24] = b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n";
 const H2_SETTINGS_ENABLE_PUSH: u16 = 0x2;
 const H2_SETTINGS_INITIAL_WINDOW_SIZE: u16 = 0x4;
@@ -109,8 +112,25 @@ fn h2_literal_indexed_name(name_index: u8, value: &[u8]) -> Vec<u8> {
   encoded
 }
 
+fn h2_literal_new_name(name: &[u8], value: &[u8]) -> Vec<u8> {
+  assert!(name.len() < 128);
+  assert!(value.len() < 128);
+  let mut encoded = vec![0, name.len() as u8];
+  encoded.extend_from_slice(name);
+  encoded.push(value.len() as u8);
+  encoded.extend_from_slice(value);
+  encoded
+}
+
 fn h2_get_headers(path: &[u8], authority: &[u8]) -> Vec<u8> {
   let mut headers = vec![0x82, 0x86];
+  headers.extend(h2_literal_indexed_name(4, path));
+  headers.extend(h2_literal_indexed_name(1, authority));
+  headers
+}
+
+fn h2_post_headers(path: &[u8], authority: &[u8]) -> Vec<u8> {
+  let mut headers = vec![0x83, 0x86];
   headers.extend(h2_literal_indexed_name(4, path));
   headers.extend(h2_literal_indexed_name(1, authority));
   headers
@@ -681,4 +701,310 @@ fn wrapper_http2_prior_knowledge_post_request_trailers_reach_server_only_as_trai
   assert_eq!("stored request trailers", response.body().string().unwrap());
 
   handle.join().expect("server thread");
+}
+
+#[test]
+fn http2_feature_socket2_padded_request_headers_reach_server_without_padding() {
+  let server = rttp::Http::server("127.0.0.1:0").expect("bind server");
+  let addr = server.local_addr().expect("server addr");
+  let (tx, rx) = mpsc::channel();
+
+  let handle = thread::spawn(move || {
+    server
+      .accept_one(|request| {
+        tx.send((
+          request.method().to_string(),
+          request.target().to_string(),
+          request.version().to_string(),
+        ))
+        .expect("send parsed padded h2 request headers");
+        HttpResponse::ok("padded headers")
+      })
+      .expect("serve padded h2 request headers");
+  });
+
+  let mut stream = TcpStream::connect(addr).expect("connect h2 server");
+  complete_h2_server_handshake_with_settings(&mut stream, &[]);
+
+  let headers = h2_get_headers(b"/padded-headers", addr.to_string().as_bytes());
+  let mut payload = Vec::new();
+  payload.push(3);
+  payload.extend_from_slice(&headers);
+  payload.extend_from_slice(&[0, 0, 0]);
+  write_h2_frame(
+    &mut stream,
+    H2_FRAME_HEADERS,
+    H2_FLAG_PADDED | H2_FLAG_END_HEADERS | H2_FLAG_END_STREAM,
+    1,
+    &payload,
+  );
+
+  let response_headers = read_h2_frame(&mut stream);
+  assert_eq!(H2_FRAME_HEADERS, response_headers.frame_type);
+  let response_body = read_h2_frame(&mut stream);
+  assert_eq!(H2_FRAME_DATA, response_body.frame_type);
+
+  assert_eq!(
+    (
+      "GET".to_string(),
+      "/padded-headers".to_string(),
+      "HTTP/2".to_string()
+    ),
+    rx.recv().expect("receive parsed padded h2 request headers")
+  );
+
+  handle.join().expect("server thread");
+}
+
+#[test]
+fn http2_feature_socket2_padded_request_data_reaches_server_without_padding() {
+  let server = rttp::Http::server("127.0.0.1:0").expect("bind server");
+  let addr = server.local_addr().expect("server addr");
+  let (tx, rx) = mpsc::channel();
+
+  let handle = thread::spawn(move || {
+    server
+      .accept_one(|request| {
+        tx.send(request.body().to_vec())
+          .expect("send parsed padded h2 request data");
+        HttpResponse::ok("padded data")
+      })
+      .expect("serve padded h2 request data");
+  });
+
+  let mut stream = TcpStream::connect(addr).expect("connect h2 server");
+  complete_h2_server_handshake_with_settings(&mut stream, &[]);
+
+  let headers = h2_post_headers(b"/padded-data", addr.to_string().as_bytes());
+  write_h2_frame(
+    &mut stream,
+    H2_FRAME_HEADERS,
+    H2_FLAG_END_HEADERS,
+    1,
+    &headers,
+  );
+
+  let mut data = Vec::new();
+  data.push(2);
+  data.extend_from_slice(b"body without padding");
+  data.extend_from_slice(&[0, 0]);
+  write_h2_frame(
+    &mut stream,
+    H2_FRAME_DATA,
+    H2_FLAG_PADDED | H2_FLAG_END_STREAM,
+    1,
+    &data,
+  );
+
+  let window_update = read_h2_frame(&mut stream);
+  assert_eq!(H2_FRAME_WINDOW_UPDATE, window_update.frame_type);
+  let stream_window_update = read_h2_frame(&mut stream);
+  assert_eq!(H2_FRAME_WINDOW_UPDATE, stream_window_update.frame_type);
+  let response_headers = read_h2_frame(&mut stream);
+  assert_eq!(H2_FRAME_HEADERS, response_headers.frame_type);
+  let response_body = read_h2_frame(&mut stream);
+  assert_eq!(H2_FRAME_DATA, response_body.frame_type);
+
+  assert_eq!(
+    b"body without padding".to_vec(),
+    rx.recv().expect("receive parsed padded h2 request data")
+  );
+
+  handle.join().expect("server thread");
+}
+
+#[test]
+fn http2_feature_socket2_padded_request_trailers_reach_server_without_padding() {
+  let server = rttp::Http::server("127.0.0.1:0").expect("bind server");
+  let addr = server.local_addr().expect("server addr");
+  let (tx, rx) = mpsc::channel();
+
+  let handle = thread::spawn(move || {
+    server
+      .accept_one(|request| {
+        tx.send((
+          request.body().to_vec(),
+          request.trailer("x-trace").map(str::to_string),
+          request.trailers().to_vec(),
+        ))
+        .expect("send parsed padded h2 request trailers");
+        HttpResponse::ok("padded trailers")
+      })
+      .expect("serve padded h2 request trailers");
+  });
+
+  let mut stream = TcpStream::connect(addr).expect("connect h2 server");
+  complete_h2_server_handshake_with_settings(&mut stream, &[]);
+
+  let headers = h2_post_headers(b"/padded-trailers", addr.to_string().as_bytes());
+  write_h2_frame(
+    &mut stream,
+    H2_FRAME_HEADERS,
+    H2_FLAG_END_HEADERS,
+    1,
+    &headers,
+  );
+  write_h2_frame(&mut stream, H2_FRAME_DATA, 0, 1, b"trailer body");
+
+  let trailers = h2_literal_new_name(b"x-trace", b"padded-trailer");
+  let mut trailer_payload = Vec::new();
+  trailer_payload.push(4);
+  trailer_payload.extend_from_slice(&trailers);
+  trailer_payload.extend_from_slice(&[0, 0, 0, 0]);
+  write_h2_frame(
+    &mut stream,
+    H2_FRAME_HEADERS,
+    H2_FLAG_PADDED | H2_FLAG_END_HEADERS | H2_FLAG_END_STREAM,
+    1,
+    &trailer_payload,
+  );
+
+  let window_update = read_h2_frame(&mut stream);
+  assert_eq!(H2_FRAME_WINDOW_UPDATE, window_update.frame_type);
+  let stream_window_update = read_h2_frame(&mut stream);
+  assert_eq!(H2_FRAME_WINDOW_UPDATE, stream_window_update.frame_type);
+  let response_headers = read_h2_frame(&mut stream);
+  assert_eq!(H2_FRAME_HEADERS, response_headers.frame_type);
+  let response_body = read_h2_frame(&mut stream);
+  assert_eq!(H2_FRAME_DATA, response_body.frame_type);
+
+  assert_eq!(
+    (
+      b"trailer body".to_vec(),
+      Some("padded-trailer".to_string()),
+      vec![("x-trace".to_string(), "padded-trailer".to_string())]
+    ),
+    rx.recv()
+      .expect("receive parsed padded h2 request trailers")
+  );
+
+  handle.join().expect("server thread");
+}
+
+#[test]
+fn http2_feature_socket2_request_headers_with_priority_reach_server_without_priority_metadata() {
+  let server = rttp::Http::server("127.0.0.1:0").expect("bind server");
+  let addr = server.local_addr().expect("server addr");
+  let (tx, rx) = mpsc::channel();
+
+  let handle = thread::spawn(move || {
+    server
+      .accept_one(|request| {
+        tx.send(request.target().to_string())
+          .expect("send parsed priority h2 request headers");
+        HttpResponse::ok("priority headers")
+      })
+      .expect("serve priority h2 request headers");
+  });
+
+  let mut stream = TcpStream::connect(addr).expect("connect h2 server");
+  complete_h2_server_handshake_with_settings(&mut stream, &[]);
+
+  let mut payload = vec![0, 0, 0, 0, 16];
+  payload.extend_from_slice(&h2_get_headers(
+    b"/priority-headers",
+    addr.to_string().as_bytes(),
+  ));
+  write_h2_frame(
+    &mut stream,
+    H2_FRAME_HEADERS,
+    H2_FLAG_PRIORITY | H2_FLAG_END_HEADERS | H2_FLAG_END_STREAM,
+    1,
+    &payload,
+  );
+
+  let response_headers = read_h2_frame(&mut stream);
+  assert_eq!(H2_FRAME_HEADERS, response_headers.frame_type);
+  let response_body = read_h2_frame(&mut stream);
+  assert_eq!(H2_FRAME_DATA, response_body.frame_type);
+
+  assert_eq!(
+    "/priority-headers",
+    rx.recv()
+      .expect("receive parsed priority h2 request headers")
+  );
+
+  handle.join().expect("server thread");
+}
+
+fn assert_malformed_h2_request_rejected_before_handler(
+  write_request: impl FnOnce(&mut TcpStream, SocketAddr),
+) {
+  let server = rttp::Http::server("127.0.0.1:0")
+    .expect("bind server")
+    .with_read_timeout(Some(Duration::from_secs(2)))
+    .with_write_timeout(Some(Duration::from_secs(2)));
+  let addr = server.local_addr().expect("server addr");
+  let (tx, rx) = mpsc::channel();
+
+  let handle = thread::spawn(move || {
+    server.accept_one(|_| {
+      tx.send(()).expect("send unexpected handler call");
+      HttpResponse::ok("unexpected")
+    })
+  });
+
+  let mut stream = TcpStream::connect(addr).expect("connect h2 server");
+  stream
+    .set_read_timeout(Some(Duration::from_millis(200)))
+    .expect("set client read timeout");
+  stream
+    .set_write_timeout(Some(Duration::from_secs(2)))
+    .expect("set client write timeout");
+  complete_h2_server_handshake_with_settings(&mut stream, &[]);
+
+  write_request(&mut stream, addr);
+  drop(stream);
+
+  let result = handle.join().expect("server thread");
+  assert!(
+    result.is_err(),
+    "malformed request should reject connection"
+  );
+  assert!(rx.try_recv().is_err(), "handler must not be called");
+}
+
+#[test]
+fn http2_feature_socket2_rejects_malformed_padded_headers_before_handler() {
+  assert_malformed_h2_request_rejected_before_handler(|stream, addr| {
+    let headers = h2_get_headers(b"/bad-padded-headers", addr.to_string().as_bytes());
+    let mut payload = Vec::new();
+    payload.push(10);
+    payload.extend_from_slice(&headers);
+    write_h2_frame(
+      stream,
+      H2_FRAME_HEADERS,
+      H2_FLAG_PADDED | H2_FLAG_END_HEADERS | H2_FLAG_END_STREAM,
+      1,
+      &payload,
+    );
+  });
+}
+
+#[test]
+fn http2_feature_socket2_rejects_short_priority_headers_before_handler() {
+  assert_malformed_h2_request_rejected_before_handler(|stream, _| {
+    write_h2_frame(
+      stream,
+      H2_FRAME_HEADERS,
+      H2_FLAG_PRIORITY | H2_FLAG_END_HEADERS | H2_FLAG_END_STREAM,
+      1,
+      &[0, 0, 0, 0],
+    );
+  });
+}
+
+#[test]
+fn http2_feature_socket2_rejects_malformed_padded_data_before_handler() {
+  assert_malformed_h2_request_rejected_before_handler(|stream, addr| {
+    let headers = h2_post_headers(b"/bad-padded-data", addr.to_string().as_bytes());
+    write_h2_frame(stream, H2_FRAME_HEADERS, H2_FLAG_END_HEADERS, 1, &headers);
+    write_h2_frame(
+      stream,
+      H2_FRAME_DATA,
+      H2_FLAG_PADDED | H2_FLAG_END_STREAM,
+      1,
+      &[10, b'x'],
+    );
+  });
 }


### PR DESCRIPTION
Adds minimal PADDED and PRIORITY handling for incoming HTTP/2 request frames on the socket2 h2c server, with focused feature coverage for valid padded headers/data/trailers and malformed-frame rejection.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1403/
work_kind: code_work
branch: hbx-1403-rttp-parse-padded-http-2
base: main
commit: 3e91f2bd86b66b4918fbcb62cabd72d281ae33dc
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1403/
    url: https://plane.kahub.in/endless/browse/HBX-1403/
    close_policy: link_only
```