### PR TITLE
feat: [rttp_client] Validate and ignore prior-knowledge h2c PRIORITY frames while receiving

### DIFF
--- a/rttp_client/src/http2.rs
+++ b/rttp_client/src/http2.rs
@@ -14,6 +14,7 @@ const CLIENT_PREFACE: &[u8; 24] = b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n";
 
 const FRAME_DATA: u8 = 0x0;
 const FRAME_HEADERS: u8 = 0x1;
+const FRAME_PRIORITY: u8 = 0x2;
 const FRAME_RST_STREAM: u8 = 0x3;
 const FRAME_SETTINGS: u8 = 0x4;
 const FRAME_PING: u8 = 0x6;
@@ -509,6 +510,9 @@ fn read_until_send_window_available(
           current_max_frame_size,
         )?;
       }
+      (FRAME_PRIORITY, _) => {
+        validate_priority_frame(&frame)?;
+      }
       (FRAME_RST_STREAM, STREAM_ID) => {
         return Err(error::bad_response("HTTP/2 stream received RST_STREAM"));
       }
@@ -872,6 +876,9 @@ fn read_single_stream_response_with_first_frame(
       (FRAME_WINDOW_UPDATE, _) => {
         window_update_increment(&frame)?;
       }
+      (FRAME_PRIORITY, _) => {
+        validate_priority_frame(&frame)?;
+      }
       (FRAME_RST_STREAM, STREAM_ID) => {
         return Err(error::bad_response("HTTP/2 stream received RST_STREAM"));
       }
@@ -1029,6 +1036,13 @@ fn window_update_increment(frame: &Frame) -> error::Result<u32> {
     ));
   }
   Ok(increment)
+}
+
+fn validate_priority_frame(frame: &Frame) -> error::Result<()> {
+  if frame.stream_id == 0 || frame.payload.len() != 5 {
+    return Err(error::bad_response("invalid HTTP/2 PRIORITY frame"));
+  }
+  Ok(())
 }
 
 fn data_payload(frame: &Frame) -> error::Result<&[u8]> {

--- a/rttp_client/tests/http2_prior_knowledge.rs
+++ b/rttp_client/tests/http2_prior_knowledge.rs
@@ -10,6 +10,7 @@ use rttp_client::HttpClient;
 
 const FRAME_DATA: u8 = 0x0;
 const FRAME_HEADERS: u8 = 0x1;
+const FRAME_PRIORITY: u8 = 0x2;
 const FRAME_RST_STREAM: u8 = 0x3;
 const FRAME_SETTINGS: u8 = 0x4;
 const FRAME_PING: u8 = 0x6;
@@ -1636,6 +1637,67 @@ fn prior_knowledge_ignores_response_headers_priority_metadata() {
   );
   assert_eq!("priority", response.body().string().unwrap());
   handle.join().expect("h2 peer thread");
+}
+
+#[test]
+fn prior_knowledge_ignores_standalone_priority_before_response_headers() {
+  let listener = TcpListener::bind("127.0.0.1:0").expect("bind h2 peer");
+  let addr = listener.local_addr().expect("h2 peer addr");
+
+  let handle = thread::spawn(move || {
+    let (mut stream, _) = listener.accept().expect("accept h2 client");
+    complete_h2_request_handshake(&mut stream);
+
+    write_frame(&mut stream, FRAME_PRIORITY, 0, 1, &[0, 0, 0, 0, 16]);
+    write_frame(&mut stream, FRAME_HEADERS, FLAG_END_HEADERS, 1, &[0x88]);
+    write_frame(&mut stream, FRAME_DATA, FLAG_END_STREAM, 1, b"priority");
+  });
+
+  let response = HttpClient::new()
+    .get()
+    .url(format!("http://{}/standalone-priority", addr))
+    .emit_http2_prior_knowledge()
+    .expect("h2 response with ignored standalone priority");
+
+  assert_eq!(200, response.code());
+  assert_eq!("priority", response.body().string().unwrap());
+  handle.join().expect("h2 peer thread");
+}
+
+#[test]
+fn prior_knowledge_rejects_malformed_standalone_priority_frames() {
+  let cases: &[(&str, u32, &[u8])] = &[
+    ("stream-zero", 0, &[0, 0, 0, 0, 16]),
+    ("short-payload", 1, &[0, 0, 0, 0]),
+    ("long-payload", 1, &[0, 0, 0, 0, 16, 0]),
+  ];
+
+  for (path, stream_id, payload) in cases {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind h2 peer");
+    let addr = listener.local_addr().expect("h2 peer addr");
+    let payload = payload.to_vec();
+
+    let handle = thread::spawn(move || {
+      let (mut stream, _) = listener.accept().expect("accept h2 client");
+      complete_h2_request_handshake(&mut stream);
+
+      write_frame(&mut stream, FRAME_PRIORITY, 0, *stream_id, &payload);
+      write_frame(&mut stream, FRAME_HEADERS, FLAG_END_HEADERS, 1, &[0x88]);
+      write_frame(&mut stream, FRAME_DATA, FLAG_END_STREAM, 1, b"unexpected");
+    });
+
+    let error = HttpClient::new()
+      .get()
+      .url(format!("http://{}/bad-priority-{}", addr, path))
+      .emit_http2_prior_knowledge()
+      .expect_err("malformed PRIORITY frame should be rejected");
+
+    assert!(
+      error.to_string().contains("invalid HTTP/2 PRIORITY frame"),
+      "unexpected error: {error}"
+    );
+    handle.join().expect("h2 peer thread");
+  }
 }
 
 #[test]


### PR DESCRIPTION
Adds rttp_client validation for standalone HTTP/2 PRIORITY frames on the prior-knowledge receive path, ignoring valid scheduling metadata and rejecting malformed frames with regression tests.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1463/
work_kind: code_work
branch: hbx-1463-rttp-client-validate-and-ignore
base: main
commit: 294075c140f79d01c3c644db9672cdf259e2024d
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1463/
    url: https://plane.kahub.in/endless/browse/HBX-1463/
    close_policy: link_only
```