### PR TITLE
feat: [rttp_client] Support prior-knowledge h2c DELETE requests

### DIFF
--- a/rttp/README.md
+++ b/rttp/README.md
@@ -83,8 +83,9 @@ unbounded multiplexing and priority scheduling, or async accept loops.
 Enable the `client` feature to access `rttp::Http::client`, or enable `async`,
 `http2`, `tls-native`, `tls-rustls`, or `all` for the corresponding
 `rttp_client` capabilities. The `http2` feature exposes the minimal
-prior-knowledge h2c client path for GET, HEAD, and buffered POST, PUT, or PATCH
-requests, including HEAD response body suppression, HPACK static Huffman
+prior-knowledge h2c client path for GET, HEAD, bodyless DELETE, and buffered
+POST, PUT, or PATCH requests, including HEAD response body suppression, HPACK
+static Huffman
 strings, request dynamic entries within the peer's advertised table size,
 response dynamic table decoding, large header blocks via CONTINUATION frames,
 padded incoming response frames, and conservative DATA flow-control for

--- a/rttp_client/README.md
+++ b/rttp_client/README.md
@@ -36,14 +36,15 @@ through `Response::trailers`, `Response::trailer`, and
 | Upgrade and tunnel handoff | `CONNECT` returns the tunnel socket after a successful `200`; `upgrade()` returns the socket after `101 Switching Protocols` and skips interim `1xx` responses | Upgraded protocols are handed to the caller and are not parsed by `rttp_client` |
 | Redirects | Auto-redirect covers 301, 302, 303, 307, and 308 method/body behavior, relative and absolute `Location` resolution, same- and cross-authority header handling, loop detection, and redirect bounds | Redirects are HTTP client behavior, not a browser policy implementation |
 | Trailers | Chunked response trailers are exposed for blocking and async APIs; streaming chunked uploads can send declared request trailers | Forbidden framing/routing trailer fields are rejected |
-| Prior-knowledge h2c | With `http2`, direct `socket2` h2c sends GET, HEAD, and buffered POST, PUT, or PATCH requests, suppresses HEAD response bodies, DATA bodies, trailers, HPACK static Huffman strings, dynamic entries within peer settings, large header blocks, padded incoming frames, and conservative DATA flow control | No TLS ALPN, proxy tunneling to h2, proxy h2, general multiplexing, or priority scheduling |
+| Prior-knowledge h2c | With `http2`, direct `socket2` h2c sends GET, HEAD, bodyless DELETE, and buffered POST, PUT, or PATCH requests, suppresses HEAD response bodies, DATA bodies, trailers, HPACK static Huffman strings, dynamic entries within peer settings, large header blocks, padded incoming frames, and conservative DATA flow control | No TLS ALPN, proxy tunneling to h2, proxy h2, general multiplexing, or priority scheduling |
 
 With the `http2` feature enabled, `emit_http2_prior_knowledge` sends a minimal
 prior-knowledge h2c request over a direct socket2 TCP connection. It supports
-GET, HEAD, and buffered POST, PUT, or PATCH requests. Non-empty buffered
-request bodies are sent as DATA frames for the write methods; HEAD requests do
-not send request DATA frames, and any response DATA frames are consumed without
-being exposed as a response body. HPACK static Huffman strings and large header
+GET, HEAD, bodyless DELETE, and buffered POST, PUT, or PATCH requests.
+Non-empty buffered request bodies are sent as DATA frames for the write methods;
+HEAD and bodyless DELETE requests do not send request DATA frames, and any HEAD
+response DATA frames are consumed without being exposed as a response body.
+HPACK static Huffman strings and large header
 blocks are supported, repeated request header and trailer fields can use HPACK
 dynamic entries within the peer's advertised table size, and incoming dynamic
 table entries, table-size updates, padded HEADERS, DATA, and trailer frames are

--- a/rttp_client/src/http2.rs
+++ b/rttp_client/src/http2.rs
@@ -95,14 +95,20 @@ impl<'a> PriorKnowledgeClient<'a> {
   pub fn get(mut self) -> error::Result<Response> {
     let method = self.request.origin().method();
     let is_head = method.eq_ignore_ascii_case("HEAD");
+    let is_delete = method.eq_ignore_ascii_case("DELETE");
     if (method.eq_ignore_ascii_case("GET") || is_head) && self.request.body().is_some() {
       return Err(error::builder_with_message(
         "HTTP/2 prior-knowledge GET or HEAD cannot send a request body",
       ));
     }
+    if is_delete && self.request.body().is_some() {
+      return Err(error::builder_with_message(
+        "HTTP/2 prior-knowledge DELETE cannot send a request body",
+      ));
+    }
     if !is_supported_request_method(method) {
       return Err(error::builder_with_message(
-        "HTTP/2 prior-knowledge client supports GET, HEAD, and buffered POST, PUT, or PATCH",
+        "HTTP/2 prior-knowledge client supports GET, HEAD, bodyless DELETE, and buffered POST, PUT, or PATCH",
       ));
     }
 
@@ -132,6 +138,7 @@ impl<'a> PriorKnowledgeClient<'a> {
 fn is_supported_request_method(method: &str) -> bool {
   method.eq_ignore_ascii_case("GET")
     || method.eq_ignore_ascii_case("HEAD")
+    || method.eq_ignore_ascii_case("DELETE")
     || method.eq_ignore_ascii_case("POST")
     || method.eq_ignore_ascii_case("PUT")
     || method.eq_ignore_ascii_case("PATCH")

--- a/rttp_client/tests/http2_prior_knowledge.rs
+++ b/rttp_client/tests/http2_prior_knowledge.rs
@@ -161,6 +161,90 @@ fn prior_knowledge_head_sends_no_request_body_and_ignores_response_data_payload(
 }
 
 #[test]
+fn prior_knowledge_delete_without_body_sends_headers_end_stream() {
+  let listener = TcpListener::bind("127.0.0.1:0").expect("bind h2 peer");
+  let addr = listener.local_addr().expect("h2 peer addr");
+
+  let handle = thread::spawn(move || {
+    let (mut stream, _) = listener.accept().expect("accept h2 client");
+    stream
+      .set_read_timeout(Some(Duration::from_millis(200)))
+      .expect("set h2 peer read timeout");
+    complete_h2_handshake_without_request(&mut stream);
+
+    let request_headers = read_frame(&mut stream);
+    assert_eq!(FRAME_HEADERS, request_headers.frame_type);
+    assert_eq!(FLAG_END_STREAM | FLAG_END_HEADERS, request_headers.flags);
+    assert_eq!(1, request_headers.stream_id);
+    assert_eq!(
+      b"DELETE",
+      find_header_value(&request_headers.payload, b":method")
+        .expect("request method")
+        .value
+        .as_slice()
+    );
+    assert!(
+      request_headers.payload.contains(&0x86),
+      "DELETE request must send :scheme http"
+    );
+    assert_eq!(
+      addr.to_string().as_bytes(),
+      find_header_value(&request_headers.payload, b":authority")
+        .expect("request authority")
+        .value
+        .as_slice()
+    );
+    assert_eq!(
+      b"/resource?hard=true",
+      find_header_value(&request_headers.payload, b":path")
+        .expect("request path")
+        .value
+        .as_slice()
+    );
+    assert!(
+      try_read_frame(&mut stream)
+        .expect("check for unexpected DELETE body")
+        .is_none(),
+      "bodyless DELETE request must not send DATA frames"
+    );
+
+    write_frame(&mut stream, FRAME_SETTINGS, FLAG_ACK, 0, &[]);
+    write_frame(&mut stream, FRAME_HEADERS, FLAG_END_HEADERS, 1, &[0x88]);
+    write_frame(&mut stream, FRAME_DATA, FLAG_END_STREAM, 1, b"deleted");
+  });
+
+  let response = HttpClient::new()
+    .delete()
+    .url(format!("http://{}/resource?hard=true", addr))
+    .emit_http2_prior_knowledge()
+    .expect("h2 DELETE response");
+
+  assert_eq!(200, response.code());
+  assert_eq!("HTTP/2", response.version());
+  assert_eq!("deleted", response.body().string().unwrap());
+
+  handle.join().expect("h2 DELETE peer thread");
+}
+
+#[test]
+fn prior_knowledge_delete_with_body_is_rejected_before_connecting() {
+  let err = HttpClient::new()
+    .delete()
+    .url("http://127.0.0.1:9/delete-body")
+    .raw("unsupported body")
+    .emit_http2_prior_knowledge()
+    .expect_err("DELETE with a body must be rejected");
+
+  assert!(err.is_builder());
+  assert!(
+    err
+      .to_string()
+      .contains("HTTP/2 prior-knowledge DELETE cannot send a request body"),
+    "unexpected error: {err}"
+  );
+}
+
+#[test]
 fn prior_knowledge_request_literals_use_huffman_only_when_smaller() {
   let listener = TcpListener::bind("127.0.0.1:0").expect("bind h2 peer");
   let addr = listener.local_addr().expect("h2 peer addr");


### PR DESCRIPTION
Adds prior-knowledge h2c support for bodyless DELETE requests in `rttp_client`, including explicit rejection for DELETE bodies, focused integration coverage, and updated capability documentation.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1443/
work_kind: code_work
branch: hbx-1443-rttp-client-support-prior-knowledge
base: main
commit: 1095ed31efa80ff9b1af6e9f0e7da605a6684ee2
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1443/
    url: https://plane.kahub.in/endless/browse/HBX-1443/
    close_policy: link_only
```