### PR TITLE
feat: [rttp] Bound socket2 h2c server behavior after inbound RST_STREAM

### DIFF
--- a/rttp/src/server.rs
+++ b/rttp/src/server.rs
@@ -608,10 +608,14 @@ impl HttpServer {
           }
         }
         (HTTP2_FRAME_RST_STREAM, id) if id != 0 => {
+          validate_http2_rst_stream_frame(id, &frame.payload)?;
           streams.retain(|request_stream| request_stream.stream_id != id);
           if !reset_streams.contains(&id) {
             reset_streams.push(id);
           }
+        }
+        (HTTP2_FRAME_RST_STREAM, id) => {
+          validate_http2_rst_stream_frame(id, &frame.payload)?;
         }
         (HTTP2_FRAME_GOAWAY, 0) => break,
         (HTTP2_FRAME_WINDOW_UPDATE, _) => {
@@ -1050,6 +1054,16 @@ fn validate_http2_priority_frame(stream_id: u32, payload: &[u8]) -> io::Result<(
     return Err(io::Error::new(
       io::ErrorKind::InvalidData,
       "invalid HTTP/2 PRIORITY frame",
+    ));
+  }
+  Ok(())
+}
+
+fn validate_http2_rst_stream_frame(stream_id: u32, payload: &[u8]) -> io::Result<()> {
+  if stream_id == 0 || payload.len() != 4 {
+    return Err(io::Error::new(
+      io::ErrorKind::InvalidData,
+      "invalid HTTP/2 RST_STREAM frame",
     ));
   }
   Ok(())
@@ -2195,6 +2209,7 @@ fn read_http2_response_flow_control_frame(
         }
       }
       (HTTP2_FRAME_RST_STREAM, id) if id != 0 => {
+        validate_http2_rst_stream_frame(id, &frame.payload)?;
         flow_control
           .streams
           .retain(|request_stream| request_stream.stream_id != id);
@@ -2204,6 +2219,9 @@ fn read_http2_response_flow_control_frame(
         if id == response_stream_id {
           return Ok(Http2ResponseFlowControlRead::ResponseReset);
         }
+      }
+      (HTTP2_FRAME_RST_STREAM, id) => {
+        validate_http2_rst_stream_frame(id, &frame.payload)?;
       }
       (_, 0) => {}
       _ => {}

--- a/rttp/tests/test_server.rs
+++ b/rttp/tests/test_server.rs
@@ -1276,6 +1276,87 @@ fn server_preserves_http2_request_frames_received_while_response_is_flow_control
 }
 
 #[test]
+fn server_cancels_blocked_http2_response_after_reset_and_serves_next_stream() {
+  let server = rttp::Http::server("127.0.0.1:0")
+    .expect("bind server")
+    .with_read_timeout(Some(Duration::from_secs(2)))
+    .with_write_timeout(Some(Duration::from_secs(2)));
+  let addr = server.local_addr().expect("server addr");
+  let (tx, rx) = mpsc::channel();
+
+  let handle = thread::spawn(move || {
+    server
+      .serve_requests(2, |request| {
+        tx.send(request.target().to_string())
+          .expect("send h2 target");
+        if request.target() == "/reset-response" {
+          HttpResponse::ok("abcdefghij")
+        } else {
+          HttpResponse::ok("after")
+        }
+      })
+      .expect("serve reset h2 response sequence");
+  });
+
+  let mut stream = TcpStream::connect(addr).expect("connect h2 server");
+  stream
+    .set_read_timeout(Some(Duration::from_millis(200)))
+    .expect("set h2 read timeout");
+  complete_h2_server_handshake_with_settings(
+    &mut stream,
+    &h2_setting(H2_SETTINGS_INITIAL_WINDOW_SIZE, 5),
+  );
+  write_h2_frame(
+    &mut stream,
+    H2_FRAME_HEADERS,
+    H2_FLAG_END_HEADERS | H2_FLAG_END_STREAM,
+    1,
+    &h2_get_headers(b"/reset-response", addr.to_string().as_bytes()),
+  );
+
+  let response_headers = read_h2_frame(&mut stream);
+  assert_eq!(H2_FRAME_HEADERS, response_headers.frame_type);
+  assert_eq!(1, response_headers.stream_id);
+  let first_data = read_h2_frame(&mut stream);
+  assert_eq!(H2_FRAME_DATA, first_data.frame_type);
+  assert_eq!(1, first_data.stream_id);
+  assert_eq!(b"abcde", first_data.payload.as_slice());
+
+  let blocked = try_read_h2_frame(&mut stream).expect_err("server must wait for stream credit");
+  assert!(
+    matches!(blocked.kind(), ErrorKind::WouldBlock | ErrorKind::TimedOut),
+    "unexpected read error: {blocked}"
+  );
+
+  write_h2_frame(&mut stream, H2_FRAME_RST_STREAM, 0, 1, &0u32.to_be_bytes());
+  write_h2_frame(
+    &mut stream,
+    H2_FRAME_HEADERS,
+    H2_FLAG_END_HEADERS | H2_FLAG_END_STREAM,
+    3,
+    &h2_get_headers(b"/after-reset", addr.to_string().as_bytes()),
+  );
+
+  let next_headers = read_h2_frame_skipping_window_updates(&mut stream);
+  assert_eq!(H2_FRAME_HEADERS, next_headers.frame_type);
+  assert_eq!(3, next_headers.stream_id);
+  let next_body = read_h2_frame(&mut stream);
+  assert_eq!(H2_FRAME_DATA, next_body.frame_type);
+  assert_eq!(3, next_body.stream_id);
+  assert_eq!(b"after", next_body.payload.as_slice());
+
+  assert_eq!(
+    vec!["/reset-response".to_string(), "/after-reset".to_string()],
+    vec![
+      rx.recv().expect("reset h2 target"),
+      rx.recv().expect("next h2 target"),
+    ]
+  );
+
+  handle.join().expect("server thread");
+}
+
+#[test]
 fn server_applies_http2_window_update_to_other_stream_while_response_is_blocked() {
   let server = rttp::Http::server("127.0.0.1:0")
     .expect("bind server")
@@ -3376,6 +3457,16 @@ fn server_ignores_reset_stream_and_serves_surviving_http2_stream() {
   assert_eq!("/survivor", rx.recv().expect("survivor h2 target"));
 
   handle.join().expect("server thread");
+}
+
+#[test]
+fn server_rejects_http2_prior_knowledge_reset_stream_with_zero_stream_id() {
+  assert_invalid_h2_frame_without_handler(H2_FRAME_RST_STREAM, 0, 0, &0u32.to_be_bytes());
+}
+
+#[test]
+fn server_rejects_http2_prior_knowledge_reset_stream_with_invalid_payload_length() {
+  assert_invalid_h2_frame_without_handler(H2_FRAME_RST_STREAM, 0, 1, &[0, 0, 0]);
 }
 
 #[test]


### PR DESCRIPTION
Adds bounded h2c server `RST_STREAM` validation and cancellation behavior with regression coverage for blocked response output, survivor stream handling, and malformed reset rejection.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1489/
work_kind: code_work
branch: hbx-1489-rttp-bound-socket2-h2c-server
base: main
commit: 2ec47fe297fcd8c4d61f2b6077cb0d2bb491c13e
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1489/
    url: https://plane.kahub.in/endless/browse/HBX-1489/
    close_policy: link_only
```