### PR TITLE
feat: [rttp] Add cross-crate HPACK Huffman interoperability matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,11 @@ available through `Response::trailers`, `Response::trailer`, and
 With the `http2` feature enabled, `emit_http2_prior_knowledge` sends a minimal
 prior-knowledge h2c request over a direct socket2 TCP connection. It supports
 GET and buffered POST, PUT, or PATCH requests, including non-empty buffered
-request bodies as DATA frames and large header blocks via CONTINUATION frames,
-and it decodes incoming padded HEADERS, DATA, and trailer frames without
-exposing padding bytes. TLS ALPN, proxy tunneling, proxy h2, general HTTP/2
-multiplexing, priority scheduling, and HPACK dynamic tables are not part of
-that client path.
+request bodies as DATA frames, HPACK static Huffman strings, and large header
+blocks via CONTINUATION frames, and it decodes incoming padded HEADERS, DATA,
+and trailer frames without exposing padding bytes. TLS ALPN, proxy tunneling,
+proxy h2, HPACK dynamic tables, and full HTTP/2 features such as general
+multiplexing and priority scheduling are not part of that client path.
 
 ```rust,no_run
 use rttp_client::HttpClient;
@@ -98,9 +98,10 @@ consistently, and accepts `Expect: 100-continue`. On the same socket2 listener,
 the accept path detects the HTTP/2 client preface and dispatches prior-knowledge
 h2c requests to a minimal single-stream handler. Incoming padded HEADERS, DATA,
 and trailer frames are accepted without exposing padding bytes to handlers, and
-large header blocks are carried with CONTINUATION frames. TLS ALPN, proxy h2,
-full HTTP/2 multiplexing, priority scheduling, and HPACK dynamic tables remain
-outside this server path.
+HPACK static Huffman strings and large header blocks are carried with
+CONTINUATION frames. TLS ALPN, proxy h2, HPACK dynamic tables, and full HTTP/2
+features such as multiplexing and priority scheduling remain outside this
+server path.
 
 It is not a full RFC-covering web server and still does not implement server
 TLS or async accept loops.

--- a/rttp/README.md
+++ b/rttp/README.md
@@ -55,22 +55,23 @@ writes response body framing and response trailers consistently, and accepts
 `Expect: 100-continue`. On the same socket2 listener, the accept path detects
 the HTTP/2 client preface and dispatches prior-knowledge h2c requests to a
 minimal single-stream handler. Incoming padded HEADERS, DATA, and trailer
-frames are accepted without exposing padding bytes to handlers, and large
-header blocks are carried with CONTINUATION frames.
+frames are accepted without exposing padding bytes to handlers, and HPACK
+static Huffman strings and large header blocks are carried with CONTINUATION
+frames.
 
 The server is intentionally not a full RFC-covering web server and still does
-not implement server TLS, TLS ALPN, proxy h2, full HTTP/2 multiplexing,
-priority scheduling, HPACK dynamic tables, or async accept loops.
+not implement server TLS, TLS ALPN, proxy h2, HPACK dynamic tables, full HTTP/2
+features such as multiplexing and priority scheduling, or async accept loops.
 
 ## Client feature
 
 Enable the `client` feature to access `rttp::Http::client`, or enable `async`,
 `http2`, `tls-native`, `tls-rustls`, or `all` for the corresponding
 `rttp_client` capabilities. The `http2` feature exposes the minimal
-prior-knowledge h2c client path, including large header blocks via
-CONTINUATION frames and padded incoming response frames; TLS ALPN, proxy h2,
-full HTTP/2 multiplexing, priority scheduling, and HPACK dynamic tables remain
-outside that path.
+prior-knowledge h2c client path, including HPACK static Huffman strings, large
+header blocks via CONTINUATION frames, and padded incoming response frames; TLS
+ALPN, proxy h2, HPACK dynamic tables, and full HTTP/2 features such as
+multiplexing and priority scheduling remain outside that path.
 
 Direct TCP client connections use `socket2`. SOCKS proxy handshakes remain
 delegated to the `socks` crate.

--- a/rttp/tests/http2_feature.rs
+++ b/rttp/tests/http2_feature.rs
@@ -888,6 +888,100 @@ fn wrapper_http2_prior_knowledge_large_request_header_reaches_socket2_server() {
 }
 
 #[test]
+fn wrapper_http2_prior_knowledge_huffman_request_headers_reach_socket2_server_decoded() {
+  let server = rttp::Http::server("127.0.0.1:0")
+    .expect("bind server")
+    .with_read_timeout(Some(Duration::from_secs(2)))
+    .with_write_timeout(Some(Duration::from_secs(2)));
+  let addr = server.local_addr().expect("server addr");
+  let huffman_header_value = "a".repeat(64);
+  let expected_header_value = huffman_header_value.clone();
+  let (tx, rx) = mpsc::channel();
+
+  let handle = thread::spawn(move || {
+    server
+      .accept_one(|request| {
+        tx.send((
+          request.version().to_string(),
+          request.target().to_string(),
+          request.header("x-hpack-huffman").map(str::to_string),
+        ))
+        .expect("send parsed Huffman h2 request header");
+        HttpResponse::ok("decoded request huffman")
+      })
+      .expect("serve Huffman h2 request header");
+  });
+
+  let response = rttp::Http::client()
+    .url(format!("http://{}/huffman-request-header", addr))
+    .header(("X-HPACK-Huffman".to_string(), huffman_header_value))
+    .emit_http2_prior_knowledge()
+    .expect("wrapper h2 response after Huffman request header");
+
+  assert_eq!("HTTP/2", response.version());
+  assert_eq!("decoded request huffman", response.body().string().unwrap());
+  assert_eq!(
+    (
+      "HTTP/2".to_string(),
+      "/huffman-request-header".to_string(),
+      Some(expected_header_value)
+    ),
+    rx.recv().expect("receive parsed Huffman h2 request header")
+  );
+
+  handle.join().expect("server thread");
+}
+
+#[test]
+fn wrapper_http2_prior_knowledge_large_huffman_request_header_reaches_socket2_server_decoded() {
+  let server = rttp::Http::server("127.0.0.1:0")
+    .expect("bind server")
+    .with_read_timeout(Some(Duration::from_secs(2)))
+    .with_write_timeout(Some(Duration::from_secs(2)));
+  let addr = server.local_addr().expect("server addr");
+  let large_huffman_value = "a".repeat(28 * 1024);
+  let expected_header_value = large_huffman_value.clone();
+  let (tx, rx) = mpsc::channel();
+
+  let handle = thread::spawn(move || {
+    server
+      .accept_one(|request| {
+        tx.send((
+          request.version().to_string(),
+          request.target().to_string(),
+          request.header("x-large-hpack-huffman").map(str::to_string),
+        ))
+        .expect("send parsed large Huffman h2 request header");
+        HttpResponse::ok("decoded large request huffman")
+      })
+      .expect("serve large Huffman h2 request header");
+  });
+
+  let response = rttp::Http::client()
+    .url(format!("http://{}/large-huffman-request-header", addr))
+    .header(("X-Large-HPACK-Huffman".to_string(), large_huffman_value))
+    .emit_http2_prior_knowledge()
+    .expect("wrapper h2 response after large Huffman request header");
+
+  assert_eq!("HTTP/2", response.version());
+  assert_eq!(
+    "decoded large request huffman",
+    response.body().string().unwrap()
+  );
+  assert_eq!(
+    (
+      "HTTP/2".to_string(),
+      "/large-huffman-request-header".to_string(),
+      Some(expected_header_value)
+    ),
+    rx.recv()
+      .expect("receive parsed large Huffman h2 request header")
+  );
+
+  handle.join().expect("server thread");
+}
+
+#[test]
 fn wrapper_http2_prior_knowledge_reads_large_response_header_from_socket2_server() {
   let server = rttp::Http::server("127.0.0.1:0")
     .expect("bind server")
@@ -916,6 +1010,93 @@ fn wrapper_http2_prior_knowledge_reads_large_response_header_from_socket2_server
   assert_eq!(
     Some(&expected_header_value),
     response.header_value("X-Large-Response")
+  );
+
+  handle.join().expect("server thread");
+}
+
+#[test]
+fn wrapper_http2_prior_knowledge_decodes_huffman_response_headers_and_trailers_from_socket2_server()
+{
+  let server = rttp::Http::server("127.0.0.1:0")
+    .expect("bind server")
+    .with_read_timeout(Some(Duration::from_secs(2)))
+    .with_write_timeout(Some(Duration::from_secs(2)));
+  let addr = server.local_addr().expect("server addr");
+  let header_value = "a".repeat(64);
+  let trailer_value = "e".repeat(64);
+  let expected_header_value = header_value.clone();
+  let expected_trailer_value = trailer_value.clone();
+
+  let handle = thread::spawn(move || {
+    server
+      .accept_one(move |_| {
+        HttpResponse::ok("decoded response huffman")
+          .header("X-HPACK-Huffman", header_value)
+          .header("Trailer", "X-HPACK-Trailer")
+          .trailer("X-HPACK-Trailer", trailer_value)
+      })
+      .expect("serve Huffman h2 response headers and trailers");
+  });
+
+  let response = rttp::Http::client()
+    .url(format!("http://{}/huffman-response-fields", addr))
+    .emit_http2_prior_knowledge()
+    .expect("wrapper h2 response with Huffman response fields");
+
+  assert_eq!("HTTP/2", response.version());
+  assert_eq!(200, response.code());
+  assert_eq!(
+    "decoded response huffman",
+    response.body().string().unwrap()
+  );
+  assert_eq!(
+    Some(&expected_header_value),
+    response.header_value("X-HPACK-Huffman")
+  );
+  assert_eq!(
+    Some(&expected_trailer_value),
+    response.trailer_value("X-HPACK-Trailer")
+  );
+  assert!(response.header_value("Trailer").is_none());
+  assert!(response.header_value("X-HPACK-Trailer").is_none());
+
+  handle.join().expect("server thread");
+}
+
+#[test]
+fn wrapper_http2_prior_knowledge_decodes_large_huffman_response_header_split_by_continuation() {
+  let server = rttp::Http::server("127.0.0.1:0")
+    .expect("bind server")
+    .with_read_timeout(Some(Duration::from_secs(2)))
+    .with_write_timeout(Some(Duration::from_secs(2)));
+  let addr = server.local_addr().expect("server addr");
+  let large_header_value = "a".repeat(28 * 1024);
+  let expected_header_value = large_header_value.clone();
+
+  let handle = thread::spawn(move || {
+    server
+      .accept_one(move |_| {
+        HttpResponse::ok("decoded large response huffman")
+          .header("X-Large-HPACK-Huffman", large_header_value)
+      })
+      .expect("serve large Huffman h2 response header");
+  });
+
+  let response = rttp::Http::client()
+    .url(format!("http://{}/large-huffman-response-header", addr))
+    .emit_http2_prior_knowledge()
+    .expect("wrapper h2 response with large Huffman response header");
+
+  assert_eq!("HTTP/2", response.version());
+  assert_eq!(200, response.code());
+  assert_eq!(
+    "decoded large response huffman",
+    response.body().string().unwrap()
+  );
+  assert_eq!(
+    Some(&expected_header_value),
+    response.header_value("X-Large-HPACK-Huffman")
   );
 
   handle.join().expect("server thread");

--- a/rttp_client/README.md
+++ b/rttp_client/README.md
@@ -28,10 +28,11 @@ through `Response::trailers`, `Response::trailer`, and
 `Response::trailer_value` for both blocking and async request APIs.
 With the `http2` feature enabled, `emit_http2_prior_knowledge` sends a minimal
 prior-knowledge h2c request over a direct socket2 TCP connection. Non-empty
-buffered request bodies are sent as DATA frames, and incoming padded HEADERS,
-DATA, and trailer frames are decoded without exposing padding bytes. TLS ALPN,
-proxy tunneling, proxy h2, general HTTP/2 multiplexing, priority scheduling,
-and HPACK dynamic tables are not part of that client path.
+buffered request bodies are sent as DATA frames, HPACK static Huffman strings
+and large header blocks are supported, and incoming padded HEADERS, DATA, and
+trailer frames are decoded without exposing padding bytes. TLS ALPN, proxy
+tunneling, proxy h2, HPACK dynamic tables, and full HTTP/2 features such as
+general multiplexing and priority scheduling are not part of that client path.
 
 ## Examples
 


### PR DESCRIPTION
HPACK static Huffman interoperability is now covered at the wrapper h2c boundary, including request decode, response header/trailer decode, and large split header blocks. README scope language was updated accordingly.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1414/
work_kind: code_work
branch: hbx-1414-rttp-add-cross-crate-hpack
base: main
commit: abab456344155e3bd9d3162f11908e4e653db0be
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1414/
    url: https://plane.kahub.in/endless/browse/HBX-1414/
    close_policy: link_only
```