### PR TITLE
feat: [rttp] Document prior-knowledge h2c PING support and limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ request APIs and TLS implementations:
 | name | comment |
 |------|---------|
 | async | Async request APIs |
-| http2 | Minimal prior-knowledge h2c over direct `socket2` TCP connections |
+| http2 | Bounded prior-knowledge h2c over direct `socket2` TCP connections |
 | tls-native | HTTPS with `native-tls` |
 | tls-rustls | HTTPS with `rustls` |
 
@@ -36,9 +36,9 @@ available through `Response::trailers`, `Response::trailer`, and
 | Upgrade and tunnel handoff | `CONNECT` returns the tunnel socket after a successful `200`; `upgrade()` returns the socket after `101 Switching Protocols` and skips interim `1xx` responses | Upgraded protocols are handed to the caller and are not parsed by `rttp_client` |
 | Redirects | Auto-redirect covers 301, 302, 303, 307, and 308 method/body behavior, relative and absolute `Location` resolution, same- and cross-authority header handling, loop detection, and redirect bounds | Redirects are HTTP client behavior, not a browser policy implementation |
 | Trailers | Chunked response trailers are exposed for blocking and async APIs; streaming chunked uploads can send declared request trailers | Forbidden framing/routing trailer fields are rejected |
-| Prior-knowledge h2c | With `http2`, direct `socket2` h2c sends GET, HEAD, bodyless DELETE, OPTIONS, or TRACE, and buffered POST, PUT, or PATCH requests, suppresses HEAD response bodies, DATA bodies, trailers, HPACK static Huffman strings, dynamic entries within peer settings, large header blocks, padded incoming frames, `GOAWAY` shutdown boundaries, PRIORITY metadata validation without scheduling, and conservative DATA flow control | `CONNECT` is rejected deterministically before opening a client socket; no TLS ALPN, proxy tunneling to h2, proxy h2, tunnel handoff, persistent HTTP/2 session pooling, automatic retry, general multiplexing, priority scheduling, or request bodies for GET, HEAD, DELETE, OPTIONS, or TRACE |
+| Prior-knowledge h2c | With `http2`, direct `socket2` h2c sends GET, HEAD, bodyless DELETE, OPTIONS, or TRACE, and buffered POST, PUT, or PATCH requests, suppresses HEAD response bodies, acknowledges valid PING frames with matching opaque data, DATA bodies, trailers, HPACK static Huffman strings, dynamic entries within peer settings, large header blocks, padded incoming frames, `GOAWAY` shutdown boundaries, PRIORITY metadata validation without scheduling, and conservative DATA flow control | `CONNECT` is rejected deterministically before opening a client socket; bounded prior-knowledge h2c only, with no TLS ALPN, external h2 integration, proxy tunneling to h2, proxy h2, tunnel handoff, connection pooling, persistent HTTP/2 session management, automatic retry, unbounded multiplex scheduling, general multiplexing, priority scheduling, or request bodies for GET, HEAD, DELETE, OPTIONS, or TRACE |
 
-With the `http2` feature enabled, `emit_http2_prior_knowledge` sends a minimal
+With the `http2` feature enabled, `emit_http2_prior_knowledge` sends a bounded
 prior-knowledge h2c request over a direct socket2 TCP connection. It supports
 GET, HEAD, bodyless DELETE, OPTIONS, or TRACE, and buffered POST, PUT, or PATCH requests,
 including non-empty buffered request bodies as DATA frames for the write
@@ -53,15 +53,18 @@ advertised table size, and it decodes response dynamic table entries and
 table-size updates from incoming padded HEADERS, DATA, and trailer frames
 without exposing padding bytes. Valid response PRIORITY frames and HEADERS
 priority fields are validated and ignored as metadata; malformed priority
-metadata is rejected, and no priority scheduling is performed. HTTP/1.1
-`CONNECT` tunnel handoff remains a separate client path; prior-knowledge h2c
-`GOAWAY` is treated as a bounded shutdown signal: a response already completed
-before `GOAWAY` remains usable, an active stream continues only when the peer's
-`last-stream-id` includes it, and a lower boundary rejects the response
-deterministically. `CONNECT` and proxy tunneling are rejected before a client
-socket is opened. TLS ALPN, proxy h2, tunnel handoff, persistent HTTP/2 session
-pooling, automatic retry, and full HTTP/2 features such as general multiplexing
-and priority scheduling are not part of that client path.
+metadata is rejected, and no priority scheduling is performed. Valid PING
+frames are acknowledged with PING ACK frames that carry the same opaque 8-byte
+data. HTTP/1.1 `CONNECT` tunnel handoff remains a separate client path;
+prior-knowledge h2c `GOAWAY` is treated as a bounded shutdown signal: a
+response already completed before `GOAWAY` remains usable, an active stream
+continues only when the peer's `last-stream-id` includes it, and a lower
+boundary rejects the response deterministically. `CONNECT` and proxy tunneling
+are rejected before a client socket is opened. TLS ALPN, external h2
+integration, proxy h2, tunnel handoff, connection pooling, persistent HTTP/2
+session management, automatic retry, and full HTTP/2 features such as
+unbounded multiplex scheduling, general multiplexing, and priority scheduling
+are not part of that bounded prior-knowledge client path.
 
 ```rust,no_run
 use rttp_client::HttpClient;
@@ -132,15 +135,18 @@ padding bytes to handlers, and HPACK static Huffman strings, request dynamic
 table entries, and large header blocks are carried with CONTINUATION frames.
 Valid standalone PRIORITY frames and HEADERS priority fields are validated and
 ignored as metadata; malformed priority metadata is rejected, and request or
-response ordering does not use priority scheduling.
+response ordering does not use priority scheduling. Valid PING frames on
+stream 0 are acknowledged with PING ACK frames that carry the same opaque
+8-byte data.
 When the bounded prior-knowledge h2c server loop finishes, it sends `GOAWAY`
 with the last completed stream id so clients have a deterministic shutdown
 boundary for already processed streams.
 The prior-knowledge h2c path does not share the HTTP/1.1 `CONNECT` handoff
-path: h2c `CONNECT` is rejected before handler dispatch. TLS ALPN, proxy h2,
-tunnel handoff, persistent HTTP/2 session pooling, and full HTTP/2 features
-such as unbounded multiplexing and priority scheduling remain outside this
-server path.
+path: h2c `CONNECT` is rejected before handler dispatch. TLS ALPN, external h2
+integration, proxy h2, tunnel handoff, connection pooling, persistent HTTP/2
+session management, and full HTTP/2 features such as unbounded multiplexing,
+unbounded multiplex scheduling, and priority scheduling remain outside this
+bounded prior-knowledge server path.
 
 It is not a full RFC-covering web server and still does not implement server
 TLS or async accept loops.
@@ -154,4 +160,4 @@ TLS or async accept loops.
 | HTTP/1.1 response framing | Automatic `Content-Length`, explicit chunked responses, bodyless `HEAD`, `101`, `204`, and `304`, response trailers after the terminating chunk | No server TLS |
 | Upgrade and tunnel targets | `CONNECT` authority-form requests are accepted as HTTP requests; `HttpResponse::upgrade` can hand an upgraded socket to caller code after a matching request | The server does not implement the upgraded protocol after handoff |
 | Trailers | Chunked request trailers are preserved on `Request`; malformed, oversized, forbidden, and pseudo-header trailers are rejected; response trailers can be serialized for chunked responses | Trailer names that affect framing or routing are rejected |
-| Prior-knowledge h2c | The same `socket2` listener detects the HTTP/2 preface, validates SETTINGS, serves bounded prior-knowledge streams including bodyless DELETE, OPTIONS, and TRACE, handles HEAD without response DATA, accepts padded HEADERS/DATA/trailers without exposing padding, handles HPACK Huffman/dynamic fields and CONTINUATION blocks, emits `GOAWAY` with the last completed stream id at bounded shutdown, validates and ignores valid PRIORITY metadata, and applies conservative DATA flow control | `CONNECT` is rejected deterministically before handler dispatch; no TLS ALPN, proxy h2, tunnel handoff, persistent HTTP/2 session pooling, unbounded multiplexing, priority scheduling, or full HTTP/2 server feature set |
+| Prior-knowledge h2c | The same `socket2` listener detects the HTTP/2 preface, validates SETTINGS, serves bounded prior-knowledge streams including bodyless DELETE, OPTIONS, and TRACE, handles HEAD without response DATA, acknowledges valid PING frames with matching opaque data, accepts padded HEADERS/DATA/trailers without exposing padding, handles HPACK Huffman/dynamic fields and CONTINUATION blocks, emits `GOAWAY` with the last completed stream id at bounded shutdown, validates and ignores valid PRIORITY metadata, and applies conservative DATA flow control | `CONNECT` is rejected deterministically before handler dispatch; bounded prior-knowledge h2c only, with no TLS ALPN, external h2 integration, proxy h2, tunnel handoff, connection pooling, persistent HTTP/2 session management, unbounded multiplexing, unbounded multiplex scheduling, priority scheduling, or full HTTP/2 server feature set |

--- a/rttp/README.md
+++ b/rttp/README.md
@@ -64,7 +64,9 @@ as metadata; malformed priority metadata is rejected, and request or response
 ordering does not use priority scheduling. Multiple prior-knowledge h2c request
 streams may be open on one connection up to the caller's bounded
 `serve_requests` loop.
-Responses are still written synchronously as requests complete. The minimal
+Valid PING frames on stream 0 are acknowledged with PING ACK frames that carry
+the same opaque 8-byte data.
+Responses are still written synchronously as requests complete. The bounded
 h2c path supports conservative DATA flow-control for prior-knowledge use. It
 uses `GOAWAY` as a bounded shutdown signal when the loop ends, reporting the
 last completed stream id so clients can apply a deterministic stream boundary.
@@ -72,9 +74,10 @@ It does not share the HTTP/1.1 `CONNECT` handoff path: prior-knowledge h2c
 `CONNECT` is rejected before handler dispatch.
 
 The server is intentionally not a full RFC-covering web server and still does
-not implement server TLS, TLS ALPN, proxy h2, h2c tunnel handoff, full HTTP/2
-features such as persistent HTTP/2 session pooling, unbounded multiplexing and
-priority scheduling, or async accept loops.
+not implement server TLS, TLS ALPN, external h2 integration, proxy h2, h2c
+tunnel handoff, connection pooling, persistent HTTP/2 session management, full
+HTTP/2 features such as unbounded multiplexing, unbounded multiplex scheduling,
+and priority scheduling, or async accept loops.
 
 ## Tested server protocol coverage
 
@@ -85,30 +88,33 @@ priority scheduling, or async accept loops.
 | HTTP/1.1 response framing | Automatic `Content-Length`, explicit chunked responses, bodyless `HEAD`, `101`, `204`, and `304`, response trailers after the terminating chunk | No server TLS |
 | Upgrade and tunnel targets | `CONNECT` authority-form requests are accepted as HTTP requests; `HttpResponse::upgrade` can hand an upgraded socket to caller code after a matching request | The server does not implement the upgraded protocol after handoff |
 | Trailers | Chunked request trailers are preserved on `Request`; malformed, oversized, forbidden, and pseudo-header trailers are rejected; response trailers can be serialized for chunked responses | Trailer names that affect framing or routing are rejected |
-| Prior-knowledge h2c | The same `socket2` listener detects the HTTP/2 preface, validates SETTINGS, serves bounded prior-knowledge streams including bodyless DELETE, OPTIONS, and TRACE, handles HEAD without response DATA, accepts padded HEADERS/DATA/trailers without exposing padding, handles HPACK Huffman/dynamic fields and CONTINUATION blocks, emits `GOAWAY` with the last completed stream id at bounded shutdown, validates and ignores valid PRIORITY metadata, and applies conservative DATA flow control | `CONNECT` is rejected deterministically before handler dispatch; no TLS ALPN, proxy h2, tunnel handoff, persistent HTTP/2 session pooling, unbounded multiplexing, priority scheduling, or full HTTP/2 server feature set |
+| Prior-knowledge h2c | The same `socket2` listener detects the HTTP/2 preface, validates SETTINGS, serves bounded prior-knowledge streams including bodyless DELETE, OPTIONS, and TRACE, handles HEAD without response DATA, acknowledges valid PING frames with matching opaque data, accepts padded HEADERS/DATA/trailers without exposing padding, handles HPACK Huffman/dynamic fields and CONTINUATION blocks, emits `GOAWAY` with the last completed stream id at bounded shutdown, validates and ignores valid PRIORITY metadata, and applies conservative DATA flow control | `CONNECT` is rejected deterministically before handler dispatch; bounded prior-knowledge h2c only, with no TLS ALPN, external h2 integration, proxy h2, tunnel handoff, connection pooling, persistent HTTP/2 session management, unbounded multiplexing, unbounded multiplex scheduling, priority scheduling, or full HTTP/2 server feature set |
 
 ## Client feature
 
 Enable the `client` feature to access `rttp::Http::client`, or enable `async`,
 `http2`, `tls-native`, `tls-rustls`, or `all` for the corresponding
-`rttp_client` capabilities. The `http2` feature exposes the minimal
-prior-knowledge h2c client path for GET, HEAD, bodyless DELETE, OPTIONS, or TRACE, and
-buffered POST, PUT, or PATCH requests, including rejection of request bodies for
-GET, HEAD, DELETE, OPTIONS, and TRACE, HEAD response body suppression, HPACK static Huffman
-strings, request dynamic entries within the peer's advertised table size,
-response dynamic table decoding, large header blocks via CONTINUATION frames,
-padded incoming response frames, and conservative DATA flow-control for
-single-stream prior-knowledge use. Valid response PRIORITY frames and HEADERS
-priority fields are validated and ignored as metadata; malformed priority
-metadata is rejected, and no priority scheduling is performed. HTTP/1.1
-`CONNECT` tunnel handoff remains a separate path; prior-knowledge h2c `CONNECT`
-`GOAWAY` is treated as a bounded shutdown signal: completed responses remain
-usable, active responses continue only when the peer's `last-stream-id`
-includes the stream, and lower boundaries reject the response deterministically.
-`CONNECT` and proxy tunneling are rejected before a client socket is opened.
-TLS ALPN, proxy h2, tunnel handoff, persistent HTTP/2 session pooling,
-automatic retry, and full HTTP/2 features such as general multiplexing and
-priority scheduling remain outside that path.
+`rttp_client` capabilities. The `http2` feature exposes the bounded
+prior-knowledge h2c client path for GET, HEAD, bodyless DELETE, OPTIONS, or
+TRACE, and buffered POST, PUT, or PATCH requests, including rejection of
+request bodies for GET, HEAD, DELETE, OPTIONS, and TRACE, HEAD response body
+suppression, HPACK static Huffman strings, request dynamic entries within the
+peer's advertised table size, response dynamic table decoding, large header
+blocks via CONTINUATION frames, padded incoming response frames, and
+conservative DATA flow-control for single-stream prior-knowledge use. Valid
+response PRIORITY frames and HEADERS priority fields are validated and ignored
+as metadata; malformed priority metadata is rejected, and no priority
+scheduling is performed. Valid PING frames are acknowledged with PING ACK
+frames that carry the same opaque 8-byte data. HTTP/1.1 `CONNECT` tunnel
+handoff remains a separate path; prior-knowledge h2c `GOAWAY` is treated as a
+bounded shutdown signal: completed responses remain usable, active responses
+continue only when the peer's `last-stream-id` includes the stream, and lower
+boundaries reject the response deterministically. `CONNECT` and proxy
+tunneling are rejected before a client socket is opened. TLS ALPN, external h2
+integration, proxy h2, tunnel handoff, connection pooling, persistent HTTP/2
+session management, automatic retry, and full HTTP/2 features such as
+unbounded multiplex scheduling, general multiplexing, and priority scheduling
+remain outside that bounded prior-knowledge path.
 
 Direct TCP client connections use `socket2`. SOCKS proxy handshakes remain
 delegated to the `socks` crate.

--- a/rttp_client/README.md
+++ b/rttp_client/README.md
@@ -7,7 +7,7 @@ optional features add async request APIs and TLS implementations.
 | name | comment |
 |------|---------|
 | async | Async request APIs |
-| http2 | Prior-knowledge h2c over direct `socket2` TCP connections |
+| http2 | Bounded prior-knowledge h2c over direct `socket2` TCP connections |
 | tls-native | HTTPS with `native-tls` |
 | tls-rustls | HTTPS with `rustls` |
 
@@ -36,9 +36,9 @@ through `Response::trailers`, `Response::trailer`, and
 | Upgrade and tunnel handoff | `CONNECT` returns the tunnel socket after a successful `200`; `upgrade()` returns the socket after `101 Switching Protocols` and skips interim `1xx` responses | Upgraded protocols are handed to the caller and are not parsed by `rttp_client` |
 | Redirects | Auto-redirect covers 301, 302, 303, 307, and 308 method/body behavior, relative and absolute `Location` resolution, same- and cross-authority header handling, loop detection, and redirect bounds | Redirects are HTTP client behavior, not a browser policy implementation |
 | Trailers | Chunked response trailers are exposed for blocking and async APIs; streaming chunked uploads can send declared request trailers | Forbidden framing/routing trailer fields are rejected |
-| Prior-knowledge h2c | With `http2`, direct `socket2` h2c sends GET, HEAD, bodyless DELETE, OPTIONS, or TRACE, and buffered POST, PUT, or PATCH requests, suppresses HEAD response bodies, DATA bodies, trailers, HPACK static Huffman strings, dynamic entries within peer settings, large header blocks, padded incoming frames, `GOAWAY` shutdown boundaries, PRIORITY metadata validation without scheduling, and conservative DATA flow control | `CONNECT` is rejected deterministically before opening a client socket; no TLS ALPN, proxy tunneling to h2, proxy h2, tunnel handoff, persistent HTTP/2 session pooling, automatic retry, general multiplexing, priority scheduling, or request bodies for GET, HEAD, DELETE, OPTIONS, or TRACE |
+| Prior-knowledge h2c | With `http2`, direct `socket2` h2c sends GET, HEAD, bodyless DELETE, OPTIONS, or TRACE, and buffered POST, PUT, or PATCH requests, suppresses HEAD response bodies, acknowledges valid PING frames with matching opaque data, DATA bodies, trailers, HPACK static Huffman strings, dynamic entries within peer settings, large header blocks, padded incoming frames, `GOAWAY` shutdown boundaries, PRIORITY metadata validation without scheduling, and conservative DATA flow control | `CONNECT` is rejected deterministically before opening a client socket; bounded prior-knowledge h2c only, with no TLS ALPN, external h2 integration, proxy tunneling to h2, proxy h2, tunnel handoff, connection pooling, persistent HTTP/2 session management, automatic retry, unbounded multiplex scheduling, general multiplexing, priority scheduling, or request bodies for GET, HEAD, DELETE, OPTIONS, or TRACE |
 
-With the `http2` feature enabled, `emit_http2_prior_knowledge` sends a minimal
+With the `http2` feature enabled, `emit_http2_prior_knowledge` sends a bounded
 prior-knowledge h2c request over a direct socket2 TCP connection. It supports
 GET, HEAD, bodyless DELETE, OPTIONS, or TRACE, and buffered POST, PUT, or PATCH requests.
 Non-empty buffered request bodies are sent as DATA frames for the write methods;
@@ -52,15 +52,19 @@ dynamic entries within the peer's advertised table size, and incoming dynamic
 table entries, table-size updates, padded HEADERS, DATA, and trailer frames are
 decoded without exposing padding bytes. Valid response PRIORITY frames and
 HEADERS priority fields are validated and ignored as metadata; malformed
-priority metadata is rejected, and no priority scheduling is performed.
+priority metadata is rejected, and no priority scheduling is performed. Valid
+PING frames are acknowledged with PING ACK frames that carry the same opaque
+8-byte data.
 HTTP/1.1 `CONNECT` tunnel handoff remains a separate client path;
 prior-knowledge h2c `GOAWAY` is treated as a bounded shutdown signal:
 completed responses remain usable, active responses continue only when the
 peer's `last-stream-id` includes the stream, and lower boundaries reject the
 response deterministically. `CONNECT` and proxy tunneling are rejected before a
-client socket is opened. TLS ALPN, proxy h2, tunnel handoff, persistent HTTP/2
-session pooling, automatic retry, and full HTTP/2 features such as general
-multiplexing and priority scheduling are not part of that client path.
+client socket is opened. TLS ALPN, external h2 integration, proxy h2, tunnel
+handoff, connection pooling, persistent HTTP/2 session management, automatic
+retry, and full HTTP/2 features such as unbounded multiplex scheduling, general
+multiplexing, and priority scheduling are not part of that bounded
+prior-knowledge client path.
 
 ## Examples
 


### PR DESCRIPTION
README documentation now covers bounded prior-knowledge h2c PING support and explicitly lists the non-goals around full HTTP/2 session management and integration scope.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1476/
work_kind: code_work
branch: hbx-1476-rttp-document-prior-knowledge-h2c
base: main
commit: 7d12b1daa7f28b242ea5525bbb68ecbe361e69ef
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1476/
    url: https://plane.kahub.in/endless/browse/HBX-1476/
    close_policy: link_only
```