### PR TITLE
feat: [rttp] Add cross-crate HTTP/2 padded-frame compliance matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,10 @@ available through `Response::trailers`, `Response::trailer`, and
 With the `http2` feature enabled, `emit_http2_prior_knowledge` sends a minimal
 prior-knowledge h2c request over a direct socket2 TCP connection. It supports
 GET and buffered POST, PUT, or PATCH requests, including non-empty buffered
-request bodies as DATA frames. TLS ALPN, proxy tunneling, and general HTTP/2
-multiplexing are not part of that client path.
+request bodies as DATA frames, and it decodes incoming padded HEADERS, DATA,
+and trailer frames without exposing padding bytes. TLS ALPN, proxy tunneling,
+proxy h2, general HTTP/2 multiplexing, priority scheduling, and HPACK dynamic
+tables are not part of that client path.
 
 ```rust,no_run
 use rttp_client::HttpClient;
@@ -93,8 +95,10 @@ honors `Connection` close/keep-alive semantics across a bounded
 `serve_requests` loop, writes response body framing and response trailers
 consistently, and accepts `Expect: 100-continue`. On the same socket2 listener,
 the accept path detects the HTTP/2 client preface and dispatches prior-knowledge
-h2c requests to a minimal single-stream handler. TLS ALPN and full HTTP/2
-multiplexing remain outside this server path.
+h2c requests to a minimal single-stream handler. Incoming padded HEADERS, DATA,
+and trailer frames are accepted without exposing padding bytes to handlers. TLS
+ALPN, proxy h2, full HTTP/2 multiplexing, priority scheduling, and HPACK dynamic
+tables remain outside this server path.
 
 It is not a full RFC-covering web server and still does not implement server
 TLS or async accept loops.

--- a/rttp/README.md
+++ b/rttp/README.md
@@ -54,18 +54,21 @@ head/body parsing, handles `HEAD` without writing a response body, honors
 writes response body framing and response trailers consistently, and accepts
 `Expect: 100-continue`. On the same socket2 listener, the accept path detects
 the HTTP/2 client preface and dispatches prior-knowledge h2c requests to a
-minimal single-stream handler.
+minimal single-stream handler. Incoming padded HEADERS, DATA, and trailer
+frames are accepted without exposing padding bytes to handlers.
 
 The server is intentionally not a full RFC-covering web server and still does
-not implement server TLS, TLS ALPN, full HTTP/2 multiplexing, or async accept
-loops.
+not implement server TLS, TLS ALPN, proxy h2, full HTTP/2 multiplexing,
+priority scheduling, HPACK dynamic tables, or async accept loops.
 
 ## Client feature
 
 Enable the `client` feature to access `rttp::Http::client`, or enable `async`,
 `http2`, `tls-native`, `tls-rustls`, or `all` for the corresponding
 `rttp_client` capabilities. The `http2` feature exposes the minimal
-prior-knowledge h2c client path; TLS ALPN remains a later integration point.
+prior-knowledge h2c client path, including padded incoming response frames; TLS
+ALPN, proxy h2, full HTTP/2 multiplexing, priority scheduling, and HPACK
+dynamic tables remain outside that path.
 
 Direct TCP client connections use `socket2`. SOCKS proxy handshakes remain
 delegated to the `socks` crate.

--- a/rttp/tests/http2_feature.rs
+++ b/rttp/tests/http2_feature.rs
@@ -375,6 +375,42 @@ fn spawn_h2_peer_with_malformed_initial_settings() -> (SocketAddr, thread::JoinH
   (addr, handle)
 }
 
+fn complete_h2_peer_request_handshake(stream: &mut TcpStream) -> H2Frame {
+  stream
+    .set_read_timeout(Some(Duration::from_secs(2)))
+    .expect("set h2 peer read timeout");
+
+  let mut preface = [0; 24];
+  stream
+    .read_exact(&mut preface)
+    .expect("read client preface");
+  assert_eq!(H2_PREFACE.as_slice(), &preface);
+
+  let client_settings = read_h2_frame(stream);
+  assert_eq!(H2_FRAME_SETTINGS, client_settings.frame_type);
+  assert_eq!(0, client_settings.flags);
+  assert_eq!(0, client_settings.stream_id);
+
+  write_h2_frame(stream, H2_FRAME_SETTINGS, 0, 0, &[]);
+
+  let client_settings_ack = read_h2_frame(stream);
+  assert_eq!(H2_FRAME_SETTINGS, client_settings_ack.frame_type);
+  assert_eq!(H2_FLAG_ACK, client_settings_ack.flags);
+  assert_eq!(0, client_settings_ack.stream_id);
+  assert!(client_settings_ack.payload.is_empty());
+
+  let request_headers = read_h2_frame(stream);
+  assert_eq!(H2_FRAME_HEADERS, request_headers.frame_type);
+  assert_eq!(
+    H2_FLAG_END_STREAM | H2_FLAG_END_HEADERS,
+    request_headers.flags
+  );
+  assert_eq!(1, request_headers.stream_id);
+
+  write_h2_frame(stream, H2_FRAME_SETTINGS, H2_FLAG_ACK, 0, &[]);
+  request_headers
+}
+
 #[test]
 fn prior_knowledge_server_acknowledges_valid_settings_payload_and_serves_request() {
   let server = rttp::Http::server("127.0.0.1:0")
@@ -545,6 +581,126 @@ fn wrapper_http2_prior_knowledge_client_acks_peer_ping_before_response() {
   assert_eq!("wrapper pong", response.body().string().unwrap());
 
   handle.join().expect("h2 ping peer thread");
+}
+
+#[test]
+fn wrapper_http2_prior_knowledge_accepts_padded_peer_response_frames_without_padding_bytes() {
+  let listener = TcpListener::bind("127.0.0.1:0").expect("bind h2 peer");
+  let addr = listener.local_addr().expect("h2 peer addr");
+
+  let handle = thread::spawn(move || {
+    let (mut stream, _) = listener.accept().expect("accept h2 client");
+    complete_h2_peer_request_handshake(&mut stream);
+
+    let mut header_payload = vec![3, 0x88];
+    header_payload.extend_from_slice(&h2_literal_new_name(b"x-padded", b"headers"));
+    header_payload.extend_from_slice(&[0, 0, 0]);
+    write_h2_frame(
+      &mut stream,
+      H2_FRAME_HEADERS,
+      H2_FLAG_PADDED | H2_FLAG_END_HEADERS,
+      1,
+      &header_payload,
+    );
+
+    write_h2_frame(
+      &mut stream,
+      H2_FRAME_DATA,
+      H2_FLAG_PADDED,
+      1,
+      &[4, b'b', b'o', b'd', b'y', 0, 0, 0, 0],
+    );
+
+    let mut trailer_payload = vec![2];
+    trailer_payload.extend_from_slice(&h2_literal_new_name(b"x-trace", b"padded-trailer"));
+    trailer_payload.extend_from_slice(&[0, 0]);
+    write_h2_frame(
+      &mut stream,
+      H2_FRAME_HEADERS,
+      H2_FLAG_PADDED | H2_FLAG_END_HEADERS | H2_FLAG_END_STREAM,
+      1,
+      &trailer_payload,
+    );
+  });
+
+  let response = rttp::Http::client()
+    .url(format!("http://{}/padded-response", addr))
+    .emit_http2_prior_knowledge()
+    .expect("wrapper h2 response with padded peer frames");
+
+  assert_eq!("HTTP/2", response.version());
+  assert_eq!(200, response.code());
+  assert_eq!(
+    Some(&"headers".to_string()),
+    response.header_value("X-Padded")
+  );
+  assert_eq!("body", response.body().string().unwrap());
+  assert_eq!(
+    Some(&"padded-trailer".to_string()),
+    response.trailer_value("X-Trace")
+  );
+
+  handle.join().expect("padded response peer thread");
+}
+
+#[test]
+fn wrapper_http2_prior_knowledge_rejects_malformed_padded_peer_response_frames() {
+  let data_listener = TcpListener::bind("127.0.0.1:0").expect("bind h2 peer");
+  let data_addr = data_listener.local_addr().expect("h2 peer addr");
+  let data_handle = thread::spawn(move || {
+    let (mut stream, _) = data_listener.accept().expect("accept h2 client");
+    complete_h2_peer_request_handshake(&mut stream);
+    write_h2_frame(
+      &mut stream,
+      H2_FRAME_HEADERS,
+      H2_FLAG_END_HEADERS,
+      1,
+      &[0x88],
+    );
+    write_h2_frame(
+      &mut stream,
+      H2_FRAME_DATA,
+      H2_FLAG_PADDED | H2_FLAG_END_STREAM,
+      1,
+      &[10, b'x'],
+    );
+  });
+
+  let data_error = rttp::Http::client()
+    .url(format!("http://{}/bad-data-padding", data_addr))
+    .emit_http2_prior_knowledge()
+    .expect_err("wrapper client must reject malformed padded DATA");
+  assert!(
+    data_error.to_string().contains("padding"),
+    "unexpected error: {data_error}"
+  );
+  data_handle.join().expect("bad data padding peer thread");
+
+  let headers_listener = TcpListener::bind("127.0.0.1:0").expect("bind h2 peer");
+  let headers_addr = headers_listener.local_addr().expect("h2 peer addr");
+  let headers_handle = thread::spawn(move || {
+    let (mut stream, _) = headers_listener.accept().expect("accept h2 client");
+    complete_h2_peer_request_handshake(&mut stream);
+    write_h2_frame(
+      &mut stream,
+      H2_FRAME_HEADERS,
+      H2_FLAG_PADDED | H2_FLAG_END_HEADERS,
+      1,
+      &[10, 0x88],
+    );
+  });
+
+  let headers_error = rttp::Http::client()
+    .url(format!("http://{}/bad-headers-padding", headers_addr))
+    .emit_http2_prior_knowledge()
+    .expect_err("wrapper client must reject malformed padded HEADERS");
+  assert!(
+    headers_error.to_string().contains("padding"),
+    "unexpected error: {headers_error}"
+  );
+  headers_handle
+    .join()
+    .expect("bad headers padding peer thread");
 }
 
 #[test]

--- a/rttp_client/README.md
+++ b/rttp_client/README.md
@@ -28,8 +28,10 @@ through `Response::trailers`, `Response::trailer`, and
 `Response::trailer_value` for both blocking and async request APIs.
 With the `http2` feature enabled, `emit_http2_prior_knowledge` sends a minimal
 prior-knowledge h2c request over a direct socket2 TCP connection. Non-empty
-buffered request bodies are sent as DATA frames. TLS ALPN, proxy tunneling, and
-general HTTP/2 multiplexing are not part of that client path.
+buffered request bodies are sent as DATA frames, and incoming padded HEADERS,
+DATA, and trailer frames are decoded without exposing padding bytes. TLS ALPN,
+proxy tunneling, proxy h2, general HTTP/2 multiplexing, priority scheduling,
+and HPACK dynamic tables are not part of that client path.
 
 ## Examples
 

--- a/rttp_client/src/lib.rs
+++ b/rttp_client/src/lib.rs
@@ -12,8 +12,10 @@
 //! to the `socks` crate.
 //! With the `http2` feature enabled, `emit_http2_prior_knowledge` sends a
 //! minimal prior-knowledge h2c request over a direct socket2 TCP connection.
-//! TLS ALPN and full HTTP/2 multiplexing are not part of that single-stream
-//! path.
+//! It decodes incoming padded HEADERS, DATA, and trailer frames without
+//! exposing padding bytes. TLS ALPN, proxy h2, full HTTP/2 multiplexing,
+//! priority scheduling, and HPACK dynamic tables are not part of that
+//! single-stream path.
 //!
 //! ```rust,no_run
 //! use rttp_client::HttpClient;


### PR DESCRIPTION
Cross-crate HTTP/2 padded-frame compliance coverage added for the wrapper API, with documentation updated to match supported minimal h2c behavior and explicit unsupported capability boundaries.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1404/
work_kind: code_work
branch: hbx-1404-rttp-add-cross-crate-http
base: main
commit: e07ba3c79881c431d078caa399871919bb699529
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1404/
    url: https://plane.kahub.in/endless/browse/HBX-1404/
    close_policy: link_only
```