### PR TITLE
feat: [rttp] Document prior-knowledge h2c HEAD coverage and limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,18 +36,21 @@ available through `Response::trailers`, `Response::trailer`, and
 | Upgrade and tunnel handoff | `CONNECT` returns the tunnel socket after a successful `200`; `upgrade()` returns the socket after `101 Switching Protocols` and skips interim `1xx` responses | Upgraded protocols are handed to the caller and are not parsed by `rttp_client` |
 | Redirects | Auto-redirect covers 301, 302, 303, 307, and 308 method/body behavior, relative and absolute `Location` resolution, same- and cross-authority header handling, loop detection, and redirect bounds | Redirects are HTTP client behavior, not a browser policy implementation |
 | Trailers | Chunked response trailers are exposed for blocking and async APIs; streaming chunked uploads can send declared request trailers | Forbidden framing/routing trailer fields are rejected |
-| Prior-knowledge h2c | With `http2`, direct `socket2` h2c sends GET and buffered POST, PUT, or PATCH requests, DATA bodies, trailers, HPACK static Huffman strings, dynamic entries within peer settings, large header blocks, padded incoming frames, and conservative DATA flow control | No TLS ALPN, proxy tunneling to h2, proxy h2, general multiplexing, or priority scheduling |
+| Prior-knowledge h2c | With `http2`, direct `socket2` h2c sends GET, HEAD, and buffered POST, PUT, or PATCH requests, suppresses HEAD response bodies, DATA bodies, trailers, HPACK static Huffman strings, dynamic entries within peer settings, large header blocks, padded incoming frames, and conservative DATA flow control | No TLS ALPN, proxy tunneling to h2, proxy h2, general multiplexing, or priority scheduling |
 
 With the `http2` feature enabled, `emit_http2_prior_knowledge` sends a minimal
 prior-knowledge h2c request over a direct socket2 TCP connection. It supports
-GET and buffered POST, PUT, or PATCH requests, including non-empty buffered
-request bodies as DATA frames, HPACK static Huffman strings, and large header
-blocks via CONTINUATION frames. It uses HPACK dynamic entries for repeated
-request header and trailer fields within the peer's advertised table size, and
-it decodes response dynamic table entries and table-size updates from incoming
-padded HEADERS, DATA, and trailer frames without exposing padding bytes. TLS
-ALPN, proxy tunneling, proxy h2, and full HTTP/2 features such as general
-multiplexing and priority scheduling are not part of that client path.
+GET, HEAD, and buffered POST, PUT, or PATCH requests, including non-empty
+buffered request bodies as DATA frames for the write methods. HEAD requests do
+not send request DATA frames, and any response DATA frames are consumed without
+being exposed as a response body. The client supports HPACK static Huffman
+strings and large header blocks via CONTINUATION frames. It uses HPACK dynamic
+entries for repeated request header and trailer fields within the peer's
+advertised table size, and it decodes response dynamic table entries and
+table-size updates from incoming padded HEADERS, DATA, and trailer frames
+without exposing padding bytes. TLS ALPN, proxy tunneling, proxy h2, and full
+HTTP/2 features such as general multiplexing and priority scheduling are not
+part of that client path.
 
 ```rust,no_run
 use rttp_client::HttpClient;
@@ -110,12 +113,13 @@ honors `Connection` close/keep-alive semantics across a bounded
 `serve_requests` loop, writes response body framing and response trailers
 consistently, and accepts `Expect: 100-continue`. On the same socket2 listener,
 the accept path detects the HTTP/2 client preface and dispatches prior-knowledge
-h2c requests to a minimal single-stream handler. Incoming padded HEADERS, DATA,
-and trailer frames are accepted without exposing padding bytes to handlers, and
-HPACK static Huffman strings, request dynamic table entries, and large header
-blocks are carried with CONTINUATION frames. TLS ALPN, proxy h2, and full
-HTTP/2 features such as multiplexing and priority scheduling remain outside
-this server path.
+h2c requests to a minimal single-stream handler. It preserves the same HEAD
+body suppression for prior-knowledge h2c responses. Incoming padded HEADERS,
+DATA, and trailer frames are accepted without exposing padding bytes to
+handlers, and HPACK static Huffman strings, request dynamic table entries, and
+large header blocks are carried with CONTINUATION frames. TLS ALPN, proxy h2,
+and full HTTP/2 features such as multiplexing and priority scheduling remain
+outside this server path.
 
 It is not a full RFC-covering web server and still does not implement server
 TLS or async accept loops.
@@ -129,4 +133,4 @@ TLS or async accept loops.
 | HTTP/1.1 response framing | Automatic `Content-Length`, explicit chunked responses, bodyless `HEAD`, `101`, `204`, and `304`, response trailers after the terminating chunk | No server TLS |
 | Upgrade and tunnel targets | `CONNECT` authority-form requests are accepted as HTTP requests; `HttpResponse::upgrade` can hand an upgraded socket to caller code after a matching request | The server does not implement the upgraded protocol after handoff |
 | Trailers | Chunked request trailers are preserved on `Request`; malformed, oversized, forbidden, and pseudo-header trailers are rejected; response trailers can be serialized for chunked responses | Trailer names that affect framing or routing are rejected |
-| Prior-knowledge h2c | The same `socket2` listener detects the HTTP/2 preface, validates SETTINGS, serves bounded prior-knowledge streams, accepts padded HEADERS/DATA/trailers without exposing padding, handles HPACK Huffman/dynamic fields and CONTINUATION blocks, and applies conservative DATA flow control | No TLS ALPN, proxy h2, unbounded multiplexing, priority scheduling, or full HTTP/2 server feature set |
+| Prior-knowledge h2c | The same `socket2` listener detects the HTTP/2 preface, validates SETTINGS, serves bounded prior-knowledge streams, handles HEAD without response DATA, accepts padded HEADERS/DATA/trailers without exposing padding, handles HPACK Huffman/dynamic fields and CONTINUATION blocks, and applies conservative DATA flow control | No TLS ALPN, proxy h2, unbounded multiplexing, priority scheduling, or full HTTP/2 server feature set |

--- a/rttp/README.md
+++ b/rttp/README.md
@@ -54,11 +54,12 @@ head/body parsing, handles `HEAD` without writing a response body, honors
 writes response body framing and response trailers consistently, and accepts
 `Expect: 100-continue`. On the same socket2 listener, the accept path detects
 the HTTP/2 client preface and dispatches prior-knowledge h2c requests to a
-minimal bounded handler. Incoming padded HEADERS, DATA, and trailer frames are
-accepted without exposing padding bytes to handlers, HPACK static Huffman
-strings, request dynamic table entries, and large header blocks are carried
-with CONTINUATION frames, and multiple prior-knowledge h2c request streams may
-be open on one connection up to the caller's bounded `serve_requests` loop.
+minimal bounded handler. The h2c path handles `HEAD` without writing response
+DATA frames. Incoming padded HEADERS, DATA, and trailer frames are accepted
+without exposing padding bytes to handlers, HPACK static Huffman strings,
+request dynamic table entries, and large header blocks are carried with
+CONTINUATION frames, and multiple prior-knowledge h2c request streams may be
+open on one connection up to the caller's bounded `serve_requests` loop.
 Responses are still written synchronously as requests complete. The minimal
 h2c path supports conservative DATA flow-control for prior-knowledge use.
 
@@ -75,19 +76,20 @@ unbounded multiplexing and priority scheduling, or async accept loops.
 | HTTP/1.1 response framing | Automatic `Content-Length`, explicit chunked responses, bodyless `HEAD`, `101`, `204`, and `304`, response trailers after the terminating chunk | No server TLS |
 | Upgrade and tunnel targets | `CONNECT` authority-form requests are accepted as HTTP requests; `HttpResponse::upgrade` can hand an upgraded socket to caller code after a matching request | The server does not implement the upgraded protocol after handoff |
 | Trailers | Chunked request trailers are preserved on `Request`; malformed, oversized, forbidden, and pseudo-header trailers are rejected; response trailers can be serialized for chunked responses | Trailer names that affect framing or routing are rejected |
-| Prior-knowledge h2c | The same `socket2` listener detects the HTTP/2 preface, validates SETTINGS, serves bounded prior-knowledge streams, accepts padded HEADERS/DATA/trailers without exposing padding, handles HPACK Huffman/dynamic fields and CONTINUATION blocks, and applies conservative DATA flow control | No TLS ALPN, proxy h2, unbounded multiplexing, priority scheduling, or full HTTP/2 server feature set |
+| Prior-knowledge h2c | The same `socket2` listener detects the HTTP/2 preface, validates SETTINGS, serves bounded prior-knowledge streams, handles HEAD without response DATA, accepts padded HEADERS/DATA/trailers without exposing padding, handles HPACK Huffman/dynamic fields and CONTINUATION blocks, and applies conservative DATA flow control | No TLS ALPN, proxy h2, unbounded multiplexing, priority scheduling, or full HTTP/2 server feature set |
 
 ## Client feature
 
 Enable the `client` feature to access `rttp::Http::client`, or enable `async`,
 `http2`, `tls-native`, `tls-rustls`, or `all` for the corresponding
 `rttp_client` capabilities. The `http2` feature exposes the minimal
-prior-knowledge h2c client path, including HPACK static Huffman strings,
-request dynamic entries within the peer's advertised table size, response
-dynamic table decoding, large header blocks via CONTINUATION frames, padded
-incoming response frames, and conservative DATA flow-control for single-stream
-prior-knowledge use; TLS ALPN, proxy h2, and full HTTP/2 features such as
-multiplexing and priority scheduling remain outside that path.
+prior-knowledge h2c client path for GET, HEAD, and buffered POST, PUT, or PATCH
+requests, including HEAD response body suppression, HPACK static Huffman
+strings, request dynamic entries within the peer's advertised table size,
+response dynamic table decoding, large header blocks via CONTINUATION frames,
+padded incoming response frames, and conservative DATA flow-control for
+single-stream prior-knowledge use; TLS ALPN, proxy h2, and full HTTP/2 features
+such as multiplexing and priority scheduling remain outside that path.
 
 Direct TCP client connections use `socket2`. SOCKS proxy handshakes remain
 delegated to the `socks` crate.

--- a/rttp_client/README.md
+++ b/rttp_client/README.md
@@ -36,17 +36,20 @@ through `Response::trailers`, `Response::trailer`, and
 | Upgrade and tunnel handoff | `CONNECT` returns the tunnel socket after a successful `200`; `upgrade()` returns the socket after `101 Switching Protocols` and skips interim `1xx` responses | Upgraded protocols are handed to the caller and are not parsed by `rttp_client` |
 | Redirects | Auto-redirect covers 301, 302, 303, 307, and 308 method/body behavior, relative and absolute `Location` resolution, same- and cross-authority header handling, loop detection, and redirect bounds | Redirects are HTTP client behavior, not a browser policy implementation |
 | Trailers | Chunked response trailers are exposed for blocking and async APIs; streaming chunked uploads can send declared request trailers | Forbidden framing/routing trailer fields are rejected |
-| Prior-knowledge h2c | With `http2`, direct `socket2` h2c sends GET and buffered POST, PUT, or PATCH requests, DATA bodies, trailers, HPACK static Huffman strings, dynamic entries within peer settings, large header blocks, padded incoming frames, and conservative DATA flow control | No TLS ALPN, proxy tunneling to h2, proxy h2, general multiplexing, or priority scheduling |
+| Prior-knowledge h2c | With `http2`, direct `socket2` h2c sends GET, HEAD, and buffered POST, PUT, or PATCH requests, suppresses HEAD response bodies, DATA bodies, trailers, HPACK static Huffman strings, dynamic entries within peer settings, large header blocks, padded incoming frames, and conservative DATA flow control | No TLS ALPN, proxy tunneling to h2, proxy h2, general multiplexing, or priority scheduling |
 
 With the `http2` feature enabled, `emit_http2_prior_knowledge` sends a minimal
-prior-knowledge h2c request over a direct socket2 TCP connection. Non-empty
-buffered request bodies are sent as DATA frames, HPACK static Huffman strings
-and large header blocks are supported, repeated request header and trailer
-fields can use HPACK dynamic entries within the peer's advertised table size,
-and incoming dynamic table entries, table-size updates, padded HEADERS, DATA,
-and trailer frames are decoded without exposing padding bytes. TLS ALPN, proxy
-tunneling, proxy h2, and full HTTP/2 features such as general multiplexing and
-priority scheduling are not part of that client path.
+prior-knowledge h2c request over a direct socket2 TCP connection. It supports
+GET, HEAD, and buffered POST, PUT, or PATCH requests. Non-empty buffered
+request bodies are sent as DATA frames for the write methods; HEAD requests do
+not send request DATA frames, and any response DATA frames are consumed without
+being exposed as a response body. HPACK static Huffman strings and large header
+blocks are supported, repeated request header and trailer fields can use HPACK
+dynamic entries within the peer's advertised table size, and incoming dynamic
+table entries, table-size updates, padded HEADERS, DATA, and trailer frames are
+decoded without exposing padding bytes. TLS ALPN, proxy tunneling, proxy h2,
+and full HTTP/2 features such as general multiplexing and priority scheduling
+are not part of that client path.
 
 ## Examples
 


### PR DESCRIPTION
Documented prior-knowledge h2c HEAD support and limits in the README coverage text for `rttp`, `rttp_client`, and the workspace README.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1441/
work_kind: code_work
branch: hbx-1441-rttp-document-prior-knowledge-h2c
base: main
commit: d543c214273b2cc6261f75dde4f929980420c4d9
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1441/
    url: https://plane.kahub.in/endless/browse/HBX-1441/
    close_policy: link_only
```