### PR TITLE
feat: [rttp_client] Decode HPACK static Huffman strings in HTTP/2 responses

### DIFF
--- a/rttp_client/src/http2.rs
+++ b/rttp_client/src/http2.rs
@@ -35,6 +35,49 @@ const DEFAULT_MAX_FRAME_SIZE: usize = 16 * 1024;
 const MAX_FRAME_SIZE_LIMIT: usize = 16_777_215;
 const MAX_INITIAL_WINDOW_SIZE: u32 = 2_147_483_647;
 const WINDOW_UPDATE_THRESHOLD: usize = 32 * 1024;
+const HPACK_HUFFMAN_EOS_SYMBOL: usize = 256;
+const HPACK_HUFFMAN_EOS_BITS: u8 = 30;
+
+const HPACK_HUFFMAN_CODES: [u32; 257] = [
+  0x1ff8, 0x7fffd8, 0xfffffe2, 0xfffffe3, 0xfffffe4, 0xfffffe5, 0xfffffe6, 0xfffffe7, 0xfffffe8,
+  0xffffea, 0x3ffffffc, 0xfffffe9, 0xfffffea, 0x3ffffffd, 0xfffffeb, 0xfffffec, 0xfffffed,
+  0xfffffee, 0xfffffef, 0xffffff0, 0xffffff1, 0xffffff2, 0x3ffffffe, 0xffffff3, 0xffffff4,
+  0xffffff5, 0xffffff6, 0xffffff7, 0xffffff8, 0xffffff9, 0xffffffa, 0xffffffb, 0x14, 0x3f8, 0x3f9,
+  0xffa, 0x1ff9, 0x15, 0xf8, 0x7fa, 0x3fa, 0x3fb, 0xf9, 0x7fb, 0xfa, 0x16, 0x17, 0x18, 0x0, 0x1,
+  0x2, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f, 0x5c, 0xfb, 0x7ffc, 0x20, 0xffb, 0x3fc, 0x1ffa,
+  0x21, 0x5d, 0x5e, 0x5f, 0x60, 0x61, 0x62, 0x63, 0x64, 0x65, 0x66, 0x67, 0x68, 0x69, 0x6a, 0x6b,
+  0x6c, 0x6d, 0x6e, 0x6f, 0x70, 0x71, 0x72, 0xfc, 0x73, 0xfd, 0x1ffb, 0x7fff0, 0x1ffc, 0x3ffc,
+  0x22, 0x7ffd, 0x3, 0x23, 0x4, 0x24, 0x5, 0x25, 0x26, 0x27, 0x6, 0x74, 0x75, 0x28, 0x29, 0x2a,
+  0x7, 0x2b, 0x76, 0x2c, 0x8, 0x9, 0x2d, 0x77, 0x78, 0x79, 0x7a, 0x7b, 0x7ffe, 0x7fc, 0x3ffd,
+  0x1ffd, 0xffffffc, 0xfffe6, 0x3fffd2, 0xfffe7, 0xfffe8, 0x3fffd3, 0x3fffd4, 0x3fffd5, 0x7fffd9,
+  0x3fffd6, 0x7fffda, 0x7fffdb, 0x7fffdc, 0x7fffdd, 0x7fffde, 0xffffeb, 0x7fffdf, 0xffffec,
+  0xffffed, 0x3fffd7, 0x7fffe0, 0xffffee, 0x7fffe1, 0x7fffe2, 0x7fffe3, 0x7fffe4, 0x1fffdc,
+  0x3fffd8, 0x7fffe5, 0x3fffd9, 0x7fffe6, 0x7fffe7, 0xffffef, 0x3fffda, 0x1fffdd, 0xfffe9,
+  0x3fffdb, 0x3fffdc, 0x7fffe8, 0x7fffe9, 0x1fffde, 0x7fffea, 0x3fffdd, 0x3fffde, 0xfffff0,
+  0x1fffdf, 0x3fffdf, 0x7fffeb, 0x7fffec, 0x1fffe0, 0x1fffe1, 0x3fffe0, 0x1fffe2, 0x7fffed,
+  0x3fffe1, 0x7fffee, 0x7fffef, 0xfffea, 0x3fffe2, 0x3fffe3, 0x3fffe4, 0x7ffff0, 0x3fffe5,
+  0x3fffe6, 0x7ffff1, 0x3ffffe0, 0x3ffffe1, 0xfffeb, 0x7fff1, 0x3fffe7, 0x7ffff2, 0x3fffe8,
+  0x1ffffec, 0x3ffffe2, 0x3ffffe3, 0x3ffffe4, 0x7ffffde, 0x7ffffdf, 0x3ffffe5, 0xfffff1, 0x1ffffed,
+  0x7fff2, 0x1fffe3, 0x3ffffe6, 0x7ffffe0, 0x7ffffe1, 0x3ffffe7, 0x7ffffe2, 0xfffff2, 0x1fffe4,
+  0x1fffe5, 0x3ffffe8, 0x3ffffe9, 0xffffffd, 0x7ffffe3, 0x7ffffe4, 0x7ffffe5, 0xfffec, 0xfffff3,
+  0xfffed, 0x1fffe6, 0x3fffe9, 0x1fffe7, 0x1fffe8, 0x7ffff3, 0x3fffea, 0x3fffeb, 0x1ffffee,
+  0x1ffffef, 0xfffff4, 0xfffff5, 0x3ffffea, 0x7ffff4, 0x3ffffeb, 0x7ffffe6, 0x3ffffec, 0x3ffffed,
+  0x7ffffe7, 0x7ffffe8, 0x7ffffe9, 0x7ffffea, 0x7ffffeb, 0xffffffe, 0x7ffffec, 0x7ffffed,
+  0x7ffffee, 0x7ffffef, 0x7fffff0, 0x3ffffee, 0x3fffffff,
+];
+
+const HPACK_HUFFMAN_CODE_LENGTHS: [u8; 257] = [
+  13, 23, 28, 28, 28, 28, 28, 28, 28, 24, 30, 28, 28, 30, 28, 28, 28, 28, 28, 28, 28, 28, 30, 28,
+  28, 28, 28, 28, 28, 28, 28, 28, 6, 10, 10, 12, 13, 6, 8, 11, 10, 10, 8, 11, 8, 6, 6, 6, 5, 5, 5,
+  6, 6, 6, 6, 6, 6, 6, 7, 8, 15, 6, 12, 10, 13, 6, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7,
+  7, 7, 7, 7, 7, 7, 8, 7, 8, 13, 19, 13, 14, 6, 15, 5, 6, 5, 6, 5, 6, 6, 6, 5, 7, 7, 6, 6, 6, 5, 6,
+  7, 6, 5, 5, 6, 7, 7, 7, 7, 7, 15, 11, 14, 13, 28, 20, 22, 20, 20, 22, 22, 22, 23, 22, 23, 23, 23,
+  23, 23, 24, 23, 24, 24, 22, 23, 24, 23, 23, 23, 23, 21, 22, 23, 22, 23, 23, 24, 22, 21, 20, 22,
+  22, 23, 23, 21, 23, 22, 22, 24, 21, 22, 23, 23, 21, 21, 22, 21, 23, 22, 23, 23, 20, 22, 22, 22,
+  23, 22, 22, 23, 26, 26, 20, 19, 22, 23, 22, 25, 26, 26, 26, 27, 27, 26, 24, 25, 19, 21, 26, 27,
+  27, 26, 27, 24, 21, 21, 26, 26, 28, 27, 27, 27, 20, 24, 20, 21, 22, 21, 21, 23, 22, 22, 25, 25,
+  24, 24, 26, 23, 26, 27, 26, 26, 27, 27, 27, 27, 27, 28, 27, 27, 27, 27, 27, 26, 30,
+];
 
 pub struct PriorKnowledgeClient<'a> {
   request: RawRequest<'a>,
@@ -957,20 +1000,76 @@ fn decode_string(block: &[u8], cursor: &mut usize) -> error::Result<String> {
   }
   let huffman = block[*cursor] & 0x80 == 0x80;
   let len = decode_integer(block, cursor, 7)?;
-  if huffman {
-    return Err(error::bad_response(
-      "HPACK Huffman strings are not supported by the minimal decoder",
-    ));
-  }
   let end = cursor
     .checked_add(len)
     .ok_or_else(|| error::bad_response("HPACK string length overflow"))?;
   if end > block.len() {
     return Err(error::bad_response("truncated HPACK string"));
   }
-  let value = String::from_utf8(block[*cursor..end].to_vec()).map_err(error::response)?;
+  let value = if huffman {
+    decode_huffman_string(&block[*cursor..end])?
+  } else {
+    String::from_utf8(block[*cursor..end].to_vec()).map_err(error::response)?
+  };
   *cursor = end;
   Ok(value)
+}
+
+fn decode_huffman_string(encoded: &[u8]) -> error::Result<String> {
+  let mut decoded = Vec::new();
+  let mut code = 0u32;
+  let mut code_len = 0u8;
+
+  for byte in encoded {
+    for bit_offset in (0..8).rev() {
+      code = (code << 1) | (((byte >> bit_offset) & 1) as u32);
+      code_len += 1;
+
+      if code_len > HPACK_HUFFMAN_EOS_BITS {
+        return Err(error::bad_response("invalid HPACK Huffman code"));
+      }
+
+      if let Some(symbol) = hpack_huffman_symbol(code, code_len) {
+        if symbol == HPACK_HUFFMAN_EOS_SYMBOL {
+          return Err(error::bad_response("HPACK Huffman EOS symbol used as data"));
+        }
+        decoded.push(symbol as u8);
+        code = 0;
+        code_len = 0;
+      }
+    }
+  }
+
+  if code_len > 0 {
+    let eos_padding = code == ((1u32 << code_len) - 1);
+    if eos_padding {
+      if code_len > 7 {
+        return Err(error::bad_response("overlong HPACK Huffman padding"));
+      }
+    } else if code_len > 7 && hpack_huffman_has_prefix(code, code_len) {
+      return Err(error::bad_response("truncated HPACK Huffman code"));
+    } else {
+      return Err(error::bad_response("invalid HPACK Huffman padding"));
+    }
+  }
+
+  String::from_utf8(decoded).map_err(error::response)
+}
+
+fn hpack_huffman_symbol(code: u32, code_len: u8) -> Option<usize> {
+  HPACK_HUFFMAN_CODES
+    .iter()
+    .zip(HPACK_HUFFMAN_CODE_LENGTHS.iter())
+    .position(|(&candidate, &candidate_len)| candidate_len == code_len && candidate == code)
+}
+
+fn hpack_huffman_has_prefix(code: u32, code_len: u8) -> bool {
+  HPACK_HUFFMAN_CODES
+    .iter()
+    .zip(HPACK_HUFFMAN_CODE_LENGTHS.iter())
+    .any(|(&candidate, &candidate_len)| {
+      candidate_len > code_len && (candidate >> (candidate_len - code_len)) == code
+    })
 }
 
 fn push_decoded_header(

--- a/rttp_client/tests/http2_prior_knowledge.rs
+++ b/rttp_client/tests/http2_prior_knowledge.rs
@@ -1340,6 +1340,103 @@ fn prior_knowledge_get_defers_small_window_updates_until_more_credit_is_needed()
   handle.join().expect("h2 peer thread");
 }
 
+#[test]
+fn prior_knowledge_decodes_hpack_huffman_response_headers_and_trailers() {
+  let listener = TcpListener::bind("127.0.0.1:0").expect("bind h2 peer");
+  let addr = listener.local_addr().expect("h2 peer addr");
+
+  let handle = thread::spawn(move || {
+    let (mut stream, _) = listener.accept().expect("accept h2 client");
+    complete_h2_request_handshake(&mut stream);
+
+    let mut headers = vec![0x88];
+    headers.extend_from_slice(&h2_literal_huffman_new_name(
+      &[0xf2, 0xb4, 0xf6, 0xcb, 0x2f],
+      &[0x3f, 0x55, 0xa7, 0xb6, 0x59, 0x7f],
+    ));
+    let trailers = h2_literal_huffman_new_name(
+      &[0xf2, 0xb2, 0x46, 0x6a, 0x3f],
+      &[0x4d, 0x83, 0x35, 0x0b, 0x4f, 0x6c, 0xb2, 0xff],
+    );
+
+    write_frame(&mut stream, FRAME_SETTINGS, FLAG_ACK, 0, &[]);
+    write_frame(&mut stream, FRAME_HEADERS, FLAG_END_HEADERS, 1, &headers);
+    write_frame(&mut stream, FRAME_DATA, 0, 1, b"huffman body");
+    write_frame(
+      &mut stream,
+      FRAME_HEADERS,
+      FLAG_END_HEADERS | FLAG_END_STREAM,
+      1,
+      &trailers,
+    );
+  });
+
+  let response = HttpClient::new()
+    .get()
+    .url(format!("http://{}/huffman", addr))
+    .emit_http2_prior_knowledge()
+    .expect("huffman h2 response");
+
+  assert_eq!(200, response.code());
+  assert_eq!("huffman body", response.body().string().unwrap());
+  assert_eq!(
+    Some(&"ok-huff".to_string()),
+    response.header_value("x-huff")
+  );
+  assert_eq!(
+    Some(&"trail-huff".to_string()),
+    response.trailer_value("x-tail")
+  );
+  handle.join().expect("h2 peer thread");
+}
+
+#[test]
+fn prior_knowledge_rejects_malformed_hpack_huffman_strings() {
+  let cases: &[(&str, &[u8], &str)] = &[
+    (
+      "eos-data",
+      &[0x88, 0, 0x84, 0xff, 0xff, 0xff, 0xff, 1, b'x'],
+      "HPACK Huffman EOS symbol used as data",
+    ),
+    (
+      "invalid-padding",
+      &[0x88, 0, 0x81, 0x00, 1, b'x'],
+      "invalid HPACK Huffman padding",
+    ),
+    (
+      "truncated-code",
+      &[0x88, 0, 0x81, 0xfe, 1, b'x'],
+      "truncated HPACK Huffman code",
+    ),
+    (
+      "overlong-padding",
+      &[0x88, 0, 0x81, 0xff, 1, b'x'],
+      "overlong HPACK Huffman padding",
+    ),
+    (
+      "invalid-utf8",
+      &[0x88, 0, 0x84, 0xff, 0xff, 0xfb, 0xbf, 1, b'x'],
+      "invalid utf-8 sequence",
+    ),
+  ];
+
+  for (path, header_block, expected) in cases {
+    let (addr, handle) = spawn_h2_prior_knowledge_peer_with_response(header_block, &[b""]);
+
+    let error = HttpClient::new()
+      .get()
+      .url(format!("http://{}/{}", addr, path))
+      .emit_http2_prior_knowledge()
+      .expect_err("malformed Huffman string should be rejected");
+
+    assert!(
+      error.to_string().contains(expected),
+      "expected {expected:?}, got {error}"
+    );
+    handle.join().expect("h2 peer thread");
+  }
+}
+
 struct Frame {
   frame_type: u8,
   flags: u8,
@@ -1549,12 +1646,29 @@ fn h2_literal_new_name(name: &[u8], value: &[u8]) -> Vec<u8> {
   block
 }
 
+fn h2_literal_huffman_new_name(name: &[u8], value: &[u8]) -> Vec<u8> {
+  let mut block = Vec::new();
+  block.push(0);
+  h2_huffman_string(&mut block, name);
+  h2_huffman_string(&mut block, value);
+  block
+}
+
 fn h2_string(block: &mut Vec<u8>, value: &[u8]) {
   assert!(
     value.len() < 128,
     "test HPACK helper only encodes short strings"
   );
   block.push(value.len() as u8);
+  block.extend_from_slice(value);
+}
+
+fn h2_huffman_string(block: &mut Vec<u8>, value: &[u8]) {
+  assert!(
+    value.len() < 128,
+    "test HPACK helper only encodes short strings"
+  );
+  block.push(0x80 | value.len() as u8);
   block.extend_from_slice(value);
 }
 


### PR DESCRIPTION
Adds HPACK static Huffman decoding for rttp_client HTTP/2 prior-knowledge responses with malformed-input coverage and passing package verification.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1410/
work_kind: code_work
branch: hbx-1410-rttp-client-decode-hpack-static
base: main
commit: afaad600a28ea0f11c13f436b77bd1a3b33a2e4d
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1410/
    url: https://plane.kahub.in/endless/browse/HBX-1410/
    close_policy: link_only
```