### PR TITLE
feat: [rttp] Document prior-knowledge h2c PRIORITY frame limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ available through `Response::trailers`, `Response::trailer`, and
 | Upgrade and tunnel handoff | `CONNECT` returns the tunnel socket after a successful `200`; `upgrade()` returns the socket after `101 Switching Protocols` and skips interim `1xx` responses | Upgraded protocols are handed to the caller and are not parsed by `rttp_client` |
 | Redirects | Auto-redirect covers 301, 302, 303, 307, and 308 method/body behavior, relative and absolute `Location` resolution, same- and cross-authority header handling, loop detection, and redirect bounds | Redirects are HTTP client behavior, not a browser policy implementation |
 | Trailers | Chunked response trailers are exposed for blocking and async APIs; streaming chunked uploads can send declared request trailers | Forbidden framing/routing trailer fields are rejected |
-| Prior-knowledge h2c | With `http2`, direct `socket2` h2c sends GET, HEAD, bodyless DELETE, OPTIONS, or TRACE, and buffered POST, PUT, or PATCH requests, suppresses HEAD response bodies, DATA bodies, trailers, HPACK static Huffman strings, dynamic entries within peer settings, large header blocks, padded incoming frames, and conservative DATA flow control | `CONNECT` is rejected deterministically before opening a client socket; no TLS ALPN, proxy tunneling to h2, proxy h2, tunnel handoff, general multiplexing, priority scheduling, or request bodies for GET, HEAD, DELETE, OPTIONS, or TRACE |
+| Prior-knowledge h2c | With `http2`, direct `socket2` h2c sends GET, HEAD, bodyless DELETE, OPTIONS, or TRACE, and buffered POST, PUT, or PATCH requests, suppresses HEAD response bodies, DATA bodies, trailers, HPACK static Huffman strings, dynamic entries within peer settings, large header blocks, padded incoming frames, PRIORITY metadata validation without scheduling, and conservative DATA flow control | `CONNECT` is rejected deterministically before opening a client socket; no TLS ALPN, proxy tunneling to h2, proxy h2, tunnel handoff, general multiplexing, priority scheduling, or request bodies for GET, HEAD, DELETE, OPTIONS, or TRACE |
 
 With the `http2` feature enabled, `emit_http2_prior_knowledge` sends a minimal
 prior-knowledge h2c request over a direct socket2 TCP connection. It supports
@@ -51,11 +51,13 @@ strings and large header blocks via CONTINUATION frames. It uses HPACK dynamic
 entries for repeated request header and trailer fields within the peer's
 advertised table size, and it decodes response dynamic table entries and
 table-size updates from incoming padded HEADERS, DATA, and trailer frames
-without exposing padding bytes. HTTP/1.1 `CONNECT` tunnel handoff remains a
-separate client path; prior-knowledge h2c `CONNECT` and proxy tunneling are
-rejected before a client socket is opened. TLS ALPN, proxy h2, tunnel handoff,
-and full HTTP/2 features such as general multiplexing and priority scheduling
-are not part of that client path.
+without exposing padding bytes. Valid response PRIORITY frames and HEADERS
+priority fields are validated and ignored as metadata; malformed priority
+metadata is rejected, and no priority scheduling is performed. HTTP/1.1
+`CONNECT` tunnel handoff remains a separate client path; prior-knowledge h2c
+`CONNECT` and proxy tunneling are rejected before a client socket is opened.
+TLS ALPN, proxy h2, tunnel handoff, and full HTTP/2 features such as general
+multiplexing and priority scheduling are not part of that client path.
 
 ```rust,no_run
 use rttp_client::HttpClient;
@@ -124,6 +126,9 @@ prior-knowledge h2c responses.
 Incoming padded HEADERS, DATA, and trailer frames are accepted without exposing
 padding bytes to handlers, and HPACK static Huffman strings, request dynamic
 table entries, and large header blocks are carried with CONTINUATION frames.
+Valid standalone PRIORITY frames and HEADERS priority fields are validated and
+ignored as metadata; malformed priority metadata is rejected, and request or
+response ordering does not use priority scheduling.
 The prior-knowledge h2c path does not share the HTTP/1.1 `CONNECT` handoff
 path: h2c `CONNECT` is rejected before handler dispatch. TLS ALPN, proxy h2,
 tunnel handoff, and full HTTP/2 features such as multiplexing and priority
@@ -141,4 +146,4 @@ TLS or async accept loops.
 | HTTP/1.1 response framing | Automatic `Content-Length`, explicit chunked responses, bodyless `HEAD`, `101`, `204`, and `304`, response trailers after the terminating chunk | No server TLS |
 | Upgrade and tunnel targets | `CONNECT` authority-form requests are accepted as HTTP requests; `HttpResponse::upgrade` can hand an upgraded socket to caller code after a matching request | The server does not implement the upgraded protocol after handoff |
 | Trailers | Chunked request trailers are preserved on `Request`; malformed, oversized, forbidden, and pseudo-header trailers are rejected; response trailers can be serialized for chunked responses | Trailer names that affect framing or routing are rejected |
-| Prior-knowledge h2c | The same `socket2` listener detects the HTTP/2 preface, validates SETTINGS, serves bounded prior-knowledge streams including bodyless DELETE, OPTIONS, and TRACE, handles HEAD without response DATA, accepts padded HEADERS/DATA/trailers without exposing padding, handles HPACK Huffman/dynamic fields and CONTINUATION blocks, and applies conservative DATA flow control | `CONNECT` is rejected deterministically before handler dispatch; no TLS ALPN, proxy h2, tunnel handoff, unbounded multiplexing, priority scheduling, or full HTTP/2 server feature set |
+| Prior-knowledge h2c | The same `socket2` listener detects the HTTP/2 preface, validates SETTINGS, serves bounded prior-knowledge streams including bodyless DELETE, OPTIONS, and TRACE, handles HEAD without response DATA, accepts padded HEADERS/DATA/trailers without exposing padding, handles HPACK Huffman/dynamic fields and CONTINUATION blocks, validates and ignores valid PRIORITY metadata, and applies conservative DATA flow control | `CONNECT` is rejected deterministically before handler dispatch; no TLS ALPN, proxy h2, tunnel handoff, unbounded multiplexing, priority scheduling, or full HTTP/2 server feature set |

--- a/rttp/README.md
+++ b/rttp/README.md
@@ -57,9 +57,12 @@ the HTTP/2 client preface and dispatches prior-knowledge h2c requests to a
 minimal bounded handler, including bodyless DELETE, OPTIONS, and TRACE
 requests. The h2c path handles `HEAD` without writing response DATA frames.
 Incoming padded HEADERS, DATA, and trailer frames are accepted without exposing
-padding bytes to handlers, HPACK static Huffman strings, request dynamic table entries, and large
-header blocks are carried with CONTINUATION frames, and multiple prior-knowledge
-h2c request streams may be open on one connection up to the caller's bounded
+padding bytes to handlers, HPACK static Huffman strings, request dynamic table
+entries, and large header blocks are carried with CONTINUATION frames. Valid
+standalone PRIORITY frames and HEADERS priority fields are validated and ignored
+as metadata; malformed priority metadata is rejected, and request or response
+ordering does not use priority scheduling. Multiple prior-knowledge h2c request
+streams may be open on one connection up to the caller's bounded
 `serve_requests` loop.
 Responses are still written synchronously as requests complete. The minimal
 h2c path supports conservative DATA flow-control for prior-knowledge use. It
@@ -80,7 +83,7 @@ accept loops.
 | HTTP/1.1 response framing | Automatic `Content-Length`, explicit chunked responses, bodyless `HEAD`, `101`, `204`, and `304`, response trailers after the terminating chunk | No server TLS |
 | Upgrade and tunnel targets | `CONNECT` authority-form requests are accepted as HTTP requests; `HttpResponse::upgrade` can hand an upgraded socket to caller code after a matching request | The server does not implement the upgraded protocol after handoff |
 | Trailers | Chunked request trailers are preserved on `Request`; malformed, oversized, forbidden, and pseudo-header trailers are rejected; response trailers can be serialized for chunked responses | Trailer names that affect framing or routing are rejected |
-| Prior-knowledge h2c | The same `socket2` listener detects the HTTP/2 preface, validates SETTINGS, serves bounded prior-knowledge streams including bodyless DELETE, OPTIONS, and TRACE, handles HEAD without response DATA, accepts padded HEADERS/DATA/trailers without exposing padding, handles HPACK Huffman/dynamic fields and CONTINUATION blocks, and applies conservative DATA flow control | `CONNECT` is rejected deterministically before handler dispatch; no TLS ALPN, proxy h2, tunnel handoff, unbounded multiplexing, priority scheduling, or full HTTP/2 server feature set |
+| Prior-knowledge h2c | The same `socket2` listener detects the HTTP/2 preface, validates SETTINGS, serves bounded prior-knowledge streams including bodyless DELETE, OPTIONS, and TRACE, handles HEAD without response DATA, accepts padded HEADERS/DATA/trailers without exposing padding, handles HPACK Huffman/dynamic fields and CONTINUATION blocks, validates and ignores valid PRIORITY metadata, and applies conservative DATA flow control | `CONNECT` is rejected deterministically before handler dispatch; no TLS ALPN, proxy h2, tunnel handoff, unbounded multiplexing, priority scheduling, or full HTTP/2 server feature set |
 
 ## Client feature
 
@@ -93,11 +96,13 @@ GET, HEAD, DELETE, OPTIONS, and TRACE, HEAD response body suppression, HPACK sta
 strings, request dynamic entries within the peer's advertised table size,
 response dynamic table decoding, large header blocks via CONTINUATION frames,
 padded incoming response frames, and conservative DATA flow-control for
-single-stream prior-knowledge use. HTTP/1.1 `CONNECT` tunnel handoff remains a
-separate path; prior-knowledge h2c `CONNECT` and proxy tunneling are rejected
-before a client socket is opened. TLS ALPN, proxy h2, tunnel handoff, and full
-HTTP/2 features such as multiplexing and priority scheduling remain outside
-that path.
+single-stream prior-knowledge use. Valid response PRIORITY frames and HEADERS
+priority fields are validated and ignored as metadata; malformed priority
+metadata is rejected, and no priority scheduling is performed. HTTP/1.1
+`CONNECT` tunnel handoff remains a separate path; prior-knowledge h2c `CONNECT`
+and proxy tunneling are rejected before a client socket is opened. TLS ALPN,
+proxy h2, tunnel handoff, and full HTTP/2 features such as multiplexing and
+priority scheduling remain outside that path.
 
 Direct TCP client connections use `socket2`. SOCKS proxy handshakes remain
 delegated to the `socks` crate.

--- a/rttp_client/README.md
+++ b/rttp_client/README.md
@@ -36,7 +36,7 @@ through `Response::trailers`, `Response::trailer`, and
 | Upgrade and tunnel handoff | `CONNECT` returns the tunnel socket after a successful `200`; `upgrade()` returns the socket after `101 Switching Protocols` and skips interim `1xx` responses | Upgraded protocols are handed to the caller and are not parsed by `rttp_client` |
 | Redirects | Auto-redirect covers 301, 302, 303, 307, and 308 method/body behavior, relative and absolute `Location` resolution, same- and cross-authority header handling, loop detection, and redirect bounds | Redirects are HTTP client behavior, not a browser policy implementation |
 | Trailers | Chunked response trailers are exposed for blocking and async APIs; streaming chunked uploads can send declared request trailers | Forbidden framing/routing trailer fields are rejected |
-| Prior-knowledge h2c | With `http2`, direct `socket2` h2c sends GET, HEAD, bodyless DELETE, OPTIONS, or TRACE, and buffered POST, PUT, or PATCH requests, suppresses HEAD response bodies, DATA bodies, trailers, HPACK static Huffman strings, dynamic entries within peer settings, large header blocks, padded incoming frames, and conservative DATA flow control | `CONNECT` is rejected deterministically before opening a client socket; no TLS ALPN, proxy tunneling to h2, proxy h2, tunnel handoff, general multiplexing, priority scheduling, or request bodies for GET, HEAD, DELETE, OPTIONS, or TRACE |
+| Prior-knowledge h2c | With `http2`, direct `socket2` h2c sends GET, HEAD, bodyless DELETE, OPTIONS, or TRACE, and buffered POST, PUT, or PATCH requests, suppresses HEAD response bodies, DATA bodies, trailers, HPACK static Huffman strings, dynamic entries within peer settings, large header blocks, padded incoming frames, PRIORITY metadata validation without scheduling, and conservative DATA flow control | `CONNECT` is rejected deterministically before opening a client socket; no TLS ALPN, proxy tunneling to h2, proxy h2, tunnel handoff, general multiplexing, priority scheduling, or request bodies for GET, HEAD, DELETE, OPTIONS, or TRACE |
 
 With the `http2` feature enabled, `emit_http2_prior_knowledge` sends a minimal
 prior-knowledge h2c request over a direct socket2 TCP connection. It supports
@@ -50,11 +50,14 @@ HPACK static Huffman strings and large header
 blocks are supported, repeated request header and trailer fields can use HPACK
 dynamic entries within the peer's advertised table size, and incoming dynamic
 table entries, table-size updates, padded HEADERS, DATA, and trailer frames are
-decoded without exposing padding bytes. HTTP/1.1 `CONNECT` tunnel handoff
-remains a separate client path; prior-knowledge h2c `CONNECT` and proxy
-tunneling are rejected before a client socket is opened. TLS ALPN, proxy h2,
-tunnel handoff, and full HTTP/2 features such as general multiplexing and
-priority scheduling are not part of that client path.
+decoded without exposing padding bytes. Valid response PRIORITY frames and
+HEADERS priority fields are validated and ignored as metadata; malformed
+priority metadata is rejected, and no priority scheduling is performed.
+HTTP/1.1 `CONNECT` tunnel handoff remains a separate client path;
+prior-knowledge h2c `CONNECT` and proxy tunneling are rejected before a client
+socket is opened. TLS ALPN, proxy h2, tunnel handoff, and full HTTP/2 features
+such as general multiplexing and priority scheduling are not part of that
+client path.
 
 ## Examples
 


### PR DESCRIPTION
README documentation now clarifies prior-knowledge h2c PRIORITY metadata validation/ignore behavior while preserving unsupported priority scheduling and HTTP/2 feature-limit boundaries.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1466/
work_kind: code_work
branch: hbx-1466-rttp-document-prior-knowledge-h2c
base: main
commit: 4524b9ce7225f4ce2967db633756337989c56436
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1466/
    url: https://plane.kahub.in/endless/browse/HBX-1466/
    close_policy: link_only
```