### PR TITLE
feat: [rttp] Add cross-crate h2c connection header boundary matrix

### DIFF
--- a/rttp/src/server.rs
+++ b/rttp/src/server.rs
@@ -1379,7 +1379,7 @@ fn decode_http2_request_headers(
       ":scheme" => decoded.scheme = Some(value),
       ":authority" => decoded.authority = Some(value),
       name if name.starts_with(':') => {}
-      name if is_forbidden_http2_request_header_name(name) => {
+      name if is_forbidden_http2_request_header(name, &value) => {
         return Err(io::Error::new(
           io::ErrorKind::InvalidData,
           "forbidden HTTP/2 request header",
@@ -1392,11 +1392,12 @@ fn decode_http2_request_headers(
   Ok(decoded)
 }
 
-fn is_forbidden_http2_request_header_name(name: &str) -> bool {
-  matches!(
-    name,
-    "connection" | "keep-alive" | "proxy-connection" | "te" | "transfer-encoding" | "upgrade"
-  )
+fn is_forbidden_http2_request_header(name: &str, value: &str) -> bool {
+  match name {
+    "te" => !value.eq_ignore_ascii_case("trailers"),
+    "connection" | "keep-alive" | "proxy-connection" | "transfer-encoding" | "upgrade" => true,
+    _ => false,
+  }
 }
 
 fn decode_http2_request_trailers(

--- a/rttp/src/server.rs
+++ b/rttp/src/server.rs
@@ -1379,12 +1379,24 @@ fn decode_http2_request_headers(
       ":scheme" => decoded.scheme = Some(value),
       ":authority" => decoded.authority = Some(value),
       name if name.starts_with(':') => {}
-      "connection" | "keep-alive" | "proxy-connection" | "transfer-encoding" | "upgrade" => {}
+      name if is_forbidden_http2_request_header_name(name) => {
+        return Err(io::Error::new(
+          io::ErrorKind::InvalidData,
+          "forbidden HTTP/2 request header",
+        ));
+      }
       _ => decoded.headers.push((name, value)),
     }
   }
 
   Ok(decoded)
+}
+
+fn is_forbidden_http2_request_header_name(name: &str) -> bool {
+  matches!(
+    name,
+    "connection" | "keep-alive" | "proxy-connection" | "te" | "transfer-encoding" | "upgrade"
+  )
 }
 
 fn decode_http2_request_trailers(

--- a/rttp/tests/http2_feature.rs
+++ b/rttp/tests/http2_feature.rs
@@ -2986,6 +2986,67 @@ fn wrapper_http2_prior_knowledge_post_body_round_trips_between_client_and_server
 }
 
 #[test]
+fn wrapper_http2_prior_knowledge_strips_connection_specific_headers_across_crates() {
+  let server = rttp::Http::server("127.0.0.1:0").expect("bind server");
+  let addr = server.local_addr().expect("server addr");
+  let (tx, rx) = mpsc::channel();
+
+  let handle = thread::spawn(move || {
+    server
+      .accept_one(|request| {
+        tx.send((
+          request.header("connection").map(str::to_string),
+          request.header("keep-alive").map(str::to_string),
+          request.header("te").map(str::to_string),
+          request.header("upgrade").map(str::to_string),
+          request.header("x-boundary").map(str::to_string),
+        ))
+        .expect("send h2 connection header boundary observation");
+        HttpResponse::ok("clean h2c response")
+          .header("Connection", "close")
+          .header("Keep-Alive", "timeout=5")
+          .header("TE", "trailers")
+          .header("Trailer", "X-Forbidden-Trailer")
+          .header("Transfer-Encoding", "chunked")
+          .header("Upgrade", "websocket")
+          .header("X-Boundary-Response", "present")
+      })
+      .expect("serve h2 connection header boundary request");
+  });
+
+  let response = HttpClient::new()
+    .get()
+    .url(format!("http://{}/connection-boundary", addr))
+    .header(("Connection", "keep-alive"))
+    .header(("Keep-Alive", "timeout=5"))
+    .header(("TE", "trailers"))
+    .header(("Upgrade", "websocket"))
+    .header(("X-Boundary", "present"))
+    .emit_http2_prior_knowledge()
+    .expect("h2 connection header boundary response");
+
+  assert_eq!("clean h2c response", response.body().string().unwrap());
+  assert_eq!(
+    (None, None, None, None, Some("present".to_string())),
+    rx.recv()
+      .expect("receive h2 connection header boundary observation")
+  );
+  assert!(response.header_value("connection").is_none());
+  assert!(response.header_value("keep-alive").is_none());
+  assert!(response.header_value("te").is_none());
+  assert!(response.header_value("trailer").is_none());
+  assert!(response.header_value("transfer-encoding").is_none());
+  assert!(response.header_value("upgrade").is_none());
+  assert_eq!(
+    Some(&"present".to_string()),
+    response.header_value("x-boundary-response")
+  );
+  assert!(response.trailers().is_empty());
+
+  handle.join().expect("server thread");
+}
+
+#[test]
 fn wrapper_http2_prior_knowledge_post_request_trailers_reach_server_only_as_trailers() {
   let server = rttp::Http::server("127.0.0.1:0").expect("bind server");
   let addr = server.local_addr().expect("server addr");
@@ -3786,6 +3847,25 @@ fn http2_feature_socket2_rejects_malformed_padded_headers_before_handler() {
       H2_FLAG_PADDED | H2_FLAG_END_HEADERS | H2_FLAG_END_STREAM,
       1,
       &payload,
+    );
+  });
+}
+
+#[test]
+fn http2_feature_socket2_rejects_connection_specific_request_headers_before_handler() {
+  assert_malformed_h2_request_rejected_before_handler(|stream, addr| {
+    let mut headers = h2_get_headers(b"/bad-connection-header", addr.to_string().as_bytes());
+    headers.extend(h2_literal_new_name(b"connection", b"keep-alive"));
+    headers.extend(h2_literal_new_name(b"keep-alive", b"timeout=5"));
+    headers.extend(h2_literal_new_name(b"te", b"gzip"));
+    headers.extend(h2_literal_new_name(b"transfer-encoding", b"chunked"));
+    headers.extend(h2_literal_new_name(b"upgrade", b"websocket"));
+    write_h2_frame(
+      stream,
+      H2_FRAME_HEADERS,
+      H2_FLAG_END_HEADERS | H2_FLAG_END_STREAM,
+      1,
+      &headers,
     );
   });
 }

--- a/rttp/tests/http2_feature.rs
+++ b/rttp/tests/http2_feature.rs
@@ -3871,6 +3871,76 @@ fn http2_feature_socket2_rejects_connection_specific_request_headers_before_hand
 }
 
 #[test]
+fn http2_feature_socket2_accepts_te_trailers_request_header() {
+  let server = rttp::Http::server("127.0.0.1:0")
+    .expect("bind server")
+    .with_read_timeout(Some(Duration::from_secs(2)))
+    .with_write_timeout(Some(Duration::from_secs(2)));
+  let addr = server.local_addr().expect("server addr");
+  let (tx, rx) = mpsc::channel();
+
+  let handle = thread::spawn(move || {
+    server.accept_one(|request| {
+      tx.send(request.header("te").map(str::to_string))
+        .expect("send observed te header");
+      HttpResponse::ok("accepted te trailers")
+    })
+  });
+
+  let mut stream = TcpStream::connect(addr).expect("connect h2 server");
+  stream
+    .set_read_timeout(Some(Duration::from_secs(2)))
+    .expect("set client read timeout");
+  stream
+    .set_write_timeout(Some(Duration::from_secs(2)))
+    .expect("set client write timeout");
+  complete_h2_server_handshake_with_settings(&mut stream, &[]);
+
+  let mut headers = h2_get_headers(b"/te-trailers", addr.to_string().as_bytes());
+  headers.extend(h2_literal_new_name(b"te", b"trailers"));
+  write_h2_frame(
+    &mut stream,
+    H2_FRAME_HEADERS,
+    H2_FLAG_END_HEADERS | H2_FLAG_END_STREAM,
+    1,
+    &headers,
+  );
+
+  let response_body = (0..8)
+    .map(|_| read_h2_frame(&mut stream))
+    .find(|frame| {
+      frame.frame_type == H2_FRAME_DATA
+        && frame.stream_id == 1
+        && frame.flags & H2_FLAG_END_STREAM == H2_FLAG_END_STREAM
+    })
+    .expect("h2 response body");
+  assert_eq!(b"accepted te trailers", response_body.payload.as_slice());
+  assert_eq!(
+    Some("trailers".to_string()),
+    rx.recv().expect("receive observed te header")
+  );
+  handle
+    .join()
+    .expect("server thread")
+    .expect("serve h2 request");
+}
+
+#[test]
+fn http2_feature_socket2_rejects_non_trailers_te_request_header_before_handler() {
+  assert_malformed_h2_request_rejected_before_handler(|stream, addr| {
+    let mut headers = h2_get_headers(b"/bad-te-header", addr.to_string().as_bytes());
+    headers.extend(h2_literal_new_name(b"te", b"gzip"));
+    write_h2_frame(
+      stream,
+      H2_FRAME_HEADERS,
+      H2_FLAG_END_HEADERS | H2_FLAG_END_STREAM,
+      1,
+      &headers,
+    );
+  });
+}
+
+#[test]
 fn http2_feature_socket2_rejects_short_priority_headers_before_handler() {
   assert_malformed_h2_request_rejected_before_handler(|stream, _| {
     write_h2_frame(

--- a/rttp_client/src/http2.rs
+++ b/rttp_client/src/http2.rs
@@ -1795,9 +1795,19 @@ fn push_decoded_header(
         .map_err(|_| error::bad_response("invalid HTTP/2 :status header"))?,
     );
   } else if !name.starts_with(':') {
+    if is_forbidden_response_header_name(name) {
+      return Err(error::bad_response("forbidden HTTP/2 response header"));
+    }
     headers.push((name.to_string(), value.to_string()));
   }
   Ok(())
+}
+
+fn is_forbidden_response_header_name(name: &str) -> bool {
+  matches!(
+    name.to_ascii_lowercase().as_str(),
+    "connection" | "keep-alive" | "proxy-connection" | "te" | "transfer-encoding" | "upgrade"
+  )
 }
 
 fn validate_response_trailer_header(name: &str, value: &str) -> error::Result<()> {

--- a/rttp_client/tests/http2_prior_knowledge.rs
+++ b/rttp_client/tests/http2_prior_knowledge.rs
@@ -1697,6 +1697,53 @@ fn prior_knowledge_decodes_padded_response_headers() {
 }
 
 #[test]
+fn prior_knowledge_rejects_connection_specific_response_headers() {
+  for (name, value) in [
+    (b"connection".as_slice(), b"close".as_slice()),
+    (b"keep-alive".as_slice(), b"timeout=5".as_slice()),
+    (b"proxy-connection".as_slice(), b"keep-alive".as_slice()),
+    (b"te".as_slice(), b"trailers".as_slice()),
+    (b"transfer-encoding".as_slice(), b"chunked".as_slice()),
+    (b"upgrade".as_slice(), b"websocket".as_slice()),
+  ] {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind h2 peer");
+    let addr = listener.local_addr().expect("h2 peer addr");
+    let header_block = {
+      let mut block = vec![0x88];
+      block.extend(h2_literal_new_name(name, value));
+      block
+    };
+
+    let handle = thread::spawn(move || {
+      let (mut stream, _) = listener.accept().expect("accept h2 client");
+      complete_h2_request_handshake(&mut stream);
+      write_frame(
+        &mut stream,
+        FRAME_HEADERS,
+        FLAG_END_HEADERS | FLAG_END_STREAM,
+        1,
+        &header_block,
+      );
+    });
+
+    let error = HttpClient::new()
+      .get()
+      .url(format!("http://{}/bad-connection-header", addr))
+      .emit_http2_prior_knowledge()
+      .expect_err("connection-specific response header must be rejected");
+
+    assert!(
+      error
+        .to_string()
+        .contains("forbidden HTTP/2 response header"),
+      "unexpected error for {}: {error}",
+      String::from_utf8_lossy(name)
+    );
+    handle.join().expect("h2 forbidden response peer thread");
+  }
+}
+
+#[test]
 fn prior_knowledge_decodes_padded_data_without_appending_padding() {
   let listener = TcpListener::bind("127.0.0.1:0").expect("bind h2 peer");
   let addr = listener.local_addr().expect("h2 peer addr");

--- a/rttp_client/tests/http2_prior_knowledge.rs
+++ b/rttp_client/tests/http2_prior_knowledge.rs
@@ -1555,15 +1555,10 @@ fn prior_knowledge_exposes_response_trailers_after_data_without_changing_headers
 }
 
 #[test]
-fn prior_knowledge_preserves_peer_response_connection_specific_headers() {
+fn prior_knowledge_preserves_peer_response_non_connection_specific_headers() {
   let mut header_block = vec![0x88];
   for (name, value) in [
-    (b"connection".as_slice(), b"close".as_slice()),
-    (b"keep-alive", b"timeout=5"),
-    (b"proxy-connection", b"keep-alive"),
-    (b"transfer-encoding", b"chunked"),
-    (b"upgrade", b"websocket"),
-    (b"trailer", b"x-trace"),
+    (b"trailer".as_slice(), b"x-trace".as_slice()),
     (b"host", b"example.invalid"),
   ] {
     header_block.extend_from_slice(&h2_literal_new_name(name, value));
@@ -1573,32 +1568,12 @@ fn prior_knowledge_preserves_peer_response_connection_specific_headers() {
 
   let response = HttpClient::new()
     .get()
-    .url(format!("http://{}/response-connection-specific", addr))
+    .url(format!("http://{}/response-non-connection-specific", addr))
     .emit_http2_prior_knowledge()
-    .expect("h2 response with peer connection-specific headers");
+    .expect("h2 response with peer non-connection-specific headers");
 
   assert_eq!(200, response.code());
   assert_eq!("headers", response.body().string().unwrap());
-  assert_eq!(
-    Some(&"close".to_string()),
-    response.header_value("connection")
-  );
-  assert_eq!(
-    Some(&"timeout=5".to_string()),
-    response.header_value("keep-alive")
-  );
-  assert_eq!(
-    Some(&"keep-alive".to_string()),
-    response.header_value("proxy-connection")
-  );
-  assert_eq!(
-    Some(&"chunked".to_string()),
-    response.header_value("transfer-encoding")
-  );
-  assert_eq!(
-    Some(&"websocket".to_string()),
-    response.header_value("upgrade")
-  );
   assert_eq!(
     Some(&"x-trace".to_string()),
     response.header_value("trailer")


### PR DESCRIPTION
Added h2c boundary coverage and enforcement for connection-specific HTTP/2 metadata across `rttp` and `rttp_client`, including normal cross-crate stripping and malicious peer rejection. Verification passed with formatting, workspace tests, and feature-enabled h2c integration tests.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1495/
work_kind: code_work
branch: hbx-1495-rttp-add-cross-crate-h2c
base: main
commit: 8fb820302218b9bf992ed5551879a774557996a6
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1495/
    url: https://plane.kahub.in/endless/browse/HBX-1495/
    close_policy: link_only
```