### PR TITLE
feat: [rttp] Document and test bounded h2c multiplexing limits

### DIFF
--- a/rttp/README.md
+++ b/rttp/README.md
@@ -54,15 +54,17 @@ head/body parsing, handles `HEAD` without writing a response body, honors
 writes response body framing and response trailers consistently, and accepts
 `Expect: 100-continue`. On the same socket2 listener, the accept path detects
 the HTTP/2 client preface and dispatches prior-knowledge h2c requests to a
-minimal single-stream handler. Incoming padded HEADERS, DATA, and trailer
-frames are accepted without exposing padding bytes to handlers, and HPACK
-static Huffman strings, request dynamic table entries, and large header blocks
-are carried with CONTINUATION frames. The minimal h2c path supports
-conservative DATA flow-control for single-stream prior-knowledge use.
+minimal bounded handler. Incoming padded HEADERS, DATA, and trailer frames are
+accepted without exposing padding bytes to handlers, HPACK static Huffman
+strings, request dynamic table entries, and large header blocks are carried
+with CONTINUATION frames, and multiple prior-knowledge h2c request streams may
+be open on one connection up to the caller's bounded `serve_requests` loop.
+Responses are still written synchronously as requests complete. The minimal
+h2c path supports conservative DATA flow-control for prior-knowledge use.
 
 The server is intentionally not a full RFC-covering web server and still does
 not implement server TLS, TLS ALPN, proxy h2, full HTTP/2 features such as
-multiplexing and priority scheduling, or async accept loops.
+unbounded multiplexing and priority scheduling, or async accept loops.
 
 ## Client feature
 

--- a/rttp/tests/http2_feature.rs
+++ b/rttp/tests/http2_feature.rs
@@ -2296,6 +2296,61 @@ fn http2_feature_socket2_interleaved_request_data_and_trailers_stay_per_stream()
 }
 
 #[test]
+fn http2_feature_socket2_bounded_h2c_multiplexing_stops_at_request_limit() {
+  let server = rttp::Http::server("127.0.0.1:0")
+    .expect("bind server")
+    .with_read_timeout(Some(Duration::from_secs(2)))
+    .with_write_timeout(Some(Duration::from_secs(2)));
+  let addr = server.local_addr().expect("server addr");
+  let (tx, rx) = mpsc::channel();
+
+  let handle = thread::spawn(move || {
+    server
+      .serve_requests(1, |request| {
+        tx.send(request.target().to_string())
+          .expect("send parsed bounded h2 request");
+        HttpResponse::ok(format!("served {}", request.target()))
+      })
+      .expect("serve bounded h2 request");
+  });
+
+  let mut stream = TcpStream::connect(addr).expect("connect h2 server");
+  stream
+    .set_read_timeout(Some(Duration::from_secs(2)))
+    .expect("set client read timeout");
+  complete_h2_server_handshake_with_settings(&mut stream, &[]);
+
+  write_h2_frame(
+    &mut stream,
+    H2_FRAME_HEADERS,
+    H2_FLAG_END_HEADERS,
+    1,
+    &h2_post_headers(b"/pending", addr.to_string().as_bytes()),
+  );
+  write_h2_frame(
+    &mut stream,
+    H2_FRAME_HEADERS,
+    H2_FLAG_END_HEADERS | H2_FLAG_END_STREAM,
+    3,
+    &h2_get_headers(b"/ready", addr.to_string().as_bytes()),
+  );
+  stream.flush().expect("flush bounded h2 requests");
+
+  assert_eq!(vec![3], read_h2_end_stream_data_streams(&mut stream, 1, 8));
+  assert_eq!(
+    "/ready",
+    rx.recv().expect("receive bounded h2 request target")
+  );
+
+  drop(stream);
+  handle.join().expect("server thread");
+  assert!(
+    rx.try_recv().is_err(),
+    "pending stream must not be dispatched after request limit"
+  );
+}
+
+#[test]
 fn http2_feature_socket2_request_headers_with_priority_reach_server_without_priority_metadata() {
   let server = rttp::Http::server("127.0.0.1:0").expect("bind server");
   let addr = server.local_addr().expect("server addr");


### PR DESCRIPTION
Documented bounded prior-knowledge h2c multiplexing limits and added integration coverage for stopping at the configured `serve_requests` request bound while another stream remains pending.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1432/
work_kind: code_work
branch: hbx-1432-rttp-document-and-test-bounded
base: main
commit: 08fddfc72ce8442eb6f12b4d6aed150e7434d380
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1432/
    url: https://plane.kahub.in/endless/browse/HBX-1432/
    close_policy: link_only
```