### PR TITLE
feat: [rttp] Split large HTTP/2 response headers and trailers on socket2 server

### DIFF
--- a/rttp/src/server.rs
+++ b/rttp/src/server.rs
@@ -367,7 +367,7 @@ impl HttpServer {
       return Err(invalid_http2_settings_error());
     }
     validate_http2_settings_payload(&frame.payload)?;
-    let peer_max_frame_size =
+    let mut peer_max_frame_size =
       http2_settings_max_frame_size(&frame.payload).unwrap_or(HTTP2_DEFAULT_MAX_FRAME_SIZE);
 
     self.normalize_connection_error(write_http2_frame(
@@ -428,6 +428,9 @@ impl HttpServer {
             }
           } else {
             validate_http2_settings_payload(&frame.payload)?;
+            if let Some(max_frame_size) = http2_settings_max_frame_size(&frame.payload) {
+              peer_max_frame_size = max_frame_size;
+            }
             self.normalize_connection_error(write_http2_frame(
               &mut stream,
               HTTP2_FRAME_SETTINGS,

--- a/rttp/src/server.rs
+++ b/rttp/src/server.rs
@@ -367,6 +367,8 @@ impl HttpServer {
       return Err(invalid_http2_settings_error());
     }
     validate_http2_settings_payload(&frame.payload)?;
+    let peer_max_frame_size =
+      http2_settings_max_frame_size(&frame.payload).unwrap_or(HTTP2_DEFAULT_MAX_FRAME_SIZE);
 
     self.normalize_connection_error(write_http2_frame(
       &mut stream,
@@ -587,6 +589,7 @@ impl HttpServer {
           stream_id,
           &response,
           !request_is_head,
+          peer_max_frame_size,
         ))?;
         served += 1;
       }
@@ -825,6 +828,20 @@ fn validate_http2_settings_payload(payload: &[u8]) -> io::Result<()> {
   }
 
   Ok(())
+}
+
+fn http2_settings_max_frame_size(payload: &[u8]) -> Option<usize> {
+  payload
+    .chunks_exact(6)
+    .fold(None, |max_frame_size, setting| {
+      let id = u16::from_be_bytes([setting[0], setting[1]]);
+      let value = u32::from_be_bytes([setting[2], setting[3], setting[4], setting[5]]);
+      if id == HTTP2_SETTINGS_MAX_FRAME_SIZE {
+        Some(value as usize)
+      } else {
+        max_frame_size
+      }
+    })
 }
 
 fn invalid_http2_settings_error() -> io::Error {
@@ -1094,16 +1111,11 @@ fn write_http2_response(
   stream_id: u32,
   response: &HttpResponse,
   write_body: bool,
+  max_frame_size: usize,
 ) -> io::Result<()> {
   let headers = encode_http2_response_headers(response)?;
   let write_trailers = write_body && response.allows_body() && !response.trailers().is_empty();
-  write_http2_frame(
-    stream,
-    HTTP2_FRAME_HEADERS,
-    HTTP2_FLAG_END_HEADERS,
-    stream_id,
-    &headers,
-  )?;
+  write_http2_header_block(stream, stream_id, 0, &headers, max_frame_size)?;
   let body = if write_body && response.allows_body() {
     response.body.as_slice()
   } else {
@@ -1117,8 +1129,8 @@ fn write_http2_response(
     };
     write_http2_frame(stream, HTTP2_FRAME_DATA, flags, stream_id, &[])?;
   } else {
-    for (index, chunk) in body.chunks(HTTP2_DEFAULT_MAX_FRAME_SIZE).enumerate() {
-      let final_data = (index + 1) * HTTP2_DEFAULT_MAX_FRAME_SIZE >= body.len();
+    for (index, chunk) in body.chunks(max_frame_size).enumerate() {
+      let final_data = (index + 1) * max_frame_size >= body.len();
       let flags = if final_data && !write_trailers {
         HTTP2_FLAG_END_STREAM
       } else {
@@ -1129,15 +1141,54 @@ fn write_http2_response(
   }
   if write_trailers {
     let trailers = encode_http2_response_trailers(response)?;
-    write_http2_frame(
+    write_http2_header_block(
       stream,
-      HTTP2_FRAME_HEADERS,
-      HTTP2_FLAG_END_HEADERS | HTTP2_FLAG_END_STREAM,
       stream_id,
+      HTTP2_FLAG_END_STREAM,
       &trailers,
+      max_frame_size,
     )?;
   }
   stream.flush()
+}
+
+fn write_http2_header_block(
+  stream: &mut TcpStream,
+  stream_id: u32,
+  first_frame_flags: u8,
+  block: &[u8],
+  max_frame_size: usize,
+) -> io::Result<()> {
+  if block.len() <= max_frame_size {
+    return write_http2_frame(
+      stream,
+      HTTP2_FRAME_HEADERS,
+      first_frame_flags | HTTP2_FLAG_END_HEADERS,
+      stream_id,
+      block,
+    );
+  }
+
+  let mut chunks = block.chunks(max_frame_size);
+  let first = chunks.next().unwrap_or(&[]);
+  write_http2_frame(
+    stream,
+    HTTP2_FRAME_HEADERS,
+    first_frame_flags,
+    stream_id,
+    first,
+  )?;
+
+  while let Some(chunk) = chunks.next() {
+    let flags = if chunks.len() == 0 {
+      HTTP2_FLAG_END_HEADERS
+    } else {
+      0
+    };
+    write_http2_frame(stream, HTTP2_FRAME_CONTINUATION, flags, stream_id, chunk)?;
+  }
+
+  Ok(())
 }
 
 fn encode_http2_response_headers(response: &HttpResponse) -> io::Result<Vec<u8>> {

--- a/rttp/tests/http2_feature.rs
+++ b/rttp/tests/http2_feature.rs
@@ -860,6 +860,66 @@ fn wrapper_http2_prior_knowledge_post_request_trailers_reach_server_only_as_trai
 }
 
 #[test]
+fn http2_feature_socket2_applies_later_max_frame_size_settings_to_response_frames() {
+  let server = rttp::Http::server("127.0.0.1:0")
+    .expect("bind server")
+    .with_read_timeout(Some(Duration::from_secs(2)))
+    .with_write_timeout(Some(Duration::from_secs(2)));
+  let addr = server.local_addr().expect("server addr");
+
+  let handle = thread::spawn(move || {
+    server
+      .accept_one(|_| HttpResponse::ok("x".repeat(20_000)))
+      .expect("serve h2 response after updated settings");
+  });
+
+  let mut stream = TcpStream::connect(addr).expect("connect h2 server");
+  complete_h2_server_handshake_with_settings(
+    &mut stream,
+    &h2_setting(H2_SETTINGS_MAX_FRAME_SIZE, 65_535),
+  );
+
+  write_h2_frame(
+    &mut stream,
+    H2_FRAME_SETTINGS,
+    0,
+    0,
+    &h2_setting(H2_SETTINGS_MAX_FRAME_SIZE, 16_384),
+  );
+  let settings_ack = read_h2_frame(&mut stream);
+  assert_eq!(H2_FRAME_SETTINGS, settings_ack.frame_type);
+  assert_eq!(H2_FLAG_ACK, settings_ack.flags);
+  assert_eq!(0, settings_ack.stream_id);
+  assert!(settings_ack.payload.is_empty());
+
+  write_h2_frame(
+    &mut stream,
+    H2_FRAME_HEADERS,
+    H2_FLAG_END_HEADERS | H2_FLAG_END_STREAM,
+    1,
+    &h2_get_headers(b"/updated-max-frame-size", addr.to_string().as_bytes()),
+  );
+
+  let response_headers = read_h2_frame(&mut stream);
+  assert_eq!(H2_FRAME_HEADERS, response_headers.frame_type);
+  assert_eq!(1, response_headers.stream_id);
+
+  let first_data = read_h2_frame(&mut stream);
+  assert_eq!(H2_FRAME_DATA, first_data.frame_type);
+  assert_eq!(1, first_data.stream_id);
+  assert_eq!(16_384, first_data.payload.len());
+  assert_eq!(0, first_data.flags & H2_FLAG_END_STREAM);
+
+  let second_data = read_h2_frame(&mut stream);
+  assert_eq!(H2_FRAME_DATA, second_data.frame_type);
+  assert_eq!(1, second_data.stream_id);
+  assert_eq!(3_616, second_data.payload.len());
+  assert_eq!(H2_FLAG_END_STREAM, second_data.flags & H2_FLAG_END_STREAM);
+
+  handle.join().expect("server thread");
+}
+
+#[test]
 fn http2_feature_socket2_padded_request_headers_reach_server_without_padding() {
   let server = rttp::Http::server("127.0.0.1:0").expect("bind server");
   let addr = server.local_addr().expect("server addr");

--- a/rttp/tests/test_server.rs
+++ b/rttp/tests/test_server.rs
@@ -19,6 +19,7 @@ const H2_FRAME_CONTINUATION: u8 = 0x9;
 const H2_FLAG_END_STREAM: u8 = 0x1;
 const H2_FLAG_ACK: u8 = 0x1;
 const H2_FLAG_END_HEADERS: u8 = 0x4;
+const H2_SETTINGS_MAX_FRAME_SIZE: u16 = 0x5;
 
 struct H2Frame {
   frame_type: u8,
@@ -102,9 +103,20 @@ fn h2_post_headers(path: &[u8], authority: &[u8]) -> Vec<u8> {
   headers
 }
 
+fn h2_setting(id: u16, value: u32) -> [u8; 6] {
+  let mut setting = [0; 6];
+  setting[..2].copy_from_slice(&id.to_be_bytes());
+  setting[2..].copy_from_slice(&value.to_be_bytes());
+  setting
+}
+
 fn complete_h2_server_handshake(stream: &mut TcpStream) {
+  complete_h2_server_handshake_with_settings(stream, &[]);
+}
+
+fn complete_h2_server_handshake_with_settings(stream: &mut TcpStream, payload: &[u8]) {
   stream.write_all(H2_PREFACE).expect("write h2 preface");
-  write_h2_frame(stream, H2_FRAME_SETTINGS, 0, 0, &[]);
+  write_h2_frame(stream, H2_FRAME_SETTINGS, 0, 0, payload);
 
   let settings = read_h2_frame(stream);
   assert_eq!(H2_FRAME_SETTINGS, settings.frame_type);
@@ -117,6 +129,40 @@ fn complete_h2_server_handshake(stream: &mut TcpStream) {
   assert_eq!(0, settings_ack.stream_id);
 
   write_h2_frame(stream, H2_FRAME_SETTINGS, H2_FLAG_ACK, 0, &[]);
+}
+
+fn assert_h2_header_block_split(
+  stream: &mut TcpStream,
+  max_frame_size: usize,
+  first_flags: u8,
+  final_flags: u8,
+) {
+  let first = read_h2_frame(stream);
+  assert_eq!(H2_FRAME_HEADERS, first.frame_type);
+  assert_eq!(first_flags, first.flags);
+  assert_eq!(1, first.stream_id);
+  assert!(first.payload.len() <= max_frame_size);
+  assert!(
+    first.flags & H2_FLAG_END_HEADERS == 0,
+    "first HEADERS frame must not end an oversized header block"
+  );
+
+  let mut continuation_count = 0;
+  loop {
+    let frame = read_h2_frame(stream);
+    assert_eq!(H2_FRAME_CONTINUATION, frame.frame_type);
+    assert_eq!(1, frame.stream_id);
+    assert!(frame.payload.len() <= max_frame_size);
+    continuation_count += 1;
+
+    if frame.flags & H2_FLAG_END_HEADERS == H2_FLAG_END_HEADERS {
+      assert_eq!(final_flags, frame.flags);
+      break;
+    }
+
+    assert_eq!(0, frame.flags);
+  }
+  assert!(continuation_count > 0);
 }
 
 fn assert_invalid_h2_headers_without_handler(header_block: &[u8]) {
@@ -438,6 +484,102 @@ fn server_accepts_http2_prior_knowledge_get_and_writes_single_stream_response() 
       .map(|value| value.as_str())
   );
   assert_eq!("hello over h2", response.body().string().unwrap());
+
+  handle.join().expect("server thread");
+}
+
+#[test]
+fn server_splits_large_http2_response_headers_to_peer_max_frame_size() {
+  let max_frame_size = 16_384usize;
+  let large_header_value = "a".repeat(max_frame_size + 1024);
+  let server = rttp::Http::server("127.0.0.1:0").expect("bind server");
+  let addr = server.local_addr().expect("server addr");
+
+  let handle = thread::spawn(move || {
+    server
+      .accept_one(move |_| HttpResponse::ok("split headers").header("X-Large", large_header_value))
+      .expect("serve split h2 headers");
+  });
+
+  let mut stream = TcpStream::connect(addr).expect("connect h2 server");
+  stream
+    .set_read_timeout(Some(Duration::from_secs(2)))
+    .expect("set h2 read timeout");
+  complete_h2_server_handshake_with_settings(
+    &mut stream,
+    &h2_setting(H2_SETTINGS_MAX_FRAME_SIZE, max_frame_size as u32),
+  );
+  write_h2_frame(
+    &mut stream,
+    H2_FRAME_HEADERS,
+    H2_FLAG_END_HEADERS | H2_FLAG_END_STREAM,
+    1,
+    &h2_get_headers(b"/large-response-headers", addr.to_string().as_bytes()),
+  );
+
+  assert_h2_header_block_split(&mut stream, max_frame_size, 0, H2_FLAG_END_HEADERS);
+  let response_body = read_h2_frame(&mut stream);
+  assert_eq!(H2_FRAME_DATA, response_body.frame_type);
+  assert_eq!(H2_FLAG_END_STREAM, response_body.flags);
+  assert_eq!(1, response_body.stream_id);
+  assert!(response_body.payload.len() <= max_frame_size);
+  assert_eq!(b"split headers", response_body.payload.as_slice());
+
+  handle.join().expect("server thread");
+}
+
+#[test]
+fn server_splits_large_http2_response_trailers_to_peer_max_frame_size() {
+  let max_frame_size = 16_384usize;
+  let large_trailer_value = "t".repeat(max_frame_size + 1024);
+  let server = rttp::Http::server("127.0.0.1:0").expect("bind server");
+  let addr = server.local_addr().expect("server addr");
+
+  let handle = thread::spawn(move || {
+    server
+      .accept_one(move |_| {
+        HttpResponse::ok("split trailers")
+          .header("Trailer", "X-Large-Trailer")
+          .trailer("X-Large-Trailer", large_trailer_value)
+      })
+      .expect("serve split h2 trailers");
+  });
+
+  let mut stream = TcpStream::connect(addr).expect("connect h2 server");
+  stream
+    .set_read_timeout(Some(Duration::from_secs(2)))
+    .expect("set h2 read timeout");
+  complete_h2_server_handshake_with_settings(
+    &mut stream,
+    &h2_setting(H2_SETTINGS_MAX_FRAME_SIZE, max_frame_size as u32),
+  );
+  write_h2_frame(
+    &mut stream,
+    H2_FRAME_HEADERS,
+    H2_FLAG_END_HEADERS | H2_FLAG_END_STREAM,
+    1,
+    &h2_get_headers(b"/large-response-trailers", addr.to_string().as_bytes()),
+  );
+
+  let response_headers = read_h2_frame(&mut stream);
+  assert_eq!(H2_FRAME_HEADERS, response_headers.frame_type);
+  assert_eq!(H2_FLAG_END_HEADERS, response_headers.flags);
+  assert_eq!(1, response_headers.stream_id);
+  assert!(response_headers.payload.len() <= max_frame_size);
+
+  let response_body = read_h2_frame(&mut stream);
+  assert_eq!(H2_FRAME_DATA, response_body.frame_type);
+  assert_eq!(0, response_body.flags);
+  assert_eq!(1, response_body.stream_id);
+  assert!(response_body.payload.len() <= max_frame_size);
+  assert_eq!(b"split trailers", response_body.payload.as_slice());
+
+  assert_h2_header_block_split(
+    &mut stream,
+    max_frame_size,
+    H2_FLAG_END_STREAM,
+    H2_FLAG_END_HEADERS,
+  );
 
   handle.join().expect("server thread");
 }


### PR DESCRIPTION
Implemented server-side HTTP/2 response header and trailer fragmentation for socket2 prior-knowledge h2c, using the peer's initial SETTINGS_MAX_FRAME_SIZE and preserving existing DATA splitting behavior.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1407/
work_kind: code_work
branch: hbx-1407-rttp-split-large-http-2
base: main
commit: 587727f976c4c099284ef7a98c7cffd43f398143
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1407/
    url: https://plane.kahub.in/endless/browse/HBX-1407/
    close_policy: link_only
```