### PR TITLE
feat: [rttp_client] Support prior-knowledge h2c TRACE requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,14 +36,14 @@ available through `Response::trailers`, `Response::trailer`, and
 | Upgrade and tunnel handoff | `CONNECT` returns the tunnel socket after a successful `200`; `upgrade()` returns the socket after `101 Switching Protocols` and skips interim `1xx` responses | Upgraded protocols are handed to the caller and are not parsed by `rttp_client` |
 | Redirects | Auto-redirect covers 301, 302, 303, 307, and 308 method/body behavior, relative and absolute `Location` resolution, same- and cross-authority header handling, loop detection, and redirect bounds | Redirects are HTTP client behavior, not a browser policy implementation |
 | Trailers | Chunked response trailers are exposed for blocking and async APIs; streaming chunked uploads can send declared request trailers | Forbidden framing/routing trailer fields are rejected |
-| Prior-knowledge h2c | With `http2`, direct `socket2` h2c sends GET, HEAD, bodyless DELETE or OPTIONS, and buffered POST, PUT, or PATCH requests, suppresses HEAD response bodies, DATA bodies, trailers, HPACK static Huffman strings, dynamic entries within peer settings, large header blocks, padded incoming frames, and conservative DATA flow control | No TLS ALPN, proxy tunneling to h2, proxy h2, general multiplexing, priority scheduling, or request bodies for GET, HEAD, DELETE, or OPTIONS |
+| Prior-knowledge h2c | With `http2`, direct `socket2` h2c sends GET, HEAD, bodyless DELETE, OPTIONS, or TRACE, and buffered POST, PUT, or PATCH requests, suppresses HEAD response bodies, DATA bodies, trailers, HPACK static Huffman strings, dynamic entries within peer settings, large header blocks, padded incoming frames, and conservative DATA flow control | No TLS ALPN, proxy tunneling to h2, proxy h2, general multiplexing, priority scheduling, or request bodies for GET, HEAD, DELETE, OPTIONS, or TRACE |
 
 With the `http2` feature enabled, `emit_http2_prior_knowledge` sends a minimal
 prior-knowledge h2c request over a direct socket2 TCP connection. It supports
-GET, HEAD, bodyless DELETE or OPTIONS, and buffered POST, PUT, or PATCH requests,
+GET, HEAD, bodyless DELETE, OPTIONS, or TRACE, and buffered POST, PUT, or PATCH requests,
 including non-empty buffered request bodies as DATA frames for the write
 methods. GET, HEAD, DELETE, and OPTIONS requests with bodies are rejected; HEAD,
-bodyless DELETE, and bodyless OPTIONS requests do not send request DATA frames,
+bodyless DELETE, OPTIONS, and TRACE requests do not send request DATA frames,
 and any HEAD response DATA frames are consumed without being exposed as a
 response body. The client
 supports HPACK static Huffman

--- a/rttp/README.md
+++ b/rttp/README.md
@@ -84,7 +84,7 @@ unbounded multiplexing and priority scheduling, or async accept loops.
 Enable the `client` feature to access `rttp::Http::client`, or enable `async`,
 `http2`, `tls-native`, `tls-rustls`, or `all` for the corresponding
 `rttp_client` capabilities. The `http2` feature exposes the minimal
-prior-knowledge h2c client path for GET, HEAD, bodyless DELETE or OPTIONS, and
+prior-knowledge h2c client path for GET, HEAD, bodyless DELETE, OPTIONS, or TRACE, and
 buffered POST, PUT, or PATCH requests, including rejection of request bodies for
 GET, HEAD, DELETE, and OPTIONS, HEAD response body suppression, HPACK static Huffman
 strings, request dynamic entries within the peer's advertised table size,

--- a/rttp_client/README.md
+++ b/rttp_client/README.md
@@ -36,14 +36,14 @@ through `Response::trailers`, `Response::trailer`, and
 | Upgrade and tunnel handoff | `CONNECT` returns the tunnel socket after a successful `200`; `upgrade()` returns the socket after `101 Switching Protocols` and skips interim `1xx` responses | Upgraded protocols are handed to the caller and are not parsed by `rttp_client` |
 | Redirects | Auto-redirect covers 301, 302, 303, 307, and 308 method/body behavior, relative and absolute `Location` resolution, same- and cross-authority header handling, loop detection, and redirect bounds | Redirects are HTTP client behavior, not a browser policy implementation |
 | Trailers | Chunked response trailers are exposed for blocking and async APIs; streaming chunked uploads can send declared request trailers | Forbidden framing/routing trailer fields are rejected |
-| Prior-knowledge h2c | With `http2`, direct `socket2` h2c sends GET, HEAD, bodyless DELETE or OPTIONS, and buffered POST, PUT, or PATCH requests, suppresses HEAD response bodies, DATA bodies, trailers, HPACK static Huffman strings, dynamic entries within peer settings, large header blocks, padded incoming frames, and conservative DATA flow control | No TLS ALPN, proxy tunneling to h2, proxy h2, general multiplexing, priority scheduling, or request bodies for GET, HEAD, DELETE, or OPTIONS |
+| Prior-knowledge h2c | With `http2`, direct `socket2` h2c sends GET, HEAD, bodyless DELETE, OPTIONS, or TRACE, and buffered POST, PUT, or PATCH requests, suppresses HEAD response bodies, DATA bodies, trailers, HPACK static Huffman strings, dynamic entries within peer settings, large header blocks, padded incoming frames, and conservative DATA flow control | No TLS ALPN, proxy tunneling to h2, proxy h2, general multiplexing, priority scheduling, or request bodies for GET, HEAD, DELETE, OPTIONS, or TRACE |
 
 With the `http2` feature enabled, `emit_http2_prior_knowledge` sends a minimal
 prior-knowledge h2c request over a direct socket2 TCP connection. It supports
-GET, HEAD, bodyless DELETE or OPTIONS, and buffered POST, PUT, or PATCH requests.
+GET, HEAD, bodyless DELETE, OPTIONS, or TRACE, and buffered POST, PUT, or PATCH requests.
 Non-empty buffered request bodies are sent as DATA frames for the write methods;
 GET, HEAD, DELETE, and OPTIONS requests with bodies are rejected. HEAD,
-bodyless DELETE, and bodyless OPTIONS requests do not send request DATA frames,
+bodyless DELETE, OPTIONS, and TRACE requests do not send request DATA frames,
 and any HEAD response DATA frames are consumed without being exposed as a
 response body.
 HPACK static Huffman strings and large header

--- a/rttp_client/src/client.rs
+++ b/rttp_client/src/client.rs
@@ -69,6 +69,11 @@ impl HttpClient {
     self.method("HEAD")
   }
 
+  /// Set trace request
+  pub fn trace(&mut self) -> &mut Self {
+    self.method("TRACE")
+  }
+
   /// Set request by method
   pub fn method<S: AsRef<str>>(&mut self, method: S) -> &mut Self {
     self.request.method_set(method);

--- a/rttp_client/src/http2.rs
+++ b/rttp_client/src/http2.rs
@@ -97,6 +97,7 @@ impl<'a> PriorKnowledgeClient<'a> {
     let is_head = method.eq_ignore_ascii_case("HEAD");
     let is_delete = method.eq_ignore_ascii_case("DELETE");
     let is_options = method.eq_ignore_ascii_case("OPTIONS");
+    let is_trace = method.eq_ignore_ascii_case("TRACE");
     if (method.eq_ignore_ascii_case("GET") || is_head) && self.request.body().is_some() {
       return Err(error::builder_with_message(
         "HTTP/2 prior-knowledge GET or HEAD cannot send a request body",
@@ -112,9 +113,14 @@ impl<'a> PriorKnowledgeClient<'a> {
         "HTTP/2 prior-knowledge OPTIONS cannot send a request body",
       ));
     }
+    if is_trace && self.request.body().is_some() {
+      return Err(error::builder_with_message(
+        "HTTP/2 prior-knowledge TRACE cannot send a request body",
+      ));
+    }
     if !is_supported_request_method(method) {
       return Err(error::builder_with_message(
-        "HTTP/2 prior-knowledge client supports GET, HEAD, bodyless DELETE or OPTIONS, and buffered POST, PUT, or PATCH",
+        "HTTP/2 prior-knowledge client supports GET, HEAD, bodyless DELETE, OPTIONS, or TRACE, and buffered POST, PUT, or PATCH",
       ));
     }
 
@@ -146,6 +152,7 @@ fn is_supported_request_method(method: &str) -> bool {
     || method.eq_ignore_ascii_case("HEAD")
     || method.eq_ignore_ascii_case("DELETE")
     || method.eq_ignore_ascii_case("OPTIONS")
+    || method.eq_ignore_ascii_case("TRACE")
     || method.eq_ignore_ascii_case("POST")
     || method.eq_ignore_ascii_case("PUT")
     || method.eq_ignore_ascii_case("PATCH")

--- a/rttp_client/tests/http2_prior_knowledge.rs
+++ b/rttp_client/tests/http2_prior_knowledge.rs
@@ -329,6 +329,90 @@ fn prior_knowledge_options_with_body_is_rejected_before_connecting() {
 }
 
 #[test]
+fn prior_knowledge_trace_without_body_sends_headers_end_stream() {
+  let listener = TcpListener::bind("127.0.0.1:0").expect("bind h2 peer");
+  let addr = listener.local_addr().expect("h2 peer addr");
+
+  let handle = thread::spawn(move || {
+    let (mut stream, _) = listener.accept().expect("accept h2 client");
+    stream
+      .set_read_timeout(Some(Duration::from_millis(200)))
+      .expect("set h2 peer read timeout");
+    complete_h2_handshake_without_request(&mut stream);
+
+    let request_headers = read_frame(&mut stream);
+    assert_eq!(FRAME_HEADERS, request_headers.frame_type);
+    assert_eq!(FLAG_END_STREAM | FLAG_END_HEADERS, request_headers.flags);
+    assert_eq!(1, request_headers.stream_id);
+    assert_eq!(
+      b"TRACE",
+      find_header_value(&request_headers.payload, b":method")
+        .expect("request method")
+        .value
+        .as_slice()
+    );
+    assert!(
+      request_headers.payload.contains(&0x86),
+      "TRACE request must send :scheme http"
+    );
+    assert_eq!(
+      addr.to_string().as_bytes(),
+      find_header_value(&request_headers.payload, b":authority")
+        .expect("request authority")
+        .value
+        .as_slice()
+    );
+    assert_eq!(
+      b"/diagnostics?loopback=true",
+      find_header_value(&request_headers.payload, b":path")
+        .expect("request path")
+        .value
+        .as_slice()
+    );
+    assert!(
+      try_read_frame(&mut stream)
+        .expect("check for unexpected TRACE body")
+        .is_none(),
+      "bodyless TRACE request must not send DATA frames"
+    );
+
+    write_frame(&mut stream, FRAME_SETTINGS, FLAG_ACK, 0, &[]);
+    write_frame(&mut stream, FRAME_HEADERS, FLAG_END_HEADERS, 1, &[0x88]);
+    write_frame(&mut stream, FRAME_DATA, FLAG_END_STREAM, 1, b"traced");
+  });
+
+  let response = HttpClient::new()
+    .trace()
+    .url(format!("http://{}/diagnostics?loopback=true", addr))
+    .emit_http2_prior_knowledge()
+    .expect("h2 TRACE response");
+
+  assert_eq!(200, response.code());
+  assert_eq!("HTTP/2", response.version());
+  assert_eq!("traced", response.body().string().unwrap());
+
+  handle.join().expect("h2 TRACE peer thread");
+}
+
+#[test]
+fn prior_knowledge_trace_with_body_is_rejected_before_connecting() {
+  let err = HttpClient::new()
+    .trace()
+    .url("http://127.0.0.1:9/trace-body")
+    .raw("unsupported body")
+    .emit_http2_prior_knowledge()
+    .expect_err("TRACE with a body must be rejected");
+
+  assert!(err.is_builder());
+  assert!(
+    err
+      .to_string()
+      .contains("HTTP/2 prior-knowledge TRACE cannot send a request body"),
+    "unexpected error: {err}"
+  );
+}
+
+#[test]
 fn prior_knowledge_request_literals_use_huffman_only_when_smaller() {
   let listener = TcpListener::bind("127.0.0.1:0").expect("bind h2 peer");
   let addr = listener.local_addr().expect("h2 peer addr");


### PR DESCRIPTION
rttp_client prior-knowledge h2c now supports bodyless TRACE requests with pre-connect body rejection and focused HTTP/2 coverage.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1453/
work_kind: code_work
branch: hbx-1453-rttp-client-support-prior-knowledge
base: main
commit: 1ab8b56ad21654fc34c36ce802751706b2269acf
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1453/
    url: https://plane.kahub.in/endless/browse/HBX-1453/
    close_policy: link_only
```