### PR TITLE
feat: [rttp] Add cross-crate HPACK dynamic table interoperability matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,11 @@ With the `http2` feature enabled, `emit_http2_prior_knowledge` sends a minimal
 prior-knowledge h2c request over a direct socket2 TCP connection. It supports
 GET and buffered POST, PUT, or PATCH requests, including non-empty buffered
 request bodies as DATA frames, HPACK static Huffman strings, and large header
-blocks via CONTINUATION frames, and it decodes incoming padded HEADERS, DATA,
-and trailer frames without exposing padding bytes. TLS ALPN, proxy tunneling,
-proxy h2, HPACK dynamic tables, and full HTTP/2 features such as general
+blocks via CONTINUATION frames. It uses HPACK dynamic entries for repeated
+request header and trailer fields within the peer's advertised table size, and
+it decodes response dynamic table entries and table-size updates from incoming
+padded HEADERS, DATA, and trailer frames without exposing padding bytes. TLS
+ALPN, proxy tunneling, proxy h2, and full HTTP/2 features such as general
 multiplexing and priority scheduling are not part of that client path.
 
 ```rust,no_run

--- a/rttp/README.md
+++ b/rttp/README.md
@@ -70,10 +70,11 @@ Enable the `client` feature to access `rttp::Http::client`, or enable `async`,
 `http2`, `tls-native`, `tls-rustls`, or `all` for the corresponding
 `rttp_client` capabilities. The `http2` feature exposes the minimal
 prior-knowledge h2c client path, including HPACK static Huffman strings,
-response dynamic table decoding, large header blocks via CONTINUATION frames,
-padded incoming response frames, and conservative DATA flow-control for
-single-stream prior-knowledge use; TLS ALPN, proxy h2, and full HTTP/2 features
-such as multiplexing and priority scheduling remain outside that path.
+request dynamic entries within the peer's advertised table size, response
+dynamic table decoding, large header blocks via CONTINUATION frames, padded
+incoming response frames, and conservative DATA flow-control for single-stream
+prior-knowledge use; TLS ALPN, proxy h2, and full HTTP/2 features such as
+multiplexing and priority scheduling remain outside that path.
 
 Direct TCP client connections use `socket2`. SOCKS proxy handshakes remain
 delegated to the `socks` crate.

--- a/rttp/tests/http2_feature.rs
+++ b/rttp/tests/http2_feature.rs
@@ -1055,6 +1055,73 @@ fn wrapper_http2_prior_knowledge_dynamic_request_fields_reach_socket2_server_dec
 }
 
 #[test]
+fn rttp_client_http2_prior_knowledge_dynamic_request_fields_reach_rttp_server_decoded() {
+  let server = rttp::Http::server("127.0.0.1:0")
+    .expect("bind server")
+    .with_read_timeout(Some(Duration::from_secs(2)))
+    .with_write_timeout(Some(Duration::from_secs(2)));
+  let addr = server.local_addr().expect("server addr");
+  let (tx, rx) = mpsc::channel();
+
+  let handle = thread::spawn(move || {
+    server
+      .accept_one(|request| {
+        tx.send((
+          request.method().to_string(),
+          request.version().to_string(),
+          request.target().to_string(),
+          request.header("x-repeat").map(str::to_string),
+          request.header("x-client-only").map(str::to_string),
+          request.trailer("x-repeat").map(str::to_string),
+          request.trailer("x-client-only").map(str::to_string),
+          request.trailers().to_vec(),
+        ))
+        .expect("send direct client dynamic h2 request fields");
+        HttpResponse::ok("decoded direct client dynamic request fields")
+      })
+      .expect("serve direct client dynamic h2 request fields");
+  });
+
+  let response = rttp_client::HttpClient::new()
+    .post()
+    .url(format!("http://{}/direct-dynamic-request-fields", addr))
+    .header(("X-Repeat", "same-value"))
+    .header(("X-Client-Only", "header-value"))
+    .trailer(("X-Repeat", "same-value"))
+    .expect("configure repeated direct client trailer")
+    .trailer(("X-Client-Only", "trailer-value"))
+    .expect("configure direct client-only trailer")
+    .raw("direct dynamic request body")
+    .emit_http2_prior_knowledge()
+    .expect("direct client h2 response after dynamic request fields");
+
+  assert_eq!("HTTP/2", response.version());
+  assert_eq!(
+    "decoded direct client dynamic request fields",
+    response.body().string().unwrap()
+  );
+  assert_eq!(
+    (
+      "POST".to_string(),
+      "HTTP/2".to_string(),
+      "/direct-dynamic-request-fields".to_string(),
+      Some("same-value".to_string()),
+      Some("header-value".to_string()),
+      Some("same-value".to_string()),
+      Some("trailer-value".to_string()),
+      vec![
+        ("x-repeat".to_string(), "same-value".to_string()),
+        ("x-client-only".to_string(), "trailer-value".to_string()),
+      ],
+    ),
+    rx.recv()
+      .expect("receive direct client dynamic h2 request fields")
+  );
+
+  handle.join().expect("server thread");
+}
+
+#[test]
 fn wrapper_http2_prior_knowledge_large_huffman_request_header_reaches_socket2_server_decoded() {
   let server = rttp::Http::server("127.0.0.1:0")
     .expect("bind server")
@@ -1345,6 +1412,61 @@ fn wrapper_http2_prior_knowledge_decodes_dynamic_response_fields_from_socket2_se
   );
   assert!(response.header_value("Trailer").is_none());
   assert!(response.header_value("X-Dynamic-Trailer").is_none());
+
+  handle.join().expect("server thread");
+}
+
+#[test]
+fn rttp_client_http2_prior_knowledge_decodes_rttp_server_dynamic_response_eviction() {
+  let server = rttp::Http::server("127.0.0.1:0")
+    .expect("bind server")
+    .with_read_timeout(Some(Duration::from_secs(2)))
+    .with_write_timeout(Some(Duration::from_secs(2)));
+  let addr = server.local_addr().expect("server addr");
+  let large_value = "v".repeat(4020);
+  let expected_large_value = large_value.clone();
+
+  let handle = thread::spawn(move || {
+    server
+      .accept_one(move |_| {
+        HttpResponse::ok("decoded direct client dynamic response eviction")
+          .header("X-Evict-Small", "small")
+          .header("X-Evict-Large", &large_value)
+          .header("X-Evict-Large", &large_value)
+          .header("X-Evict-Small", "small")
+          .header("Trailer", "X-Evict-Trailer")
+          .trailer("X-Evict-Trailer", "trailer-repeat")
+          .trailer("X-Evict-Trailer", "trailer-repeat")
+      })
+      .expect("serve direct client dynamic h2 response eviction");
+  });
+
+  let response = rttp_client::HttpClient::new()
+    .get()
+    .url(format!("http://{}/direct-dynamic-response-eviction", addr))
+    .emit_http2_prior_knowledge()
+    .expect("direct client h2 response with dynamic response eviction");
+
+  assert_eq!("HTTP/2", response.version());
+  assert_eq!(200, response.code());
+  assert_eq!(
+    "decoded direct client dynamic response eviction",
+    response.body().string().unwrap()
+  );
+  assert_eq!(
+    vec![&"small".to_string(), &"small".to_string()],
+    response.header_values("X-Evict-Small")
+  );
+  assert_eq!(
+    vec![&expected_large_value, &expected_large_value],
+    response.header_values("X-Evict-Large")
+  );
+  assert_eq!(
+    vec![&"trailer-repeat".to_string(), &"trailer-repeat".to_string()],
+    response.trailer_values("X-Evict-Trailer")
+  );
+  assert!(response.header_value("Trailer").is_none());
+  assert!(response.header_value("X-Evict-Trailer").is_none());
 
   handle.join().expect("server thread");
 }

--- a/rttp_client/README.md
+++ b/rttp_client/README.md
@@ -29,10 +29,12 @@ through `Response::trailers`, `Response::trailer`, and
 With the `http2` feature enabled, `emit_http2_prior_knowledge` sends a minimal
 prior-knowledge h2c request over a direct socket2 TCP connection. Non-empty
 buffered request bodies are sent as DATA frames, HPACK static Huffman strings
-and large header blocks are supported, and incoming padded HEADERS, DATA, and
-trailer frames are decoded without exposing padding bytes. TLS ALPN, proxy
-tunneling, proxy h2, HPACK dynamic tables, and full HTTP/2 features such as
-general multiplexing and priority scheduling are not part of that client path.
+and large header blocks are supported, repeated request header and trailer
+fields can use HPACK dynamic entries within the peer's advertised table size,
+and incoming dynamic table entries, table-size updates, padded HEADERS, DATA,
+and trailer frames are decoded without exposing padding bytes. TLS ALPN, proxy
+tunneling, proxy h2, and full HTTP/2 features such as general multiplexing and
+priority scheduling are not part of that client path.
 
 ## Examples
 


### PR DESCRIPTION
Cross-crate HPACK dynamic table h2c coverage was added for direct client/server public APIs, with README scope updated to match the implemented support boundary. Verification passed for formatting and relevant HTTP/2 test suites.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1426/
work_kind: code_work
branch: hbx-1426-rttp-add-cross-crate-hpack
base: main
commit: 402127feb24c2550c8a5f6c648ccec7e75be5ffa
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1426/
    url: https://plane.kahub.in/endless/browse/HBX-1426/
    close_policy: link_only
```