### PR TITLE
feat: [rttp] Document h2c RST_STREAM reset boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ available through `Response::trailers`, `Response::trailer`, and
 | Upgrade and tunnel handoff | `CONNECT` returns the tunnel socket after a successful `200`; `upgrade()` returns the socket after `101 Switching Protocols` and skips interim `1xx` responses | Upgraded protocols are handed to the caller and are not parsed by `rttp_client` |
 | Redirects | Auto-redirect covers 301, 302, 303, 307, and 308 method/body behavior, relative and absolute `Location` resolution, same- and cross-authority header handling, loop detection, and redirect bounds | Redirects are HTTP client behavior, not a browser policy implementation |
 | Trailers | Chunked response trailers are exposed for blocking and async APIs; streaming chunked uploads can send declared request trailers | Forbidden framing/routing trailer fields are rejected |
-| Prior-knowledge h2c | With `http2`, direct `socket2` h2c sends GET, HEAD, bodyless DELETE, OPTIONS, or TRACE, and buffered POST, PUT, or PATCH requests, suppresses HEAD response bodies, acknowledges valid PING frames with matching opaque data, DATA bodies, trailers, HPACK static Huffman strings, dynamic entries within peer settings, large header blocks, padded incoming frames, `GOAWAY` shutdown boundaries, PRIORITY metadata validation without scheduling, HTTP/2-allowed unknown/extension frame ignoring inside this bounded path, reserved stream-id high-bit normalization, and conservative DATA flow control | `CONNECT` is rejected deterministically before opening a client socket, and `PUSH_PROMISE`/server push is rejected instead of managed; bounded prior-knowledge h2c only, with no extension callback API, full extension negotiation, TLS ALPN, external h2 integration, proxy tunneling to h2, proxy h2, tunnel handoff, connection pooling, persistent HTTP/2 session management, automatic retry, server push, unbounded multiplex scheduling, general multiplexing, priority scheduling, or request bodies for GET, HEAD, DELETE, OPTIONS, or TRACE |
+| Prior-knowledge h2c | With `http2`, direct `socket2` h2c sends GET, HEAD, bodyless DELETE, OPTIONS, or TRACE, and buffered POST, PUT, or PATCH requests, suppresses HEAD response bodies, treats `RST_STREAM` on the active stream as a bounded reset/cancellation signal, acknowledges valid PING frames with matching opaque data, DATA bodies, trailers, HPACK static Huffman strings, dynamic entries within peer settings, large header blocks, padded incoming frames, `GOAWAY` shutdown boundaries, PRIORITY metadata validation without scheduling, HTTP/2-allowed unknown/extension frame ignoring inside this bounded path, reserved stream-id high-bit normalization, and conservative DATA flow control | `CONNECT` is rejected deterministically before opening a client socket, and `PUSH_PROMISE`/server push is rejected instead of managed; bounded prior-knowledge h2c only, with no public cancellation callback API, no extension callback API, full extension negotiation, TLS ALPN, external h2 integration, proxy tunneling to h2, proxy h2, tunnel handoff, connection pooling, persistent HTTP/2 session management, automatic retry, server push, full stream state machine, unbounded multiplex scheduling, general multiplexing, priority scheduling, or request bodies for GET, HEAD, DELETE, OPTIONS, or TRACE |
 
 With the `http2` feature enabled, `emit_http2_prior_knowledge` sends a bounded
 prior-knowledge h2c request over a direct socket2 TCP connection. It supports
@@ -68,13 +68,17 @@ client path;
 prior-knowledge h2c `GOAWAY` is treated as a bounded shutdown signal: a
 response already completed before `GOAWAY` remains usable, an active stream
 continues only when the peer's `last-stream-id` includes it, and a lower
-boundary rejects the response deterministically. `CONNECT` and proxy tunneling
-are rejected before a client socket is opened. TLS ALPN, extension callback
-APIs, full extension negotiation, external h2 integration, proxy h2, tunnel
-handoff, connection pooling, persistent HTTP/2 session management, automatic
-retry, server push, and full HTTP/2 features such as unbounded multiplex
-scheduling, general multiplexing, and priority scheduling are not part of that
-bounded prior-knowledge client path.
+boundary rejects the response deterministically. `RST_STREAM` is likewise
+bounded to this prior-knowledge h2c client path: a reset for the active stream
+is reported as response cancellation, while malformed reset frames are rejected
+deterministically. RTTP does not expose a public cancellation callback API or
+retry the request automatically. `CONNECT` and proxy tunneling are rejected
+before a client socket is opened. TLS ALPN, extension callback APIs, full
+extension negotiation, external h2 integration, proxy h2, tunnel handoff,
+connection pooling, persistent HTTP/2 session management, automatic retry,
+server push, full stream state machines, and full HTTP/2 features such as
+unbounded multiplex scheduling, general multiplexing, and priority scheduling
+are not part of that bounded prior-knowledge client path.
 
 ```rust,no_run
 use rttp_client::HttpClient;
@@ -161,13 +165,19 @@ push state management.
 When the bounded prior-knowledge h2c server loop finishes, it sends `GOAWAY`
 with the last completed stream id so clients have a deterministic shutdown
 boundary for already processed streams.
+Within that same prior-knowledge h2c server path, inbound `RST_STREAM` is a
+bounded reset/cancellation signal for the affected stream: reset request
+streams are not dispatched to handlers, and reset response streams stop within
+the bounded write path. RTTP does not expose a public cancellation callback API,
+retry work automatically, keep persistent HTTP/2 sessions, or model a full
+HTTP/2 stream state machine around those resets.
 The prior-knowledge h2c path does not share the HTTP/1.1 `CONNECT` handoff
 path: h2c `CONNECT` is rejected before handler dispatch. TLS ALPN, extension
 callback APIs, full extension negotiation, external h2 integration, proxy h2,
 tunnel handoff, connection pooling, persistent HTTP/2 session management, and
 full HTTP/2 features such as unbounded multiplexing, unbounded multiplex
-scheduling, server push, and priority scheduling remain outside this bounded
-prior-knowledge server path.
+scheduling, general multiplexing, server push, and priority scheduling remain
+outside this bounded prior-knowledge server path.
 
 It is not a full RFC-covering web server and still does not implement server
 TLS or async accept loops.
@@ -181,4 +191,4 @@ TLS or async accept loops.
 | HTTP/1.1 response framing | Automatic `Content-Length`, explicit chunked responses, bodyless `HEAD`, `101`, `204`, and `304`, response trailers after the terminating chunk | No server TLS |
 | Upgrade and tunnel targets | `CONNECT` authority-form requests are accepted as HTTP requests; `HttpResponse::upgrade` can hand an upgraded socket to caller code after a matching request | The server does not implement the upgraded protocol after handoff |
 | Trailers | Chunked request trailers are preserved on `Request`; malformed, oversized, forbidden, and pseudo-header trailers are rejected; response trailers can be serialized for chunked responses | Trailer names that affect framing or routing are rejected |
-| Prior-knowledge h2c | The same `socket2` listener detects the HTTP/2 preface, validates SETTINGS, serves bounded prior-knowledge streams including bodyless DELETE, OPTIONS, and TRACE, handles HEAD without response DATA, acknowledges valid PING frames with matching opaque data, accepts padded HEADERS/DATA/trailers without exposing padding, handles HPACK Huffman/dynamic fields and CONTINUATION blocks, emits `GOAWAY` with the last completed stream id at bounded shutdown, validates and ignores valid PRIORITY metadata, ignores HTTP/2-allowed unknown/extension frames inside this bounded path, normalizes reserved stream-id high bits, and applies conservative DATA flow control | `CONNECT` and `PUSH_PROMISE` are rejected deterministically before handler dispatch; bounded prior-knowledge h2c only, with no extension callback API, full extension negotiation, TLS ALPN, external h2 integration, proxy h2, tunnel handoff, connection pooling, persistent HTTP/2 session management, server push, unbounded multiplexing, unbounded multiplex scheduling, priority scheduling, or full HTTP/2 server feature set |
+| Prior-knowledge h2c | The same `socket2` listener detects the HTTP/2 preface, validates SETTINGS, serves bounded prior-knowledge streams including bodyless DELETE, OPTIONS, and TRACE, handles HEAD without response DATA, treats `RST_STREAM` as a bounded reset/cancellation signal for the affected stream, acknowledges valid PING frames with matching opaque data, accepts padded HEADERS/DATA/trailers without exposing padding, handles HPACK Huffman/dynamic fields and CONTINUATION blocks, emits `GOAWAY` with the last completed stream id at bounded shutdown, validates and ignores valid PRIORITY metadata, ignores HTTP/2-allowed unknown/extension frames inside this bounded path, normalizes reserved stream-id high bits, and applies conservative DATA flow control | `CONNECT` and `PUSH_PROMISE` are rejected deterministically before handler dispatch; bounded prior-knowledge h2c only, with no public cancellation callback API, no extension callback API, full extension negotiation, TLS ALPN, external h2 integration, proxy h2, tunnel handoff, connection pooling, persistent HTTP/2 session management, automatic retry, server push, full stream state machine, unbounded multiplexing, unbounded multiplex scheduling, general multiplexing, priority scheduling, or full HTTP/2 server feature set |

--- a/rttp/README.md
+++ b/rttp/README.md
@@ -80,15 +80,22 @@ Responses are still written synchronously as requests complete. The bounded
 h2c path supports conservative DATA flow-control for prior-knowledge use. It
 uses `GOAWAY` as a bounded shutdown signal when the loop ends, reporting the
 last completed stream id so clients can apply a deterministic stream boundary.
+Within that same prior-knowledge h2c server path, inbound `RST_STREAM` is a
+bounded reset/cancellation signal for the affected stream: reset request
+streams are not dispatched to handlers, and reset response streams stop within
+the bounded write path. RTTP does not expose a public cancellation callback API,
+retry work automatically, keep persistent HTTP/2 sessions, or model a full
+HTTP/2 stream state machine around those resets.
 It does not share the HTTP/1.1 `CONNECT` handoff path: prior-knowledge h2c
 `CONNECT` is rejected before handler dispatch.
 
 The server is intentionally not a full RFC-covering web server and still does
 not implement server TLS, TLS ALPN, extension callback APIs, full extension
 negotiation, external h2 integration, proxy h2, h2c tunnel handoff, connection
-pooling, persistent HTTP/2 session management, full HTTP/2 features such as
-unbounded multiplexing, unbounded multiplex scheduling, server push, and
-priority scheduling, or async accept loops.
+pooling, persistent HTTP/2 session management, automatic retry, public
+cancellation callbacks, full stream state machines, full HTTP/2 features such
+as unbounded multiplexing, unbounded multiplex scheduling, general
+multiplexing, server push, and priority scheduling, or async accept loops.
 
 ## Tested server protocol coverage
 
@@ -99,7 +106,7 @@ priority scheduling, or async accept loops.
 | HTTP/1.1 response framing | Automatic `Content-Length`, explicit chunked responses, bodyless `HEAD`, `101`, `204`, and `304`, response trailers after the terminating chunk | No server TLS |
 | Upgrade and tunnel targets | `CONNECT` authority-form requests are accepted as HTTP requests; `HttpResponse::upgrade` can hand an upgraded socket to caller code after a matching request | The server does not implement the upgraded protocol after handoff |
 | Trailers | Chunked request trailers are preserved on `Request`; malformed, oversized, forbidden, and pseudo-header trailers are rejected; response trailers can be serialized for chunked responses | Trailer names that affect framing or routing are rejected |
-| Prior-knowledge h2c | The same `socket2` listener detects the HTTP/2 preface, validates SETTINGS, serves bounded prior-knowledge streams including bodyless DELETE, OPTIONS, and TRACE, handles HEAD without response DATA, acknowledges valid PING frames with matching opaque data, accepts padded HEADERS/DATA/trailers without exposing padding, handles HPACK Huffman/dynamic fields and CONTINUATION blocks, emits `GOAWAY` with the last completed stream id at bounded shutdown, validates and ignores valid PRIORITY metadata, ignores HTTP/2-allowed unknown/extension frames inside this bounded path, normalizes reserved stream-id high bits, and applies conservative DATA flow control | `CONNECT` and `PUSH_PROMISE` are rejected deterministically before handler dispatch; bounded prior-knowledge h2c only, with no extension callback API, full extension negotiation, TLS ALPN, external h2 integration, proxy h2, tunnel handoff, connection pooling, persistent HTTP/2 session management, server push, unbounded multiplexing, unbounded multiplex scheduling, priority scheduling, or full HTTP/2 server feature set |
+| Prior-knowledge h2c | The same `socket2` listener detects the HTTP/2 preface, validates SETTINGS, serves bounded prior-knowledge streams including bodyless DELETE, OPTIONS, and TRACE, handles HEAD without response DATA, treats `RST_STREAM` as a bounded reset/cancellation signal for the affected stream, acknowledges valid PING frames with matching opaque data, accepts padded HEADERS/DATA/trailers without exposing padding, handles HPACK Huffman/dynamic fields and CONTINUATION blocks, emits `GOAWAY` with the last completed stream id at bounded shutdown, validates and ignores valid PRIORITY metadata, ignores HTTP/2-allowed unknown/extension frames inside this bounded path, normalizes reserved stream-id high bits, and applies conservative DATA flow control | `CONNECT` and `PUSH_PROMISE` are rejected deterministically before handler dispatch; bounded prior-knowledge h2c only, with no public cancellation callback API, no extension callback API, full extension negotiation, TLS ALPN, external h2 integration, proxy h2, tunnel handoff, connection pooling, persistent HTTP/2 session management, automatic retry, server push, full stream state machine, unbounded multiplexing, unbounded multiplex scheduling, general multiplexing, priority scheduling, or full HTTP/2 server feature set |
 
 ## Client feature
 
@@ -128,13 +135,17 @@ deterministically instead of creating or tracking push state. HTTP/1.1
 `CONNECT` tunnel handoff remains a separate path; prior-knowledge h2c `GOAWAY`
 is treated as a bounded shutdown signal: completed responses remain usable,
 active responses continue only when the peer's `last-stream-id` includes the
-stream, and lower boundaries reject the response deterministically. `CONNECT`
+stream, and lower boundaries reject the response deterministically.
+`RST_STREAM` is likewise bounded to this prior-knowledge h2c client path: a
+reset for the active stream is reported as response cancellation, while
+malformed reset frames are rejected deterministically. RTTP does not expose a
+public cancellation callback API or retry the request automatically. `CONNECT`
 and proxy tunneling are rejected before a client socket is opened. TLS ALPN,
 extension callback APIs, full extension negotiation, external h2 integration,
 proxy h2, tunnel handoff, connection pooling, persistent HTTP/2 session
-management, automatic retry, server push, and full HTTP/2 features such as
-unbounded multiplex scheduling, general multiplexing, and priority scheduling
-remain outside that bounded prior-knowledge path.
+management, automatic retry, server push, full stream state machines, and full
+HTTP/2 features such as unbounded multiplex scheduling, general multiplexing,
+and priority scheduling remain outside that bounded prior-knowledge path.
 
 Direct TCP client connections use `socket2`. SOCKS proxy handshakes remain
 delegated to the `socks` crate.

--- a/rttp_client/README.md
+++ b/rttp_client/README.md
@@ -36,7 +36,7 @@ through `Response::trailers`, `Response::trailer`, and
 | Upgrade and tunnel handoff | `CONNECT` returns the tunnel socket after a successful `200`; `upgrade()` returns the socket after `101 Switching Protocols` and skips interim `1xx` responses | Upgraded protocols are handed to the caller and are not parsed by `rttp_client` |
 | Redirects | Auto-redirect covers 301, 302, 303, 307, and 308 method/body behavior, relative and absolute `Location` resolution, same- and cross-authority header handling, loop detection, and redirect bounds | Redirects are HTTP client behavior, not a browser policy implementation |
 | Trailers | Chunked response trailers are exposed for blocking and async APIs; streaming chunked uploads can send declared request trailers | Forbidden framing/routing trailer fields are rejected |
-| Prior-knowledge h2c | With `http2`, direct `socket2` h2c sends GET, HEAD, bodyless DELETE, OPTIONS, or TRACE, and buffered POST, PUT, or PATCH requests, suppresses HEAD response bodies, acknowledges valid PING frames with matching opaque data, DATA bodies, trailers, HPACK static Huffman strings, dynamic entries within peer settings, large header blocks, padded incoming frames, `GOAWAY` shutdown boundaries, PRIORITY metadata validation without scheduling, HTTP/2-allowed unknown/extension frame ignoring inside this bounded path, reserved stream-id high-bit normalization, and conservative DATA flow control | `CONNECT` is rejected deterministically before opening a client socket, and `PUSH_PROMISE`/server push is rejected instead of managed; bounded prior-knowledge h2c only, with no extension callback API, full extension negotiation, TLS ALPN, external h2 integration, proxy tunneling to h2, proxy h2, tunnel handoff, connection pooling, persistent HTTP/2 session management, automatic retry, server push, unbounded multiplex scheduling, general multiplexing, priority scheduling, or request bodies for GET, HEAD, DELETE, OPTIONS, or TRACE |
+| Prior-knowledge h2c | With `http2`, direct `socket2` h2c sends GET, HEAD, bodyless DELETE, OPTIONS, or TRACE, and buffered POST, PUT, or PATCH requests, suppresses HEAD response bodies, treats `RST_STREAM` on the active stream as a bounded reset/cancellation signal, acknowledges valid PING frames with matching opaque data, DATA bodies, trailers, HPACK static Huffman strings, dynamic entries within peer settings, large header blocks, padded incoming frames, `GOAWAY` shutdown boundaries, PRIORITY metadata validation without scheduling, HTTP/2-allowed unknown/extension frame ignoring inside this bounded path, reserved stream-id high-bit normalization, and conservative DATA flow control | `CONNECT` is rejected deterministically before opening a client socket, and `PUSH_PROMISE`/server push is rejected instead of managed; bounded prior-knowledge h2c only, with no public cancellation callback API, no extension callback API, full extension negotiation, TLS ALPN, external h2 integration, proxy tunneling to h2, proxy h2, tunnel handoff, connection pooling, persistent HTTP/2 session management, automatic retry, server push, full stream state machine, unbounded multiplex scheduling, general multiplexing, priority scheduling, or request bodies for GET, HEAD, DELETE, OPTIONS, or TRACE |
 
 With the `http2` feature enabled, `emit_http2_prior_knowledge` sends a bounded
 prior-knowledge h2c request over a direct socket2 TCP connection. It supports
@@ -67,13 +67,17 @@ HTTP/1.1 `CONNECT` tunnel handoff remains a separate client path;
 prior-knowledge h2c `GOAWAY` is treated as a bounded shutdown signal:
 completed responses remain usable, active responses continue only when the
 peer's `last-stream-id` includes the stream, and lower boundaries reject the
-response deterministically. `CONNECT` and proxy tunneling are rejected before a
-client socket is opened. TLS ALPN, extension callback APIs, full extension
-negotiation, external h2 integration, proxy h2, tunnel handoff, connection
-pooling, persistent HTTP/2 session management, automatic retry, server push,
-and full HTTP/2 features such as unbounded multiplex scheduling, general
-multiplexing, and priority scheduling are not part of that bounded
-prior-knowledge client path.
+response deterministically. `RST_STREAM` is likewise bounded to this
+prior-knowledge h2c client path: a reset for the active stream is reported as
+response cancellation, while malformed reset frames are rejected
+deterministically. RTTP does not expose a public cancellation callback API or
+retry the request automatically. `CONNECT` and proxy tunneling are rejected
+before a client socket is opened. TLS ALPN, extension callback APIs, full
+extension negotiation, external h2 integration, proxy h2, tunnel handoff,
+connection pooling, persistent HTTP/2 session management, automatic retry,
+server push, full stream state machines, and full HTTP/2 features such as
+unbounded multiplex scheduling, general multiplexing, and priority scheduling
+are not part of that bounded prior-knowledge client path.
 
 ## Examples
 


### PR DESCRIPTION
README documentation now clarifies bounded prior-knowledge h2c `RST_STREAM` reset/cancellation behavior for client and server paths while preserving unsupported HTTP/2 boundary language. Runtime behavior is unchanged, and requested verification passed.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1491/
work_kind: code_work
branch: hbx-1491-rttp-document-h2c-rst-stream
base: main
commit: 765fe96c329e0c8b56729b43658a97b958e9ae3e
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1491/
    url: https://plane.kahub.in/endless/browse/HBX-1491/
    close_policy: link_only
```