### PR TITLE
feat: [rttp] Generate HTTP/1.1 Trailer declarations for chunked response trailers

### DIFF
--- a/rttp/src/server.rs
+++ b/rttp/src/server.rs
@@ -3382,8 +3382,12 @@ impl HttpResponse {
       }
     }
 
-    if self.allows_body() && !self.uses_chunked_transfer_encoding() {
-      write!(writer, "Content-Length: {}\r\n", self.body.len())?;
+    if self.allows_body() {
+      if self.uses_chunked_transfer_encoding() {
+        self.write_http11_trailer_declaration(writer)?;
+      } else {
+        write!(writer, "Content-Length: {}\r\n", self.body.len())?;
+      }
     }
     if default_connection == DefaultConnectionHeader::ForceClose
       || connection_header_index.is_none()
@@ -3397,6 +3401,24 @@ impl HttpResponse {
       }
     }
 
+    writer.write_all(b"\r\n")
+  }
+
+  fn write_http11_trailer_declaration<W>(&self, writer: &mut W) -> io::Result<()>
+  where
+    W: Write,
+  {
+    if self.trailers.is_empty() {
+      return Ok(());
+    }
+
+    writer.write_all(b"Trailer: ")?;
+    for (index, trailer) in self.trailers.iter().enumerate() {
+      if index > 0 {
+        writer.write_all(b", ")?;
+      }
+      writer.write_all(trailer.name.as_bytes())?;
+    }
     writer.write_all(b"\r\n")
   }
 
@@ -3466,6 +3488,13 @@ impl HttpResponse {
       return false;
     }
     if !self.allows_body() && header.name.eq_ignore_ascii_case("Transfer-Encoding") {
+      return false;
+    }
+    if self.allows_body()
+      && self.uses_chunked_transfer_encoding()
+      && !self.trailers.is_empty()
+      && header.name.eq_ignore_ascii_case("Trailer")
+    {
       return false;
     }
     if !header.name.eq_ignore_ascii_case("Connection") {

--- a/rttp/tests/test_server.rs
+++ b/rttp/tests/test_server.rs
@@ -3400,6 +3400,7 @@ fn server_writes_chunked_response_trailers_on_live_connection() {
     concat!(
       "HTTP/1.1 200 OK\r\n",
       "Transfer-Encoding: chunked\r\n",
+      "Trailer: X-Trace, X-Signature\r\n",
       "Connection: close\r\n",
       "\r\n",
       "5\r\n",

--- a/rttp/tests/test_server_models.rs
+++ b/rttp/tests/test_server_models.rs
@@ -400,6 +400,7 @@ fn serializes_chunked_response_trailers() {
     concat!(
       "HTTP/1.1 200 OK\r\n",
       "Transfer-Encoding: chunked\r\n",
+      "Trailer: X-Trace, X-Signature\r\n",
       "\r\n",
       "5\r\n",
       "hello\r\n",
@@ -470,6 +471,18 @@ fn rejects_forbidden_response_trailer_names() {
 #[test]
 fn serializes_empty_http_response_without_content_length_for_204() {
   let response = HttpResponse::new(204, "No Content");
+
+  let serialized = response.to_bytes();
+
+  assert_eq!(b"HTTP/1.1 204 No Content\r\n\r\n", serialized.as_slice());
+}
+
+#[test]
+fn omits_chunked_trailer_declaration_for_bodyless_response() {
+  let response = HttpResponse::new(204, "No Content")
+    .header("Transfer-Encoding", "chunked")
+    .trailer("X-Trace", "abc")
+    .body("ignored");
 
   let serialized = response.to_bytes();
 


### PR DESCRIPTION
HTTP/1.1 chunked response trailers now emit matching Trailer declarations without changing bodyless or HTTP/2 response semantics. Workspace verification passes.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1435/
work_kind: code_work
branch: hbx-1435-rttp-generate-http-1-1
base: main
commit: 8a447c453db444788e09c72beac3ff3f961258ff
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1435/
    url: https://plane.kahub.in/endless/browse/HBX-1435/
    close_policy: link_only
```