### PR TITLE
feat: [rttp_client] Decode HPACK dynamic table response headers and trailers

### DIFF
--- a/rttp/README.md
+++ b/rttp/README.md
@@ -69,11 +69,11 @@ features such as multiplexing and priority scheduling, or async accept loops.
 Enable the `client` feature to access `rttp::Http::client`, or enable `async`,
 `http2`, `tls-native`, `tls-rustls`, or `all` for the corresponding
 `rttp_client` capabilities. The `http2` feature exposes the minimal
-prior-knowledge h2c client path, including HPACK static Huffman strings, large
-header blocks via CONTINUATION frames, padded incoming response frames, and
-conservative DATA flow-control for single-stream prior-knowledge use; TLS ALPN,
-proxy h2, HPACK dynamic tables, and full HTTP/2 features such as multiplexing
-and priority scheduling remain outside that path.
+prior-knowledge h2c client path, including HPACK static Huffman strings,
+response dynamic table decoding, large header blocks via CONTINUATION frames,
+padded incoming response frames, and conservative DATA flow-control for
+single-stream prior-knowledge use; TLS ALPN, proxy h2, and full HTTP/2 features
+such as multiplexing and priority scheduling remain outside that path.
 
 Direct TCP client connections use `socket2`. SOCKS proxy handshakes remain
 delegated to the `socks` crate.

--- a/rttp_client/src/http2.rs
+++ b/rttp_client/src/http2.rs
@@ -36,6 +36,8 @@ const DEFAULT_MAX_FRAME_SIZE: usize = 16 * 1024;
 const MAX_FRAME_SIZE_LIMIT: usize = 16_777_215;
 const MAX_INITIAL_WINDOW_SIZE: u32 = 2_147_483_647;
 const WINDOW_UPDATE_THRESHOLD: usize = 32 * 1024;
+const DEFAULT_HPACK_DYNAMIC_TABLE_SIZE: usize = 4096;
+const HPACK_STATIC_TABLE_LENGTH: usize = 61;
 const HPACK_HUFFMAN_EOS_SYMBOL: usize = 256;
 const HPACK_HUFFMAN_EOS_BITS: u8 = 30;
 
@@ -658,6 +660,7 @@ fn read_single_stream_response_with_first_frame(
   let mut pending_header_block = None;
   let mut final_response_started = false;
   let mut response_body_started = false;
+  let mut hpack = HpackDecoder::new(DEFAULT_HPACK_DYNAMIC_TABLE_SIZE);
   let mut connection_receive_window = ReceiveWindow::new();
   let mut stream_receive_window = ReceiveWindow::new();
   let mut connection_send_window = SendWindow::new();
@@ -704,6 +707,7 @@ fn read_single_stream_response_with_first_frame(
             &mut status,
             &mut headers,
             &mut trailers,
+            &mut hpack,
           )? {
             final_response_started = true;
           }
@@ -728,6 +732,7 @@ fn read_single_stream_response_with_first_frame(
             &mut status,
             &mut headers,
             &mut trailers,
+            &mut hpack,
           )? {
             final_response_started = true;
           }
@@ -984,10 +989,11 @@ fn apply_header_block(
   status: &mut Option<u32>,
   headers: &mut Vec<(String, String)>,
   trailers: &mut Vec<Header>,
+  hpack: &mut HpackDecoder,
 ) -> error::Result<bool> {
   match kind {
     HeaderBlockKind::ResponseHeaders => {
-      let decoded = decode_header_block(block)?;
+      let decoded = decode_header_block(block, hpack)?;
       if decoded.status.is_some_and(is_informational_status) {
         return Ok(false);
       }
@@ -996,7 +1002,7 @@ fn apply_header_block(
       Ok(status.is_some())
     }
     HeaderBlockKind::Trailers => {
-      trailers.extend(decode_trailer_block(block)?);
+      trailers.extend(decode_trailer_block(block, hpack)?);
       Ok(false)
     }
   }
@@ -1254,8 +1260,136 @@ struct DecodedHeaders {
   headers: Vec<(String, String)>,
 }
 
-fn decode_header_block(block: &[u8]) -> error::Result<DecodedHeaders> {
-  let entries = decode_header_entries(block)?;
+struct HpackDecoder {
+  dynamic_entries: Vec<(String, String)>,
+  dynamic_size: usize,
+  max_dynamic_size: usize,
+  peer_max_dynamic_size: usize,
+}
+
+impl HpackDecoder {
+  fn new(peer_max_dynamic_size: usize) -> Self {
+    Self {
+      dynamic_entries: Vec::new(),
+      dynamic_size: 0,
+      max_dynamic_size: peer_max_dynamic_size,
+      peer_max_dynamic_size,
+    }
+  }
+
+  fn decode_entries(&mut self, block: &[u8]) -> error::Result<Vec<(String, String)>> {
+    let mut cursor = 0;
+    let mut entries = Vec::new();
+
+    while cursor < block.len() {
+      let byte = block[cursor];
+      if byte & 0x80 == 0x80 {
+        let (name, value) = self.decode_indexed(block, &mut cursor)?;
+        entries.push((name, value));
+        continue;
+      }
+
+      if byte & 0x40 == 0x40 {
+        let (name, value) = self.decode_literal(block, &mut cursor, 6)?;
+        self.insert(name.clone(), value.clone())?;
+        entries.push((name, value));
+      } else if byte & 0x20 == 0x20 {
+        self.update_dynamic_size(decode_integer(block, &mut cursor, 5)?)?;
+      } else {
+        entries.push(self.decode_literal(block, &mut cursor, 4)?);
+      }
+    }
+
+    Ok(entries)
+  }
+
+  fn decode_indexed(&self, block: &[u8], cursor: &mut usize) -> error::Result<(String, String)> {
+    self.header(decode_integer(block, cursor, 7)?)
+  }
+
+  fn decode_literal(
+    &self,
+    block: &[u8],
+    cursor: &mut usize,
+    prefix_bits: u8,
+  ) -> error::Result<(String, String)> {
+    let name_index = decode_integer(block, cursor, prefix_bits)?;
+    let name = if name_index == 0 {
+      decode_string(block, cursor)?
+    } else {
+      self.header(name_index)?.0
+    };
+    let value = decode_string(block, cursor)?;
+    Ok((name, value))
+  }
+
+  fn header(&self, index: usize) -> error::Result<(String, String)> {
+    if index == 0 {
+      return Err(error::bad_response("invalid HPACK header index"));
+    }
+    if index <= HPACK_STATIC_TABLE_LENGTH {
+      let (name, value) = static_header(index)?;
+      return Ok((name.to_string(), value.to_string()));
+    }
+
+    let dynamic_index = index - HPACK_STATIC_TABLE_LENGTH - 1;
+    self
+      .dynamic_entries
+      .get(dynamic_index)
+      .cloned()
+      .ok_or_else(|| error::bad_response("invalid HPACK dynamic table index"))
+  }
+
+  fn update_dynamic_size(&mut self, size: usize) -> error::Result<()> {
+    if size > self.peer_max_dynamic_size {
+      return Err(error::bad_response(
+        "HPACK dynamic table size update exceeds limit",
+      ));
+    }
+    self.max_dynamic_size = size;
+    self.evict_to_capacity();
+    Ok(())
+  }
+
+  fn insert(&mut self, name: String, value: String) -> error::Result<()> {
+    let entry_size = name
+      .len()
+      .checked_add(value.len())
+      .and_then(|size| size.checked_add(32))
+      .ok_or_else(|| error::bad_response("HPACK dynamic table entry is too large"))?;
+
+    if entry_size > self.max_dynamic_size {
+      self.dynamic_entries.clear();
+      self.dynamic_size = 0;
+      return Ok(());
+    }
+
+    self.dynamic_entries.insert(0, (name, value));
+    self.dynamic_size = self
+      .dynamic_size
+      .checked_add(entry_size)
+      .ok_or_else(|| error::bad_response("HPACK dynamic table size overflow"))?;
+    self.evict_to_capacity();
+    Ok(())
+  }
+
+  fn evict_to_capacity(&mut self) {
+    while self.dynamic_size > self.max_dynamic_size {
+      if let Some((name, value)) = self.dynamic_entries.pop() {
+        self.dynamic_size -= dynamic_entry_size(&name, &value);
+      } else {
+        self.dynamic_size = 0;
+      }
+    }
+  }
+}
+
+fn dynamic_entry_size(name: &str, value: &str) -> usize {
+  32 + name.len() + value.len()
+}
+
+fn decode_header_block(block: &[u8], hpack: &mut HpackDecoder) -> error::Result<DecodedHeaders> {
+  let entries = hpack.decode_entries(block)?;
   let mut status = None;
   let mut headers = Vec::new();
 
@@ -1266,8 +1400,8 @@ fn decode_header_block(block: &[u8]) -> error::Result<DecodedHeaders> {
   Ok(DecodedHeaders { status, headers })
 }
 
-fn decode_trailer_block(block: &[u8]) -> error::Result<Vec<Header>> {
-  let entries = decode_header_entries(block)?;
+fn decode_trailer_block(block: &[u8], hpack: &mut HpackDecoder) -> error::Result<Vec<Header>> {
+  let entries = hpack.decode_entries(block)?;
   let mut trailers = Vec::new();
 
   for (name, value) in entries {
@@ -1279,49 +1413,6 @@ fn decode_trailer_block(block: &[u8]) -> error::Result<Vec<Header>> {
   }
 
   Ok(trailers)
-}
-
-fn decode_header_entries(block: &[u8]) -> error::Result<Vec<(String, String)>> {
-  let mut cursor = 0;
-  let mut entries = Vec::new();
-
-  while cursor < block.len() {
-    let byte = block[cursor];
-    if byte & 0x80 == 0x80 {
-      let index = decode_integer(block, &mut cursor, 7)?;
-      let (name, value) = static_header(index)?;
-      entries.push((name.to_string(), value.to_string()));
-      continue;
-    }
-
-    let (name, value) = if byte & 0x40 == 0x40 {
-      decode_literal(block, &mut cursor, 6)?
-    } else if byte & 0x20 == 0x20 {
-      return Err(error::bad_response(
-        "HTTP/2 dynamic table size updates are not supported",
-      ));
-    } else {
-      decode_literal(block, &mut cursor, 4)?
-    };
-    entries.push((name, value));
-  }
-
-  Ok(entries)
-}
-
-fn decode_literal(
-  block: &[u8],
-  cursor: &mut usize,
-  prefix_bits: u8,
-) -> error::Result<(String, String)> {
-  let name_index = decode_integer(block, cursor, prefix_bits)?;
-  let name = if name_index == 0 {
-    decode_string(block, cursor)?
-  } else {
-    static_header(name_index)?.0.to_string()
-  };
-  let value = decode_string(block, cursor)?;
-  Ok((name, value))
 }
 
 fn decode_integer(block: &[u8], cursor: &mut usize, prefix_bits: u8) -> error::Result<usize> {

--- a/rttp_client/src/lib.rs
+++ b/rttp_client/src/lib.rs
@@ -13,9 +13,9 @@
 //! With the `http2` feature enabled, `emit_http2_prior_knowledge` sends a
 //! minimal prior-knowledge h2c request over a direct socket2 TCP connection.
 //! It decodes incoming padded HEADERS, DATA, and trailer frames without
-//! exposing padding bytes. TLS ALPN, proxy h2, full HTTP/2 multiplexing,
-//! priority scheduling, and HPACK dynamic tables are not part of that
-//! single-stream path.
+//! exposing padding bytes, including response HPACK dynamic table entries. TLS
+//! ALPN, proxy h2, full HTTP/2 multiplexing, and priority scheduling are not
+//! part of that single-stream path.
 //!
 //! ```rust,no_run
 //! use rttp_client::HttpClient;

--- a/rttp_client/tests/http2_prior_knowledge.rs
+++ b/rttp_client/tests/http2_prior_knowledge.rs
@@ -1831,6 +1831,129 @@ fn prior_knowledge_decodes_hpack_huffman_response_headers_and_trailers() {
 }
 
 #[test]
+fn prior_knowledge_decodes_hpack_dynamic_indexed_response_headers() {
+  let mut header_block = vec![0x88];
+  header_block.extend_from_slice(&h2_literal_new_name_with_indexing(b"x-dyn", b"alpha"));
+  header_block.extend_from_slice(&h2_indexed(62));
+  let header_block = Box::leak(header_block.into_boxed_slice());
+  let (addr, handle) = spawn_h2_prior_knowledge_peer_with_response(header_block, &[b"dynamic"]);
+
+  let response = HttpClient::new()
+    .get()
+    .url(format!("http://{}/dynamic-index", addr))
+    .emit_http2_prior_knowledge()
+    .expect("h2 response with dynamic indexed header");
+
+  assert_eq!(200, response.code());
+  assert_eq!("dynamic", response.body().string().unwrap());
+  assert_eq!(
+    vec![&"alpha".to_string(), &"alpha".to_string()],
+    response.header_values("x-dyn")
+  );
+  handle.join().expect("h2 peer thread");
+}
+
+#[test]
+fn prior_knowledge_applies_hpack_dynamic_table_size_update_and_eviction() {
+  let mut header_block = vec![0x88];
+  header_block.extend_from_slice(&h2_dynamic_table_size_update(64));
+  header_block.extend_from_slice(&h2_literal_new_name_with_indexing(b"x-one", b"a"));
+  header_block.extend_from_slice(&h2_literal_new_name_with_indexing(b"x-two", b"b"));
+  header_block.extend_from_slice(&h2_indexed(62));
+  let header_block = Box::leak(header_block.into_boxed_slice());
+  let (addr, handle) = spawn_h2_prior_knowledge_peer_with_response(header_block, &[b"evict"]);
+
+  let response = HttpClient::new()
+    .get()
+    .url(format!("http://{}/dynamic-eviction", addr))
+    .emit_http2_prior_knowledge()
+    .expect("h2 response with evicted dynamic table entries");
+
+  assert_eq!(200, response.code());
+  assert_eq!("evict", response.body().string().unwrap());
+  assert_eq!(vec![&"a".to_string()], response.header_values("x-one"));
+  assert_eq!(
+    vec![&"b".to_string(), &"b".to_string()],
+    response.header_values("x-two")
+  );
+  handle.join().expect("h2 peer thread");
+}
+
+#[test]
+fn prior_knowledge_decodes_response_trailers_from_hpack_dynamic_entries() {
+  let listener = TcpListener::bind("127.0.0.1:0").expect("bind h2 peer");
+  let addr = listener.local_addr().expect("h2 peer addr");
+
+  let handle = thread::spawn(move || {
+    let (mut stream, _) = listener.accept().expect("accept h2 client");
+    complete_h2_request_handshake(&mut stream);
+
+    let mut headers = vec![0x88];
+    headers.extend_from_slice(&h2_literal_new_name_with_indexing(
+      b"x-tail",
+      b"dyn-trailer",
+    ));
+
+    write_frame(&mut stream, FRAME_SETTINGS, FLAG_ACK, 0, &[]);
+    write_frame(&mut stream, FRAME_HEADERS, FLAG_END_HEADERS, 1, &headers);
+    write_frame(&mut stream, FRAME_DATA, 0, 1, b"dynamic trailers");
+    write_frame(
+      &mut stream,
+      FRAME_HEADERS,
+      FLAG_END_HEADERS | FLAG_END_STREAM,
+      1,
+      &h2_indexed(62),
+    );
+  });
+
+  let response = HttpClient::new()
+    .get()
+    .url(format!("http://{}/dynamic-trailers", addr))
+    .emit_http2_prior_knowledge()
+    .expect("h2 response with dynamic indexed trailer");
+
+  assert_eq!(200, response.code());
+  assert_eq!("dynamic trailers", response.body().string().unwrap());
+  assert_eq!(
+    Some(&"dyn-trailer".to_string()),
+    response.trailer_value("x-tail")
+  );
+  handle.join().expect("h2 peer thread");
+}
+
+#[test]
+fn prior_knowledge_rejects_malformed_hpack_dynamic_references() {
+  let cases: &[(&str, &[u8], &str)] = &[
+    (
+      "missing-dynamic-entry",
+      &[0x88, 0xbe],
+      "invalid HPACK dynamic table index",
+    ),
+    (
+      "truncated-dynamic-index",
+      &[0x88, 0xff],
+      "truncated HPACK integer",
+    ),
+  ];
+
+  for (path, header_block, expected) in cases {
+    let (addr, handle) = spawn_h2_prior_knowledge_peer_with_response(header_block, &[b""]);
+
+    let error = HttpClient::new()
+      .get()
+      .url(format!("http://{}/{}", addr, path))
+      .emit_http2_prior_knowledge()
+      .expect_err("malformed dynamic HPACK reference should be rejected");
+
+    assert!(
+      error.to_string().contains(expected),
+      "expected {expected:?}, got {error}"
+    );
+    handle.join().expect("h2 peer thread");
+  }
+}
+
+#[test]
 fn prior_knowledge_rejects_malformed_hpack_huffman_strings() {
   let cases: &[(&str, &[u8], &str)] = &[
     (
@@ -2113,11 +2236,45 @@ fn h2_literal_new_name(name: &[u8], value: &[u8]) -> Vec<u8> {
   block
 }
 
+fn h2_literal_new_name_with_indexing(name: &[u8], value: &[u8]) -> Vec<u8> {
+  let mut block = Vec::new();
+  block.push(0x40);
+  h2_string(&mut block, name);
+  h2_string(&mut block, value);
+  block
+}
+
 fn h2_literal_huffman_new_name(name: &[u8], value: &[u8]) -> Vec<u8> {
   let mut block = Vec::new();
   block.push(0);
   h2_huffman_string(&mut block, name);
   h2_huffman_string(&mut block, value);
+  block
+}
+
+fn h2_indexed(index: usize) -> Vec<u8> {
+  h2_integer(index, 7, 0x80)
+}
+
+fn h2_dynamic_table_size_update(size: usize) -> Vec<u8> {
+  h2_integer(size, 5, 0x20)
+}
+
+fn h2_integer(mut value: usize, prefix_bits: u8, first_byte_prefix: u8) -> Vec<u8> {
+  let max_prefix = (1usize << prefix_bits) - 1;
+  let mut block = Vec::new();
+  if value < max_prefix {
+    block.push(first_byte_prefix | value as u8);
+    return block;
+  }
+
+  block.push(first_byte_prefix | max_prefix as u8);
+  value -= max_prefix;
+  while value >= 128 {
+    block.push((value % 128) as u8 + 128);
+    value /= 128;
+  }
+  block.push(value as u8);
   block
 }
 


### PR DESCRIPTION
Adds HPACK dynamic table decoding to the rttp_client prior-knowledge h2c response path, including dynamic headers, dynamic trailers, table size updates, eviction, and malformed-reference errors. Verified with formatting and the rttp_client http2 feature test suite.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1422/
work_kind: code_work
branch: hbx-1422-rttp-client-decode-hpack-dynamic
base: main
commit: 2b8a8d18c9ebe01290f9b9fc6bd31dd0887ffef4
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1422/
    url: https://plane.kahub.in/endless/browse/HBX-1422/
    close_policy: link_only
```