### PR TITLE
feat: [rttp] Reject forbidden h2c connection-specific request headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,8 @@ prior-knowledge h2c responses.
 Incoming padded HEADERS, DATA, and trailer frames are accepted without exposing
 padding bytes to handlers, and HPACK static Huffman strings, request dynamic
 table entries, and large header blocks are carried with CONTINUATION frames.
+Prior-knowledge h2c request headers reject HTTP/1.x connection-specific fields
+before handler dispatch; `TE` is accepted only as `te: trailers`.
 Valid standalone PRIORITY frames and HEADERS priority fields are validated and
 ignored as metadata; malformed priority metadata is rejected, and request or
 response ordering does not use priority scheduling. Valid PING frames on

--- a/rttp/README.md
+++ b/rttp/README.md
@@ -59,6 +59,8 @@ requests. The h2c path handles `HEAD` without writing response DATA frames.
 Incoming padded HEADERS, DATA, and trailer frames are accepted without exposing
 padding bytes to handlers, HPACK static Huffman strings, request dynamic table
 entries, and large header blocks are carried with CONTINUATION frames. Valid
+prior-knowledge h2c request headers reject HTTP/1.x connection-specific fields
+before handler dispatch; `TE` is accepted only as `te: trailers`. Valid
 standalone PRIORITY frames and HEADERS priority fields are validated and ignored
 as metadata; malformed priority metadata is rejected, and request or response
 ordering does not use priority scheduling. Multiple prior-knowledge h2c request

--- a/rttp/src/server.rs
+++ b/rttp/src/server.rs
@@ -1385,8 +1385,10 @@ fn decode_http2_request_headers(
           "forbidden HTTP/2 request header",
         ));
       }
-      "te" if value.eq_ignore_ascii_case("trailers") => decoded.headers.push((name, value)),
-      "te" => {
+      name if name.eq_ignore_ascii_case("te") && value.eq_ignore_ascii_case("trailers") => {
+        decoded.headers.push((name.to_string(), value))
+      }
+      name if name.eq_ignore_ascii_case("te") => {
         return Err(io::Error::new(
           io::ErrorKind::InvalidData,
           "forbidden HTTP/2 request header",
@@ -1400,10 +1402,15 @@ fn decode_http2_request_headers(
 }
 
 fn is_forbidden_http2_request_header_name(name: &str) -> bool {
-  matches!(
-    name,
-    "connection" | "keep-alive" | "proxy-connection" | "transfer-encoding" | "upgrade"
-  )
+  [
+    "connection",
+    "keep-alive",
+    "proxy-connection",
+    "transfer-encoding",
+    "upgrade",
+  ]
+  .iter()
+  .any(|forbidden| name.eq_ignore_ascii_case(forbidden))
 }
 
 fn decode_http2_request_trailers(

--- a/rttp/src/server.rs
+++ b/rttp/src/server.rs
@@ -1379,12 +1379,31 @@ fn decode_http2_request_headers(
       ":scheme" => decoded.scheme = Some(value),
       ":authority" => decoded.authority = Some(value),
       name if name.starts_with(':') => {}
-      "connection" | "keep-alive" | "proxy-connection" | "transfer-encoding" | "upgrade" => {}
+      name if is_forbidden_http2_request_header_name(name) => {
+        return Err(io::Error::new(
+          io::ErrorKind::InvalidData,
+          "forbidden HTTP/2 request header",
+        ));
+      }
+      "te" if value.eq_ignore_ascii_case("trailers") => decoded.headers.push((name, value)),
+      "te" => {
+        return Err(io::Error::new(
+          io::ErrorKind::InvalidData,
+          "forbidden HTTP/2 request header",
+        ));
+      }
       _ => decoded.headers.push((name, value)),
     }
   }
 
   Ok(decoded)
+}
+
+fn is_forbidden_http2_request_header_name(name: &str) -> bool {
+  matches!(
+    name,
+    "connection" | "keep-alive" | "proxy-connection" | "transfer-encoding" | "upgrade"
+  )
 }
 
 fn decode_http2_request_trailers(

--- a/rttp/tests/test_server.rs
+++ b/rttp/tests/test_server.rs
@@ -2042,6 +2042,74 @@ fn server_rejects_http2_prior_knowledge_connection_push_promise_without_handler(
 }
 
 #[test]
+fn server_rejects_http2_prior_knowledge_connection_specific_request_headers_without_handler() {
+  for (name, value) in [
+    (b"connection".as_slice(), b"close".as_slice()),
+    (b"keep-alive".as_slice(), b"timeout=5".as_slice()),
+    (b"proxy-connection".as_slice(), b"keep-alive".as_slice()),
+    (b"transfer-encoding".as_slice(), b"chunked".as_slice()),
+    (b"upgrade".as_slice(), b"h2c".as_slice()),
+  ] {
+    let mut headers = h2_get_headers(b"/forbidden-headers", b"localhost");
+    headers.extend(h2_literal_new_name(name, value));
+
+    assert_invalid_h2_headers_without_handler(&headers);
+  }
+}
+
+#[test]
+fn server_accepts_http2_prior_knowledge_te_trailers_request_header() {
+  let server = rttp::Http::server("127.0.0.1:0").expect("bind server");
+  let addr = server.local_addr().expect("server addr");
+  let (tx, rx) = mpsc::channel();
+
+  let handle = thread::spawn(move || {
+    server
+      .accept_one(|request| {
+        tx.send(request.header("te").map(str::to_string))
+          .expect("send h2 TE header");
+        HttpResponse::ok("accepted")
+      })
+      .expect("serve h2 TE trailers request");
+  });
+
+  let mut stream = TcpStream::connect(addr).expect("connect h2 server");
+  stream
+    .set_read_timeout(Some(Duration::from_secs(2)))
+    .expect("set h2 read timeout");
+  complete_h2_server_handshake(&mut stream);
+
+  let mut headers = h2_get_headers(b"/te-trailers", addr.to_string().as_bytes());
+  headers.extend(h2_literal_new_name(b"te", b"trailers"));
+  write_h2_frame(
+    &mut stream,
+    H2_FRAME_HEADERS,
+    H2_FLAG_END_HEADERS | H2_FLAG_END_STREAM,
+    1,
+    &headers,
+  );
+
+  let response_headers = read_h2_frame(&mut stream);
+  assert_eq!(H2_FRAME_HEADERS, response_headers.frame_type);
+  assert_eq!(1, response_headers.stream_id);
+  let response_body = read_h2_frame(&mut stream);
+  assert_eq!(H2_FRAME_DATA, response_body.frame_type);
+  assert_eq!(H2_FLAG_END_STREAM, response_body.flags);
+  assert_eq!(b"accepted", response_body.payload.as_slice());
+
+  assert_eq!(Some("trailers".to_string()), rx.recv().expect("TE header"));
+  handle.join().expect("server thread");
+}
+
+#[test]
+fn server_rejects_http2_prior_knowledge_invalid_te_request_header_without_handler() {
+  let mut headers = h2_get_headers(b"/invalid-te", b"localhost");
+  headers.extend(h2_literal_new_name(b"te", b"gzip"));
+
+  assert_invalid_h2_headers_without_handler(&headers);
+}
+
+#[test]
 fn server_rejects_http2_prior_knowledge_truncated_push_promise_without_handler() {
   let server = rttp::Http::server("127.0.0.1:0")
     .expect("bind server")

--- a/rttp/tests/test_server.rs
+++ b/rttp/tests/test_server.rs
@@ -2049,6 +2049,8 @@ fn server_rejects_http2_prior_knowledge_connection_specific_request_headers_with
     (b"proxy-connection".as_slice(), b"keep-alive".as_slice()),
     (b"transfer-encoding".as_slice(), b"chunked".as_slice()),
     (b"upgrade".as_slice(), b"h2c".as_slice()),
+    (b"Connection".as_slice(), b"close".as_slice()),
+    (b"TE".as_slice(), b"gzip".as_slice()),
   ] {
     let mut headers = h2_get_headers(b"/forbidden-headers", b"localhost");
     headers.extend(h2_literal_new_name(name, value));


### PR DESCRIPTION
Hardened RTTP's prior-knowledge h2c server request decoder to reject forbidden connection-specific headers before handler dispatch, preserved valid `te: trailers`, documented the behavior, and verified formatting plus targeted and workspace tests.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1494/
work_kind: code_work
branch: hbx-1494-rttp-reject-forbidden-h2c-connection
base: main
commit: 44f0523a8fd69c2d6699d317f8dc78e569a512c4
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1494/
    url: https://plane.kahub.in/endless/browse/HBX-1494/
    close_policy: link_only
```