### PR TITLE
feat: [rttp_client] Support prior-knowledge h2c OPTIONS requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,15 +36,16 @@ available through `Response::trailers`, `Response::trailer`, and
 | Upgrade and tunnel handoff | `CONNECT` returns the tunnel socket after a successful `200`; `upgrade()` returns the socket after `101 Switching Protocols` and skips interim `1xx` responses | Upgraded protocols are handed to the caller and are not parsed by `rttp_client` |
 | Redirects | Auto-redirect covers 301, 302, 303, 307, and 308 method/body behavior, relative and absolute `Location` resolution, same- and cross-authority header handling, loop detection, and redirect bounds | Redirects are HTTP client behavior, not a browser policy implementation |
 | Trailers | Chunked response trailers are exposed for blocking and async APIs; streaming chunked uploads can send declared request trailers | Forbidden framing/routing trailer fields are rejected |
-| Prior-knowledge h2c | With `http2`, direct `socket2` h2c sends GET, HEAD, bodyless DELETE, and buffered POST, PUT, or PATCH requests, suppresses HEAD response bodies, DATA bodies, trailers, HPACK static Huffman strings, dynamic entries within peer settings, large header blocks, padded incoming frames, and conservative DATA flow control | No TLS ALPN, proxy tunneling to h2, proxy h2, general multiplexing, priority scheduling, or request bodies for GET, HEAD, or DELETE |
+| Prior-knowledge h2c | With `http2`, direct `socket2` h2c sends GET, HEAD, bodyless DELETE or OPTIONS, and buffered POST, PUT, or PATCH requests, suppresses HEAD response bodies, DATA bodies, trailers, HPACK static Huffman strings, dynamic entries within peer settings, large header blocks, padded incoming frames, and conservative DATA flow control | No TLS ALPN, proxy tunneling to h2, proxy h2, general multiplexing, priority scheduling, or request bodies for GET, HEAD, DELETE, or OPTIONS |
 
 With the `http2` feature enabled, `emit_http2_prior_knowledge` sends a minimal
 prior-knowledge h2c request over a direct socket2 TCP connection. It supports
-GET, HEAD, bodyless DELETE, and buffered POST, PUT, or PATCH requests,
+GET, HEAD, bodyless DELETE or OPTIONS, and buffered POST, PUT, or PATCH requests,
 including non-empty buffered request bodies as DATA frames for the write
-methods. GET, HEAD, and DELETE requests with bodies are rejected; HEAD and
-bodyless DELETE requests do not send request DATA frames, and any HEAD response
-DATA frames are consumed without being exposed as a response body. The client
+methods. GET, HEAD, DELETE, and OPTIONS requests with bodies are rejected; HEAD,
+bodyless DELETE, and bodyless OPTIONS requests do not send request DATA frames,
+and any HEAD response DATA frames are consumed without being exposed as a
+response body. The client
 supports HPACK static Huffman
 strings and large header blocks via CONTINUATION frames. It uses HPACK dynamic
 entries for repeated request header and trailer fields within the peer's

--- a/rttp/README.md
+++ b/rttp/README.md
@@ -84,9 +84,9 @@ unbounded multiplexing and priority scheduling, or async accept loops.
 Enable the `client` feature to access `rttp::Http::client`, or enable `async`,
 `http2`, `tls-native`, `tls-rustls`, or `all` for the corresponding
 `rttp_client` capabilities. The `http2` feature exposes the minimal
-prior-knowledge h2c client path for GET, HEAD, bodyless DELETE, and buffered
-POST, PUT, or PATCH requests, including rejection of request bodies for GET,
-HEAD, and DELETE, HEAD response body suppression, HPACK static Huffman
+prior-knowledge h2c client path for GET, HEAD, bodyless DELETE or OPTIONS, and
+buffered POST, PUT, or PATCH requests, including rejection of request bodies for
+GET, HEAD, DELETE, and OPTIONS, HEAD response body suppression, HPACK static Huffman
 strings, request dynamic entries within the peer's advertised table size,
 response dynamic table decoding, large header blocks via CONTINUATION frames,
 padded incoming response frames, and conservative DATA flow-control for

--- a/rttp_client/README.md
+++ b/rttp_client/README.md
@@ -36,15 +36,16 @@ through `Response::trailers`, `Response::trailer`, and
 | Upgrade and tunnel handoff | `CONNECT` returns the tunnel socket after a successful `200`; `upgrade()` returns the socket after `101 Switching Protocols` and skips interim `1xx` responses | Upgraded protocols are handed to the caller and are not parsed by `rttp_client` |
 | Redirects | Auto-redirect covers 301, 302, 303, 307, and 308 method/body behavior, relative and absolute `Location` resolution, same- and cross-authority header handling, loop detection, and redirect bounds | Redirects are HTTP client behavior, not a browser policy implementation |
 | Trailers | Chunked response trailers are exposed for blocking and async APIs; streaming chunked uploads can send declared request trailers | Forbidden framing/routing trailer fields are rejected |
-| Prior-knowledge h2c | With `http2`, direct `socket2` h2c sends GET, HEAD, bodyless DELETE, and buffered POST, PUT, or PATCH requests, suppresses HEAD response bodies, DATA bodies, trailers, HPACK static Huffman strings, dynamic entries within peer settings, large header blocks, padded incoming frames, and conservative DATA flow control | No TLS ALPN, proxy tunneling to h2, proxy h2, general multiplexing, priority scheduling, or request bodies for GET, HEAD, or DELETE |
+| Prior-knowledge h2c | With `http2`, direct `socket2` h2c sends GET, HEAD, bodyless DELETE or OPTIONS, and buffered POST, PUT, or PATCH requests, suppresses HEAD response bodies, DATA bodies, trailers, HPACK static Huffman strings, dynamic entries within peer settings, large header blocks, padded incoming frames, and conservative DATA flow control | No TLS ALPN, proxy tunneling to h2, proxy h2, general multiplexing, priority scheduling, or request bodies for GET, HEAD, DELETE, or OPTIONS |
 
 With the `http2` feature enabled, `emit_http2_prior_knowledge` sends a minimal
 prior-knowledge h2c request over a direct socket2 TCP connection. It supports
-GET, HEAD, bodyless DELETE, and buffered POST, PUT, or PATCH requests.
+GET, HEAD, bodyless DELETE or OPTIONS, and buffered POST, PUT, or PATCH requests.
 Non-empty buffered request bodies are sent as DATA frames for the write methods;
-GET, HEAD, and DELETE requests with bodies are rejected. HEAD and bodyless
-DELETE requests do not send request DATA frames, and any HEAD response DATA
-frames are consumed without being exposed as a response body.
+GET, HEAD, DELETE, and OPTIONS requests with bodies are rejected. HEAD,
+bodyless DELETE, and bodyless OPTIONS requests do not send request DATA frames,
+and any HEAD response DATA frames are consumed without being exposed as a
+response body.
 HPACK static Huffman strings and large header
 blocks are supported, repeated request header and trailer fields can use HPACK
 dynamic entries within the peer's advertised table size, and incoming dynamic

--- a/rttp_client/src/http2.rs
+++ b/rttp_client/src/http2.rs
@@ -96,6 +96,7 @@ impl<'a> PriorKnowledgeClient<'a> {
     let method = self.request.origin().method();
     let is_head = method.eq_ignore_ascii_case("HEAD");
     let is_delete = method.eq_ignore_ascii_case("DELETE");
+    let is_options = method.eq_ignore_ascii_case("OPTIONS");
     if (method.eq_ignore_ascii_case("GET") || is_head) && self.request.body().is_some() {
       return Err(error::builder_with_message(
         "HTTP/2 prior-knowledge GET or HEAD cannot send a request body",
@@ -106,9 +107,14 @@ impl<'a> PriorKnowledgeClient<'a> {
         "HTTP/2 prior-knowledge DELETE cannot send a request body",
       ));
     }
+    if is_options && self.request.body().is_some() {
+      return Err(error::builder_with_message(
+        "HTTP/2 prior-knowledge OPTIONS cannot send a request body",
+      ));
+    }
     if !is_supported_request_method(method) {
       return Err(error::builder_with_message(
-        "HTTP/2 prior-knowledge client supports GET, HEAD, bodyless DELETE, and buffered POST, PUT, or PATCH",
+        "HTTP/2 prior-knowledge client supports GET, HEAD, bodyless DELETE or OPTIONS, and buffered POST, PUT, or PATCH",
       ));
     }
 
@@ -139,6 +145,7 @@ fn is_supported_request_method(method: &str) -> bool {
   method.eq_ignore_ascii_case("GET")
     || method.eq_ignore_ascii_case("HEAD")
     || method.eq_ignore_ascii_case("DELETE")
+    || method.eq_ignore_ascii_case("OPTIONS")
     || method.eq_ignore_ascii_case("POST")
     || method.eq_ignore_ascii_case("PUT")
     || method.eq_ignore_ascii_case("PATCH")

--- a/rttp_client/tests/http2_prior_knowledge.rs
+++ b/rttp_client/tests/http2_prior_knowledge.rs
@@ -245,6 +245,90 @@ fn prior_knowledge_delete_with_body_is_rejected_before_connecting() {
 }
 
 #[test]
+fn prior_knowledge_options_without_body_sends_headers_end_stream() {
+  let listener = TcpListener::bind("127.0.0.1:0").expect("bind h2 peer");
+  let addr = listener.local_addr().expect("h2 peer addr");
+
+  let handle = thread::spawn(move || {
+    let (mut stream, _) = listener.accept().expect("accept h2 client");
+    stream
+      .set_read_timeout(Some(Duration::from_millis(200)))
+      .expect("set h2 peer read timeout");
+    complete_h2_handshake_without_request(&mut stream);
+
+    let request_headers = read_frame(&mut stream);
+    assert_eq!(FRAME_HEADERS, request_headers.frame_type);
+    assert_eq!(FLAG_END_STREAM | FLAG_END_HEADERS, request_headers.flags);
+    assert_eq!(1, request_headers.stream_id);
+    assert_eq!(
+      b"OPTIONS",
+      find_header_value(&request_headers.payload, b":method")
+        .expect("request method")
+        .value
+        .as_slice()
+    );
+    assert!(
+      request_headers.payload.contains(&0x86),
+      "OPTIONS request must send :scheme http"
+    );
+    assert_eq!(
+      addr.to_string().as_bytes(),
+      find_header_value(&request_headers.payload, b":authority")
+        .expect("request authority")
+        .value
+        .as_slice()
+    );
+    assert_eq!(
+      b"/resource",
+      find_header_value(&request_headers.payload, b":path")
+        .expect("request path")
+        .value
+        .as_slice()
+    );
+    assert!(
+      try_read_frame(&mut stream)
+        .expect("check for unexpected OPTIONS body")
+        .is_none(),
+      "bodyless OPTIONS request must not send DATA frames"
+    );
+
+    write_frame(&mut stream, FRAME_SETTINGS, FLAG_ACK, 0, &[]);
+    write_frame(&mut stream, FRAME_HEADERS, FLAG_END_HEADERS, 1, &[0x88]);
+    write_frame(&mut stream, FRAME_DATA, FLAG_END_STREAM, 1, b"options");
+  });
+
+  let response = HttpClient::new()
+    .options()
+    .url(format!("http://{}/resource", addr))
+    .emit_http2_prior_knowledge()
+    .expect("h2 OPTIONS response");
+
+  assert_eq!(200, response.code());
+  assert_eq!("HTTP/2", response.version());
+  assert_eq!("options", response.body().string().unwrap());
+
+  handle.join().expect("h2 OPTIONS peer thread");
+}
+
+#[test]
+fn prior_knowledge_options_with_body_is_rejected_before_connecting() {
+  let err = HttpClient::new()
+    .options()
+    .url("http://127.0.0.1:9/options-body")
+    .raw("unsupported body")
+    .emit_http2_prior_knowledge()
+    .expect_err("OPTIONS with a body must be rejected");
+
+  assert!(err.is_builder());
+  assert!(
+    err
+      .to_string()
+      .contains("HTTP/2 prior-knowledge OPTIONS cannot send a request body"),
+    "unexpected error: {err}"
+  );
+}
+
+#[test]
 fn prior_knowledge_request_literals_use_huffman_only_when_smaller() {
   let listener = TcpListener::bind("127.0.0.1:0").expect("bind h2 peer");
   let addr = listener.local_addr().expect("h2 peer addr");


### PR DESCRIPTION
Implemented bodyless prior-knowledge h2c `OPTIONS` support in `rttp_client`, including explicit body rejection and focused regression coverage. Workspace formatting and tests pass.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1448/
work_kind: code_work
branch: hbx-1448-rttp-client-support-prior-knowledge
base: main
commit: e52646268dc923b2ab54f3eec21c26002a2c87a8
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1448/
    url: https://plane.kahub.in/endless/browse/HBX-1448/
    close_policy: link_only
```