### PR TITLE
feat: [rttp] Document prior-knowledge h2c CONNECT limits without overstating support

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ available through `Response::trailers`, `Response::trailer`, and
 | Upgrade and tunnel handoff | `CONNECT` returns the tunnel socket after a successful `200`; `upgrade()` returns the socket after `101 Switching Protocols` and skips interim `1xx` responses | Upgraded protocols are handed to the caller and are not parsed by `rttp_client` |
 | Redirects | Auto-redirect covers 301, 302, 303, 307, and 308 method/body behavior, relative and absolute `Location` resolution, same- and cross-authority header handling, loop detection, and redirect bounds | Redirects are HTTP client behavior, not a browser policy implementation |
 | Trailers | Chunked response trailers are exposed for blocking and async APIs; streaming chunked uploads can send declared request trailers | Forbidden framing/routing trailer fields are rejected |
-| Prior-knowledge h2c | With `http2`, direct `socket2` h2c sends GET, HEAD, bodyless DELETE, OPTIONS, or TRACE, and buffered POST, PUT, or PATCH requests, suppresses HEAD response bodies, DATA bodies, trailers, HPACK static Huffman strings, dynamic entries within peer settings, large header blocks, padded incoming frames, and conservative DATA flow control | No TLS ALPN, proxy tunneling to h2, proxy h2, general multiplexing, priority scheduling, or request bodies for GET, HEAD, DELETE, OPTIONS, or TRACE |
+| Prior-knowledge h2c | With `http2`, direct `socket2` h2c sends GET, HEAD, bodyless DELETE, OPTIONS, or TRACE, and buffered POST, PUT, or PATCH requests, suppresses HEAD response bodies, DATA bodies, trailers, HPACK static Huffman strings, dynamic entries within peer settings, large header blocks, padded incoming frames, and conservative DATA flow control | `CONNECT` is rejected deterministically before opening a client socket; no TLS ALPN, proxy tunneling to h2, proxy h2, tunnel handoff, general multiplexing, priority scheduling, or request bodies for GET, HEAD, DELETE, OPTIONS, or TRACE |
 
 With the `http2` feature enabled, `emit_http2_prior_knowledge` sends a minimal
 prior-knowledge h2c request over a direct socket2 TCP connection. It supports
@@ -51,9 +51,11 @@ strings and large header blocks via CONTINUATION frames. It uses HPACK dynamic
 entries for repeated request header and trailer fields within the peer's
 advertised table size, and it decodes response dynamic table entries and
 table-size updates from incoming padded HEADERS, DATA, and trailer frames
-without exposing padding bytes. TLS ALPN, proxy tunneling, proxy h2, and full
-HTTP/2 features such as general multiplexing and priority scheduling are not
-part of that client path.
+without exposing padding bytes. HTTP/1.1 `CONNECT` tunnel handoff remains a
+separate client path; prior-knowledge h2c `CONNECT` and proxy tunneling are
+rejected before a client socket is opened. TLS ALPN, proxy h2, tunnel handoff,
+and full HTTP/2 features such as general multiplexing and priority scheduling
+are not part of that client path.
 
 ```rust,no_run
 use rttp_client::HttpClient;
@@ -122,7 +124,9 @@ prior-knowledge h2c responses.
 Incoming padded HEADERS, DATA, and trailer frames are accepted without exposing
 padding bytes to handlers, and HPACK static Huffman strings, request dynamic
 table entries, and large header blocks are carried with CONTINUATION frames.
-TLS ALPN, proxy h2, and full HTTP/2 features such as multiplexing and priority
+The prior-knowledge h2c path does not share the HTTP/1.1 `CONNECT` handoff
+path: h2c `CONNECT` is rejected before handler dispatch. TLS ALPN, proxy h2,
+tunnel handoff, and full HTTP/2 features such as multiplexing and priority
 scheduling remain outside this server path.
 
 It is not a full RFC-covering web server and still does not implement server
@@ -137,4 +141,4 @@ TLS or async accept loops.
 | HTTP/1.1 response framing | Automatic `Content-Length`, explicit chunked responses, bodyless `HEAD`, `101`, `204`, and `304`, response trailers after the terminating chunk | No server TLS |
 | Upgrade and tunnel targets | `CONNECT` authority-form requests are accepted as HTTP requests; `HttpResponse::upgrade` can hand an upgraded socket to caller code after a matching request | The server does not implement the upgraded protocol after handoff |
 | Trailers | Chunked request trailers are preserved on `Request`; malformed, oversized, forbidden, and pseudo-header trailers are rejected; response trailers can be serialized for chunked responses | Trailer names that affect framing or routing are rejected |
-| Prior-knowledge h2c | The same `socket2` listener detects the HTTP/2 preface, validates SETTINGS, serves bounded prior-knowledge streams including bodyless DELETE, OPTIONS, and TRACE, handles HEAD without response DATA, accepts padded HEADERS/DATA/trailers without exposing padding, handles HPACK Huffman/dynamic fields and CONTINUATION blocks, and applies conservative DATA flow control | No TLS ALPN, proxy h2, unbounded multiplexing, priority scheduling, or full HTTP/2 server feature set |
+| Prior-knowledge h2c | The same `socket2` listener detects the HTTP/2 preface, validates SETTINGS, serves bounded prior-knowledge streams including bodyless DELETE, OPTIONS, and TRACE, handles HEAD without response DATA, accepts padded HEADERS/DATA/trailers without exposing padding, handles HPACK Huffman/dynamic fields and CONTINUATION blocks, and applies conservative DATA flow control | `CONNECT` is rejected deterministically before handler dispatch; no TLS ALPN, proxy h2, tunnel handoff, unbounded multiplexing, priority scheduling, or full HTTP/2 server feature set |

--- a/rttp/README.md
+++ b/rttp/README.md
@@ -62,11 +62,14 @@ header blocks are carried with CONTINUATION frames, and multiple prior-knowledge
 h2c request streams may be open on one connection up to the caller's bounded
 `serve_requests` loop.
 Responses are still written synchronously as requests complete. The minimal
-h2c path supports conservative DATA flow-control for prior-knowledge use.
+h2c path supports conservative DATA flow-control for prior-knowledge use. It
+does not share the HTTP/1.1 `CONNECT` handoff path: prior-knowledge h2c
+`CONNECT` is rejected before handler dispatch.
 
 The server is intentionally not a full RFC-covering web server and still does
-not implement server TLS, TLS ALPN, proxy h2, full HTTP/2 features such as
-unbounded multiplexing and priority scheduling, or async accept loops.
+not implement server TLS, TLS ALPN, proxy h2, h2c tunnel handoff, full HTTP/2
+features such as unbounded multiplexing and priority scheduling, or async
+accept loops.
 
 ## Tested server protocol coverage
 
@@ -77,7 +80,7 @@ unbounded multiplexing and priority scheduling, or async accept loops.
 | HTTP/1.1 response framing | Automatic `Content-Length`, explicit chunked responses, bodyless `HEAD`, `101`, `204`, and `304`, response trailers after the terminating chunk | No server TLS |
 | Upgrade and tunnel targets | `CONNECT` authority-form requests are accepted as HTTP requests; `HttpResponse::upgrade` can hand an upgraded socket to caller code after a matching request | The server does not implement the upgraded protocol after handoff |
 | Trailers | Chunked request trailers are preserved on `Request`; malformed, oversized, forbidden, and pseudo-header trailers are rejected; response trailers can be serialized for chunked responses | Trailer names that affect framing or routing are rejected |
-| Prior-knowledge h2c | The same `socket2` listener detects the HTTP/2 preface, validates SETTINGS, serves bounded prior-knowledge streams including bodyless DELETE, OPTIONS, and TRACE, handles HEAD without response DATA, accepts padded HEADERS/DATA/trailers without exposing padding, handles HPACK Huffman/dynamic fields and CONTINUATION blocks, and applies conservative DATA flow control | No TLS ALPN, proxy h2, unbounded multiplexing, priority scheduling, or full HTTP/2 server feature set |
+| Prior-knowledge h2c | The same `socket2` listener detects the HTTP/2 preface, validates SETTINGS, serves bounded prior-knowledge streams including bodyless DELETE, OPTIONS, and TRACE, handles HEAD without response DATA, accepts padded HEADERS/DATA/trailers without exposing padding, handles HPACK Huffman/dynamic fields and CONTINUATION blocks, and applies conservative DATA flow control | `CONNECT` is rejected deterministically before handler dispatch; no TLS ALPN, proxy h2, tunnel handoff, unbounded multiplexing, priority scheduling, or full HTTP/2 server feature set |
 
 ## Client feature
 
@@ -90,8 +93,11 @@ GET, HEAD, DELETE, OPTIONS, and TRACE, HEAD response body suppression, HPACK sta
 strings, request dynamic entries within the peer's advertised table size,
 response dynamic table decoding, large header blocks via CONTINUATION frames,
 padded incoming response frames, and conservative DATA flow-control for
-single-stream prior-knowledge use; TLS ALPN, proxy h2, and full HTTP/2 features
-such as multiplexing and priority scheduling remain outside that path.
+single-stream prior-knowledge use. HTTP/1.1 `CONNECT` tunnel handoff remains a
+separate path; prior-knowledge h2c `CONNECT` and proxy tunneling are rejected
+before a client socket is opened. TLS ALPN, proxy h2, tunnel handoff, and full
+HTTP/2 features such as multiplexing and priority scheduling remain outside
+that path.
 
 Direct TCP client connections use `socket2`. SOCKS proxy handshakes remain
 delegated to the `socks` crate.

--- a/rttp_client/README.md
+++ b/rttp_client/README.md
@@ -36,7 +36,7 @@ through `Response::trailers`, `Response::trailer`, and
 | Upgrade and tunnel handoff | `CONNECT` returns the tunnel socket after a successful `200`; `upgrade()` returns the socket after `101 Switching Protocols` and skips interim `1xx` responses | Upgraded protocols are handed to the caller and are not parsed by `rttp_client` |
 | Redirects | Auto-redirect covers 301, 302, 303, 307, and 308 method/body behavior, relative and absolute `Location` resolution, same- and cross-authority header handling, loop detection, and redirect bounds | Redirects are HTTP client behavior, not a browser policy implementation |
 | Trailers | Chunked response trailers are exposed for blocking and async APIs; streaming chunked uploads can send declared request trailers | Forbidden framing/routing trailer fields are rejected |
-| Prior-knowledge h2c | With `http2`, direct `socket2` h2c sends GET, HEAD, bodyless DELETE, OPTIONS, or TRACE, and buffered POST, PUT, or PATCH requests, suppresses HEAD response bodies, DATA bodies, trailers, HPACK static Huffman strings, dynamic entries within peer settings, large header blocks, padded incoming frames, and conservative DATA flow control | No TLS ALPN, proxy tunneling to h2, proxy h2, general multiplexing, priority scheduling, or request bodies for GET, HEAD, DELETE, OPTIONS, or TRACE |
+| Prior-knowledge h2c | With `http2`, direct `socket2` h2c sends GET, HEAD, bodyless DELETE, OPTIONS, or TRACE, and buffered POST, PUT, or PATCH requests, suppresses HEAD response bodies, DATA bodies, trailers, HPACK static Huffman strings, dynamic entries within peer settings, large header blocks, padded incoming frames, and conservative DATA flow control | `CONNECT` is rejected deterministically before opening a client socket; no TLS ALPN, proxy tunneling to h2, proxy h2, tunnel handoff, general multiplexing, priority scheduling, or request bodies for GET, HEAD, DELETE, OPTIONS, or TRACE |
 
 With the `http2` feature enabled, `emit_http2_prior_knowledge` sends a minimal
 prior-knowledge h2c request over a direct socket2 TCP connection. It supports
@@ -50,9 +50,11 @@ HPACK static Huffman strings and large header
 blocks are supported, repeated request header and trailer fields can use HPACK
 dynamic entries within the peer's advertised table size, and incoming dynamic
 table entries, table-size updates, padded HEADERS, DATA, and trailer frames are
-decoded without exposing padding bytes. TLS ALPN, proxy tunneling, proxy h2,
-and full HTTP/2 features such as general multiplexing and priority scheduling
-are not part of that client path.
+decoded without exposing padding bytes. HTTP/1.1 `CONNECT` tunnel handoff
+remains a separate client path; prior-knowledge h2c `CONNECT` and proxy
+tunneling are rejected before a client socket is opened. TLS ALPN, proxy h2,
+tunnel handoff, and full HTTP/2 features such as general multiplexing and
+priority scheduling are not part of that client path.
 
 ## Examples
 


### PR DESCRIPTION
Updated README documentation to clarify that prior-knowledge h2c rejects CONNECT deterministically while HTTP/1.1 CONNECT handoff remains separate and supported.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1461/
work_kind: code_work
branch: hbx-1461-rttp-document-prior-knowledge-h2c
base: main
commit: 7b30d266750ba32993466c06697fd575a9ea3a07
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1461/
    url: https://plane.kahub.in/endless/browse/HBX-1461/
    close_policy: link_only
```