### PR TITLE
feat: [rttp_client] Emit HPACK dynamic table request headers when smaller

### DIFF
--- a/rttp/tests/http2_feature.rs
+++ b/rttp/tests/http2_feature.rs
@@ -934,6 +934,58 @@ fn wrapper_http2_prior_knowledge_huffman_request_headers_reach_socket2_server_de
 }
 
 #[test]
+fn wrapper_http2_prior_knowledge_dynamic_request_fields_reach_socket2_server_decoded() {
+  let server = rttp::Http::server("127.0.0.1:0")
+    .expect("bind server")
+    .with_read_timeout(Some(Duration::from_secs(2)))
+    .with_write_timeout(Some(Duration::from_secs(2)));
+  let addr = server.local_addr().expect("server addr");
+  let (tx, rx) = mpsc::channel();
+
+  let handle = thread::spawn(move || {
+    server
+      .accept_one(|request| {
+        tx.send((
+          request.version().to_string(),
+          request.target().to_string(),
+          request.header("x-repeat").map(str::to_string),
+          request.trailer("x-repeat").map(str::to_string),
+        ))
+        .expect("send parsed dynamic h2 request fields");
+        HttpResponse::ok("decoded dynamic request fields")
+      })
+      .expect("serve dynamic h2 request fields");
+  });
+
+  let response = rttp::Http::client()
+    .post()
+    .url(format!("http://{}/dynamic-request-fields", addr))
+    .header(("X-Repeat", "same-value"))
+    .trailer(("X-Repeat", "same-value"))
+    .expect("configure repeated trailer")
+    .raw("dynamic request body")
+    .emit_http2_prior_knowledge()
+    .expect("wrapper h2 response after dynamic request fields");
+
+  assert_eq!("HTTP/2", response.version());
+  assert_eq!(
+    "decoded dynamic request fields",
+    response.body().string().unwrap()
+  );
+  assert_eq!(
+    (
+      "HTTP/2".to_string(),
+      "/dynamic-request-fields".to_string(),
+      Some("same-value".to_string()),
+      Some("same-value".to_string())
+    ),
+    rx.recv().expect("receive parsed dynamic h2 request fields")
+  );
+
+  handle.join().expect("server thread");
+}
+
+#[test]
 fn wrapper_http2_prior_knowledge_large_huffman_request_header_reaches_socket2_server_decoded() {
   let server = rttp::Http::server("127.0.0.1:0")
     .expect("bind server")

--- a/rttp_client/src/http2.rs
+++ b/rttp_client/src/http2.rs
@@ -28,6 +28,7 @@ const FLAG_PADDED: u8 = 0x8;
 const FLAG_PRIORITY: u8 = 0x20;
 
 const STREAM_ID: u32 = 1;
+const SETTING_HEADER_TABLE_SIZE: u16 = 0x1;
 const SETTING_ENABLE_PUSH: u16 = 0x2;
 const SETTING_INITIAL_WINDOW_SIZE: u16 = 0x4;
 const SETTING_MAX_FRAME_SIZE: u16 = 0x5;
@@ -222,6 +223,7 @@ fn read_settings_and_ack(stream: &mut TcpStream) -> error::Result<PeerSettings> 
 
 #[derive(Clone, Copy)]
 struct PeerSettings {
+  header_table_size: usize,
   initial_window_size: u32,
   initial_window_size_changed: bool,
   max_frame_size: usize,
@@ -234,6 +236,7 @@ fn validate_settings_payload(payload: &[u8]) -> error::Result<PeerSettings> {
   }
 
   let mut settings = PeerSettings {
+    header_table_size: DEFAULT_HPACK_DYNAMIC_TABLE_SIZE,
     initial_window_size: DEFAULT_INITIAL_WINDOW_SIZE as u32,
     initial_window_size_changed: false,
     max_frame_size: DEFAULT_MAX_FRAME_SIZE,
@@ -243,6 +246,7 @@ fn validate_settings_payload(payload: &[u8]) -> error::Result<PeerSettings> {
     let identifier = u16::from_be_bytes([setting[0], setting[1]]);
     let value = u32::from_be_bytes([setting[2], setting[3], setting[4], setting[5]]);
     match identifier {
+      SETTING_HEADER_TABLE_SIZE => settings.header_table_size = value as usize,
       SETTING_ENABLE_PUSH => {
         if value > 1 {
           return Err(error::bad_response(
@@ -298,7 +302,30 @@ fn write_request(
   response_url: RoUrl,
   peer_settings: PeerSettings,
 ) -> error::Result<Option<Response>> {
-  let header_block = encode_request_headers(request, url)?;
+  let mut hpack = RequestHpackEncoder::new(
+    peer_settings
+      .header_table_size
+      .min(DEFAULT_HPACK_DYNAMIC_TABLE_SIZE),
+  );
+  let regular_header_fields = regular_headers(request.header());
+  let trailer_announcement = (!request.origin().trailers().is_empty())
+    .then(|| ("trailer".to_string(), request_trailer_field_value(request)));
+  let trailer_fields = request_trailer_fields(request);
+  let mut dynamic_field_plan = Vec::new();
+  dynamic_field_plan.extend(regular_header_fields.iter().cloned());
+  dynamic_field_plan.extend(trailer_announcement.iter().cloned());
+  dynamic_field_plan.extend(trailer_fields.iter().cloned());
+  let mut dynamic_field_position = 0;
+
+  let header_block = encode_request_headers(
+    request,
+    url,
+    &regular_header_fields,
+    trailer_announcement.as_ref(),
+    &dynamic_field_plan,
+    &mut dynamic_field_position,
+    &mut hpack,
+  )?;
   let body = request
     .body()
     .as_ref()
@@ -325,7 +352,12 @@ fn write_request(
     }
   }
   if has_trailers {
-    let trailer_block = encode_request_trailers(request)?;
+    let trailer_block = encode_request_trailers(
+      &trailer_fields,
+      &dynamic_field_plan,
+      &mut dynamic_field_position,
+      &mut hpack,
+    )?;
     write_header_block_frames(
       stream,
       FLAG_END_STREAM,
@@ -511,7 +543,15 @@ fn handle_settings_while_sending(
   stream.flush().map_err(error::request)
 }
 
-fn encode_request_headers(request: &RawRequest<'_>, url: &Url) -> error::Result<Vec<u8>> {
+fn encode_request_headers(
+  request: &RawRequest<'_>,
+  url: &Url,
+  regular_header_fields: &[(String, String)],
+  trailer_announcement: Option<&(String, String)>,
+  dynamic_field_plan: &[(String, String)],
+  dynamic_field_position: &mut usize,
+  hpack: &mut RequestHpackEncoder,
+) -> error::Result<Vec<u8>> {
   let mut block = Vec::new();
   encode_method(&mut block, request.origin().method())?;
   if url.scheme() == "http" {
@@ -528,16 +568,20 @@ fn encode_request_headers(request: &RawRequest<'_>, url: &Url) -> error::Result<
   }
   encode_literal_indexed_name_without_indexing(&mut block, 1, authority(url)?.as_bytes())?;
 
-  for (name, value) in regular_headers(request.header()) {
-    encode_literal_new_name_without_indexing(&mut block, name.as_bytes(), value.as_bytes())?;
+  for (name, value) in regular_header_fields {
+    let remaining = dynamic_field_plan
+      .get(*dynamic_field_position + 1..)
+      .unwrap_or(&[]);
+    hpack.encode_field(&mut block, name, value, remaining)?;
+    *dynamic_field_position += 1;
   }
 
-  if !request.origin().trailers().is_empty() {
-    encode_literal_new_name_without_indexing(
-      &mut block,
-      b"trailer",
-      request_trailer_field_value(request).as_bytes(),
-    )?;
+  if let Some((name, value)) = trailer_announcement {
+    let remaining = dynamic_field_plan
+      .get(*dynamic_field_position + 1..)
+      .unwrap_or(&[]);
+    hpack.encode_field(&mut block, name, value, remaining)?;
+    *dynamic_field_position += 1;
   }
 
   Ok(block)
@@ -553,14 +597,33 @@ fn request_trailer_field_value(request: &RawRequest<'_>) -> String {
     .join(", ")
 }
 
-fn encode_request_trailers(request: &RawRequest<'_>) -> error::Result<Vec<u8>> {
+fn request_trailer_fields(request: &RawRequest<'_>) -> Vec<(String, String)> {
+  request
+    .origin()
+    .trailers()
+    .iter()
+    .map(|header| {
+      (
+        header.name().to_ascii_lowercase(),
+        header.value().to_string(),
+      )
+    })
+    .collect()
+}
+
+fn encode_request_trailers(
+  trailer_fields: &[(String, String)],
+  dynamic_field_plan: &[(String, String)],
+  dynamic_field_position: &mut usize,
+  hpack: &mut RequestHpackEncoder,
+) -> error::Result<Vec<u8>> {
   let mut block = Vec::new();
-  for header in request.origin().trailers() {
-    encode_literal_new_name_without_indexing(
-      &mut block,
-      header.name().to_ascii_lowercase().as_bytes(),
-      header.value().as_bytes(),
-    )?;
+  for (name, value) in trailer_fields {
+    let remaining = dynamic_field_plan
+      .get(*dynamic_field_position + 1..)
+      .unwrap_or(&[]);
+    hpack.encode_field(&mut block, name, value, remaining)?;
+    *dynamic_field_position += 1;
   }
   Ok(block)
 }
@@ -1176,6 +1239,122 @@ fn encode_literal_new_name_without_indexing(
   block.push(0);
   encode_string(block, name)?;
   encode_string(block, value)
+}
+
+fn encode_literal_new_name_with_indexing(
+  block: &mut Vec<u8>,
+  name: &[u8],
+  value: &[u8],
+) -> error::Result<()> {
+  block.push(0x40);
+  encode_string(block, name)?;
+  encode_string(block, value)
+}
+
+struct RequestHpackEncoder {
+  dynamic_entries: Vec<(String, String)>,
+  max_size: usize,
+  current_size: usize,
+}
+
+impl RequestHpackEncoder {
+  fn new(max_size: usize) -> Self {
+    Self {
+      dynamic_entries: Vec::new(),
+      max_size,
+      current_size: 0,
+    }
+  }
+
+  fn encode_field(
+    &mut self,
+    block: &mut Vec<u8>,
+    name: &str,
+    value: &str,
+    remaining_fields: &[(String, String)],
+  ) -> error::Result<()> {
+    let literal_len = literal_new_name_without_indexing_len(name.as_bytes(), value.as_bytes())?;
+    if let Some(index) = self.index(name, value) {
+      if hpack_integer_len(index, 7) < literal_len {
+        return encode_integer(block, index, 7, 0x80);
+      }
+    }
+
+    if self.should_index(name, value, literal_len, remaining_fields) {
+      encode_literal_new_name_with_indexing(block, name.as_bytes(), value.as_bytes())?;
+      self.insert(name.to_string(), value.to_string());
+      return Ok(());
+    }
+
+    encode_literal_new_name_without_indexing(block, name.as_bytes(), value.as_bytes())
+  }
+
+  fn should_index(
+    &self,
+    name: &str,
+    value: &str,
+    literal_len: usize,
+    remaining_fields: &[(String, String)],
+  ) -> bool {
+    self.max_size > 0
+      && dynamic_entry_size(name, value) <= self.max_size
+      && hpack_integer_len(HPACK_STATIC_TABLE_LENGTH + 1, 7) < literal_len
+      && remaining_fields
+        .iter()
+        .any(|(remaining_name, remaining_value)| remaining_name == name && remaining_value == value)
+  }
+
+  fn index(&self, name: &str, value: &str) -> Option<usize> {
+    self
+      .dynamic_entries
+      .iter()
+      .position(|(entry_name, entry_value)| entry_name == name && entry_value == value)
+      .map(|position| HPACK_STATIC_TABLE_LENGTH + 1 + position)
+  }
+
+  fn insert(&mut self, name: String, value: String) {
+    let entry_size = dynamic_entry_size(&name, &value);
+    if entry_size > self.max_size {
+      self.dynamic_entries.clear();
+      self.current_size = 0;
+      return;
+    }
+
+    self.dynamic_entries.insert(0, (name, value));
+    self.current_size += entry_size;
+    self.evict_to_capacity();
+  }
+
+  fn evict_to_capacity(&mut self) {
+    while self.current_size > self.max_size {
+      let Some((name, value)) = self.dynamic_entries.pop() else {
+        self.current_size = 0;
+        return;
+      };
+      self.current_size -= dynamic_entry_size(&name, &value);
+    }
+  }
+}
+
+fn literal_new_name_without_indexing_len(name: &[u8], value: &[u8]) -> error::Result<usize> {
+  let mut block = Vec::new();
+  encode_literal_new_name_without_indexing(&mut block, name, value)?;
+  Ok(block.len())
+}
+
+fn hpack_integer_len(mut value: usize, prefix_bits: u8) -> usize {
+  let max_prefix = (1usize << prefix_bits) - 1;
+  if value < max_prefix {
+    return 1;
+  }
+
+  let mut len = 1;
+  value -= max_prefix;
+  while value >= 128 {
+    len += 1;
+    value /= 128;
+  }
+  len + 1
 }
 
 fn encode_string(block: &mut Vec<u8>, value: &[u8]) -> error::Result<()> {

--- a/rttp_client/tests/http2_prior_knowledge.rs
+++ b/rttp_client/tests/http2_prior_knowledge.rs
@@ -23,6 +23,7 @@ const FLAG_PADDED: u8 = 0x8;
 const FLAG_ACK: u8 = 0x1;
 const FLAG_PRIORITY: u8 = 0x20;
 
+const SETTING_HEADER_TABLE_SIZE: u16 = 0x1;
 const SETTING_ENABLE_PUSH: u16 = 0x2;
 const SETTING_INITIAL_WINDOW_SIZE: u16 = 0x4;
 const SETTING_MAX_FRAME_SIZE: u16 = 0x5;
@@ -175,6 +176,175 @@ fn prior_knowledge_request_literals_use_huffman_only_when_smaller() {
     find_literal_new_name_value(&request_trailer_block, b"x-t").expect("huffman request trailer");
   assert!(encoded_trailer.huffman);
   assert_eq!(expected_trailer_value.as_bytes(), encoded_trailer.value);
+}
+
+#[test]
+fn prior_knowledge_request_uses_dynamic_table_for_repeated_fields_when_smaller() {
+  let listener = TcpListener::bind("127.0.0.1:0").expect("bind h2 peer");
+  let addr = listener.local_addr().expect("h2 peer addr");
+
+  let handle = thread::spawn(move || {
+    let (mut stream, _) = listener.accept().expect("accept h2 client");
+    complete_h2_handshake_without_request(&mut stream);
+
+    let request_headers = read_frame(&mut stream);
+    assert_eq!(FRAME_HEADERS, request_headers.frame_type);
+    assert_eq!(FLAG_END_HEADERS, request_headers.flags);
+    assert_eq!(1, request_headers.stream_id);
+
+    let request_body = read_frame(&mut stream);
+    assert_eq!(FRAME_DATA, request_body.frame_type);
+    assert_eq!(0, request_body.flags);
+    assert_eq!(1, request_body.stream_id);
+    assert_eq!(b"dynamic body", request_body.payload.as_slice());
+
+    let request_trailers = read_frame(&mut stream);
+    assert_eq!(FRAME_HEADERS, request_trailers.frame_type);
+    assert_eq!(FLAG_END_HEADERS | FLAG_END_STREAM, request_trailers.flags);
+    assert_eq!(1, request_trailers.stream_id);
+
+    write_frame(&mut stream, FRAME_SETTINGS, FLAG_ACK, 0, &[]);
+    write_frame(&mut stream, FRAME_HEADERS, FLAG_END_HEADERS, 1, &[0x88]);
+    write_frame(&mut stream, FRAME_DATA, FLAG_END_STREAM, 1, b"ok");
+
+    (request_headers.payload, request_trailers.payload)
+  });
+
+  let response = HttpClient::new()
+    .post()
+    .url(format!("http://{}/dynamic-request-fields", addr))
+    .header(("X-Repeat", "same-value"))
+    .trailer(("X-Repeat", "same-value"))
+    .expect("configure repeated trailer")
+    .raw("dynamic body")
+    .emit_http2_prior_knowledge()
+    .expect("h2 POST response");
+
+  assert_eq!(200, response.code());
+  assert_eq!("ok", response.body().string().unwrap());
+
+  let (request_header_block, request_trailer_block) = handle.join().expect("h2 peer thread");
+  let indexed_header =
+    find_literal_with_indexing_new_name_value(&request_header_block, b"x-repeat")
+      .expect("first repeated request header is indexed");
+  assert_eq!(b"same-value", indexed_header.value.as_slice());
+  assert!(
+    dynamic_indexed_fields(&request_trailer_block) >= 1,
+    "repeated request trailer should use the dynamic indexed request header field"
+  );
+}
+
+#[test]
+fn prior_knowledge_request_respects_disabled_peer_dynamic_table() {
+  let listener = TcpListener::bind("127.0.0.1:0").expect("bind h2 peer");
+  let addr = listener.local_addr().expect("h2 peer addr");
+  let settings = settings_payload(SETTING_HEADER_TABLE_SIZE, 0);
+
+  let handle = thread::spawn(move || {
+    let (mut stream, _) = listener.accept().expect("accept h2 client");
+    complete_h2_handshake_without_request_with_settings(&mut stream, &settings);
+
+    let request_headers = read_frame(&mut stream);
+    assert_eq!(FRAME_HEADERS, request_headers.frame_type);
+    assert_eq!(FLAG_END_HEADERS, request_headers.flags);
+    assert_eq!(1, request_headers.stream_id);
+
+    let request_body = read_frame(&mut stream);
+    assert_eq!(FRAME_DATA, request_body.frame_type);
+    assert_eq!(0, request_body.flags);
+    assert_eq!(1, request_body.stream_id);
+
+    let request_trailers = read_frame(&mut stream);
+    assert_eq!(FRAME_HEADERS, request_trailers.frame_type);
+    assert_eq!(FLAG_END_HEADERS | FLAG_END_STREAM, request_trailers.flags);
+    assert_eq!(1, request_trailers.stream_id);
+
+    write_frame(&mut stream, FRAME_SETTINGS, FLAG_ACK, 0, &[]);
+    write_frame(&mut stream, FRAME_HEADERS, FLAG_END_HEADERS, 1, &[0x88]);
+    write_frame(&mut stream, FRAME_DATA, FLAG_END_STREAM, 1, b"ok");
+
+    (request_headers.payload, request_trailers.payload)
+  });
+
+  let response = HttpClient::new()
+    .post()
+    .url(format!("http://{}/no-dynamic-request-fields", addr))
+    .header(("X-Repeat", "same-value"))
+    .trailer(("X-Repeat", "same-value"))
+    .expect("configure repeated trailer")
+    .raw("dynamic body")
+    .emit_http2_prior_knowledge()
+    .expect("h2 POST response");
+
+  assert_eq!(200, response.code());
+  assert_eq!("ok", response.body().string().unwrap());
+
+  let (request_header_block, request_trailer_block) = handle.join().expect("h2 peer thread");
+  assert_eq!(0, literal_with_indexing_fields(&request_header_block));
+  assert_eq!(0, dynamic_indexed_fields(&request_header_block));
+  assert_eq!(0, literal_with_indexing_fields(&request_trailer_block));
+  assert_eq!(0, dynamic_indexed_fields(&request_trailer_block));
+}
+
+#[test]
+fn prior_knowledge_request_evicts_dynamic_entries_to_peer_table_size() {
+  let listener = TcpListener::bind("127.0.0.1:0").expect("bind h2 peer");
+  let addr = listener.local_addr().expect("h2 peer addr");
+  let settings = settings_payload(SETTING_HEADER_TABLE_SIZE, 64);
+
+  let handle = thread::spawn(move || {
+    let (mut stream, _) = listener.accept().expect("accept h2 client");
+    complete_h2_handshake_without_request_with_settings(&mut stream, &settings);
+
+    let request_headers = read_frame(&mut stream);
+    assert_eq!(FRAME_HEADERS, request_headers.frame_type);
+    assert_eq!(FLAG_END_HEADERS, request_headers.flags);
+    assert_eq!(1, request_headers.stream_id);
+
+    let request_body = read_frame(&mut stream);
+    assert_eq!(FRAME_DATA, request_body.frame_type);
+    assert_eq!(0, request_body.flags);
+    assert_eq!(1, request_body.stream_id);
+
+    let request_trailers = read_frame(&mut stream);
+    assert_eq!(FRAME_HEADERS, request_trailers.frame_type);
+    assert_eq!(FLAG_END_HEADERS | FLAG_END_STREAM, request_trailers.flags);
+    assert_eq!(1, request_trailers.stream_id);
+
+    write_frame(&mut stream, FRAME_SETTINGS, FLAG_ACK, 0, &[]);
+    write_frame(&mut stream, FRAME_HEADERS, FLAG_END_HEADERS, 1, &[0x88]);
+    write_frame(&mut stream, FRAME_DATA, FLAG_END_STREAM, 1, b"ok");
+
+    (request_headers.payload, request_trailers.payload)
+  });
+
+  let response = HttpClient::new()
+    .post()
+    .url(format!("http://{}/dynamic-request-eviction", addr))
+    .header(("X-One", "a"))
+    .header(("X-Two", "b"))
+    .trailer(("X-One", "a"))
+    .expect("configure first repeated trailer")
+    .trailer(("X-Two", "b"))
+    .expect("configure second repeated trailer")
+    .raw("dynamic body")
+    .emit_http2_prior_knowledge()
+    .expect("h2 POST response");
+
+  assert_eq!(200, response.code());
+  assert_eq!("ok", response.body().string().unwrap());
+
+  let (request_header_block, request_trailer_block) = handle.join().expect("h2 peer thread");
+  assert_eq!(2, literal_with_indexing_fields(&request_header_block));
+  assert_eq!(
+    1,
+    dynamic_indexed_fields(&request_trailer_block),
+    "only the newest repeated field should survive the peer-bounded dynamic table"
+  );
+  assert!(
+    find_literal_new_name_value(&request_trailer_block, b"x-one").is_some(),
+    "evicted repeated field should fall back to literal encoding"
+  );
 }
 
 #[test]
@@ -2285,6 +2455,104 @@ struct TestHpackString {
 
 fn find_literal_new_name_value(block: &[u8], expected_name: &[u8]) -> Option<TestHpackString> {
   find_test_header_value(block, expected_name, true)
+}
+
+fn find_literal_with_indexing_new_name_value(
+  block: &[u8],
+  expected_name: &[u8],
+) -> Option<TestHpackString> {
+  let mut cursor = 0;
+  while cursor < block.len() {
+    let byte = block[cursor];
+    if byte & 0x80 == 0x80 {
+      decode_test_integer(block, &mut cursor, 7);
+      continue;
+    }
+    if byte & 0x40 == 0x40 {
+      let name_index = decode_test_integer(block, &mut cursor, 6);
+      let name = if name_index == 0 {
+        Some(decode_test_string(block, &mut cursor))
+      } else {
+        None
+      };
+      let value = decode_test_string(block, &mut cursor);
+      if name
+        .as_ref()
+        .is_some_and(|name| name.value.as_slice() == expected_name)
+      {
+        return Some(value);
+      }
+      continue;
+    }
+
+    assert_eq!(0, byte & 0x20, "dynamic table update in request block");
+    let name_index = decode_test_integer(block, &mut cursor, 4);
+    if name_index == 0 {
+      decode_test_string(block, &mut cursor);
+    }
+    decode_test_string(block, &mut cursor);
+  }
+  None
+}
+
+fn dynamic_indexed_fields(block: &[u8]) -> usize {
+  let mut cursor = 0;
+  let mut count = 0;
+  while cursor < block.len() {
+    let byte = block[cursor];
+    if byte & 0x80 == 0x80 {
+      let index = decode_test_integer(block, &mut cursor, 7);
+      if index > 61 {
+        count += 1;
+      }
+      continue;
+    }
+    if byte & 0x40 == 0x40 {
+      let name_index = decode_test_integer(block, &mut cursor, 6);
+      if name_index == 0 {
+        decode_test_string(block, &mut cursor);
+      }
+      decode_test_string(block, &mut cursor);
+      continue;
+    }
+
+    assert_eq!(0, byte & 0x20, "dynamic table update in request block");
+    let name_index = decode_test_integer(block, &mut cursor, 4);
+    if name_index == 0 {
+      decode_test_string(block, &mut cursor);
+    }
+    decode_test_string(block, &mut cursor);
+  }
+  count
+}
+
+fn literal_with_indexing_fields(block: &[u8]) -> usize {
+  let mut cursor = 0;
+  let mut count = 0;
+  while cursor < block.len() {
+    let byte = block[cursor];
+    if byte & 0x80 == 0x80 {
+      decode_test_integer(block, &mut cursor, 7);
+      continue;
+    }
+    if byte & 0x40 == 0x40 {
+      count += 1;
+      let name_index = decode_test_integer(block, &mut cursor, 6);
+      if name_index == 0 {
+        decode_test_string(block, &mut cursor);
+      }
+      decode_test_string(block, &mut cursor);
+      continue;
+    }
+
+    assert_eq!(0, byte & 0x20, "dynamic table update in request block");
+    let name_index = decode_test_integer(block, &mut cursor, 4);
+    if name_index == 0 {
+      decode_test_string(block, &mut cursor);
+    }
+    decode_test_string(block, &mut cursor);
+  }
+  count
 }
 
 fn find_header_value(block: &[u8], expected_name: &[u8]) -> Option<TestHpackString> {


### PR DESCRIPTION
Adds request-side HPACK dynamic table emission for prior-knowledge h2c, including peer table-size handling, eviction, and wrapper interop coverage.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1424/
work_kind: code_work
branch: hbx-1424-rttp-client-emit-hpack-dynamic
base: main
commit: 30556a47f01074a1edf839afca5d760ce0c0c8fc
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1424/
    url: https://plane.kahub.in/endless/browse/HBX-1424/
    close_policy: link_only
```