### PR TITLE
feat: [rttp] Reject malformed prior-knowledge h2c CONNECT request headers before handler

### DIFF
--- a/rttp/src/server.rs
+++ b/rttp/src/server.rs
@@ -1148,6 +1148,12 @@ impl DecodedHttp2RequestHeaders {
     let method = self
       .method
       .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "missing HTTP/2 :method"))?;
+    if method.eq_ignore_ascii_case("CONNECT") {
+      return Err(io::Error::new(
+        io::ErrorKind::InvalidData,
+        "HTTP/2 prior-knowledge CONNECT/proxy tunneling is unsupported",
+      ));
+    }
     let target = self
       .target
       .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "missing HTTP/2 :path"))?;

--- a/rttp/tests/test_server.rs
+++ b/rttp/tests/test_server.rs
@@ -2652,6 +2652,24 @@ fn server_rejects_http2_prior_knowledge_request_missing_scheme() {
 }
 
 #[test]
+fn server_rejects_http2_prior_knowledge_connect_without_path_or_scheme_before_handler() {
+  let mut headers = h2_literal_indexed_name(2, b"CONNECT");
+  headers.extend(h2_literal_indexed_name(1, b"example.test:443"));
+
+  assert_invalid_h2_headers_without_handler(&headers);
+}
+
+#[test]
+fn server_rejects_http2_prior_knowledge_connect_authority_form_before_handler() {
+  let mut headers = h2_literal_indexed_name(2, b"CONNECT");
+  headers.push(0x86);
+  headers.extend(h2_literal_indexed_name(4, b"example.test:443"));
+  headers.extend(h2_literal_indexed_name(1, b"example.test:443"));
+
+  assert_invalid_h2_headers_without_handler(&headers);
+}
+
+#[test]
 fn server_rejects_http2_prior_knowledge_hpack_huffman_eos_symbol_before_handler() {
   assert_invalid_h2_headers_without_handler(&h2_get_headers_with_huffman_path(&[
     0xff, 0xff, 0xff, 0xff,


### PR DESCRIPTION
Implemented deterministic rejection of unsupported prior-knowledge h2c CONNECT requests before handler dispatch, with regression tests for classic CONNECT pseudo-header shapes and authority-form CONNECT-shaped header blocks. Requested formatting, package, workspace, and diff checks passed.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1459/
work_kind: code_work
branch: hbx-1459-rttp-reject-malformed-prior-knowledge
base: main
commit: 95c5db9f9077202f0b993a61adc0c602c26919b9
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1459/
    url: https://plane.kahub.in/endless/browse/HBX-1459/
    close_policy: link_only
```