### PR TITLE
feat: [rttp_client] Support prior-knowledge h2c HEAD requests

### DIFF
--- a/rttp_client/src/http2.rs
+++ b/rttp_client/src/http2.rs
@@ -94,14 +94,15 @@ impl<'a> PriorKnowledgeClient<'a> {
 
   pub fn get(mut self) -> error::Result<Response> {
     let method = self.request.origin().method();
-    if method.eq_ignore_ascii_case("GET") && self.request.body().is_some() {
+    let is_head = method.eq_ignore_ascii_case("HEAD");
+    if (method.eq_ignore_ascii_case("GET") || is_head) && self.request.body().is_some() {
       return Err(error::builder_with_message(
-        "HTTP/2 prior-knowledge GET cannot send a request body",
+        "HTTP/2 prior-knowledge GET or HEAD cannot send a request body",
       ));
     }
     if !is_supported_request_method(method) {
       return Err(error::builder_with_message(
-        "HTTP/2 prior-knowledge client supports GET and buffered POST, PUT, or PATCH",
+        "HTTP/2 prior-knowledge client supports GET, HEAD, and buffered POST, PUT, or PATCH",
       ));
     }
 
@@ -121,7 +122,7 @@ impl<'a> PriorKnowledgeClient<'a> {
       peer_settings,
     )? {
       Some(response) => response,
-      None => read_single_stream_response(&mut stream, self.request.url().clone())?,
+      None => read_single_stream_response(&mut stream, self.request.url().clone(), !is_head)?,
     };
     self.request.origin_mut().closed_set(true);
     Ok(response)
@@ -130,6 +131,7 @@ impl<'a> PriorKnowledgeClient<'a> {
 
 fn is_supported_request_method(method: &str) -> bool {
   method.eq_ignore_ascii_case("GET")
+    || method.eq_ignore_ascii_case("HEAD")
     || method.eq_ignore_ascii_case("POST")
     || method.eq_ignore_ascii_case("PUT")
     || method.eq_ignore_ascii_case("PATCH")
@@ -698,8 +700,12 @@ struct PendingHeaderBlock {
   end_stream: bool,
 }
 
-fn read_single_stream_response(stream: &mut TcpStream, url: RoUrl) -> error::Result<Response> {
-  read_single_stream_response_with_first_frame(stream, url, None)
+fn read_single_stream_response(
+  stream: &mut TcpStream,
+  url: RoUrl,
+  include_data_payload: bool,
+) -> error::Result<Response> {
+  read_single_stream_response_with_first_frame(stream, url, None, include_data_payload)
 }
 
 fn read_single_stream_response_from_frame(
@@ -707,13 +713,14 @@ fn read_single_stream_response_from_frame(
   url: RoUrl,
   first_frame: Frame,
 ) -> error::Result<Response> {
-  read_single_stream_response_with_first_frame(stream, url, Some(first_frame))
+  read_single_stream_response_with_first_frame(stream, url, Some(first_frame), true)
 }
 
 fn read_single_stream_response_with_first_frame(
   stream: &mut TcpStream,
   url: RoUrl,
   mut first_frame: Option<Frame>,
+  include_data_payload: bool,
 ) -> error::Result<Response> {
   let mut header_block = Vec::new();
   let mut headers = Vec::new();
@@ -810,7 +817,9 @@ fn read_single_stream_response_with_first_frame(
         let end_stream = frame.flags & FLAG_END_STREAM == FLAG_END_STREAM;
         let data = data_payload(&frame)?;
         response_body_started = true;
-        body.extend_from_slice(data);
+        if include_data_payload {
+          body.extend_from_slice(data);
+        }
         let stream_update = stream_receive_window.consume(frame.payload.len())?;
         let connection_update = connection_receive_window.consume(frame.payload.len())?;
         if !end_stream && (stream_update > 0 || connection_update > 0) {

--- a/rttp_client/tests/http2_prior_knowledge.rs
+++ b/rttp_client/tests/http2_prior_knowledge.rs
@@ -113,6 +113,54 @@ fn prior_knowledge_get_sends_h2_handshake_and_reads_single_response_stream() {
 }
 
 #[test]
+fn prior_knowledge_head_sends_no_request_body_and_ignores_response_data_payload() {
+  let listener = TcpListener::bind("127.0.0.1:0").expect("bind h2 peer");
+  let addr = listener.local_addr().expect("h2 peer addr");
+
+  let handle = thread::spawn(move || {
+    let (mut stream, _) = listener.accept().expect("accept h2 client");
+    stream
+      .set_read_timeout(Some(Duration::from_millis(200)))
+      .expect("set h2 peer read timeout");
+    complete_h2_handshake_without_request(&mut stream);
+
+    let request_headers = read_frame(&mut stream);
+    assert_eq!(FRAME_HEADERS, request_headers.frame_type);
+    assert_eq!(FLAG_END_STREAM | FLAG_END_HEADERS, request_headers.flags);
+    assert_eq!(1, request_headers.stream_id);
+    assert_eq!(
+      b"HEAD",
+      find_header_value(&request_headers.payload, b":method")
+        .expect("request method")
+        .value
+        .as_slice()
+    );
+    assert!(
+      try_read_frame(&mut stream)
+        .expect("check for unexpected request body")
+        .is_none(),
+      "HEAD request must not send DATA frames"
+    );
+
+    write_frame(&mut stream, FRAME_SETTINGS, FLAG_ACK, 0, &[]);
+    write_frame(&mut stream, FRAME_HEADERS, FLAG_END_HEADERS, 1, &[0x88]);
+    write_frame(&mut stream, FRAME_DATA, FLAG_END_STREAM, 1, b"not payload");
+  });
+
+  let response = HttpClient::new()
+    .head()
+    .url(format!("http://{}/metadata", addr))
+    .emit_http2_prior_knowledge()
+    .expect("h2 HEAD response");
+
+  assert_eq!(200, response.code());
+  assert_eq!("HTTP/2", response.version());
+  assert_eq!(b"", response.body().binary());
+
+  handle.join().expect("h2 HEAD peer thread");
+}
+
+#[test]
 fn prior_knowledge_request_literals_use_huffman_only_when_smaller() {
   let listener = TcpListener::bind("127.0.0.1:0").expect("bind h2 peer");
   let addr = listener.local_addr().expect("h2 peer addr");


### PR DESCRIPTION
Adds prior-knowledge h2c `HEAD` support for `rttp_client`, including header-only request framing and bodyless response handling for `HEAD`.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1438/
work_kind: code_work
branch: hbx-1438-rttp-client-support-prior-knowledge
base: main
commit: e67b05651345f1f019fe75cdc54e1d6152eeaed5
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1438/
    url: https://plane.kahub.in/endless/browse/HBX-1438/
    close_policy: link_only
```