### PR TITLE
feat: [rttp] Reject socket2 prior-knowledge h2c client PUSH_PROMISE before handler dispatch

### DIFF
--- a/rttp/src/server.rs
+++ b/rttp/src/server.rs
@@ -15,6 +15,7 @@ const HTTP2_FRAME_HEADERS: u8 = 0x1;
 const HTTP2_FRAME_PRIORITY: u8 = 0x2;
 const HTTP2_FRAME_RST_STREAM: u8 = 0x3;
 const HTTP2_FRAME_SETTINGS: u8 = 0x4;
+const HTTP2_FRAME_PUSH_PROMISE: u8 = 0x5;
 const HTTP2_FRAME_PING: u8 = 0x6;
 const HTTP2_FRAME_GOAWAY: u8 = 0x7;
 const HTTP2_FRAME_WINDOW_UPDATE: u8 = 0x8;
@@ -490,6 +491,9 @@ impl HttpServer {
         }
         (HTTP2_FRAME_PRIORITY, id) => {
           validate_http2_priority_frame(id, &frame.payload)?;
+        }
+        (HTTP2_FRAME_PUSH_PROMISE, _) => {
+          return Err(invalid_http2_push_promise_error());
         }
         (HTTP2_FRAME_HEADERS, id) if id != 0 => {
           let header_block_fragment =
@@ -989,7 +993,16 @@ fn read_http2_frame(stream: &mut TcpStream) -> io::Result<Http2Frame> {
   stream.read_exact(&mut header)?;
   let length = ((header[0] as usize) << 16) | ((header[1] as usize) << 8) | header[2] as usize;
   let mut payload = vec![0; length];
-  stream.read_exact(&mut payload)?;
+  stream.read_exact(&mut payload).map_err(|err| {
+    if err.kind() == io::ErrorKind::UnexpectedEof {
+      io::Error::new(
+        io::ErrorKind::InvalidData,
+        "incomplete HTTP/2 frame payload",
+      )
+    } else {
+      err
+    }
+  })?;
   Ok(Http2Frame {
     frame_type: header[3],
     flags: header[4],
@@ -1040,6 +1053,13 @@ fn validate_http2_priority_frame(stream_id: u32, payload: &[u8]) -> io::Result<(
     ));
   }
   Ok(())
+}
+
+fn invalid_http2_push_promise_error() -> io::Error {
+  io::Error::new(
+    io::ErrorKind::InvalidData,
+    "HTTP/2 PUSH_PROMISE frame is unsupported",
+  )
 }
 
 fn invalid_http2_window_update_error() -> io::Error {

--- a/rttp/tests/test_server.rs
+++ b/rttp/tests/test_server.rs
@@ -13,6 +13,7 @@ const H2_FRAME_HEADERS: u8 = 0x1;
 const H2_FRAME_PRIORITY: u8 = 0x2;
 const H2_FRAME_RST_STREAM: u8 = 0x3;
 const H2_FRAME_SETTINGS: u8 = 0x4;
+const H2_FRAME_PUSH_PROMISE: u8 = 0x5;
 const H2_FRAME_PING: u8 = 0x6;
 const H2_FRAME_GOAWAY: u8 = 0x7;
 const H2_FRAME_WINDOW_UPDATE: u8 = 0x8;
@@ -1750,6 +1751,65 @@ fn server_rejects_http2_prior_knowledge_priority_with_zero_stream_id() {
 #[test]
 fn server_rejects_http2_prior_knowledge_priority_with_invalid_payload_length() {
   assert_invalid_h2_frame_without_handler(H2_FRAME_PRIORITY, 0, 1, &[0, 0, 0, 0]);
+}
+
+#[test]
+fn server_rejects_http2_prior_knowledge_push_promise_without_handler() {
+  let mut payload = 2u32.to_be_bytes().to_vec();
+  payload.extend(h2_get_headers(b"/promised", b"localhost"));
+  assert_invalid_h2_frame_without_handler(H2_FRAME_PUSH_PROMISE, H2_FLAG_END_HEADERS, 1, &payload);
+}
+
+#[test]
+fn server_rejects_http2_prior_knowledge_connection_push_promise_without_handler() {
+  let mut payload = 2u32.to_be_bytes().to_vec();
+  payload.extend(h2_get_headers(b"/promised", b"localhost"));
+  assert_invalid_h2_frame_without_handler(H2_FRAME_PUSH_PROMISE, H2_FLAG_END_HEADERS, 0, &payload);
+}
+
+#[test]
+fn server_rejects_http2_prior_knowledge_truncated_push_promise_without_handler() {
+  let server = rttp::Http::server("127.0.0.1:0")
+    .expect("bind server")
+    .with_read_timeout(Some(Duration::from_secs(2)));
+  let addr = server.local_addr().expect("server addr");
+  let (tx, rx) = mpsc::channel();
+
+  let handle = thread::spawn(move || {
+    server.accept_one(|request| {
+      tx.send(request).expect("send unexpected h2 request");
+      HttpResponse::ok("unexpected")
+    })
+  });
+
+  let mut stream = TcpStream::connect(addr).expect("connect h2 server");
+  stream
+    .set_read_timeout(Some(Duration::from_secs(2)))
+    .expect("set h2 read timeout");
+  complete_h2_server_handshake(&mut stream);
+
+  let declared_length = 4usize;
+  let mut header = [0; 9];
+  header[0] = ((declared_length >> 16) & 0xff) as u8;
+  header[1] = ((declared_length >> 8) & 0xff) as u8;
+  header[2] = (declared_length & 0xff) as u8;
+  header[3] = H2_FRAME_PUSH_PROMISE;
+  header[4] = H2_FLAG_END_HEADERS;
+  header[5..9].copy_from_slice(&1u32.to_be_bytes());
+  stream.write_all(&header).expect("write h2 frame head");
+  stream
+    .write_all(&[0, 0])
+    .expect("write truncated h2 frame payload");
+  stream
+    .shutdown(std::net::Shutdown::Write)
+    .expect("shutdown h2 write");
+
+  let error = handle
+    .join()
+    .expect("server thread")
+    .expect_err("truncated PUSH_PROMISE should reject connection");
+  assert_eq!(ErrorKind::InvalidData, error.kind());
+  assert!(rx.try_recv().is_err());
 }
 
 #[test]


### PR DESCRIPTION
Socket2 prior-knowledge h2c server now rejects client `PUSH_PROMISE` frames before handler dispatch, with low-level coverage for complete and truncated malformed cases.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1479/
work_kind: code_work
branch: hbx-1479-rttp-reject-socket2-prior-knowledge
base: main
commit: 9b1cf5bfef09d59f4a431554201ac85808014f07
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1479/
    url: https://plane.kahub.in/endless/browse/HBX-1479/
    close_policy: link_only
```