### PR TITLE
feat: [rttp_client] Reject prior-knowledge h2c CONNECT before opening a socket

### DIFF
--- a/rttp_client/src/http2.rs
+++ b/rttp_client/src/http2.rs
@@ -98,6 +98,11 @@ impl<'a> PriorKnowledgeClient<'a> {
     let is_delete = method.eq_ignore_ascii_case("DELETE");
     let is_options = method.eq_ignore_ascii_case("OPTIONS");
     let is_trace = method.eq_ignore_ascii_case("TRACE");
+    if method.eq_ignore_ascii_case("CONNECT") {
+      return Err(error::builder_with_message(
+        "HTTP/2 prior-knowledge CONNECT/proxy tunneling is unsupported",
+      ));
+    }
     if (method.eq_ignore_ascii_case("GET") || is_head) && self.request.body().is_some() {
       return Err(error::builder_with_message(
         "HTTP/2 prior-knowledge GET or HEAD cannot send a request body",

--- a/rttp_client/tests/http2_prior_knowledge.rs
+++ b/rttp_client/tests/http2_prior_knowledge.rs
@@ -245,6 +245,33 @@ fn prior_knowledge_delete_with_body_is_rejected_before_connecting() {
 }
 
 #[test]
+fn prior_knowledge_connect_is_rejected_before_connecting() {
+  let listener = TcpListener::bind("127.0.0.1:0").expect("bind h2 peer");
+  listener
+    .set_nonblocking(true)
+    .expect("set listener nonblocking");
+  let addr = listener.local_addr().expect("h2 peer addr");
+
+  let err = HttpClient::new()
+    .method("CONNECT")
+    .url(format!("http://{}/tunnel", addr))
+    .emit_http2_prior_knowledge()
+    .expect_err("CONNECT must be rejected");
+
+  assert!(err.is_builder());
+  assert!(
+    err
+      .to_string()
+      .contains("HTTP/2 prior-knowledge CONNECT/proxy tunneling is unsupported"),
+    "unexpected error: {err}"
+  );
+  assert!(
+    matches!(listener.accept(), Err(ref err) if err.kind() == io::ErrorKind::WouldBlock),
+    "prior-knowledge CONNECT must not open a server connection"
+  );
+}
+
+#[test]
 fn prior_knowledge_options_without_body_sends_headers_end_stream() {
   let listener = TcpListener::bind("127.0.0.1:0").expect("bind h2 peer");
   let addr = listener.local_addr().expect("h2 peer addr");


### PR DESCRIPTION
rttp_client now rejects prior-knowledge h2c CONNECT/proxy tunneling before opening a socket, with regression coverage proving no server connection is accepted and HTTP/1.1 CONNECT handoff behavior remains intact.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1458/
work_kind: code_work
branch: hbx-1458-rttp-client-reject-prior-knowledge
base: main
commit: 4a2c05f32be0fbe22eba8e0c3921ef4b19449c54
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1458/
    url: https://plane.kahub.in/endless/browse/HBX-1458/
    close_policy: link_only
```