### PR TITLE
feat: [rttp] Add cross-crate HTTP/2 large header block compliance matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,11 @@ available through `Response::trailers`, `Response::trailer`, and
 With the `http2` feature enabled, `emit_http2_prior_knowledge` sends a minimal
 prior-knowledge h2c request over a direct socket2 TCP connection. It supports
 GET and buffered POST, PUT, or PATCH requests, including non-empty buffered
-request bodies as DATA frames, and it decodes incoming padded HEADERS, DATA,
-and trailer frames without exposing padding bytes. TLS ALPN, proxy tunneling,
-proxy h2, general HTTP/2 multiplexing, priority scheduling, and HPACK dynamic
-tables are not part of that client path.
+request bodies as DATA frames and large header blocks via CONTINUATION frames,
+and it decodes incoming padded HEADERS, DATA, and trailer frames without
+exposing padding bytes. TLS ALPN, proxy tunneling, proxy h2, general HTTP/2
+multiplexing, priority scheduling, and HPACK dynamic tables are not part of
+that client path.
 
 ```rust,no_run
 use rttp_client::HttpClient;
@@ -96,9 +97,10 @@ honors `Connection` close/keep-alive semantics across a bounded
 consistently, and accepts `Expect: 100-continue`. On the same socket2 listener,
 the accept path detects the HTTP/2 client preface and dispatches prior-knowledge
 h2c requests to a minimal single-stream handler. Incoming padded HEADERS, DATA,
-and trailer frames are accepted without exposing padding bytes to handlers. TLS
-ALPN, proxy h2, full HTTP/2 multiplexing, priority scheduling, and HPACK dynamic
-tables remain outside this server path.
+and trailer frames are accepted without exposing padding bytes to handlers, and
+large header blocks are carried with CONTINUATION frames. TLS ALPN, proxy h2,
+full HTTP/2 multiplexing, priority scheduling, and HPACK dynamic tables remain
+outside this server path.
 
 It is not a full RFC-covering web server and still does not implement server
 TLS or async accept loops.

--- a/rttp/README.md
+++ b/rttp/README.md
@@ -55,7 +55,8 @@ writes response body framing and response trailers consistently, and accepts
 `Expect: 100-continue`. On the same socket2 listener, the accept path detects
 the HTTP/2 client preface and dispatches prior-knowledge h2c requests to a
 minimal single-stream handler. Incoming padded HEADERS, DATA, and trailer
-frames are accepted without exposing padding bytes to handlers.
+frames are accepted without exposing padding bytes to handlers, and large
+header blocks are carried with CONTINUATION frames.
 
 The server is intentionally not a full RFC-covering web server and still does
 not implement server TLS, TLS ALPN, proxy h2, full HTTP/2 multiplexing,
@@ -66,9 +67,10 @@ priority scheduling, HPACK dynamic tables, or async accept loops.
 Enable the `client` feature to access `rttp::Http::client`, or enable `async`,
 `http2`, `tls-native`, `tls-rustls`, or `all` for the corresponding
 `rttp_client` capabilities. The `http2` feature exposes the minimal
-prior-knowledge h2c client path, including padded incoming response frames; TLS
-ALPN, proxy h2, full HTTP/2 multiplexing, priority scheduling, and HPACK
-dynamic tables remain outside that path.
+prior-knowledge h2c client path, including large header blocks via
+CONTINUATION frames and padded incoming response frames; TLS ALPN, proxy h2,
+full HTTP/2 multiplexing, priority scheduling, and HPACK dynamic tables remain
+outside that path.
 
 Direct TCP client connections use `socket2`. SOCKS proxy handshakes remain
 delegated to the `socks` crate.

--- a/rttp/tests/http2_feature.rs
+++ b/rttp/tests/http2_feature.rs
@@ -738,6 +738,123 @@ fn wrapper_http2_feature_exposes_response_trailers_from_prior_knowledge_server()
 }
 
 #[test]
+fn wrapper_http2_prior_knowledge_large_request_header_reaches_socket2_server() {
+  let server = rttp::Http::server("127.0.0.1:0")
+    .expect("bind server")
+    .with_read_timeout(Some(Duration::from_secs(2)))
+    .with_write_timeout(Some(Duration::from_secs(2)));
+  let addr = server.local_addr().expect("server addr");
+  let large_header_value = "r".repeat(16 * 1024 + 512);
+  let expected_header_value = large_header_value.clone();
+  let (tx, rx) = mpsc::channel();
+
+  let handle = thread::spawn(move || {
+    server
+      .accept_one(|request| {
+        tx.send((
+          request.version().to_string(),
+          request.target().to_string(),
+          request.header("x-large-header").map(str::to_string),
+        ))
+        .expect("send parsed large h2 request header");
+        HttpResponse::ok("large request header")
+      })
+      .expect("serve large h2 request header");
+  });
+
+  let response = rttp::Http::client()
+    .url(format!("http://{}/large-request-header", addr))
+    .header(("X-Large-Header".to_string(), large_header_value))
+    .emit_http2_prior_knowledge()
+    .expect("wrapper h2 response after large request header");
+
+  assert_eq!("HTTP/2", response.version());
+  assert_eq!("large request header", response.body().string().unwrap());
+  assert_eq!(
+    (
+      "HTTP/2".to_string(),
+      "/large-request-header".to_string(),
+      Some(expected_header_value)
+    ),
+    rx.recv().expect("receive parsed large h2 request header")
+  );
+
+  handle.join().expect("server thread");
+}
+
+#[test]
+fn wrapper_http2_prior_knowledge_reads_large_response_header_from_socket2_server() {
+  let server = rttp::Http::server("127.0.0.1:0")
+    .expect("bind server")
+    .with_read_timeout(Some(Duration::from_secs(2)))
+    .with_write_timeout(Some(Duration::from_secs(2)));
+  let addr = server.local_addr().expect("server addr");
+  let large_header_value = "h".repeat(16 * 1024 + 512);
+  let expected_header_value = large_header_value.clone();
+
+  let handle = thread::spawn(move || {
+    server
+      .accept_one(move |_| {
+        HttpResponse::ok("large response header").header("X-Large-Response", large_header_value)
+      })
+      .expect("serve large h2 response header");
+  });
+
+  let response = rttp::Http::client()
+    .url(format!("http://{}/large-response-header", addr))
+    .emit_http2_prior_knowledge()
+    .expect("wrapper h2 response with large response header");
+
+  assert_eq!("HTTP/2", response.version());
+  assert_eq!(200, response.code());
+  assert_eq!("large response header", response.body().string().unwrap());
+  assert_eq!(
+    Some(&expected_header_value),
+    response.header_value("X-Large-Response")
+  );
+
+  handle.join().expect("server thread");
+}
+
+#[test]
+fn wrapper_http2_prior_knowledge_reads_large_response_trailer_from_socket2_server() {
+  let server = rttp::Http::server("127.0.0.1:0")
+    .expect("bind server")
+    .with_read_timeout(Some(Duration::from_secs(2)))
+    .with_write_timeout(Some(Duration::from_secs(2)));
+  let addr = server.local_addr().expect("server addr");
+  let large_trailer_value = "t".repeat(16 * 1024 + 512);
+  let expected_trailer_value = large_trailer_value.clone();
+
+  let handle = thread::spawn(move || {
+    server
+      .accept_one(move |_| {
+        HttpResponse::ok("large response trailer")
+          .header("Trailer", "X-Large-Trailer")
+          .trailer("X-Large-Trailer", large_trailer_value)
+      })
+      .expect("serve large h2 response trailer");
+  });
+
+  let response = rttp::Http::client()
+    .url(format!("http://{}/large-response-trailer", addr))
+    .emit_http2_prior_knowledge()
+    .expect("wrapper h2 response with large response trailer");
+
+  assert_eq!("HTTP/2", response.version());
+  assert_eq!(200, response.code());
+  assert_eq!("large response trailer", response.body().string().unwrap());
+  assert_eq!(
+    Some(&expected_trailer_value),
+    response.trailer_value("X-Large-Trailer")
+  );
+  assert!(response.header_value("Trailer").is_none());
+  assert!(response.header_value("X-Large-Trailer").is_none());
+
+  handle.join().expect("server thread");
+}
+
+#[test]
 fn wrapper_http2_prior_knowledge_post_body_round_trips_between_client_and_server() {
   let server = rttp::Http::server("127.0.0.1:0").expect("bind server");
   let addr = server.local_addr().expect("server addr");


### PR DESCRIPTION
Added wrapper-level cross-crate HTTP/2 CONTINUATION coverage for large request headers, response headers, and response trailers against the socket2 h2c server. Documentation now reflects large header block support and retained minimal-h2c limitations.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1408/
work_kind: code_work
branch: hbx-1408-rttp-add-cross-crate-http
base: main
commit: 2a7245254ddfd95d6a9785d538f73c66789a61af
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1408/
    url: https://plane.kahub.in/endless/browse/HBX-1408/
    close_policy: link_only
```