### PR TITLE
feat: [rttp] Decode HPACK static Huffman strings on socket2 h2c server

### DIFF
--- a/rttp/src/server.rs
+++ b/rttp/src/server.rs
@@ -2,6 +2,7 @@ use std::error::Error;
 use std::fmt;
 use std::io::{self, BufRead, BufReader, Cursor, Read, Write};
 use std::net::{SocketAddr, TcpListener, TcpStream, ToSocketAddrs};
+use std::sync::OnceLock;
 use std::time::Duration;
 
 use socket2::{Domain, Protocol, Socket, Type};
@@ -1109,16 +1110,22 @@ fn decode_http2_string(block: &[u8], cursor: &mut usize) -> io::Result<String> {
 }
 
 fn decode_http2_huffman_string(encoded: &[u8]) -> io::Result<Vec<u8>> {
+  let table = http2_huffman_decode_table();
   let mut decoded = Vec::with_capacity(encoded.len());
   let mut code = 0u32;
   let mut code_len = 0u8;
+  let mut node = 0usize;
 
   for byte in encoded {
     for bit_index in (0..8).rev() {
-      code = (code << 1) | (((byte >> bit_index) & 1) as u32);
+      let bit = ((byte >> bit_index) & 1) as usize;
+      code = (code << 1) | (bit as u32);
       code_len += 1;
+      node = table
+        .next_node(node, bit)
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "invalid HPACK Huffman code"))?;
 
-      if let Some(symbol) = http2_huffman_symbol(code, code_len) {
+      if let Some(symbol) = table.symbol(node) {
         if symbol == HTTP2_HUFFMAN_EOS {
           return Err(io::Error::new(
             io::ErrorKind::InvalidData,
@@ -1128,6 +1135,7 @@ fn decode_http2_huffman_string(encoded: &[u8]) -> io::Result<Vec<u8>> {
         decoded.push(symbol as u8);
         code = 0;
         code_len = 0;
+        node = 0;
       } else if code_len > HTTP2_HUFFMAN_EOS_BITS {
         return Err(io::Error::new(
           io::ErrorKind::InvalidData,
@@ -1151,11 +1159,68 @@ fn decode_http2_huffman_string(encoded: &[u8]) -> io::Result<Vec<u8>> {
   Ok(decoded)
 }
 
-fn http2_huffman_symbol(code: u32, code_len: u8) -> Option<u16> {
-  HTTP2_HUFFMAN_CODES
-    .iter()
-    .position(|&(bits, table_code)| bits == code_len && table_code == code)
-    .map(|index| index as u16)
+fn http2_huffman_decode_table() -> &'static Http2HuffmanDecodeTable {
+  static TABLE: OnceLock<Http2HuffmanDecodeTable> = OnceLock::new();
+  TABLE.get_or_init(Http2HuffmanDecodeTable::from_codes)
+}
+
+struct Http2HuffmanDecodeTable {
+  nodes: Vec<Http2HuffmanNode>,
+}
+
+impl Http2HuffmanDecodeTable {
+  fn from_codes() -> Self {
+    let mut table = Self {
+      nodes: vec![Http2HuffmanNode::default()],
+    };
+
+    for (symbol, &(code_len, code)) in HTTP2_HUFFMAN_CODES.iter().enumerate() {
+      table.insert(code, code_len, symbol as u16);
+    }
+
+    table
+  }
+
+  fn insert(&mut self, code: u32, code_len: u8, symbol: u16) {
+    let mut node = 0usize;
+    for bit_index in (0..code_len).rev() {
+      let bit = ((code >> bit_index) & 1) as usize;
+      node = match self.nodes[node].children[bit] {
+        Some(child) => child,
+        None => {
+          let child = self.nodes.len();
+          self.nodes.push(Http2HuffmanNode::default());
+          self.nodes[node].children[bit] = Some(child);
+          child
+        }
+      };
+    }
+    assert!(self.nodes[node].symbol.replace(symbol).is_none());
+  }
+
+  #[cfg(test)]
+  fn decode_symbol(&self, code: u32, code_len: u8) -> Option<u16> {
+    let mut node = 0usize;
+    for bit_index in (0..code_len).rev() {
+      let bit = ((code >> bit_index) & 1) as usize;
+      node = self.next_node(node, bit)?;
+    }
+    self.symbol(node)
+  }
+
+  fn next_node(&self, node: usize, bit: usize) -> Option<usize> {
+    self.nodes[node].children[bit]
+  }
+
+  fn symbol(&self, node: usize) -> Option<u16> {
+    self.nodes[node].symbol
+  }
+}
+
+#[derive(Default)]
+struct Http2HuffmanNode {
+  children: [Option<usize>; 2],
+  symbol: Option<u16>,
 }
 
 const HTTP2_HUFFMAN_EOS: u16 = 256;
@@ -3498,6 +3563,20 @@ impl Error for UnsupportedExpectation {}
 mod tests {
   use super::*;
   use std::io::{BufRead, BufReader, Cursor};
+
+  #[test]
+  fn http2_huffman_decode_table_resolves_symbols_without_linear_scan() {
+    let table = http2_huffman_decode_table();
+
+    assert_eq!(Some(b'0' as u16), table.decode_symbol(0x00, 5));
+    assert_eq!(Some(b'.' as u16), table.decode_symbol(0x17, 6));
+    assert_eq!(Some(b'/' as u16), table.decode_symbol(0x18, 6));
+    assert_eq!(
+      Some(HTTP2_HUFFMAN_EOS),
+      table.decode_symbol(0x3fff_ffff, 30)
+    );
+    assert_eq!(None, table.decode_symbol(0x00, 1));
+  }
 
   #[test]
   fn read_next_from_consumes_one_fully_framed_request_at_a_time() {

--- a/rttp/src/server.rs
+++ b/rttp/src/server.rs
@@ -1088,12 +1088,6 @@ fn decode_http2_string(block: &[u8], cursor: &mut usize) -> io::Result<String> {
   }
   let huffman = block[*cursor] & 0x80 == 0x80;
   let len = decode_http2_integer(block, cursor, 7)?;
-  if huffman {
-    return Err(io::Error::new(
-      io::ErrorKind::InvalidData,
-      "HPACK Huffman strings are not supported by the minimal decoder",
-    ));
-  }
   let end = cursor
     .checked_add(len)
     .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "HPACK string length overflow"))?;
@@ -1103,11 +1097,329 @@ fn decode_http2_string(block: &[u8], cursor: &mut usize) -> io::Result<String> {
       "truncated HPACK string",
     ));
   }
-  let value = String::from_utf8(block[*cursor..end].to_vec())
-    .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))?;
+  let bytes = if huffman {
+    decode_http2_huffman_string(&block[*cursor..end])?
+  } else {
+    block[*cursor..end].to_vec()
+  };
+  let value =
+    String::from_utf8(bytes).map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))?;
   *cursor = end;
   Ok(value)
 }
+
+fn decode_http2_huffman_string(encoded: &[u8]) -> io::Result<Vec<u8>> {
+  let mut decoded = Vec::with_capacity(encoded.len());
+  let mut code = 0u32;
+  let mut code_len = 0u8;
+
+  for byte in encoded {
+    for bit_index in (0..8).rev() {
+      code = (code << 1) | (((byte >> bit_index) & 1) as u32);
+      code_len += 1;
+
+      if let Some(symbol) = http2_huffman_symbol(code, code_len) {
+        if symbol == HTTP2_HUFFMAN_EOS {
+          return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "HPACK Huffman EOS symbol used as data",
+          ));
+        }
+        decoded.push(symbol as u8);
+        code = 0;
+        code_len = 0;
+      } else if code_len > HTTP2_HUFFMAN_EOS_BITS {
+        return Err(io::Error::new(
+          io::ErrorKind::InvalidData,
+          "invalid HPACK Huffman code",
+        ));
+      }
+    }
+  }
+
+  if code_len == 0 {
+    return Ok(decoded);
+  }
+
+  if code_len > 7 || code != (1u32 << code_len) - 1 {
+    return Err(io::Error::new(
+      io::ErrorKind::InvalidData,
+      "invalid HPACK Huffman padding",
+    ));
+  }
+
+  Ok(decoded)
+}
+
+fn http2_huffman_symbol(code: u32, code_len: u8) -> Option<u16> {
+  HTTP2_HUFFMAN_CODES
+    .iter()
+    .position(|&(bits, table_code)| bits == code_len && table_code == code)
+    .map(|index| index as u16)
+}
+
+const HTTP2_HUFFMAN_EOS: u16 = 256;
+const HTTP2_HUFFMAN_EOS_BITS: u8 = 30;
+
+const HTTP2_HUFFMAN_CODES: [(u8, u32); 257] = [
+  (13, 0x1ff8),
+  (23, 0x7ffd8),
+  (28, 0xfffffe2),
+  (28, 0xfffffe3),
+  (28, 0xfffffe4),
+  (28, 0xfffffe5),
+  (28, 0xfffffe6),
+  (28, 0xfffffe7),
+  (28, 0xfffffe8),
+  (24, 0xffffea),
+  (30, 0x3ffffffc),
+  (28, 0xfffffe9),
+  (28, 0xfffffea),
+  (30, 0x3ffffffd),
+  (28, 0xfffffeb),
+  (28, 0xfffffec),
+  (28, 0xfffffed),
+  (28, 0xfffffee),
+  (28, 0xfffffef),
+  (28, 0xffffff0),
+  (28, 0xffffff1),
+  (28, 0xffffff2),
+  (30, 0x3ffffffe),
+  (28, 0xffffff3),
+  (28, 0xffffff4),
+  (28, 0xffffff5),
+  (28, 0xffffff6),
+  (28, 0xffffff7),
+  (28, 0xffffff8),
+  (28, 0xffffff9),
+  (28, 0xffffffa),
+  (28, 0xffffffb),
+  (6, 0x14),
+  (10, 0x3f8),
+  (10, 0x3f9),
+  (12, 0xffa),
+  (13, 0x1ff9),
+  (6, 0x15),
+  (8, 0xf8),
+  (11, 0x7fa),
+  (10, 0x3fa),
+  (10, 0x3fb),
+  (8, 0xf9),
+  (11, 0x7fb),
+  (8, 0xfa),
+  (6, 0x16),
+  (6, 0x17),
+  (6, 0x18),
+  (5, 0x0),
+  (5, 0x1),
+  (5, 0x2),
+  (6, 0x19),
+  (6, 0x1a),
+  (6, 0x1b),
+  (6, 0x1c),
+  (6, 0x1d),
+  (6, 0x1e),
+  (6, 0x1f),
+  (7, 0x5c),
+  (8, 0xfb),
+  (15, 0x7ffc),
+  (6, 0x20),
+  (12, 0xffb),
+  (10, 0x3fc),
+  (13, 0x1ffa),
+  (6, 0x21),
+  (7, 0x5d),
+  (7, 0x5e),
+  (7, 0x5f),
+  (7, 0x60),
+  (7, 0x61),
+  (7, 0x62),
+  (7, 0x63),
+  (7, 0x64),
+  (7, 0x65),
+  (7, 0x66),
+  (7, 0x67),
+  (7, 0x68),
+  (7, 0x69),
+  (7, 0x6a),
+  (7, 0x6b),
+  (7, 0x6c),
+  (7, 0x6d),
+  (7, 0x6e),
+  (7, 0x6f),
+  (7, 0x70),
+  (7, 0x71),
+  (7, 0x72),
+  (8, 0xfc),
+  (7, 0x73),
+  (8, 0xfd),
+  (13, 0x1ffb),
+  (19, 0x7fff0),
+  (13, 0x1ffc),
+  (14, 0x3ffc),
+  (6, 0x22),
+  (15, 0x7ffd),
+  (5, 0x3),
+  (6, 0x23),
+  (5, 0x4),
+  (6, 0x24),
+  (5, 0x5),
+  (6, 0x25),
+  (6, 0x26),
+  (6, 0x27),
+  (5, 0x6),
+  (7, 0x74),
+  (7, 0x75),
+  (6, 0x28),
+  (6, 0x29),
+  (6, 0x2a),
+  (5, 0x7),
+  (6, 0x2b),
+  (7, 0x76),
+  (6, 0x2c),
+  (5, 0x8),
+  (5, 0x9),
+  (6, 0x2d),
+  (7, 0x77),
+  (7, 0x78),
+  (7, 0x79),
+  (7, 0x7a),
+  (7, 0x7b),
+  (15, 0x7ffe),
+  (11, 0x7fc),
+  (14, 0x3ffd),
+  (13, 0x1ffd),
+  (28, 0xffffffc),
+  (20, 0xfffe6),
+  (22, 0x3fffd2),
+  (20, 0xfffe7),
+  (20, 0xfffe8),
+  (22, 0x3fffd3),
+  (22, 0x3fffd4),
+  (22, 0x3fffd5),
+  (23, 0x7fffd9),
+  (22, 0x3fffd6),
+  (23, 0x7fffda),
+  (23, 0x7fffdb),
+  (23, 0x7fffdc),
+  (23, 0x7fffdd),
+  (23, 0x7fffde),
+  (24, 0xffffeb),
+  (23, 0x7fffdf),
+  (24, 0xffffec),
+  (24, 0xffffed),
+  (22, 0x3fffd7),
+  (23, 0x7fffe0),
+  (24, 0xffffee),
+  (23, 0x7fffe1),
+  (23, 0x7fffe2),
+  (23, 0x7fffe3),
+  (23, 0x7fffe4),
+  (21, 0x1fffdc),
+  (22, 0x3fffd8),
+  (23, 0x7fffe5),
+  (22, 0x3fffd9),
+  (23, 0x7fffe6),
+  (23, 0x7fffe7),
+  (24, 0xffffef),
+  (22, 0x3fffda),
+  (21, 0x1fffdd),
+  (20, 0xfffe9),
+  (22, 0x3fffdb),
+  (22, 0x3fffdc),
+  (23, 0x7fffe8),
+  (23, 0x7fffe9),
+  (21, 0x1fffde),
+  (23, 0x7fffea),
+  (22, 0x3fffdd),
+  (22, 0x3fffde),
+  (24, 0xfffff0),
+  (21, 0x1fffdf),
+  (22, 0x3fffdf),
+  (23, 0x7fffeb),
+  (23, 0x7fffec),
+  (21, 0x1fffe0),
+  (21, 0x1fffe1),
+  (22, 0x3fffe0),
+  (21, 0x1fffe2),
+  (23, 0x7fffed),
+  (22, 0x3fffe1),
+  (23, 0x7fffee),
+  (23, 0x7fffef),
+  (20, 0xfffea),
+  (22, 0x3fffe2),
+  (22, 0x3fffe3),
+  (22, 0x3fffe4),
+  (23, 0x7ffff0),
+  (22, 0x3fffe5),
+  (22, 0x3fffe6),
+  (23, 0x7ffff1),
+  (26, 0x3ffffe0),
+  (26, 0x3ffffe1),
+  (20, 0xfffeb),
+  (19, 0x7fff1),
+  (22, 0x3fffe7),
+  (23, 0x7ffff2),
+  (22, 0x3fffe8),
+  (25, 0x1ffffec),
+  (26, 0x3ffffe2),
+  (26, 0x3ffffe3),
+  (26, 0x3ffffe4),
+  (27, 0x7ffffde),
+  (27, 0x7ffffdf),
+  (26, 0x3ffffe5),
+  (24, 0xfffff1),
+  (25, 0x1ffffed),
+  (19, 0x7fff2),
+  (21, 0x1fffe3),
+  (26, 0x3ffffe6),
+  (27, 0x7ffffe0),
+  (27, 0x7ffffe1),
+  (26, 0x3ffffe7),
+  (27, 0x7ffffe2),
+  (24, 0xfffff2),
+  (21, 0x1fffe4),
+  (21, 0x1fffe5),
+  (26, 0x3ffffe8),
+  (26, 0x3ffffe9),
+  (28, 0xffffffd),
+  (27, 0x7ffffe3),
+  (27, 0x7ffffe4),
+  (27, 0x7ffffe5),
+  (20, 0xfffec),
+  (24, 0xfffff3),
+  (20, 0xfffed),
+  (21, 0x1fffe6),
+  (22, 0x3fffe9),
+  (21, 0x1fffe7),
+  (21, 0x1fffe8),
+  (23, 0x7ffff3),
+  (22, 0x3fffea),
+  (22, 0x3fffeb),
+  (25, 0x1ffffee),
+  (25, 0x1ffffef),
+  (24, 0xfffff4),
+  (24, 0xfffff5),
+  (26, 0x3ffffea),
+  (23, 0x7ffff4),
+  (26, 0x3ffffeb),
+  (27, 0x7ffffe6),
+  (26, 0x3ffffec),
+  (26, 0x3ffffed),
+  (27, 0x7ffffe7),
+  (27, 0x7ffffe8),
+  (27, 0x7ffffe9),
+  (27, 0x7ffffea),
+  (27, 0x7ffffeb),
+  (28, 0xffffffe),
+  (27, 0x7ffffec),
+  (27, 0x7ffffed),
+  (27, 0x7ffffee),
+  (27, 0x7ffffef),
+  (27, 0x7fffff0),
+  (26, 0x3ffffee),
+  (30, 0x3fffffff),
+];
 
 fn write_http2_response(
   stream: &mut TcpStream,

--- a/rttp/tests/test_server.rs
+++ b/rttp/tests/test_server.rs
@@ -79,6 +79,13 @@ fn h2_literal_indexed_name(name_index: u8, value: &[u8]) -> Vec<u8> {
   encoded
 }
 
+fn h2_literal_indexed_name_huffman(name_index: u8, encoded_value: &[u8]) -> Vec<u8> {
+  assert!(encoded_value.len() < 128);
+  let mut encoded = vec![name_index, 0x80 | encoded_value.len() as u8];
+  encoded.extend_from_slice(encoded_value);
+  encoded
+}
+
 fn h2_literal_new_name(name: &[u8], value: &[u8]) -> Vec<u8> {
   assert!(name.len() < 128);
   assert!(value.len() < 128);
@@ -86,6 +93,16 @@ fn h2_literal_new_name(name: &[u8], value: &[u8]) -> Vec<u8> {
   encoded.extend_from_slice(name);
   encoded.push(value.len() as u8);
   encoded.extend_from_slice(value);
+  encoded
+}
+
+fn h2_literal_new_name_huffman(encoded_name: &[u8], encoded_value: &[u8]) -> Vec<u8> {
+  assert!(encoded_name.len() < 128);
+  assert!(encoded_value.len() < 128);
+  let mut encoded = vec![0, 0x80 | encoded_name.len() as u8];
+  encoded.extend_from_slice(encoded_name);
+  encoded.push(0x80 | encoded_value.len() as u8);
+  encoded.extend_from_slice(encoded_value);
   encoded
 }
 
@@ -102,6 +119,26 @@ fn h2_post_headers(path: &[u8], authority: &[u8]) -> Vec<u8> {
   headers.extend(h2_literal_indexed_name(1, authority));
   headers
 }
+
+fn h2_get_headers_with_huffman_path(encoded_path: &[u8]) -> Vec<u8> {
+  let mut headers = vec![0x82, 0x86];
+  headers.extend(h2_literal_indexed_name_huffman(4, encoded_path));
+  headers.extend(h2_literal_indexed_name(1, b"localhost"));
+  headers
+}
+
+const H2_HUFFMAN_PATH: &[u8] = &[0x62, 0x7b, 0x65, 0x96, 0x91, 0xd4, 0xb5, 0x63, 0x4c, 0xff];
+const H2_HUFFMAN_LOCALHOST: &[u8] = &[0xa0, 0xe4, 0x1d, 0x13, 0x9d, 0x09];
+const H2_HUFFMAN_X_HUFFMAN: &[u8] = &[0xf2, 0xb4, 0xf6, 0xcb, 0x2d, 0x23, 0xab];
+const H2_HUFFMAN_DECODED_HEADER: &[u8] =
+  &[0x90, 0xa4, 0x3c, 0x85, 0x91, 0x69, 0xca, 0x39, 0x0b, 0x67];
+const H2_HUFFMAN_X_HUFF_TRAILER: &[u8] = &[
+  0xf2, 0xb4, 0xf6, 0xcb, 0x2a, 0xc9, 0xb0, 0x66, 0xa0, 0xb6, 0x7f,
+];
+const H2_HUFFMAN_DECODED_TRAILER: &[u8] = &[
+  0x90, 0xa4, 0x3c, 0x85, 0x91, 0x64, 0xd8, 0x33, 0x50, 0x5b, 0x3f,
+];
+const H2_HUFFMAN_NON_UTF8: &[u8] = &[0xff, 0xff, 0xfb, 0xbf];
 
 fn h2_setting(id: u16, value: u32) -> [u8; 6] {
   let mut setting = [0; 6];
@@ -709,6 +746,85 @@ fn server_accepts_http2_prior_knowledge_headers_and_data_before_calling_handler(
 }
 
 #[test]
+fn server_decodes_http2_prior_knowledge_hpack_huffman_request_headers_and_trailers() {
+  let server = rttp::Http::server("127.0.0.1:0").expect("bind server");
+  let addr = server.local_addr().expect("server addr");
+  let (tx, rx) = mpsc::channel();
+
+  let handle = thread::spawn(move || {
+    server
+      .accept_one(|request| {
+        tx.send((
+          request.method().to_string(),
+          request.target().to_string(),
+          request.header("host").map(str::to_string),
+          request.header("x-huffman").map(str::to_string),
+          request.trailer("x-huff-trailer").map(str::to_string),
+          request.trailers().to_vec(),
+        ))
+        .expect("send parsed huffman h2 request");
+        HttpResponse::ok("decoded")
+      })
+      .expect("serve huffman h2 request");
+  });
+
+  let mut stream = TcpStream::connect(addr).expect("connect h2 server");
+  stream
+    .set_read_timeout(Some(Duration::from_secs(2)))
+    .expect("set h2 read timeout");
+  complete_h2_server_handshake(&mut stream);
+
+  let mut headers = vec![0x83, 0x86];
+  headers.extend(h2_literal_indexed_name_huffman(4, H2_HUFFMAN_PATH));
+  headers.extend(h2_literal_indexed_name_huffman(1, H2_HUFFMAN_LOCALHOST));
+  headers.extend(h2_literal_new_name_huffman(
+    H2_HUFFMAN_X_HUFFMAN,
+    H2_HUFFMAN_DECODED_HEADER,
+  ));
+  write_h2_frame(
+    &mut stream,
+    H2_FRAME_HEADERS,
+    H2_FLAG_END_HEADERS,
+    1,
+    &headers,
+  );
+  write_h2_frame(&mut stream, H2_FRAME_DATA, 0, 1, b"huffman body");
+
+  let trailers = h2_literal_new_name_huffman(H2_HUFFMAN_X_HUFF_TRAILER, H2_HUFFMAN_DECODED_TRAILER);
+  write_h2_frame(
+    &mut stream,
+    H2_FRAME_HEADERS,
+    H2_FLAG_END_HEADERS | H2_FLAG_END_STREAM,
+    1,
+    &trailers,
+  );
+
+  let response_headers = read_h2_frame_skipping_window_updates(&mut stream);
+  assert_eq!(H2_FRAME_HEADERS, response_headers.frame_type);
+  assert_eq!(H2_FLAG_END_HEADERS, response_headers.flags);
+  assert_eq!(1, response_headers.stream_id);
+
+  let response_body = read_h2_frame_skipping_window_updates(&mut stream);
+  assert_eq!(H2_FRAME_DATA, response_body.frame_type);
+  assert_eq!(H2_FLAG_END_STREAM, response_body.flags);
+  assert_eq!(1, response_body.stream_id);
+  assert_eq!(b"decoded", response_body.payload.as_slice());
+
+  assert_eq!(
+    (
+      "POST".to_string(),
+      "/huffman-path".to_string(),
+      Some("localhost".to_string()),
+      Some("decoded-header".to_string()),
+      Some("decoded-trailer".to_string()),
+      vec![("x-huff-trailer".to_string(), "decoded-trailer".to_string())]
+    ),
+    rx.recv().expect("receive parsed huffman h2 request")
+  );
+  handle.join().expect("server thread");
+}
+
+#[test]
 fn server_decodes_http2_prior_knowledge_request_trailers_after_data() {
   let server = rttp::Http::server("127.0.0.1:0").expect("bind server");
   let addr = server.local_addr().expect("server addr");
@@ -853,6 +969,14 @@ fn server_decodes_http2_prior_knowledge_request_trailers_with_continuation() {
 #[test]
 fn server_rejects_http2_prior_knowledge_request_trailer_pseudo_header() {
   assert_invalid_h2_request_trailers_without_handler(&h2_literal_indexed_name(2, b"GET"));
+}
+
+#[test]
+fn server_rejects_http2_prior_knowledge_hpack_huffman_request_trailer_before_handler() {
+  assert_invalid_h2_request_trailers_without_handler(&h2_literal_new_name_huffman(
+    H2_HUFFMAN_X_HUFF_TRAILER,
+    &[0xff],
+  ));
 }
 
 #[test]
@@ -1334,6 +1458,33 @@ fn server_rejects_http2_prior_knowledge_request_missing_scheme() {
   headers.extend(h2_literal_indexed_name(1, b"localhost"));
 
   assert_invalid_h2_headers_without_handler(&headers);
+}
+
+#[test]
+fn server_rejects_http2_prior_knowledge_hpack_huffman_eos_symbol_before_handler() {
+  assert_invalid_h2_headers_without_handler(&h2_get_headers_with_huffman_path(&[
+    0xff, 0xff, 0xff, 0xff,
+  ]));
+}
+
+#[test]
+fn server_rejects_http2_prior_knowledge_hpack_huffman_invalid_padding_before_handler() {
+  assert_invalid_h2_headers_without_handler(&h2_get_headers_with_huffman_path(&[0x00]));
+}
+
+#[test]
+fn server_rejects_http2_prior_knowledge_hpack_huffman_truncated_code_before_handler() {
+  assert_invalid_h2_headers_without_handler(&h2_get_headers_with_huffman_path(&[0xfe]));
+}
+
+#[test]
+fn server_rejects_http2_prior_knowledge_hpack_huffman_overlong_padding_before_handler() {
+  assert_invalid_h2_headers_without_handler(&h2_get_headers_with_huffman_path(&[0xff]));
+}
+
+#[test]
+fn server_rejects_http2_prior_knowledge_hpack_huffman_non_utf8_before_handler() {
+  assert_invalid_h2_headers_without_handler(&h2_get_headers_with_huffman_path(H2_HUFFMAN_NON_UTF8));
 }
 
 #[test]


### PR DESCRIPTION
Adds RFC 7541 static Huffman decoding to the minimal h2c server HPACK string path, with live socket2 tests for decoded headers/trailers and malformed Huffman rejection.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1411/
work_kind: code_work
branch: hbx-1411-rttp-decode-hpack-static-huffman
base: main
commit: 8af43847d5442a42b3b36ba015c758ac986120ad
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1411/
    url: https://plane.kahub.in/endless/browse/HBX-1411/
    close_policy: link_only
```