### PR TITLE
feat: [rttp] Ignore reset h2c streams while serving remaining streams

### DIFF
--- a/rttp/src/server.rs
+++ b/rttp/src/server.rs
@@ -1776,6 +1776,11 @@ struct Http2ResponseFlowControl<'a> {
   request_header_decoder: &'a mut Http2HeaderDecoder,
 }
 
+enum Http2ResponseFlowControlRead {
+  WindowAvailable,
+  ResponseReset,
+}
+
 fn write_http2_response(
   stream: &mut TcpStream,
   stream_id: u32,
@@ -1806,7 +1811,10 @@ fn write_http2_response(
       while flow_control.connection_send_window.available() == 0
         || flow_control.stream_send_window.available() == 0
       {
-        read_http2_response_flow_control_frame(stream, stream_id, flow_control)?;
+        match read_http2_response_flow_control_frame(stream, stream_id, flow_control)? {
+          Http2ResponseFlowControlRead::WindowAvailable => {}
+          Http2ResponseFlowControlRead::ResponseReset => return Ok(()),
+        }
       }
 
       let chunk_len = (body.len() - offset)
@@ -1845,7 +1853,7 @@ fn read_http2_response_flow_control_frame(
   stream: &mut TcpStream,
   response_stream_id: u32,
   flow_control: &mut Http2ResponseFlowControl<'_>,
-) -> io::Result<()> {
+) -> io::Result<Http2ResponseFlowControlRead> {
   loop {
     let frame = read_http2_frame(stream)?;
     if let Some(stream_id) = active_http2_header_continuation_stream(flow_control.streams) {
@@ -1861,13 +1869,13 @@ fn read_http2_response_flow_control_frame(
         flow_control
           .connection_send_window
           .increase(http2_window_update_increment(&frame.payload)?)?;
-        return Ok(());
+        return Ok(Http2ResponseFlowControlRead::WindowAvailable);
       }
       (HTTP2_FRAME_WINDOW_UPDATE, id) if id == response_stream_id => {
         flow_control
           .stream_send_window
           .increase(http2_window_update_increment(&frame.payload)?)?;
-        return Ok(());
+        return Ok(Http2ResponseFlowControlRead::WindowAvailable);
       }
       (HTTP2_FRAME_WINDOW_UPDATE, id) => {
         let increment = http2_window_update_increment(&frame.payload)?;
@@ -2045,6 +2053,9 @@ fn read_http2_response_flow_control_frame(
         if !flow_control.reset_streams.contains(&id) {
           flow_control.reset_streams.push(id);
         }
+        if id == response_stream_id {
+          return Ok(Http2ResponseFlowControlRead::ResponseReset);
+        }
       }
       (_, 0) => {}
       _ => {}
@@ -2052,7 +2063,7 @@ fn read_http2_response_flow_control_frame(
     if flow_control.connection_send_window.available() > 0
       && flow_control.stream_send_window.available() > 0
     {
-      return Ok(());
+      return Ok(Http2ResponseFlowControlRead::WindowAvailable);
     }
   }
 }

--- a/rttp/tests/http2_feature.rs
+++ b/rttp/tests/http2_feature.rs
@@ -10,6 +10,7 @@ use rttp::server::HttpResponse;
 
 const H2_FRAME_DATA: u8 = 0x0;
 const H2_FRAME_HEADERS: u8 = 0x1;
+const H2_FRAME_RST_STREAM: u8 = 0x3;
 const H2_FRAME_SETTINGS: u8 = 0x4;
 const H2_FRAME_PING: u8 = 0x6;
 const H2_FRAME_WINDOW_UPDATE: u8 = 0x8;
@@ -23,6 +24,7 @@ const H2_SETTINGS_ENABLE_PUSH: u16 = 0x2;
 const H2_SETTINGS_INITIAL_WINDOW_SIZE: u16 = 0x4;
 const H2_SETTINGS_MAX_FRAME_SIZE: u16 = 0x5;
 const H2_DEFAULT_INITIAL_WINDOW_SIZE: usize = 65_535;
+const H2_ERROR_CANCEL: u32 = 0x8;
 
 struct H2Frame {
   frame_type: u8,
@@ -679,6 +681,89 @@ fn prior_knowledge_server_serves_two_complete_streams_on_one_socket2_connection(
   assert_eq!(H2_FLAG_END_STREAM, second_body.flags);
   assert_eq!(3, second_body.stream_id);
   assert_eq!(b"served /second", second_body.payload.as_slice());
+
+  handle.join().expect("server thread");
+}
+
+#[test]
+fn prior_knowledge_server_ignores_reset_stream_blocked_on_response_flow_control() {
+  let server = rttp::Http::server("127.0.0.1:0")
+    .expect("bind server")
+    .with_read_timeout(Some(Duration::from_millis(500)))
+    .with_write_timeout(Some(Duration::from_secs(2)));
+  let addr = server.local_addr().expect("server addr");
+
+  let handle = thread::spawn(move || {
+    server
+      .serve_requests(2, |request| {
+        assert_eq!("HTTP/2", request.version());
+        match request.target() {
+          "/reset" => HttpResponse::ok("x".repeat(H2_DEFAULT_INITIAL_WINDOW_SIZE + 1024)),
+          "/second" => HttpResponse::ok("served second"),
+          target => panic!("unexpected request target {target}"),
+        }
+      })
+      .expect("serve h2 streams after reset")
+  });
+
+  let mut stream = TcpStream::connect(addr).expect("connect h2 server");
+  stream
+    .set_read_timeout(Some(Duration::from_secs(2)))
+    .expect("set client read timeout");
+  complete_h2_server_handshake_with_settings(&mut stream, &[]);
+  write_h2_frame(
+    &mut stream,
+    H2_FRAME_HEADERS,
+    H2_FLAG_END_HEADERS | H2_FLAG_END_STREAM,
+    1,
+    &h2_get_headers(b"/reset", addr.to_string().as_bytes()),
+  );
+  stream.flush().expect("flush reset h2 request");
+
+  let reset_headers = read_h2_frame(&mut stream);
+  assert_eq!(H2_FRAME_HEADERS, reset_headers.frame_type);
+  assert_eq!(1, reset_headers.stream_id);
+
+  let mut reset_body_len = 0;
+  while reset_body_len < H2_DEFAULT_INITIAL_WINDOW_SIZE {
+    let reset_body = read_h2_frame(&mut stream);
+    assert_eq!(H2_FRAME_DATA, reset_body.frame_type);
+    assert_eq!(1, reset_body.stream_id);
+    reset_body_len += reset_body.payload.len();
+  }
+  assert_eq!(H2_DEFAULT_INITIAL_WINDOW_SIZE, reset_body_len);
+
+  write_h2_frame(
+    &mut stream,
+    H2_FRAME_RST_STREAM,
+    0,
+    1,
+    &H2_ERROR_CANCEL.to_be_bytes(),
+  );
+  write_h2_frame(
+    &mut stream,
+    H2_FRAME_WINDOW_UPDATE,
+    0,
+    0,
+    &(H2_DEFAULT_INITIAL_WINDOW_SIZE as u32).to_be_bytes(),
+  );
+  write_h2_frame(
+    &mut stream,
+    H2_FRAME_HEADERS,
+    H2_FLAG_END_HEADERS | H2_FLAG_END_STREAM,
+    3,
+    &h2_get_headers(b"/second", addr.to_string().as_bytes()),
+  );
+  stream.flush().expect("flush second h2 request");
+
+  let second_headers = read_h2_frame(&mut stream);
+  assert_eq!(H2_FRAME_HEADERS, second_headers.frame_type);
+  assert_eq!(3, second_headers.stream_id);
+  let second_body = read_h2_frame(&mut stream);
+  assert_eq!(H2_FRAME_DATA, second_body.frame_type);
+  assert_eq!(H2_FLAG_END_STREAM, second_body.flags);
+  assert_eq!(3, second_body.stream_id);
+  assert_eq!(b"served second", second_body.payload.as_slice());
 
   handle.join().expect("server thread");
 }


### PR DESCRIPTION
Added RST_STREAM recovery for bounded h2c multi-stream serving so canceled flow-control-blocked response streams no longer prevent remaining streams from being served. Verified with formatting and `rttp` HTTP/2 package tests.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1430/
work_kind: code_work
branch: hbx-1430-rttp-ignore-reset-h2c-streams
base: main
commit: b9ac7ab6926912cf905441810656b3e7829b6d69
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1430/
    url: https://plane.kahub.in/endless/browse/HBX-1430/
    close_policy: link_only
```