### PR TITLE
feat: [rttp] Emit HPACK dynamic table response headers when smaller

### DIFF
--- a/rttp/src/server.rs
+++ b/rttp/src/server.rs
@@ -1783,7 +1783,9 @@ fn write_http2_response(
   write_body: bool,
   flow_control: &mut Http2ResponseFlowControl<'_>,
 ) -> io::Result<()> {
-  let headers = encode_http2_response_headers(response)?;
+  let mut header_encoder = Http2HeaderEncoder::new(HTTP2_DEFAULT_HEADER_TABLE_SIZE);
+  let dynamic_candidates = repeated_http2_response_fields(response);
+  let headers = encode_http2_response_headers(response, &mut header_encoder, &dynamic_candidates)?;
   let write_trailers = write_body && response.allows_body() && !response.trailers().is_empty();
   write_http2_header_block(stream, stream_id, 0, &headers, *flow_control.max_frame_size)?;
   let body = if write_body && response.allows_body() {
@@ -1826,7 +1828,8 @@ fn write_http2_response(
     }
   }
   if write_trailers {
-    let trailers = encode_http2_response_trailers(response)?;
+    let trailers =
+      encode_http2_response_trailers(response, &mut header_encoder, &dynamic_candidates)?;
     write_http2_header_block(
       stream,
       stream_id,
@@ -2093,7 +2096,104 @@ fn write_http2_header_block(
   Ok(())
 }
 
-fn encode_http2_response_headers(response: &HttpResponse) -> io::Result<Vec<u8>> {
+struct Http2HeaderEncoder {
+  dynamic_entries: Vec<(String, String)>,
+  max_size: usize,
+  current_size: usize,
+}
+
+impl Http2HeaderEncoder {
+  fn new(max_size: usize) -> Self {
+    Self {
+      dynamic_entries: Vec::new(),
+      max_size,
+      current_size: 0,
+    }
+  }
+
+  fn dynamic_header_index(&self, name: &str, value: &str) -> Option<usize> {
+    self
+      .dynamic_entries
+      .iter()
+      .position(|(entry_name, entry_value)| entry_name == name && entry_value == value)
+      .map(|position| HTTP2_STATIC_TABLE_LEN + position + 1)
+  }
+
+  fn can_insert(&self, name: &str, value: &str) -> bool {
+    hpack_dynamic_entry_size(name, value) <= self.max_size
+  }
+
+  fn insert(&mut self, name: String, value: String) {
+    let entry_size = hpack_dynamic_entry_size(&name, &value);
+    if entry_size > self.max_size {
+      self.dynamic_entries.clear();
+      self.current_size = 0;
+      return;
+    }
+    self.dynamic_entries.insert(0, (name, value));
+    self.current_size += entry_size;
+    self.evict_to_max_size();
+  }
+
+  fn evict_to_max_size(&mut self) {
+    while self.current_size > self.max_size {
+      let Some((name, value)) = self.dynamic_entries.pop() else {
+        self.current_size = 0;
+        return;
+      };
+      self.current_size -= hpack_dynamic_entry_size(&name, &value);
+    }
+  }
+}
+
+fn repeated_http2_response_fields(response: &HttpResponse) -> Vec<(String, String)> {
+  let mut fields = Vec::<(String, String)>::new();
+  for header in &response.headers {
+    let name = header.name.to_ascii_lowercase();
+    if !is_http2_skipped_response_header_name(&name) {
+      fields.push((name, header.value.clone()));
+    }
+  }
+  for trailer in response.trailers() {
+    let name = trailer.name.to_ascii_lowercase();
+    if !is_http2_skipped_response_trailer_name(&name) {
+      fields.push((name, trailer.value.clone()));
+    }
+  }
+
+  let mut repeated = Vec::<(String, String)>::new();
+  for (index, (name, value)) in fields.iter().enumerate() {
+    if repeated
+      .iter()
+      .any(|(repeated_name, repeated_value)| repeated_name == name && repeated_value == value)
+    {
+      continue;
+    }
+    if fields[index + 1..]
+      .iter()
+      .any(|(other_name, other_value)| other_name == name && other_value == value)
+    {
+      repeated.push((name.clone(), value.clone()));
+    }
+  }
+  repeated
+}
+
+fn is_repeated_http2_response_field(
+  dynamic_candidates: &[(String, String)],
+  name: &str,
+  value: &str,
+) -> bool {
+  dynamic_candidates
+    .iter()
+    .any(|(candidate_name, candidate_value)| candidate_name == name && candidate_value == value)
+}
+
+fn encode_http2_response_headers(
+  response: &HttpResponse,
+  encoder: &mut Http2HeaderEncoder,
+  dynamic_candidates: &[(String, String)],
+) -> io::Result<Vec<u8>> {
   let mut block = Vec::new();
   match response.status_code {
     200 => block.push(0x88),
@@ -2123,60 +2223,139 @@ fn encode_http2_response_headers(response: &HttpResponse) -> io::Result<Vec<u8>>
 
   for header in &response.headers {
     let name = header.name.to_ascii_lowercase();
-    if matches!(
-      name.as_str(),
-      "connection"
-        | "keep-alive"
-        | "proxy-connection"
-        | "te"
-        | "trailer"
-        | "transfer-encoding"
-        | "upgrade"
-        | "content-length"
-    ) {
+    if is_http2_skipped_response_header_name(&name) {
       continue;
     }
-    encode_http2_literal_new_name_without_indexing(
+    encode_http2_response_field(
       &mut block,
-      name.as_bytes(),
-      header.value.as_bytes(),
+      encoder,
+      dynamic_candidates,
+      &name,
+      &header.value,
     )?;
   }
 
   Ok(block)
 }
 
-fn encode_http2_response_trailers(response: &HttpResponse) -> io::Result<Vec<u8>> {
+fn encode_http2_response_trailers(
+  response: &HttpResponse,
+  encoder: &mut Http2HeaderEncoder,
+  dynamic_candidates: &[(String, String)],
+) -> io::Result<Vec<u8>> {
   let mut block = Vec::new();
   for trailer in response.trailers() {
     let name = trailer.name.to_ascii_lowercase();
-    if matches!(
-      name.as_str(),
-      "authorization"
-        | "connection"
-        | "content-length"
-        | "cookie"
-        | "host"
-        | "keep-alive"
-        | "proxy-authenticate"
-        | "proxy-authorization"
-        | "proxy-connection"
-        | "set-cookie"
-        | "te"
-        | "trailer"
-        | "transfer-encoding"
-        | "upgrade"
-        | "www-authenticate"
-    ) {
+    if is_http2_skipped_response_trailer_name(&name) {
       continue;
     }
-    encode_http2_literal_new_name_without_indexing(
+    encode_http2_response_field(
       &mut block,
-      name.as_bytes(),
-      trailer.value.as_bytes(),
+      encoder,
+      dynamic_candidates,
+      &name,
+      &trailer.value,
     )?;
   }
   Ok(block)
+}
+
+fn encode_http2_response_field(
+  block: &mut Vec<u8>,
+  encoder: &mut Http2HeaderEncoder,
+  dynamic_candidates: &[(String, String)],
+  name: &str,
+  value: &str,
+) -> io::Result<()> {
+  let literal_without_indexing_len =
+    encoded_http2_literal_new_name_without_indexing_len(name.as_bytes(), value.as_bytes())?;
+  if let Some(index) = encoder.dynamic_header_index(name, value) {
+    let indexed_len = encoded_http2_indexed_len(index)?;
+    if indexed_len < literal_without_indexing_len {
+      return encode_http2_indexed(block, index);
+    }
+  }
+
+  if is_repeated_http2_response_field(dynamic_candidates, name, value)
+    && encoder.can_insert(name, value)
+  {
+    let indexed_len = encoded_http2_indexed_len(HTTP2_STATIC_TABLE_LEN + 1)?;
+    if indexed_len < literal_without_indexing_len {
+      encode_http2_literal_new_name_with_incremental_indexing(
+        block,
+        name.as_bytes(),
+        value.as_bytes(),
+      )?;
+      encoder.insert(name.to_string(), value.to_string());
+      return Ok(());
+    }
+  }
+
+  encode_http2_literal_new_name_without_indexing(block, name.as_bytes(), value.as_bytes())
+}
+
+fn is_http2_skipped_response_header_name(name: &str) -> bool {
+  matches!(
+    name,
+    "connection"
+      | "keep-alive"
+      | "proxy-connection"
+      | "te"
+      | "trailer"
+      | "transfer-encoding"
+      | "upgrade"
+      | "content-length"
+  )
+}
+
+fn is_http2_skipped_response_trailer_name(name: &str) -> bool {
+  matches!(
+    name,
+    "authorization"
+      | "connection"
+      | "content-length"
+      | "cookie"
+      | "host"
+      | "keep-alive"
+      | "proxy-authenticate"
+      | "proxy-authorization"
+      | "proxy-connection"
+      | "set-cookie"
+      | "te"
+      | "trailer"
+      | "transfer-encoding"
+      | "upgrade"
+      | "www-authenticate"
+  )
+}
+
+fn encode_http2_indexed(block: &mut Vec<u8>, index: usize) -> io::Result<()> {
+  encode_http2_integer(block, index, 7, 0x80)
+}
+
+fn encode_http2_literal_new_name_with_incremental_indexing(
+  block: &mut Vec<u8>,
+  name: &[u8],
+  value: &[u8],
+) -> io::Result<()> {
+  block.push(0x40);
+  encode_http2_string(block, name)?;
+  encode_http2_string(block, value)
+}
+
+fn encoded_http2_indexed_len(index: usize) -> io::Result<usize> {
+  let mut encoded = Vec::new();
+  encode_http2_indexed(&mut encoded, index)?;
+  Ok(encoded.len())
+}
+
+fn encoded_http2_literal_new_name_without_indexing_len(
+  name: &[u8],
+  value: &[u8],
+) -> io::Result<usize> {
+  let mut encoded = Vec::new();
+  encode_http2_literal_new_name_without_indexing(&mut encoded, name, value)?;
+  Ok(encoded.len())
 }
 
 fn encode_http2_literal_indexed_name_without_indexing(

--- a/rttp/tests/http2_feature.rs
+++ b/rttp/tests/http2_feature.rs
@@ -191,6 +191,75 @@ fn decode_hpack_string(block: &[u8], cursor: &mut usize) -> Vec<u8> {
   }
 }
 
+fn skip_hpack_string(block: &[u8], cursor: &mut usize) {
+  let len = decode_hpack_integer(block, cursor, 7);
+  *cursor += len;
+}
+
+fn count_hpack_dynamic_indexed_fields(block: &[u8]) -> usize {
+  let mut cursor = 0;
+  let mut indexed = 0;
+  while cursor < block.len() {
+    let byte = block[cursor];
+    if byte & 0x80 == 0x80 {
+      let index = decode_hpack_integer(block, &mut cursor, 7);
+      if index > 61 {
+        indexed += 1;
+      }
+      continue;
+    }
+    if byte & 0x40 == 0x40 {
+      let name_index = decode_hpack_integer(block, &mut cursor, 6);
+      if name_index == 0 {
+        skip_hpack_string(block, &mut cursor);
+      }
+      skip_hpack_string(block, &mut cursor);
+      continue;
+    }
+    if byte & 0x20 == 0x20 {
+      let _ = decode_hpack_integer(block, &mut cursor, 5);
+      continue;
+    }
+    let name_index = decode_hpack_integer(block, &mut cursor, 4);
+    if name_index == 0 {
+      skip_hpack_string(block, &mut cursor);
+    }
+    skip_hpack_string(block, &mut cursor);
+  }
+  indexed
+}
+
+fn count_hpack_incrementally_indexed_fields(block: &[u8]) -> usize {
+  let mut cursor = 0;
+  let mut indexed = 0;
+  while cursor < block.len() {
+    let byte = block[cursor];
+    if byte & 0x80 == 0x80 {
+      let _ = decode_hpack_integer(block, &mut cursor, 7);
+      continue;
+    }
+    if byte & 0x40 == 0x40 {
+      indexed += 1;
+      let name_index = decode_hpack_integer(block, &mut cursor, 6);
+      if name_index == 0 {
+        skip_hpack_string(block, &mut cursor);
+      }
+      skip_hpack_string(block, &mut cursor);
+      continue;
+    }
+    if byte & 0x20 == 0x20 {
+      let _ = decode_hpack_integer(block, &mut cursor, 5);
+      continue;
+    }
+    let name_index = decode_hpack_integer(block, &mut cursor, 4);
+    if name_index == 0 {
+      skip_hpack_string(block, &mut cursor);
+    }
+    skip_hpack_string(block, &mut cursor);
+  }
+  indexed
+}
+
 fn decode_path_huffman_string(encoded: &[u8]) -> Vec<u8> {
   let mut value = Vec::new();
   let mut code = 0u32;
@@ -1061,6 +1130,169 @@ fn wrapper_http2_prior_knowledge_decodes_huffman_response_headers_and_trailers_f
   );
   assert!(response.header_value("Trailer").is_none());
   assert!(response.header_value("X-HPACK-Trailer").is_none());
+
+  handle.join().expect("server thread");
+}
+
+#[test]
+fn socket2_h2_response_uses_dynamic_entries_for_repeated_smaller_fields() {
+  let server = rttp::Http::server("127.0.0.1:0")
+    .expect("bind server")
+    .with_read_timeout(Some(Duration::from_secs(2)))
+    .with_write_timeout(Some(Duration::from_secs(2)));
+  let addr = server.local_addr().expect("server addr");
+
+  let handle = thread::spawn(move || {
+    server
+      .accept_one(move |_| {
+        HttpResponse::ok("dynamic fields")
+          .header("X-Dynamic-Response", "repeatable-response-value")
+          .header("X-Dynamic-Response", "repeatable-response-value")
+          .header("Trailer", "X-Dynamic-Trailer")
+          .trailer("X-Dynamic-Trailer", "repeatable-trailer-value")
+          .trailer("X-Dynamic-Trailer", "repeatable-trailer-value")
+      })
+      .expect("serve dynamic h2 response fields");
+  });
+
+  let mut stream = TcpStream::connect(addr).expect("connect h2 server");
+  complete_h2_server_handshake_with_settings(&mut stream, &[]);
+  write_h2_frame(
+    &mut stream,
+    H2_FRAME_HEADERS,
+    H2_FLAG_END_HEADERS | H2_FLAG_END_STREAM,
+    1,
+    &h2_get_headers(b"/dynamic-response-fields", addr.to_string().as_bytes()),
+  );
+
+  let response_headers = read_h2_frame(&mut stream);
+  assert_eq!(H2_FRAME_HEADERS, response_headers.frame_type);
+  assert_eq!(1, response_headers.stream_id);
+  assert_eq!(
+    1,
+    count_hpack_dynamic_indexed_fields(&response_headers.payload)
+  );
+  assert_eq!(
+    1,
+    count_hpack_incrementally_indexed_fields(&response_headers.payload)
+  );
+
+  let response_data = read_h2_frame(&mut stream);
+  assert_eq!(H2_FRAME_DATA, response_data.frame_type);
+  assert_eq!(0, response_data.flags & H2_FLAG_END_STREAM);
+
+  let response_trailers = read_h2_frame(&mut stream);
+  assert_eq!(H2_FRAME_HEADERS, response_trailers.frame_type);
+  assert_eq!(
+    H2_FLAG_END_HEADERS | H2_FLAG_END_STREAM,
+    response_trailers.flags
+  );
+  assert_eq!(
+    1,
+    count_hpack_dynamic_indexed_fields(&response_trailers.payload)
+  );
+  assert_eq!(
+    1,
+    count_hpack_incrementally_indexed_fields(&response_trailers.payload)
+  );
+
+  handle.join().expect("server thread");
+}
+
+#[test]
+fn socket2_h2_response_dynamic_table_evicts_entries_at_default_size() {
+  let server = rttp::Http::server("127.0.0.1:0")
+    .expect("bind server")
+    .with_read_timeout(Some(Duration::from_secs(2)))
+    .with_write_timeout(Some(Duration::from_secs(2)));
+  let addr = server.local_addr().expect("server addr");
+  let large_value = "v".repeat(4020);
+
+  let handle = thread::spawn(move || {
+    server
+      .accept_one(move |_| {
+        HttpResponse::ok("evicted dynamic fields")
+          .header("X-Evict-Small", "small")
+          .header("X-Evict-Large", &large_value)
+          .header("X-Evict-Large", &large_value)
+          .header("X-Evict-Small", "small")
+      })
+      .expect("serve h2 response with dynamic table eviction");
+  });
+
+  let mut stream = TcpStream::connect(addr).expect("connect h2 server");
+  complete_h2_server_handshake_with_settings(&mut stream, &[]);
+  write_h2_frame(
+    &mut stream,
+    H2_FRAME_HEADERS,
+    H2_FLAG_END_HEADERS | H2_FLAG_END_STREAM,
+    1,
+    &h2_get_headers(b"/dynamic-eviction", addr.to_string().as_bytes()),
+  );
+
+  let response_headers = read_h2_frame(&mut stream);
+  assert_eq!(H2_FRAME_HEADERS, response_headers.frame_type);
+  assert_eq!(1, response_headers.stream_id);
+  assert_eq!(
+    1,
+    count_hpack_dynamic_indexed_fields(&response_headers.payload)
+  );
+  assert_eq!(
+    3,
+    count_hpack_incrementally_indexed_fields(&response_headers.payload)
+  );
+
+  handle.join().expect("server thread");
+}
+
+#[test]
+fn wrapper_http2_prior_knowledge_decodes_dynamic_response_fields_from_socket2_server() {
+  let server = rttp::Http::server("127.0.0.1:0")
+    .expect("bind server")
+    .with_read_timeout(Some(Duration::from_secs(2)))
+    .with_write_timeout(Some(Duration::from_secs(2)));
+  let addr = server.local_addr().expect("server addr");
+
+  let handle = thread::spawn(move || {
+    server
+      .accept_one(move |_| {
+        HttpResponse::ok("decoded dynamic response fields")
+          .header("X-Dynamic-Response", "repeatable-response-value")
+          .header("X-Dynamic-Response", "repeatable-response-value")
+          .header("Trailer", "X-Dynamic-Trailer")
+          .trailer("X-Dynamic-Trailer", "repeatable-trailer-value")
+          .trailer("X-Dynamic-Trailer", "repeatable-trailer-value")
+      })
+      .expect("serve dynamic h2 response fields");
+  });
+
+  let response = rttp::Http::client()
+    .url(format!("http://{}/dynamic-response-fields", addr))
+    .emit_http2_prior_knowledge()
+    .expect("wrapper h2 response with dynamic response fields");
+
+  assert_eq!("HTTP/2", response.version());
+  assert_eq!(200, response.code());
+  assert_eq!(
+    "decoded dynamic response fields",
+    response.body().string().unwrap()
+  );
+  assert_eq!(
+    vec![
+      &"repeatable-response-value".to_string(),
+      &"repeatable-response-value".to_string()
+    ],
+    response.header_values("X-Dynamic-Response")
+  );
+  assert_eq!(
+    vec![
+      &"repeatable-trailer-value".to_string(),
+      &"repeatable-trailer-value".to_string()
+    ],
+    response.trailer_values("X-Dynamic-Trailer")
+  );
+  assert!(response.header_value("Trailer").is_none());
+  assert!(response.header_value("X-Dynamic-Trailer").is_none());
 
   handle.join().expect("server thread");
 }

--- a/rttp/tests/test_server.rs
+++ b/rttp/tests/test_server.rs
@@ -692,9 +692,9 @@ fn server_huffman_encodes_http2_response_header_and_trailer_literals_only_when_s
         HttpResponse::ok("hpack body")
           .header("X", "aaaaaaaaaaaaaaaa")
           .header("Y", "x")
-          .header("Trailer", "X")
-          .trailer("X", "aaaaaaaaaaaaaaaa")
-          .trailer("Y", "x")
+          .header("Trailer", "Z, W")
+          .trailer("Z", "aaaaaaaaaaaaaaaa")
+          .trailer("W", "x")
       })
       .expect("serve huffman h2 response");
   });
@@ -745,11 +745,11 @@ fn server_huffman_encodes_http2_response_header_and_trailer_literals_only_when_s
   assert_eq!(1, response_trailers.stream_id);
 
   let trailer_literals = captured_hpack_literals(&response_trailers.payload);
-  let compressed_trailer = captured_hpack_literal(&trailer_literals, "x");
+  let compressed_trailer = captured_hpack_literal(&trailer_literals, "z");
   assert!(!compressed_trailer.name_huffman);
   assert!(compressed_trailer.value_huffman);
   assert_eq!(None, compressed_trailer.value);
-  let raw_trailer = captured_hpack_literal(&trailer_literals, "y");
+  let raw_trailer = captured_hpack_literal(&trailer_literals, "w");
   assert!(!raw_trailer.name_huffman);
   assert!(!raw_trailer.value_huffman);
   assert_eq!(Some("x"), raw_trailer.value.as_deref());


### PR DESCRIPTION
Added per-response-stream HPACK dynamic indexing for repeated h2c response headers and trailers, with bounded table eviction and interop coverage through the existing prior-knowledge client path.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1425/
work_kind: code_work
branch: hbx-1425-rttp-emit-hpack-dynamic-table
base: main
commit: 916d41b8b84a0672b7bfaad16a5c6e2cde519bde
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1425/
    url: https://plane.kahub.in/endless/browse/HBX-1425/
    close_policy: link_only
```