### PR TITLE
feat: [rttp_client] Respect peer flow-control windows when sending h2c request bodies

### DIFF
--- a/rttp_client/src/http2.rs
+++ b/rttp_client/src/http2.rs
@@ -110,8 +110,16 @@ impl<'a> PriorKnowledgeClient<'a> {
     let mut stream = connect_tcp_stream(addr(&url)?, self.request.origin().config())?;
     write_connection_preface(&mut stream)?;
     let peer_settings = read_settings_and_ack(&mut stream)?;
-    write_request(&mut stream, &self.request, &url, peer_settings)?;
-    let response = read_single_stream_response(&mut stream, self.request.url().clone())?;
+    let response = match write_request(
+      &mut stream,
+      &self.request,
+      &url,
+      self.request.url().clone(),
+      peer_settings,
+    )? {
+      Some(response) => response,
+      None => read_single_stream_response(&mut stream, self.request.url().clone())?,
+    };
     self.request.origin_mut().closed_set(true);
     Ok(response)
   }
@@ -215,6 +223,7 @@ struct PeerSettings {
   initial_window_size: u32,
   initial_window_size_changed: bool,
   max_frame_size: usize,
+  max_frame_size_changed: bool,
 }
 
 fn validate_settings_payload(payload: &[u8]) -> error::Result<PeerSettings> {
@@ -226,6 +235,7 @@ fn validate_settings_payload(payload: &[u8]) -> error::Result<PeerSettings> {
     initial_window_size: DEFAULT_INITIAL_WINDOW_SIZE as u32,
     initial_window_size_changed: false,
     max_frame_size: DEFAULT_MAX_FRAME_SIZE,
+    max_frame_size_changed: false,
   };
   for setting in payload.chunks_exact(6) {
     let identifier = u16::from_be_bytes([setting[0], setting[1]]);
@@ -255,6 +265,7 @@ fn validate_settings_payload(payload: &[u8]) -> error::Result<PeerSettings> {
           ));
         }
         settings.max_frame_size = value;
+        settings.max_frame_size_changed = true;
       }
       _ => {}
     }
@@ -282,8 +293,9 @@ fn write_request(
   stream: &mut TcpStream,
   request: &RawRequest<'_>,
   url: &Url,
+  response_url: RoUrl,
   peer_settings: PeerSettings,
-) -> error::Result<()> {
+) -> error::Result<Option<Response>> {
   let header_block = encode_request_headers(request, url)?;
   let body = request
     .body()
@@ -304,7 +316,11 @@ fn write_request(
     peer_settings.max_frame_size,
   )?;
   if !body.is_empty() {
-    write_data_frames(stream, body, peer_settings, has_trailers)?;
+    if let Some(response) =
+      write_data_frames(stream, body, peer_settings, has_trailers, response_url)?
+    {
+      return Ok(Some(response));
+    }
   }
   if has_trailers {
     let trailer_block = encode_request_trailers(request)?;
@@ -316,7 +332,7 @@ fn write_request(
       peer_settings.max_frame_size,
     )?;
   }
-  stream.flush().map_err(error::request)
+  stream.flush().map_err(error::request).map(|()| None)
 }
 
 fn write_header_block_frames(
@@ -355,11 +371,13 @@ fn write_data_frames(
   body: &[u8],
   peer_settings: PeerSettings,
   has_trailers: bool,
-) -> error::Result<()> {
+  url: RoUrl,
+) -> error::Result<Option<Response>> {
   let mut connection_send_window = SendWindow::new();
   let mut stream_send_window =
     SendWindow::with_available(i64::from(peer_settings.initial_window_size));
   let mut current_initial_window_size = peer_settings.initial_window_size;
+  let mut current_max_frame_size = peer_settings.max_frame_size;
   let mut sent = 0;
 
   while sent < body.len() {
@@ -367,19 +385,22 @@ fn write_data_frames(
       .available()
       .min(stream_send_window.available());
     if available <= 0 {
-      read_until_send_window_available(
+      if let Some(response) = read_until_send_window_available(
         stream,
         &mut connection_send_window,
         &mut stream_send_window,
         &mut current_initial_window_size,
-      )?;
+        &mut current_max_frame_size,
+        url.clone(),
+      )? {
+        return Ok(Some(response));
+      }
       continue;
     }
 
     let window_chunk_size = usize::try_from(available)
       .map_err(|_| error::request(io::Error::other("HTTP/2 send window is too large")))?;
-    let chunk_size = peer_settings
-      .max_frame_size
+    let chunk_size = current_max_frame_size
       .min(window_chunk_size)
       .min(body.len() - sent);
     let chunk = &body[sent..sent + chunk_size];
@@ -394,7 +415,7 @@ fn write_data_frames(
     };
     write_frame(stream, FRAME_DATA, flags, STREAM_ID, chunk)?;
   }
-  Ok(())
+  Ok(None)
 }
 
 fn read_until_send_window_available(
@@ -402,7 +423,9 @@ fn read_until_send_window_available(
   connection_send_window: &mut SendWindow,
   stream_send_window: &mut SendWindow,
   current_initial_window_size: &mut u32,
-) -> error::Result<()> {
+  current_max_frame_size: &mut usize,
+  url: RoUrl,
+) -> error::Result<Option<Response>> {
   loop {
     let frame = read_frame(stream)?;
     match (frame.frame_type, frame.stream_id) {
@@ -421,6 +444,7 @@ fn read_until_send_window_available(
           &frame,
           stream_send_window,
           current_initial_window_size,
+          current_max_frame_size,
         )?;
       }
       (FRAME_RST_STREAM, STREAM_ID) => {
@@ -444,9 +468,7 @@ fn read_until_send_window_available(
         }
       }
       (FRAME_HEADERS, STREAM_ID) | (FRAME_DATA, STREAM_ID) | (FRAME_CONTINUATION, STREAM_ID) => {
-        return Err(error::bad_response(
-          "HTTP/2 peer responded before request body was sent",
-        ));
+        return read_single_stream_response_from_frame(stream, url, frame).map(Some);
       }
       _ => {}
     }
@@ -456,7 +478,7 @@ fn read_until_send_window_available(
       .min(stream_send_window.available())
       > 0
     {
-      return Ok(());
+      return Ok(None);
     }
   }
 }
@@ -466,6 +488,7 @@ fn handle_settings_while_sending(
   frame: &Frame,
   stream_send_window: &mut SendWindow,
   current_initial_window_size: &mut u32,
+  current_max_frame_size: &mut usize,
 ) -> error::Result<()> {
   validate_settings_frame(frame)?;
   if frame.flags & FLAG_ACK == FLAG_ACK {
@@ -478,6 +501,9 @@ fn handle_settings_while_sending(
       stream_send_window.adjust(delta)?;
       *current_initial_window_size = settings.initial_window_size;
     }
+  }
+  if settings.max_frame_size_changed {
+    *current_max_frame_size = settings.max_frame_size;
   }
   write_frame(stream, FRAME_SETTINGS, FLAG_ACK, 0, &[])?;
   stream.flush().map_err(error::request)
@@ -608,6 +634,22 @@ struct PendingHeaderBlock {
 }
 
 fn read_single_stream_response(stream: &mut TcpStream, url: RoUrl) -> error::Result<Response> {
+  read_single_stream_response_with_first_frame(stream, url, None)
+}
+
+fn read_single_stream_response_from_frame(
+  stream: &mut TcpStream,
+  url: RoUrl,
+  first_frame: Frame,
+) -> error::Result<Response> {
+  read_single_stream_response_with_first_frame(stream, url, Some(first_frame))
+}
+
+fn read_single_stream_response_with_first_frame(
+  stream: &mut TcpStream,
+  url: RoUrl,
+  mut first_frame: Option<Frame>,
+) -> error::Result<Response> {
   let mut header_block = Vec::new();
   let mut headers = Vec::new();
   let mut trailers = Vec::new();
@@ -622,12 +664,15 @@ fn read_single_stream_response(stream: &mut TcpStream, url: RoUrl) -> error::Res
   let mut stream_send_window = SendWindow::new();
 
   loop {
-    let frame = match read_frame(stream) {
-      Ok(frame) => frame,
-      Err(err) if pending_header_block.is_some() && is_unexpected_eof(&err) => {
-        return Err(error::bad_response("incomplete HTTP/2 header block"));
-      }
-      Err(err) => return Err(err),
+    let frame = match first_frame.take() {
+      Some(frame) => frame,
+      None => match read_frame(stream) {
+        Ok(frame) => frame,
+        Err(err) if pending_header_block.is_some() && is_unexpected_eof(&err) => {
+          return Err(error::bad_response("incomplete HTTP/2 header block"));
+        }
+        Err(err) => return Err(err),
+      },
     };
     if pending_header_block.is_some()
       && (frame.frame_type != FRAME_CONTINUATION || frame.stream_id != STREAM_ID)

--- a/rttp_client/src/http2.rs
+++ b/rttp_client/src/http2.rs
@@ -109,8 +109,8 @@ impl<'a> PriorKnowledgeClient<'a> {
 
     let mut stream = connect_tcp_stream(addr(&url)?, self.request.origin().config())?;
     write_connection_preface(&mut stream)?;
-    let peer_max_frame_size = read_settings_and_ack(&mut stream)?;
-    write_request(&mut stream, &self.request, &url, peer_max_frame_size)?;
+    let peer_settings = read_settings_and_ack(&mut stream)?;
+    write_request(&mut stream, &self.request, &url, peer_settings)?;
     let response = read_single_stream_response(&mut stream, self.request.url().clone())?;
     self.request.origin_mut().closed_set(true);
     Ok(response)
@@ -184,7 +184,7 @@ fn write_connection_preface(stream: &mut TcpStream) -> error::Result<()> {
   stream.flush().map_err(error::request)
 }
 
-fn read_settings_and_ack(stream: &mut TcpStream) -> error::Result<usize> {
+fn read_settings_and_ack(stream: &mut TcpStream) -> error::Result<PeerSettings> {
   loop {
     let frame = read_frame(stream)?;
     if frame.frame_type != FRAME_SETTINGS {
@@ -203,19 +203,30 @@ fn read_settings_and_ack(stream: &mut TcpStream) -> error::Result<usize> {
     if frame.stream_id != 0 {
       return Err(error::bad_response("invalid HTTP/2 SETTINGS frame"));
     }
-    let peer_max_frame_size = validate_settings_payload(&frame.payload)?;
+    let peer_settings = validate_settings_payload(&frame.payload)?;
     write_frame(stream, FRAME_SETTINGS, FLAG_ACK, 0, &[])?;
     stream.flush().map_err(error::request)?;
-    return Ok(peer_max_frame_size);
+    return Ok(peer_settings);
   }
 }
 
-fn validate_settings_payload(payload: &[u8]) -> error::Result<usize> {
+#[derive(Clone, Copy)]
+struct PeerSettings {
+  initial_window_size: u32,
+  initial_window_size_changed: bool,
+  max_frame_size: usize,
+}
+
+fn validate_settings_payload(payload: &[u8]) -> error::Result<PeerSettings> {
   if payload.len() % 6 != 0 {
     return Err(error::bad_response("invalid HTTP/2 SETTINGS frame"));
   }
 
-  let mut max_frame_size = DEFAULT_MAX_FRAME_SIZE;
+  let mut settings = PeerSettings {
+    initial_window_size: DEFAULT_INITIAL_WINDOW_SIZE as u32,
+    initial_window_size_changed: false,
+    max_frame_size: DEFAULT_MAX_FRAME_SIZE,
+  };
   for setting in payload.chunks_exact(6) {
     let identifier = u16::from_be_bytes([setting[0], setting[1]]);
     let value = u32::from_be_bytes([setting[2], setting[3], setting[4], setting[5]]);
@@ -233,6 +244,8 @@ fn validate_settings_payload(payload: &[u8]) -> error::Result<usize> {
             "invalid HTTP/2 SETTINGS_INITIAL_WINDOW_SIZE value",
           ));
         }
+        settings.initial_window_size = value;
+        settings.initial_window_size_changed = true;
       }
       SETTING_MAX_FRAME_SIZE => {
         let value = value as usize;
@@ -241,12 +254,12 @@ fn validate_settings_payload(payload: &[u8]) -> error::Result<usize> {
             "invalid HTTP/2 SETTINGS_MAX_FRAME_SIZE value",
           ));
         }
-        max_frame_size = value;
+        settings.max_frame_size = value;
       }
       _ => {}
     }
   }
-  Ok(max_frame_size)
+  Ok(settings)
 }
 
 fn validate_settings_frame(frame: &Frame) -> error::Result<()> {
@@ -269,7 +282,7 @@ fn write_request(
   stream: &mut TcpStream,
   request: &RawRequest<'_>,
   url: &Url,
-  peer_max_frame_size: usize,
+  peer_settings: PeerSettings,
 ) -> error::Result<()> {
   let header_block = encode_request_headers(request, url)?;
   let body = request
@@ -288,10 +301,10 @@ fn write_request(
     header_flags,
     STREAM_ID,
     &header_block,
-    peer_max_frame_size,
+    peer_settings.max_frame_size,
   )?;
   if !body.is_empty() {
-    write_data_frames(stream, body, peer_max_frame_size, has_trailers)?;
+    write_data_frames(stream, body, peer_settings, has_trailers)?;
   }
   if has_trailers {
     let trailer_block = encode_request_trailers(request)?;
@@ -300,7 +313,7 @@ fn write_request(
       FLAG_END_STREAM,
       STREAM_ID,
       &trailer_block,
-      peer_max_frame_size,
+      peer_settings.max_frame_size,
     )?;
   }
   stream.flush().map_err(error::request)
@@ -340,14 +353,41 @@ fn write_header_block_frames(
 fn write_data_frames(
   stream: &mut TcpStream,
   body: &[u8],
-  peer_max_frame_size: usize,
+  peer_settings: PeerSettings,
   has_trailers: bool,
 ) -> error::Result<()> {
-  for (index, chunk) in body.chunks(peer_max_frame_size).enumerate() {
-    let sent = index
-      .checked_mul(peer_max_frame_size)
-      .ok_or_else(|| error::request(io::Error::other("HTTP/2 request body is too large")))?;
-    let flags = if sent + chunk.len() == body.len() && !has_trailers {
+  let mut connection_send_window = SendWindow::new();
+  let mut stream_send_window =
+    SendWindow::with_available(i64::from(peer_settings.initial_window_size));
+  let mut current_initial_window_size = peer_settings.initial_window_size;
+  let mut sent = 0;
+
+  while sent < body.len() {
+    let available = connection_send_window
+      .available()
+      .min(stream_send_window.available());
+    if available <= 0 {
+      read_until_send_window_available(
+        stream,
+        &mut connection_send_window,
+        &mut stream_send_window,
+        &mut current_initial_window_size,
+      )?;
+      continue;
+    }
+
+    let window_chunk_size = usize::try_from(available)
+      .map_err(|_| error::request(io::Error::other("HTTP/2 send window is too large")))?;
+    let chunk_size = peer_settings
+      .max_frame_size
+      .min(window_chunk_size)
+      .min(body.len() - sent);
+    let chunk = &body[sent..sent + chunk_size];
+    sent += chunk_size;
+    connection_send_window.consume(chunk_size)?;
+    stream_send_window.consume(chunk_size)?;
+
+    let flags = if sent == body.len() && !has_trailers {
       FLAG_END_STREAM
     } else {
       0
@@ -355,6 +395,92 @@ fn write_data_frames(
     write_frame(stream, FRAME_DATA, flags, STREAM_ID, chunk)?;
   }
   Ok(())
+}
+
+fn read_until_send_window_available(
+  stream: &mut TcpStream,
+  connection_send_window: &mut SendWindow,
+  stream_send_window: &mut SendWindow,
+  current_initial_window_size: &mut u32,
+) -> error::Result<()> {
+  loop {
+    let frame = read_frame(stream)?;
+    match (frame.frame_type, frame.stream_id) {
+      (FRAME_WINDOW_UPDATE, 0) => {
+        connection_send_window.increase(window_update_increment(&frame)?)?;
+      }
+      (FRAME_WINDOW_UPDATE, STREAM_ID) => {
+        stream_send_window.increase(window_update_increment(&frame)?)?;
+      }
+      (FRAME_WINDOW_UPDATE, _) => {
+        window_update_increment(&frame)?;
+      }
+      (FRAME_SETTINGS, _) => {
+        handle_settings_while_sending(
+          stream,
+          &frame,
+          stream_send_window,
+          current_initial_window_size,
+        )?;
+      }
+      (FRAME_RST_STREAM, STREAM_ID) => {
+        return Err(error::bad_response("HTTP/2 stream received RST_STREAM"));
+      }
+      (FRAME_PING, 0) => {
+        if frame.payload.len() != 8 {
+          return Err(error::bad_response("invalid HTTP/2 PING frame"));
+        }
+        if frame.flags & FLAG_ACK == 0 {
+          write_frame(stream, FRAME_PING, FLAG_ACK, 0, &frame.payload)?;
+          stream.flush().map_err(error::request)?;
+        }
+      }
+      (FRAME_PING, _) => {
+        return Err(error::bad_response("invalid HTTP/2 PING frame"));
+      }
+      (FRAME_GOAWAY, 0) => {
+        if goaway_last_stream_id(&frame.payload)? < STREAM_ID {
+          return Err(error::bad_response("HTTP/2 connection received GOAWAY"));
+        }
+      }
+      (FRAME_HEADERS, STREAM_ID) | (FRAME_DATA, STREAM_ID) | (FRAME_CONTINUATION, STREAM_ID) => {
+        return Err(error::bad_response(
+          "HTTP/2 peer responded before request body was sent",
+        ));
+      }
+      _ => {}
+    }
+
+    if connection_send_window
+      .available()
+      .min(stream_send_window.available())
+      > 0
+    {
+      return Ok(());
+    }
+  }
+}
+
+fn handle_settings_while_sending(
+  stream: &mut TcpStream,
+  frame: &Frame,
+  stream_send_window: &mut SendWindow,
+  current_initial_window_size: &mut u32,
+) -> error::Result<()> {
+  validate_settings_frame(frame)?;
+  if frame.flags & FLAG_ACK == FLAG_ACK {
+    return Ok(());
+  }
+  let settings = validate_settings_payload(&frame.payload)?;
+  if settings.initial_window_size_changed {
+    let delta = i64::from(settings.initial_window_size) - i64::from(*current_initial_window_size);
+    if delta != 0 {
+      stream_send_window.adjust(delta)?;
+      *current_initial_window_size = settings.initial_window_size;
+    }
+  }
+  write_frame(stream, FRAME_SETTINGS, FLAG_ACK, 0, &[])?;
+  stream.flush().map_err(error::request)
 }
 
 fn encode_request_headers(request: &RawRequest<'_>, url: &Url) -> error::Result<Vec<u8>> {
@@ -698,6 +824,24 @@ impl SendWindow {
     }
   }
 
+  fn with_available(available: i64) -> Self {
+    Self { available }
+  }
+
+  fn available(&self) -> i64 {
+    self.available
+  }
+
+  fn consume(&mut self, amount: usize) -> error::Result<()> {
+    let amount = i64::try_from(amount)
+      .map_err(|_| error::request(io::Error::other("HTTP/2 DATA frame is too large")))?;
+    self.available = self
+      .available
+      .checked_sub(amount)
+      .ok_or_else(|| error::request(io::Error::other("HTTP/2 send window underflow")))?;
+    Ok(())
+  }
+
   fn increase(&mut self, amount: u32) -> error::Result<()> {
     self.available = self
       .available
@@ -705,6 +849,17 @@ impl SendWindow {
       .ok_or_else(|| error::bad_response("HTTP/2 WINDOW_UPDATE overflow"))?;
     if self.available > MAX_INITIAL_WINDOW_SIZE as i64 {
       return Err(error::bad_response("HTTP/2 WINDOW_UPDATE overflow"));
+    }
+    Ok(())
+  }
+
+  fn adjust(&mut self, delta: i64) -> error::Result<()> {
+    self.available = self
+      .available
+      .checked_add(delta)
+      .ok_or_else(|| error::bad_response("HTTP/2 flow-control window overflow"))?;
+    if self.available > MAX_INITIAL_WINDOW_SIZE as i64 {
+      return Err(error::bad_response("HTTP/2 flow-control window overflow"));
     }
     Ok(())
   }

--- a/rttp_client/tests/http2_prior_knowledge.rs
+++ b/rttp_client/tests/http2_prior_knowledge.rs
@@ -368,6 +368,156 @@ fn prior_knowledge_post_splits_body_data_frames_at_default_peer_max_frame_size()
 }
 
 #[test]
+fn prior_knowledge_post_pauses_request_body_at_peer_initial_stream_window() {
+  let listener = TcpListener::bind("127.0.0.1:0").expect("bind h2 peer");
+  let addr = listener.local_addr().expect("h2 peer addr");
+
+  let handle = thread::spawn(move || {
+    let (mut stream, _) = listener.accept().expect("accept h2 client");
+    stream
+      .set_read_timeout(Some(Duration::from_millis(200)))
+      .expect("set h2 peer read timeout");
+    complete_h2_handshake_without_request_with_settings(
+      &mut stream,
+      &settings_payload(SETTING_INITIAL_WINDOW_SIZE, 5),
+    );
+
+    let request_headers = read_frame(&mut stream);
+    assert_eq!(FRAME_HEADERS, request_headers.frame_type);
+    assert_eq!(FLAG_END_HEADERS, request_headers.flags);
+    assert_eq!(1, request_headers.stream_id);
+
+    let first_body = read_frame(&mut stream);
+    assert_eq!(FRAME_DATA, first_body.frame_type);
+    assert_eq!(0, first_body.flags);
+    assert_eq!(1, first_body.stream_id);
+    assert_eq!(b"abcde", first_body.payload.as_slice());
+
+    match try_read_frame(&mut stream) {
+      Ok(None) => {}
+      Ok(Some(frame)) => panic!(
+        "client sent request frame without stream credit: type={}, stream_id={}, len={}",
+        frame.frame_type,
+        frame.stream_id,
+        frame.payload.len()
+      ),
+      Err(err) => panic!("unexpected frame read error: {err}"),
+    }
+
+    write_frame(&mut stream, FRAME_WINDOW_UPDATE, 0, 1, &7_u32.to_be_bytes());
+
+    let second_body = read_frame(&mut stream);
+    assert_eq!(FRAME_DATA, second_body.frame_type);
+    assert_eq!(0, second_body.flags);
+    assert_eq!(1, second_body.stream_id);
+    assert_eq!(b"fghijkl", second_body.payload.as_slice());
+
+    let request_trailers = read_frame(&mut stream);
+    assert_eq!(FRAME_HEADERS, request_trailers.frame_type);
+    assert_eq!(FLAG_END_HEADERS | FLAG_END_STREAM, request_trailers.flags);
+    assert_eq!(1, request_trailers.stream_id);
+    assert_eq!(
+      b"flowed",
+      find_header_value(&request_trailers.payload, b"x-flow")
+        .expect("request trailer")
+        .value
+        .as_slice()
+    );
+
+    write_frame(&mut stream, FRAME_HEADERS, FLAG_END_HEADERS, 1, &[0x88]);
+    write_frame(&mut stream, FRAME_DATA, FLAG_END_STREAM, 1, b"ok");
+  });
+
+  let response = HttpClient::new()
+    .post()
+    .url(format!("http://{}/flow-controlled-trailers", addr))
+    .trailer(("X-Flow", "flowed"))
+    .expect("configure request trailer")
+    .raw("abcdefghijkl")
+    .emit_http2_prior_knowledge()
+    .expect("h2 POST response");
+
+  assert_eq!(200, response.code());
+  assert_eq!("ok", response.body().string().unwrap());
+  handle.join().expect("h2 peer thread");
+}
+
+#[test]
+fn prior_knowledge_post_requires_connection_and_stream_window_updates_to_resume_body() {
+  let listener = TcpListener::bind("127.0.0.1:0").expect("bind h2 peer");
+  let addr = listener.local_addr().expect("h2 peer addr");
+  let body = "x".repeat(65_536);
+
+  let handle = thread::spawn(move || {
+    let (mut stream, _) = listener.accept().expect("accept h2 client");
+    stream
+      .set_read_timeout(Some(Duration::from_millis(200)))
+      .expect("set h2 peer read timeout");
+    complete_h2_handshake_without_request(&mut stream);
+
+    let request_headers = read_frame(&mut stream);
+    assert_eq!(FRAME_HEADERS, request_headers.frame_type);
+    assert_eq!(FLAG_END_HEADERS, request_headers.flags);
+    assert_eq!(1, request_headers.stream_id);
+
+    let mut received = 0;
+    while received < 65_535 {
+      let data = read_frame(&mut stream);
+      assert_eq!(FRAME_DATA, data.frame_type);
+      assert_eq!(0, data.flags);
+      assert_eq!(1, data.stream_id);
+      assert!(data.payload.len() <= 65_535 - received);
+      received += data.payload.len();
+    }
+
+    match try_read_frame(&mut stream) {
+      Ok(None) => {}
+      Ok(Some(frame)) => panic!(
+        "client sent request frame without connection and stream credit: type={}, stream_id={}, len={}",
+        frame.frame_type,
+        frame.stream_id,
+        frame.payload.len()
+      ),
+      Err(err) => panic!("unexpected frame read error: {err}"),
+    }
+
+    write_frame(&mut stream, FRAME_WINDOW_UPDATE, 0, 0, &1_u32.to_be_bytes());
+    match try_read_frame(&mut stream) {
+      Ok(None) => {}
+      Ok(Some(frame)) => panic!(
+        "client resumed without stream credit: type={}, stream_id={}, len={}",
+        frame.frame_type,
+        frame.stream_id,
+        frame.payload.len()
+      ),
+      Err(err) => panic!("unexpected frame read error: {err}"),
+    }
+
+    write_frame(&mut stream, FRAME_WINDOW_UPDATE, 0, 1, &1_u32.to_be_bytes());
+
+    let final_body = read_frame(&mut stream);
+    assert_eq!(FRAME_DATA, final_body.frame_type);
+    assert_eq!(FLAG_END_STREAM, final_body.flags);
+    assert_eq!(1, final_body.stream_id);
+    assert_eq!(1, final_body.payload.len());
+
+    write_frame(&mut stream, FRAME_HEADERS, FLAG_END_HEADERS, 1, &[0x88]);
+    write_frame(&mut stream, FRAME_DATA, FLAG_END_STREAM, 1, b"ok");
+  });
+
+  let response = HttpClient::new()
+    .post()
+    .url(format!("http://{}/connection-window", addr))
+    .raw(&body)
+    .emit_http2_prior_knowledge()
+    .expect("h2 POST response");
+
+  assert_eq!(200, response.code());
+  assert_eq!("ok", response.body().string().unwrap());
+  handle.join().expect("h2 peer thread");
+}
+
+#[test]
 fn prior_knowledge_get_splits_large_request_headers_at_peer_max_frame_size() {
   let listener = TcpListener::bind("127.0.0.1:0").expect("bind h2 peer");
   let addr = listener.local_addr().expect("h2 peer addr");

--- a/rttp_client/tests/http2_prior_knowledge.rs
+++ b/rttp_client/tests/http2_prior_knowledge.rs
@@ -518,6 +518,130 @@ fn prior_knowledge_post_requires_connection_and_stream_window_updates_to_resume_
 }
 
 #[test]
+fn prior_knowledge_post_returns_early_response_while_blocked_on_send_window() {
+  let listener = TcpListener::bind("127.0.0.1:0").expect("bind h2 peer");
+  let addr = listener.local_addr().expect("h2 peer addr");
+
+  let handle = thread::spawn(move || {
+    let (mut stream, _) = listener.accept().expect("accept h2 client");
+    complete_h2_handshake_without_request_with_settings(
+      &mut stream,
+      &settings_payload(SETTING_INITIAL_WINDOW_SIZE, 5),
+    );
+
+    let request_headers = read_frame(&mut stream);
+    assert_eq!(FRAME_HEADERS, request_headers.frame_type);
+    assert_eq!(FLAG_END_HEADERS, request_headers.flags);
+    assert_eq!(1, request_headers.stream_id);
+
+    let first_body = read_frame(&mut stream);
+    assert_eq!(FRAME_DATA, first_body.frame_type);
+    assert_eq!(0, first_body.flags);
+    assert_eq!(1, first_body.stream_id);
+    assert_eq!(b"abcde", first_body.payload.as_slice());
+
+    write_frame(
+      &mut stream,
+      FRAME_HEADERS,
+      FLAG_END_HEADERS,
+      1,
+      &h2_literal_new_name(b":status", b"413"),
+    );
+    write_frame(&mut stream, FRAME_DATA, FLAG_END_STREAM, 1, b"rejected");
+  });
+
+  let response = HttpClient::new()
+    .post()
+    .url(format!("http://{}/early-reject", addr))
+    .raw("abcdefghijkl")
+    .emit_http2_prior_knowledge()
+    .expect("early final response while request body is blocked");
+
+  assert_eq!(413, response.code());
+  assert_eq!("rejected", response.body().string().unwrap());
+  handle.join().expect("h2 peer thread");
+}
+
+#[test]
+fn prior_knowledge_post_uses_later_max_frame_size_after_send_window_resumes() {
+  let listener = TcpListener::bind("127.0.0.1:0").expect("bind h2 peer");
+  let addr = listener.local_addr().expect("h2 peer addr");
+  let body = "x".repeat(20_005);
+
+  let handle = thread::spawn(move || {
+    let (mut stream, _) = listener.accept().expect("accept h2 client");
+    let mut initial_settings = settings_payload(SETTING_INITIAL_WINDOW_SIZE, 5);
+    initial_settings.extend_from_slice(&settings_payload(SETTING_MAX_FRAME_SIZE, 32_768));
+    complete_h2_handshake_without_request_with_settings(&mut stream, &initial_settings);
+
+    let request_headers = read_frame(&mut stream);
+    assert_eq!(FRAME_HEADERS, request_headers.frame_type);
+    assert_eq!(FLAG_END_HEADERS, request_headers.flags);
+    assert_eq!(1, request_headers.stream_id);
+
+    let first_body = read_frame(&mut stream);
+    assert_eq!(FRAME_DATA, first_body.frame_type);
+    assert_eq!(0, first_body.flags);
+    assert_eq!(1, first_body.stream_id);
+    assert_eq!(5, first_body.payload.len());
+
+    write_frame(
+      &mut stream,
+      FRAME_SETTINGS,
+      0,
+      0,
+      &settings_payload(SETTING_MAX_FRAME_SIZE, 16_384),
+    );
+    let settings_ack = read_frame(&mut stream);
+    assert_eq!(FRAME_SETTINGS, settings_ack.frame_type);
+    assert_eq!(FLAG_ACK, settings_ack.flags);
+    assert_eq!(0, settings_ack.stream_id);
+    assert!(settings_ack.payload.is_empty());
+
+    write_frame(
+      &mut stream,
+      FRAME_WINDOW_UPDATE,
+      0,
+      1,
+      &20_000_u32.to_be_bytes(),
+    );
+
+    let resumed_body = read_frame(&mut stream);
+    assert_eq!(FRAME_DATA, resumed_body.frame_type);
+    assert_eq!(0, resumed_body.flags);
+    assert_eq!(1, resumed_body.stream_id);
+    assert_eq!(16_384, resumed_body.payload.len());
+
+    write_frame(
+      &mut stream,
+      FRAME_WINDOW_UPDATE,
+      0,
+      1,
+      &3_616_u32.to_be_bytes(),
+    );
+    let final_body = read_frame(&mut stream);
+    assert_eq!(FRAME_DATA, final_body.frame_type);
+    assert_eq!(FLAG_END_STREAM, final_body.flags);
+    assert_eq!(1, final_body.stream_id);
+    assert_eq!(3_616, final_body.payload.len());
+
+    write_frame(&mut stream, FRAME_HEADERS, FLAG_END_HEADERS, 1, &[0x88]);
+    write_frame(&mut stream, FRAME_DATA, FLAG_END_STREAM, 1, b"ok");
+  });
+
+  let response = HttpClient::new()
+    .post()
+    .url(format!("http://{}/later-max-frame-size", addr))
+    .raw(&body)
+    .emit_http2_prior_knowledge()
+    .expect("h2 POST response");
+
+  assert_eq!(200, response.code());
+  assert_eq!("ok", response.body().string().unwrap());
+  handle.join().expect("h2 peer thread");
+}
+
+#[test]
 fn prior_knowledge_get_splits_large_request_headers_at_peer_max_frame_size() {
   let listener = TcpListener::bind("127.0.0.1:0").expect("bind h2 peer");
   let addr = listener.local_addr().expect("h2 peer addr");


### PR DESCRIPTION
rttp_client h2c request uploads now honor peer HTTP/2 send flow-control windows, including initial stream windows and connection/stream WINDOW_UPDATE gating, with regression coverage for paused/resumed DATA and trailer ordering.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1418/
work_kind: code_work
branch: hbx-1418-rttp-client-respect-peer-flow
base: main
commit: 963e218720ee512f8c4da8400abca809458758cc
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1418/
    url: https://plane.kahub.in/endless/browse/HBX-1418/
    close_policy: link_only
```