### PR TITLE
feat: [rttp] Cover prior-knowledge h2c OPTIONS on socket2 server

### DIFF
--- a/rttp/tests/test_server.rs
+++ b/rttp/tests/test_server.rs
@@ -2728,6 +2728,68 @@ fn server_accepts_http2_prior_knowledge_options_asterisk_without_authority() {
 }
 
 #[test]
+fn server_accepts_http2_prior_knowledge_options_origin_form_with_end_stream_once() {
+  let server = rttp::Http::server("127.0.0.1:0").expect("bind server");
+  let addr = server.local_addr().expect("server addr");
+  let (tx, rx) = mpsc::channel();
+
+  let handle = thread::spawn(move || {
+    server
+      .accept_one(|request| {
+        tx.send((
+          request.method().to_string(),
+          request.target().to_string(),
+          request.header("host").map(str::to_string),
+        ))
+        .expect("send h2 origin-form OPTIONS request");
+        HttpResponse::ok("resource options")
+      })
+      .expect("serve h2 origin-form OPTIONS request");
+  });
+
+  let mut stream = TcpStream::connect(addr).expect("connect h2 server");
+  complete_h2_server_handshake(&mut stream);
+  let mut headers = h2_literal_indexed_name(2, b"OPTIONS");
+  headers.push(0x86);
+  headers.extend(h2_literal_indexed_name(4, b"/resource"));
+  headers.extend(h2_literal_indexed_name(1, addr.to_string().as_bytes()));
+  write_h2_frame(
+    &mut stream,
+    H2_FRAME_HEADERS,
+    H2_FLAG_END_HEADERS | H2_FLAG_END_STREAM,
+    1,
+    &headers,
+  );
+
+  let response_headers = read_h2_frame(&mut stream);
+  assert_eq!(H2_FRAME_HEADERS, response_headers.frame_type);
+  assert_eq!(H2_FLAG_END_HEADERS, response_headers.flags);
+  assert_eq!(1, response_headers.stream_id);
+  assert_eq!(
+    0x88, response_headers.payload[0],
+    "200 response must use the HTTP/2 static status entry"
+  );
+
+  let response_body = read_h2_frame(&mut stream);
+  assert_eq!(H2_FRAME_DATA, response_body.frame_type);
+  assert_eq!(H2_FLAG_END_STREAM, response_body.flags);
+  assert_eq!(1, response_body.stream_id);
+  assert_eq!(b"resource options", response_body.payload.as_slice());
+
+  let request = rx.recv().expect("receive h2 origin-form OPTIONS request");
+  assert_eq!(
+    (
+      "OPTIONS".to_string(),
+      "/resource".to_string(),
+      Some(addr.to_string())
+    ),
+    request
+  );
+  assert!(rx.try_recv().is_err(), "handler must run exactly once");
+  handle.join().expect("server thread");
+}
+
+#[test]
 fn server_rejects_http2_prior_knowledge_request_duplicate_pseudo_header() {
   let mut headers = vec![0x82, 0x82, 0x86];
   headers.extend(h2_literal_indexed_name(4, b"/duplicate-method"));


### PR DESCRIPTION
Focused h2c socket2 server coverage now verifies origin-form `OPTIONS /resource` with `END_STREAM`, single handler delivery, and correct HTTP/2 response framing while preserving existing `OPTIONS *` behavior.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1449/
work_kind: code_work
branch: hbx-1449-rttp-cover-prior-knowledge-h2c
base: main
commit: 87326546f6c27c9ca6982a2ff6f73ae076ea2eb6
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1449/
    url: https://plane.kahub.in/endless/browse/HBX-1449/
    close_policy: link_only
```