### PR TITLE
feat: [rttp] Emit bounded socket2 h2c GOAWAY on graceful request-limit shutdown

### DIFF
--- a/rttp/src/server.rs
+++ b/rttp/src/server.rs
@@ -31,6 +31,7 @@ const HTTP2_STATIC_TABLE_LEN: usize = 61;
 const HTTP2_SETTINGS_ENABLE_PUSH: u16 = 0x2;
 const HTTP2_SETTINGS_INITIAL_WINDOW_SIZE: u16 = 0x4;
 const HTTP2_SETTINGS_MAX_FRAME_SIZE: u16 = 0x5;
+const HTTP2_ERROR_NO_ERROR: u32 = 0x0;
 
 pub struct HttpServer {
   listener: TcpListener,
@@ -400,6 +401,7 @@ impl HttpServer {
     let mut connection_send_window = Http2SendWindow::new(HTTP2_DEFAULT_INITIAL_WINDOW_SIZE);
     let mut request_header_decoder = Http2HeaderDecoder::new(HTTP2_DEFAULT_HEADER_TABLE_SIZE);
     let mut served = 0;
+    let mut last_processed_stream_id = 0;
 
     while served < request_limit {
       let frame = match self.normalize_connection_error(read_http2_frame(&mut stream)) {
@@ -654,8 +656,18 @@ impl HttpServer {
             request_header_decoder: &mut request_header_decoder,
           },
         ))?;
+        last_processed_stream_id = stream_id;
         served += 1;
       }
+    }
+
+    if served == request_limit && last_processed_stream_id != 0 {
+      self.normalize_connection_error(write_http2_goaway(
+        &mut stream,
+        last_processed_stream_id,
+        HTTP2_ERROR_NO_ERROR,
+      ))?;
+      self.normalize_connection_error(stream.flush())?;
     }
 
     Ok(served)
@@ -1147,6 +1159,17 @@ fn write_http2_window_update(
     stream_id,
     &increment.to_be_bytes(),
   )
+}
+
+fn write_http2_goaway(
+  stream: &mut TcpStream,
+  last_stream_id: u32,
+  error_code: u32,
+) -> io::Result<()> {
+  let mut payload = [0; 8];
+  payload[..4].copy_from_slice(&(last_stream_id & 0x7fff_ffff).to_be_bytes());
+  payload[4..].copy_from_slice(&error_code.to_be_bytes());
+  write_http2_frame(stream, HTTP2_FRAME_GOAWAY, 0, 0, &payload)
 }
 
 struct DecodedHttp2RequestHeaders {

--- a/rttp/tests/http2_feature.rs
+++ b/rttp/tests/http2_feature.rs
@@ -15,6 +15,7 @@ const H2_FRAME_PRIORITY: u8 = 0x2;
 const H2_FRAME_RST_STREAM: u8 = 0x3;
 const H2_FRAME_SETTINGS: u8 = 0x4;
 const H2_FRAME_PING: u8 = 0x6;
+const H2_FRAME_GOAWAY: u8 = 0x7;
 const H2_FRAME_WINDOW_UPDATE: u8 = 0x8;
 const H2_FLAG_END_STREAM: u8 = 0x1;
 const H2_FLAG_ACK: u8 = 0x1;
@@ -716,9 +717,21 @@ fn prior_knowledge_server_ends_head_response_on_headers_without_data_frame() {
   stream
     .set_read_timeout(Some(Duration::from_millis(200)))
     .expect("set short client read timeout");
-  assert!(
-    try_read_h2_frame(&mut stream).is_err(),
-    "HEAD responses must end on HEADERS without a DATA frame"
+  let shutdown = read_h2_frame(&mut stream);
+  assert_eq!(
+    H2_FRAME_GOAWAY, shutdown.frame_type,
+    "HEAD responses must end on HEADERS before graceful shutdown"
+  );
+  assert_eq!(0, shutdown.flags);
+  assert_eq!(0, shutdown.stream_id);
+  assert_eq!(8, shutdown.payload.len());
+  assert_eq!(
+    1,
+    u32::from_be_bytes(shutdown.payload[0..4].try_into().unwrap())
+  );
+  assert_eq!(
+    0,
+    u32::from_be_bytes(shutdown.payload[4..8].try_into().unwrap())
   );
 
   handle.join().expect("server thread");

--- a/rttp/tests/test_server.rs
+++ b/rttp/tests/test_server.rs
@@ -104,6 +104,18 @@ fn h2_window_update(increment: u32) -> [u8; 4] {
   increment.to_be_bytes()
 }
 
+fn h2_goaway_last_stream_id(frame: &H2Frame) -> u32 {
+  assert_eq!(H2_FRAME_GOAWAY, frame.frame_type);
+  assert_eq!(0, frame.flags);
+  assert_eq!(0, frame.stream_id);
+  assert_eq!(8, frame.payload.len());
+  assert_eq!(
+    0,
+    u32::from_be_bytes(frame.payload[4..8].try_into().unwrap())
+  );
+  u32::from_be_bytes(frame.payload[0..4].try_into().unwrap()) & 0x7fff_ffff
+}
+
 fn h2_literal_indexed_name(name_index: u8, value: &[u8]) -> Vec<u8> {
   assert!(value.len() < 128);
   let mut encoded = vec![name_index, value.len() as u8];
@@ -734,6 +746,110 @@ fn server_accepts_http2_prior_knowledge_delete_with_end_stream_once() {
   let request = rx.recv().expect("receive parsed h2 DELETE request");
   assert_eq!(("DELETE".to_string(), "/resource".to_string()), request);
   assert!(rx.try_recv().is_err(), "handler must run exactly once");
+
+  handle.join().expect("server thread");
+}
+
+#[test]
+fn server_sends_http2_prior_knowledge_goaway_after_bounded_request_limit() {
+  let server = rttp::Http::server("127.0.0.1:0")
+    .expect("bind server")
+    .with_read_timeout(Some(Duration::from_secs(2)))
+    .with_write_timeout(Some(Duration::from_secs(2)));
+  let addr = server.local_addr().expect("server addr");
+
+  let handle = thread::spawn(move || {
+    server
+      .serve_requests(1, |request| {
+        HttpResponse::ok(format!("served {}", request.target()))
+      })
+      .expect("serve bounded h2 request");
+  });
+
+  let mut stream = TcpStream::connect(addr).expect("connect h2 server");
+  stream
+    .set_read_timeout(Some(Duration::from_secs(2)))
+    .expect("set h2 read timeout");
+  complete_h2_server_handshake(&mut stream);
+  write_h2_frame(
+    &mut stream,
+    H2_FRAME_HEADERS,
+    H2_FLAG_END_HEADERS | H2_FLAG_END_STREAM,
+    1,
+    &h2_get_headers(b"/bounded", addr.to_string().as_bytes()),
+  );
+
+  let response_headers = read_h2_frame_skipping_window_updates(&mut stream);
+  assert_eq!(H2_FRAME_HEADERS, response_headers.frame_type);
+  assert_eq!(1, response_headers.stream_id);
+  let response_body = read_h2_frame_skipping_window_updates(&mut stream);
+  assert_eq!(H2_FRAME_DATA, response_body.frame_type);
+  assert_eq!(H2_FLAG_END_STREAM, response_body.flags);
+  assert_eq!(1, response_body.stream_id);
+  assert_eq!(b"served /bounded", response_body.payload.as_slice());
+
+  let goaway = read_h2_frame_skipping_window_updates(&mut stream);
+  assert_eq!(1, h2_goaway_last_stream_id(&goaway));
+
+  handle.join().expect("server thread");
+}
+
+#[test]
+fn server_sends_http2_prior_knowledge_goaway_with_last_processed_stream_id() {
+  let server = rttp::Http::server("127.0.0.1:0")
+    .expect("bind server")
+    .with_read_timeout(Some(Duration::from_secs(2)))
+    .with_write_timeout(Some(Duration::from_secs(2)));
+  let addr = server.local_addr().expect("server addr");
+
+  let handle = thread::spawn(move || {
+    server
+      .serve_requests(2, |request| {
+        HttpResponse::ok(format!("served {}", request.target()))
+      })
+      .expect("serve bounded h2 requests");
+  });
+
+  let mut stream = TcpStream::connect(addr).expect("connect h2 server");
+  stream
+    .set_read_timeout(Some(Duration::from_secs(2)))
+    .expect("set h2 read timeout");
+  complete_h2_server_handshake(&mut stream);
+  write_h2_frame(
+    &mut stream,
+    H2_FRAME_HEADERS,
+    H2_FLAG_END_HEADERS | H2_FLAG_END_STREAM,
+    1,
+    &h2_get_headers(b"/first", addr.to_string().as_bytes()),
+  );
+  write_h2_frame(
+    &mut stream,
+    H2_FRAME_HEADERS,
+    H2_FLAG_END_HEADERS | H2_FLAG_END_STREAM,
+    3,
+    &h2_get_headers(b"/second", addr.to_string().as_bytes()),
+  );
+
+  let first_headers = read_h2_frame_skipping_window_updates(&mut stream);
+  assert_eq!(H2_FRAME_HEADERS, first_headers.frame_type);
+  assert_eq!(1, first_headers.stream_id);
+  let first_body = read_h2_frame_skipping_window_updates(&mut stream);
+  assert_eq!(H2_FRAME_DATA, first_body.frame_type);
+  assert_eq!(H2_FLAG_END_STREAM, first_body.flags);
+  assert_eq!(1, first_body.stream_id);
+  assert_eq!(b"served /first", first_body.payload.as_slice());
+
+  let second_headers = read_h2_frame_skipping_window_updates(&mut stream);
+  assert_eq!(H2_FRAME_HEADERS, second_headers.frame_type);
+  assert_eq!(3, second_headers.stream_id);
+  let second_body = read_h2_frame_skipping_window_updates(&mut stream);
+  assert_eq!(H2_FRAME_DATA, second_body.frame_type);
+  assert_eq!(H2_FLAG_END_STREAM, second_body.flags);
+  assert_eq!(3, second_body.stream_id);
+  assert_eq!(b"served /second", second_body.payload.as_slice());
+
+  let goaway = read_h2_frame_skipping_window_updates(&mut stream);
+  assert_eq!(3, h2_goaway_last_stream_id(&goaway));
 
   handle.join().expect("server thread");
 }


### PR DESCRIPTION
Bounded socket2 h2c request-limit shutdown now emits GOAWAY with NO_ERROR and the last processed client stream id after completing accepted responses. Coverage was added for the low-level h2c frame behavior, and the required formatting, package, workspace, and diff checks passed.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1469/
work_kind: code_work
branch: hbx-1469-rttp-emit-bounded-socket2-h2c
base: main
commit: 5a32fc9f4d4ee57ab9378a39d792b48e6923851b
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1469/
    url: https://plane.kahub.in/endless/browse/HBX-1469/
    close_policy: link_only
```