### PR TITLE
feat: [rttp] Send WINDOW_UPDATE while consuming large socket2 h2c request bodies

### DIFF
--- a/rttp/src/server.rs
+++ b/rttp/src/server.rs
@@ -24,6 +24,7 @@ const HTTP2_FLAG_END_HEADERS: u8 = 0x4;
 const HTTP2_FLAG_PADDED: u8 = 0x8;
 const HTTP2_FLAG_PRIORITY: u8 = 0x20;
 const HTTP2_DEFAULT_MAX_FRAME_SIZE: usize = 16 * 1024;
+const HTTP2_DEFAULT_INITIAL_WINDOW_SIZE: i32 = 65_535;
 const HTTP2_SETTINGS_ENABLE_PUSH: u16 = 0x2;
 const HTTP2_SETTINGS_INITIAL_WINDOW_SIZE: u16 = 0x4;
 const HTTP2_SETTINGS_MAX_FRAME_SIZE: u16 = 0x5;
@@ -389,6 +390,7 @@ impl HttpServer {
 
     let mut streams = Vec::<Http2RequestStream>::new();
     let mut reset_streams = Vec::<u32>::new();
+    let mut connection_receive_window = HTTP2_DEFAULT_INITIAL_WINDOW_SIZE;
     let mut served = 0;
 
     while served < request_limit {
@@ -547,6 +549,10 @@ impl HttpServer {
           }
 
           let data_payload = http2_data_payload_to_data(&frame.payload, frame.flags)?;
+          let flow_controlled_len =
+            i32::try_from(frame.payload.len()).map_err(|_| http2_flow_control_error())?;
+          request_stream
+            .receive_flow_controlled_data(&mut connection_receive_window, flow_controlled_len)?;
           let new_len = request_stream
             .body
             .len()
@@ -559,6 +565,8 @@ impl HttpServer {
           if !frame.payload.is_empty() {
             write_http2_window_update(&mut stream, 0, frame.payload.len())?;
             write_http2_window_update(&mut stream, id, frame.payload.len())?;
+            request_stream
+              .release_flow_controlled_data(&mut connection_receive_window, flow_controlled_len)?;
           }
           if frame.flags & HTTP2_FLAG_END_STREAM == HTTP2_FLAG_END_STREAM {
             request_stream.end_stream = true;
@@ -571,7 +579,9 @@ impl HttpServer {
           }
         }
         (HTTP2_FRAME_GOAWAY, 0) => break,
-        (HTTP2_FRAME_WINDOW_UPDATE, _) => {}
+        (HTTP2_FRAME_WINDOW_UPDATE, _) => {
+          validate_http2_window_update_payload(&frame.payload)?;
+        }
         (_, 0) => {}
         _ => {}
       }
@@ -666,6 +676,7 @@ struct Http2RequestStream {
   body: Vec<u8>,
   end_stream: bool,
   in_header_continuation: bool,
+  receive_window: i32,
 }
 
 #[derive(Clone, Copy)]
@@ -685,6 +696,7 @@ impl Http2RequestStream {
       body: Vec::new(),
       end_stream: false,
       in_header_continuation: false,
+      receive_window: HTTP2_DEFAULT_INITIAL_WINDOW_SIZE,
     }
   }
 
@@ -717,6 +729,36 @@ impl Http2RequestStream {
       io::Error::new(io::ErrorKind::InvalidData, "missing HTTP/2 request headers")
     })?;
     decoded_headers.into_request(self.body, self.decoded_trailers)
+  }
+
+  fn receive_flow_controlled_data(
+    &mut self,
+    connection_receive_window: &mut i32,
+    len: i32,
+  ) -> io::Result<()> {
+    if len > *connection_receive_window || len > self.receive_window {
+      return Err(http2_flow_control_error());
+    }
+    *connection_receive_window -= len;
+    self.receive_window -= len;
+    Ok(())
+  }
+
+  fn release_flow_controlled_data(
+    &mut self,
+    connection_receive_window: &mut i32,
+    len: i32,
+  ) -> io::Result<()> {
+    *connection_receive_window = connection_receive_window
+      .checked_add(len)
+      .filter(|window| *window <= HTTP2_DEFAULT_INITIAL_WINDOW_SIZE)
+      .ok_or_else(http2_flow_control_error)?;
+    self.receive_window = self
+      .receive_window
+      .checked_add(len)
+      .filter(|window| *window <= HTTP2_DEFAULT_INITIAL_WINDOW_SIZE)
+      .ok_or_else(http2_flow_control_error)?;
+    Ok(())
   }
 }
 
@@ -832,6 +874,31 @@ fn validate_http2_settings_payload(payload: &[u8]) -> io::Result<()> {
   }
 
   Ok(())
+}
+
+fn validate_http2_window_update_payload(payload: &[u8]) -> io::Result<()> {
+  if payload.len() != 4 {
+    return Err(invalid_http2_window_update_error());
+  }
+  let increment = u32::from_be_bytes([payload[0] & 0x7f, payload[1], payload[2], payload[3]]);
+  if increment == 0 {
+    return Err(invalid_http2_window_update_error());
+  }
+  Ok(())
+}
+
+fn invalid_http2_window_update_error() -> io::Error {
+  io::Error::new(
+    io::ErrorKind::InvalidData,
+    "invalid HTTP/2 WINDOW_UPDATE frame",
+  )
+}
+
+fn http2_flow_control_error() -> io::Error {
+  io::Error::new(
+    io::ErrorKind::InvalidData,
+    "HTTP/2 flow-control window exceeded",
+  )
 }
 
 fn http2_settings_max_frame_size(payload: &[u8]) -> Option<usize> {

--- a/rttp/tests/test_server.rs
+++ b/rttp/tests/test_server.rs
@@ -72,6 +72,17 @@ fn read_h2_frame_skipping_window_updates(stream: &mut TcpStream) -> H2Frame {
   }
 }
 
+fn h2_window_update_increment(frame: &H2Frame) -> u32 {
+  assert_eq!(H2_FRAME_WINDOW_UPDATE, frame.frame_type);
+  assert_eq!(4, frame.payload.len());
+  u32::from_be_bytes([
+    frame.payload[0] & 0x7f,
+    frame.payload[1],
+    frame.payload[2],
+    frame.payload[3],
+  ])
+}
+
 fn h2_literal_indexed_name(name_index: u8, value: &[u8]) -> Vec<u8> {
   assert!(value.len() < 128);
   let mut encoded = vec![name_index, value.len() as u8];
@@ -910,6 +921,149 @@ fn server_accepts_http2_prior_knowledge_headers_and_data_before_calling_handler(
   assert_eq!(b"stored", response_body.payload.as_slice());
 
   handle.join().expect("server thread");
+}
+
+#[test]
+fn server_sends_http2_window_updates_while_consuming_large_request_body() {
+  let server = rttp::Http::server("127.0.0.1:0").expect("bind server");
+  let addr = server.local_addr().expect("server addr");
+  let (tx, rx) = mpsc::channel();
+
+  let handle = thread::spawn(move || {
+    server
+      .accept_one(|request| {
+        tx.send((
+          request.body().len(),
+          request.trailer("x-large-body").map(str::to_string),
+        ))
+        .expect("send large h2 request details");
+        HttpResponse::ok("large body")
+      })
+      .expect("serve large h2 request");
+  });
+
+  let mut stream = TcpStream::connect(addr).expect("connect h2 server");
+  stream
+    .set_read_timeout(Some(Duration::from_secs(2)))
+    .expect("set h2 read timeout");
+  complete_h2_server_handshake(&mut stream);
+
+  write_h2_frame(
+    &mut stream,
+    H2_FRAME_HEADERS,
+    H2_FLAG_END_HEADERS,
+    1,
+    &h2_post_headers(b"/large-body", addr.to_string().as_bytes()),
+  );
+
+  let first_chunk = vec![b'a'; 65_535];
+  write_h2_frame(&mut stream, H2_FRAME_DATA, 0, 1, &first_chunk);
+
+  let first_update = read_h2_frame(&mut stream);
+  let second_update = read_h2_frame(&mut stream);
+  assert_eq!(
+    vec![(0, 65_535), (1, 65_535)],
+    vec![
+      (
+        first_update.stream_id,
+        h2_window_update_increment(&first_update)
+      ),
+      (
+        second_update.stream_id,
+        h2_window_update_increment(&second_update)
+      ),
+    ]
+  );
+
+  write_h2_frame(&mut stream, H2_FRAME_DATA, 0, 1, b"tail");
+  let trailers = h2_literal_new_name(b"x-large-body", b"complete");
+  write_h2_frame(
+    &mut stream,
+    H2_FRAME_HEADERS,
+    H2_FLAG_END_HEADERS | H2_FLAG_END_STREAM,
+    1,
+    &trailers,
+  );
+
+  let tail_connection_update = read_h2_frame(&mut stream);
+  let tail_stream_update = read_h2_frame(&mut stream);
+  assert_eq!(
+    vec![(0, 4), (1, 4)],
+    vec![
+      (
+        tail_connection_update.stream_id,
+        h2_window_update_increment(&tail_connection_update)
+      ),
+      (
+        tail_stream_update.stream_id,
+        h2_window_update_increment(&tail_stream_update)
+      ),
+    ]
+  );
+
+  let response_headers = read_h2_frame(&mut stream);
+  assert_eq!(H2_FRAME_HEADERS, response_headers.frame_type);
+  let response_body = read_h2_frame(&mut stream);
+  assert_eq!(H2_FRAME_DATA, response_body.frame_type);
+  assert_eq!(b"large body", response_body.payload.as_slice());
+
+  assert_eq!(
+    (65_539, Some("complete".to_string())),
+    rx.recv().expect("receive large h2 body details")
+  );
+
+  handle.join().expect("server thread");
+}
+
+#[test]
+fn server_rejects_http2_prior_knowledge_zero_window_update_increment() {
+  assert_invalid_h2_frame_without_handler(H2_FRAME_WINDOW_UPDATE, 0, 0, &0u32.to_be_bytes());
+}
+
+#[test]
+fn server_rejects_http2_prior_knowledge_data_beyond_receive_window() {
+  let server = rttp::Http::server("127.0.0.1:0")
+    .expect("bind server")
+    .with_read_timeout(Some(Duration::from_secs(2)));
+  let addr = server.local_addr().expect("server addr");
+  let (tx, rx) = mpsc::channel();
+
+  let handle = thread::spawn(move || {
+    server.accept_one(|request| {
+      tx.send(request).expect("send unexpected h2 request");
+      HttpResponse::ok("unexpected")
+    })
+  });
+
+  let mut stream = TcpStream::connect(addr).expect("connect h2 server");
+  stream
+    .set_read_timeout(Some(Duration::from_secs(2)))
+    .expect("set h2 read timeout");
+  complete_h2_server_handshake(&mut stream);
+  write_h2_frame(
+    &mut stream,
+    H2_FRAME_HEADERS,
+    H2_FLAG_END_HEADERS,
+    1,
+    &h2_post_headers(b"/window-exhaustion", addr.to_string().as_bytes()),
+  );
+  write_h2_frame(
+    &mut stream,
+    H2_FRAME_DATA,
+    H2_FLAG_END_STREAM,
+    1,
+    &vec![b'x'; 65_536],
+  );
+  stream
+    .shutdown(std::net::Shutdown::Write)
+    .expect("shutdown h2 write");
+
+  let error = handle
+    .join()
+    .expect("server thread")
+    .expect_err("DATA beyond receive window should reject request");
+  assert_eq!(ErrorKind::InvalidData, error.kind());
+  assert!(rx.try_recv().is_err());
 }
 
 #[test]


### PR DESCRIPTION
Adds inbound HTTP/2 DATA receive-window accounting and WINDOW_UPDATE behavior for the socket2 h2c server path, with regression coverage for large request bodies and protocol errors.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1417/
work_kind: code_work
branch: hbx-1417-rttp-send-window-update-while
base: main
commit: 79f619d74958d459eea2fd881edf06adb73d6840
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1417/
    url: https://plane.kahub.in/endless/browse/HBX-1417/
    close_policy: link_only
```