### PR TITLE
feat: [rttp] Suppress prior-knowledge h2c server response bodies for HEAD

### DIFF
--- a/rttp/src/server.rs
+++ b/rttp/src/server.rs
@@ -1859,6 +1859,16 @@ fn write_http2_response(
   let mut header_encoder = Http2HeaderEncoder::new(HTTP2_DEFAULT_HEADER_TABLE_SIZE);
   let dynamic_candidates = repeated_http2_response_fields(response);
   let headers = encode_http2_response_headers(response, &mut header_encoder, &dynamic_candidates)?;
+  if !write_body {
+    write_http2_header_block(
+      stream,
+      stream_id,
+      HTTP2_FLAG_END_STREAM,
+      &headers,
+      *flow_control.max_frame_size,
+    )?;
+    return stream.flush();
+  }
   let write_trailers = write_body && response.allows_body() && !response.trailers().is_empty();
   write_http2_header_block(stream, stream_id, 0, &headers, *flow_control.max_frame_size)?;
   let body = if write_body && response.allows_body() {

--- a/rttp/tests/http2_feature.rs
+++ b/rttp/tests/http2_feature.rs
@@ -160,6 +160,14 @@ fn h2_post_headers(path: &[u8], authority: &[u8]) -> Vec<u8> {
   headers
 }
 
+fn h2_head_headers(path: &[u8], authority: &[u8]) -> Vec<u8> {
+  let mut headers = vec![0x86];
+  headers.extend(h2_literal_indexed_name(2, b"HEAD"));
+  headers.extend(h2_literal_indexed_name(4, path));
+  headers.extend(h2_literal_indexed_name(1, authority));
+  headers
+}
+
 fn find_request_path(block: &[u8]) -> Option<Vec<u8>> {
   let mut cursor = 0;
   while cursor < block.len() {
@@ -643,6 +651,57 @@ fn prior_knowledge_server_acknowledges_valid_settings_payload_and_serves_request
   assert_eq!(H2_FRAME_DATA, response_body.frame_type);
   assert_eq!(H2_FLAG_END_STREAM, response_body.flags);
   assert_eq!(b"settings accepted", response_body.payload.as_slice());
+
+  handle.join().expect("server thread");
+}
+
+#[test]
+fn prior_knowledge_server_ends_head_response_on_headers_without_data_frame() {
+  let server = rttp::Http::server("127.0.0.1:0")
+    .expect("bind server")
+    .with_read_timeout(Some(Duration::from_secs(2)))
+    .with_write_timeout(Some(Duration::from_secs(2)));
+  let addr = server.local_addr().expect("server addr");
+
+  let handle = thread::spawn(move || {
+    server
+      .accept_one(|request| {
+        assert_eq!("HTTP/2", request.version());
+        assert_eq!("HEAD", request.method());
+        assert_eq!("/metadata", request.target());
+        HttpResponse::ok("metadata body")
+      })
+      .expect("serve h2 HEAD request")
+  });
+
+  let mut stream = TcpStream::connect(addr).expect("connect h2 server");
+  stream
+    .set_read_timeout(Some(Duration::from_secs(2)))
+    .expect("set client read timeout");
+  complete_h2_server_handshake_with_settings(&mut stream, &[]);
+  write_h2_frame(
+    &mut stream,
+    H2_FRAME_HEADERS,
+    H2_FLAG_END_HEADERS | H2_FLAG_END_STREAM,
+    1,
+    &h2_head_headers(b"/metadata", addr.to_string().as_bytes()),
+  );
+  stream.flush().expect("flush h2 HEAD request");
+
+  let response_headers = read_h2_frame(&mut stream);
+  assert_eq!(H2_FRAME_HEADERS, response_headers.frame_type);
+  assert_eq!(
+    H2_FLAG_END_HEADERS | H2_FLAG_END_STREAM,
+    response_headers.flags
+  );
+  assert_eq!(1, response_headers.stream_id);
+  stream
+    .set_read_timeout(Some(Duration::from_millis(200)))
+    .expect("set short client read timeout");
+  assert!(
+    try_read_h2_frame(&mut stream).is_err(),
+    "HEAD responses must end on HEADERS without a DATA frame"
+  );
 
   handle.join().expect("server thread");
 }


### PR DESCRIPTION
Prior-knowledge h2c HEAD responses now send headers only and terminate the stream without DATA frames. Regression coverage was added for the socket2 h2c server path, and rttp http2-feature verification passes.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1439/
work_kind: code_work
branch: hbx-1439-rttp-suppress-prior-knowledge-h2c
base: main
commit: 40d7bba32da539aa9445ad58e4d7767753f3dd82
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1439/
    url: https://plane.kahub.in/endless/browse/HBX-1439/
    close_policy: link_only
```