### PR TITLE
feat: [rttp_client] Reject prior-knowledge h2c PUSH_PROMISE frames while receiving

### DIFF
--- a/rttp_client/src/http2.rs
+++ b/rttp_client/src/http2.rs
@@ -17,6 +17,7 @@ const FRAME_HEADERS: u8 = 0x1;
 const FRAME_PRIORITY: u8 = 0x2;
 const FRAME_RST_STREAM: u8 = 0x3;
 const FRAME_SETTINGS: u8 = 0x4;
+const FRAME_PUSH_PROMISE: u8 = 0x5;
 const FRAME_PING: u8 = 0x6;
 const FRAME_GOAWAY: u8 = 0x7;
 const FRAME_WINDOW_UPDATE: u8 = 0x8;
@@ -513,6 +514,9 @@ fn read_until_send_window_available(
       (FRAME_PRIORITY, _) => {
         validate_priority_frame(&frame)?;
       }
+      (FRAME_PUSH_PROMISE, _) => {
+        reject_push_promise_frame(&frame)?;
+      }
       (FRAME_RST_STREAM, STREAM_ID) => {
         return Err(error::bad_response("HTTP/2 stream received RST_STREAM"));
       }
@@ -879,6 +883,9 @@ fn read_single_stream_response_with_first_frame(
       (FRAME_PRIORITY, _) => {
         validate_priority_frame(&frame)?;
       }
+      (FRAME_PUSH_PROMISE, _) => {
+        reject_push_promise_frame(&frame)?;
+      }
       (FRAME_RST_STREAM, STREAM_ID) => {
         return Err(error::bad_response("HTTP/2 stream received RST_STREAM"));
       }
@@ -1043,6 +1050,15 @@ fn validate_priority_frame(frame: &Frame) -> error::Result<()> {
     return Err(error::bad_response("invalid HTTP/2 PRIORITY frame"));
   }
   Ok(())
+}
+
+fn reject_push_promise_frame(frame: &Frame) -> error::Result<()> {
+  if frame.stream_id == 0 || frame.payload.len() < 4 {
+    return Err(error::bad_response("invalid HTTP/2 PUSH_PROMISE frame"));
+  }
+  Err(error::bad_response(
+    "unsupported HTTP/2 PUSH_PROMISE server push",
+  ))
 }
 
 fn data_payload(frame: &Frame) -> error::Result<&[u8]> {

--- a/rttp_client/tests/http2_prior_knowledge.rs
+++ b/rttp_client/tests/http2_prior_knowledge.rs
@@ -13,6 +13,7 @@ const FRAME_HEADERS: u8 = 0x1;
 const FRAME_PRIORITY: u8 = 0x2;
 const FRAME_RST_STREAM: u8 = 0x3;
 const FRAME_SETTINGS: u8 = 0x4;
+const FRAME_PUSH_PROMISE: u8 = 0x5;
 const FRAME_PING: u8 = 0x6;
 const FRAME_GOAWAY: u8 = 0x7;
 const FRAME_WINDOW_UPDATE: u8 = 0x8;
@@ -2010,6 +2011,57 @@ fn prior_knowledge_get_reports_stream_reset_and_goaway() {
 }
 
 #[test]
+fn prior_knowledge_get_rejects_push_promise_on_active_stream() {
+  let (addr, handle) = spawn_push_promise_peer(1, &[0, 0, 0, 2, 0x82]);
+
+  let error = HttpClient::new()
+    .get()
+    .url(format!("http://{}/push-promise", addr))
+    .emit_http2_prior_knowledge()
+    .expect_err("PUSH_PROMISE must fail the response");
+
+  assert!(
+    error.to_string().contains("PUSH_PROMISE"),
+    "unexpected error: {error}"
+  );
+  handle.join().expect("push promise peer thread");
+}
+
+#[test]
+fn prior_knowledge_get_rejects_malformed_push_promise_frames() {
+  let (connection_addr, connection_handle) = spawn_push_promise_peer(0, &[0, 0, 0, 2, 0x82]);
+  let connection_error = HttpClient::new()
+    .get()
+    .url(format!(
+      "http://{}/connection-push-promise",
+      connection_addr
+    ))
+    .emit_http2_prior_knowledge()
+    .expect_err("PUSH_PROMISE on stream 0 must fail the response");
+  assert!(
+    connection_error.to_string().contains("PUSH_PROMISE"),
+    "unexpected error: {connection_error}"
+  );
+  connection_handle
+    .join()
+    .expect("connection push promise peer thread");
+
+  let (truncated_addr, truncated_handle) = spawn_push_promise_peer(1, &[0, 0, 0]);
+  let truncated_error = HttpClient::new()
+    .get()
+    .url(format!("http://{}/truncated-push-promise", truncated_addr))
+    .emit_http2_prior_knowledge()
+    .expect_err("truncated PUSH_PROMISE promised stream id must fail the response");
+  assert!(
+    truncated_error.to_string().contains("PUSH_PROMISE"),
+    "unexpected error: {truncated_error}"
+  );
+  truncated_handle
+    .join()
+    .expect("truncated push promise peer thread");
+}
+
+#[test]
 fn prior_knowledge_get_continues_after_graceful_goaway_for_active_stream() {
   let listener = TcpListener::bind("127.0.0.1:0").expect("bind h2 peer");
   let addr = listener.local_addr().expect("h2 peer addr");
@@ -3319,6 +3371,30 @@ fn spawn_ping_peer(
     let (mut stream, _) = listener.accept().expect("accept h2 client");
     complete_h2_request_handshake(&mut stream);
     write_frame(&mut stream, FRAME_PING, flags, stream_id, payload);
+  });
+
+  (addr, handle)
+}
+
+fn spawn_push_promise_peer(
+  stream_id: u32,
+  payload: &'static [u8],
+) -> (SocketAddr, thread::JoinHandle<()>) {
+  let listener = TcpListener::bind("127.0.0.1:0").expect("bind h2 peer");
+  let addr = listener.local_addr().expect("h2 peer addr");
+
+  let handle = thread::spawn(move || {
+    let (mut stream, _) = listener.accept().expect("accept h2 client");
+    complete_h2_request_handshake(&mut stream);
+    write_frame(
+      &mut stream,
+      FRAME_PUSH_PROMISE,
+      FLAG_END_HEADERS,
+      stream_id,
+      payload,
+    );
+    write_frame(&mut stream, FRAME_HEADERS, FLAG_END_HEADERS, 1, &[0x88]);
+    write_frame(&mut stream, FRAME_DATA, FLAG_END_STREAM, 1, b"ignored");
   });
 
   (addr, handle)


### PR DESCRIPTION
Reject unsupported HTTP/2 `PUSH_PROMISE` frames in the prior-knowledge h2c client and add focused regression tests for active-stream and malformed frame cases.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1478/
work_kind: code_work
branch: hbx-1478-rttp-client-reject-prior-knowledge
base: main
commit: 3b9e007da298d85d3326b89bef1d87bdea541e9c
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1478/
    url: https://plane.kahub.in/endless/browse/HBX-1478/
    close_policy: link_only
```