### PR TITLE
feat: [rttp_client] Enforce h2c connection-specific request header limits

### DIFF
--- a/rttp_client/src/client.rs
+++ b/rttp_client/src/client.rs
@@ -427,6 +427,7 @@ fn is_forbidden_request_trailer_name(name: &str) -> bool {
     "connection"
       | "content-length"
       | "host"
+      | "keep-alive"
       | "proxy-authenticate"
       | "proxy-authorization"
       | "proxy-connection"

--- a/rttp_client/src/http2.rs
+++ b/rttp_client/src/http2.rs
@@ -338,12 +338,9 @@ fn write_request(
       .min(DEFAULT_HPACK_DYNAMIC_TABLE_SIZE),
   );
   let regular_header_fields = regular_headers(request.header());
-  let trailer_announcement = (!request.origin().trailers().is_empty())
-    .then(|| ("trailer".to_string(), request_trailer_field_value(request)));
   let trailer_fields = request_trailer_fields(request);
   let mut dynamic_field_plan = Vec::new();
   dynamic_field_plan.extend(regular_header_fields.iter().cloned());
-  dynamic_field_plan.extend(trailer_announcement.iter().cloned());
   dynamic_field_plan.extend(trailer_fields.iter().cloned());
   let mut dynamic_field_position = 0;
 
@@ -351,7 +348,6 @@ fn write_request(
     request,
     url,
     &regular_header_fields,
-    trailer_announcement.as_ref(),
     &dynamic_field_plan,
     &mut dynamic_field_position,
     &mut hpack,
@@ -589,7 +585,6 @@ fn encode_request_headers(
   request: &RawRequest<'_>,
   url: &Url,
   regular_header_fields: &[(String, String)],
-  trailer_announcement: Option<&(String, String)>,
   dynamic_field_plan: &[(String, String)],
   dynamic_field_position: &mut usize,
   hpack: &mut RequestHpackEncoder,
@@ -618,25 +613,7 @@ fn encode_request_headers(
     *dynamic_field_position += 1;
   }
 
-  if let Some((name, value)) = trailer_announcement {
-    let remaining = dynamic_field_plan
-      .get(*dynamic_field_position + 1..)
-      .unwrap_or(&[]);
-    hpack.encode_field(&mut block, name, value, remaining)?;
-    *dynamic_field_position += 1;
-  }
-
   Ok(block)
-}
-
-fn request_trailer_field_value(request: &RawRequest<'_>) -> String {
-  request
-    .origin()
-    .trailers()
-    .iter()
-    .map(|header| header.name().as_str())
-    .collect::<Vec<_>>()
-    .join(", ")
 }
 
 fn request_trailer_fields(request: &RawRequest<'_>) -> Vec<(String, String)> {
@@ -707,25 +684,42 @@ fn authority(url: &Url) -> error::Result<String> {
 }
 
 fn regular_headers(header: &str) -> Vec<(String, String)> {
+  let connection_tokens = header
+    .lines()
+    .skip(1)
+    .filter_map(|line| line.split_once(':'))
+    .filter(|(name, _)| name.trim().eq_ignore_ascii_case("connection"))
+    .flat_map(|(_, value)| value.split(','))
+    .map(|token| token.trim().to_ascii_lowercase())
+    .filter(|token| !token.is_empty())
+    .collect::<Vec<_>>();
+
   header
     .lines()
     .skip(1)
     .filter_map(|line| line.split_once(':'))
     .map(|(name, value)| (name.trim().to_ascii_lowercase(), value.trim().to_string()))
-    .filter(|(name, _)| {
-      !matches!(
-        name.as_str(),
-        "connection"
-          | "host"
-          | "keep-alive"
-          | "proxy-connection"
-          | "te"
-          | "trailer"
-          | "transfer-encoding"
-          | "upgrade"
-      )
-    })
+    .filter(|(name, _)| !is_forbidden_request_header_name(name, &connection_tokens))
     .collect()
+}
+
+fn is_forbidden_request_header_name(name: &str, connection_tokens: &[String]) -> bool {
+  is_connection_specific_header_name(name)
+    || name == "te"
+    || connection_tokens.iter().any(|token| token == name)
+}
+
+fn is_connection_specific_header_name(name: &str) -> bool {
+  matches!(
+    name,
+    "connection"
+      | "host"
+      | "keep-alive"
+      | "proxy-connection"
+      | "trailer"
+      | "transfer-encoding"
+      | "upgrade"
+  )
 }
 
 #[derive(Clone, Copy)]
@@ -1828,8 +1822,10 @@ fn is_forbidden_response_trailer_name(name: &str) -> bool {
       | "content-length"
       | "cookie"
       | "host"
+      | "keep-alive"
       | "proxy-authenticate"
       | "proxy-authorization"
+      | "proxy-connection"
       | "www-authenticate"
       | "set-cookie"
       | "te"

--- a/rttp_client/tests/http2_prior_knowledge.rs
+++ b/rttp_client/tests/http2_prior_knowledge.rs
@@ -749,6 +749,71 @@ fn prior_knowledge_post_sends_headers_then_body_data_frame() {
 }
 
 #[test]
+fn prior_knowledge_request_omits_connection_specific_headers_and_connection_tokens() {
+  let listener = TcpListener::bind("127.0.0.1:0").expect("bind h2 peer");
+  let addr = listener.local_addr().expect("h2 peer addr");
+
+  let handle = thread::spawn(move || {
+    let (mut stream, _) = listener.accept().expect("accept h2 client");
+    complete_h2_handshake_without_request(&mut stream);
+
+    let request_headers = read_frame(&mut stream);
+    assert_eq!(FRAME_HEADERS, request_headers.frame_type);
+    assert_eq!(FLAG_END_STREAM | FLAG_END_HEADERS, request_headers.flags);
+    assert_eq!(1, request_headers.stream_id);
+
+    write_frame(&mut stream, FRAME_SETTINGS, FLAG_ACK, 0, &[]);
+    write_frame(&mut stream, FRAME_HEADERS, FLAG_END_HEADERS, 1, &[0x88]);
+    write_frame(&mut stream, FRAME_DATA, FLAG_END_STREAM, 1, b"filtered");
+
+    request_headers.payload
+  });
+
+  let response = HttpClient::new()
+    .get()
+    .url(format!("http://{}/connection-specific", addr))
+    .header(("Connection", "Keep-Alive, X-Hop, upgrade"))
+    .header(("Keep-Alive", "timeout=5"))
+    .header(("Proxy-Connection", "keep-alive"))
+    .header(("Transfer-Encoding", "chunked"))
+    .header(("Upgrade", "websocket"))
+    .header(("Trailer", "X-Trailer"))
+    .header(("Host".to_string(), addr.to_string()))
+    .header(("X-Hop", "remove-me"))
+    .header(("X-End-To-End", "keep-me"))
+    .emit_http2_prior_knowledge()
+    .expect("h2 GET response");
+
+  assert_eq!(200, response.code());
+  assert_eq!("filtered", response.body().string().unwrap());
+
+  let request_header_block = handle.join().expect("h2 peer thread");
+  for forbidden in [
+    b"connection".as_slice(),
+    b"keep-alive",
+    b"proxy-connection",
+    b"transfer-encoding",
+    b"upgrade",
+    b"trailer",
+    b"host",
+    b"x-hop",
+  ] {
+    assert!(
+      find_header_value(&request_header_block, forbidden).is_none(),
+      "request must not encode {} as an HTTP/2 header",
+      String::from_utf8_lossy(forbidden)
+    );
+  }
+  assert_eq!(
+    b"keep-me",
+    find_header_value(&request_header_block, b"x-end-to-end")
+      .expect("end-to-end request header")
+      .value
+      .as_slice()
+  );
+}
+
+#[test]
 fn prior_knowledge_post_sends_request_trailers_after_body_data_frame() {
   let listener = TcpListener::bind("127.0.0.1:0").expect("bind h2 peer");
   let addr = listener.local_addr().expect("h2 peer addr");
@@ -783,7 +848,6 @@ fn prior_knowledge_post_sends_request_trailers_after_body_data_frame() {
   let response = HttpClient::new()
     .post()
     .url(format!("http://{}/submit-with-tail", addr))
-    .header(("Trailer", "X-Trace"))
     .trailer(("X-Trace", "abc"))
     .expect("configure request trailer")
     .raw("trace body")
@@ -801,13 +865,7 @@ fn prior_knowledge_post_sends_request_trailers_after_body_data_frame() {
       .value
       .as_slice()
   );
-  assert_eq!(
-    b"X-Trace",
-    find_header_value(&request_header_block, b"trailer")
-      .expect("trailer request header")
-      .value
-      .as_slice()
-  );
+  assert!(find_header_value(&request_header_block, b"trailer").is_none());
   assert_eq!(
     b"abc",
     find_header_value(&request_trailer_block, b"x-trace")
@@ -1494,6 +1552,110 @@ fn prior_knowledge_exposes_response_trailers_after_data_without_changing_headers
   );
   assert!(response.header("x-trace").is_none());
   handle.join().expect("h2 peer thread");
+}
+
+#[test]
+fn prior_knowledge_preserves_peer_response_connection_specific_headers() {
+  let mut header_block = vec![0x88];
+  for (name, value) in [
+    (b"connection".as_slice(), b"close".as_slice()),
+    (b"keep-alive", b"timeout=5"),
+    (b"proxy-connection", b"keep-alive"),
+    (b"transfer-encoding", b"chunked"),
+    (b"upgrade", b"websocket"),
+    (b"trailer", b"x-trace"),
+    (b"host", b"example.invalid"),
+  ] {
+    header_block.extend_from_slice(&h2_literal_new_name(name, value));
+  }
+  let header_block = Box::leak(header_block.into_boxed_slice());
+  let (addr, handle) = spawn_h2_prior_knowledge_peer_with_response(header_block, &[b"headers"]);
+
+  let response = HttpClient::new()
+    .get()
+    .url(format!("http://{}/response-connection-specific", addr))
+    .emit_http2_prior_knowledge()
+    .expect("h2 response with peer connection-specific headers");
+
+  assert_eq!(200, response.code());
+  assert_eq!("headers", response.body().string().unwrap());
+  assert_eq!(
+    Some(&"close".to_string()),
+    response.header_value("connection")
+  );
+  assert_eq!(
+    Some(&"timeout=5".to_string()),
+    response.header_value("keep-alive")
+  );
+  assert_eq!(
+    Some(&"keep-alive".to_string()),
+    response.header_value("proxy-connection")
+  );
+  assert_eq!(
+    Some(&"chunked".to_string()),
+    response.header_value("transfer-encoding")
+  );
+  assert_eq!(
+    Some(&"websocket".to_string()),
+    response.header_value("upgrade")
+  );
+  assert_eq!(
+    Some(&"x-trace".to_string()),
+    response.header_value("trailer")
+  );
+  assert_eq!(
+    Some(&"example.invalid".to_string()),
+    response.header_value("host")
+  );
+  handle.join().expect("h2 peer thread");
+}
+
+#[test]
+fn prior_knowledge_rejects_peer_response_connection_specific_trailers() {
+  for (name, path) in [
+    (b"connection".as_slice(), "connection"),
+    (b"keep-alive", "keep-alive"),
+    (b"proxy-connection", "proxy-connection"),
+    (b"transfer-encoding", "transfer-encoding"),
+    (b"upgrade", "upgrade"),
+    (b"trailer", "trailer"),
+    (b"host", "host"),
+  ] {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind h2 peer");
+    let addr = listener.local_addr().expect("h2 peer addr");
+    let trailer_block = h2_literal_new_name(name, b"forbidden");
+
+    let handle = thread::spawn(move || {
+      let (mut stream, _) = listener.accept().expect("accept h2 client");
+      complete_h2_request_handshake(&mut stream);
+
+      write_frame(&mut stream, FRAME_HEADERS, FLAG_END_HEADERS, 1, &[0x88]);
+      write_frame(&mut stream, FRAME_DATA, 0, 1, b"body");
+      write_frame(
+        &mut stream,
+        FRAME_HEADERS,
+        FLAG_END_HEADERS | FLAG_END_STREAM,
+        1,
+        &trailer_block,
+      );
+    });
+
+    let result = HttpClient::new()
+      .get()
+      .url(format!("http://{}/forbidden-trailer-{}", addr, path))
+      .emit_http2_prior_knowledge();
+
+    let error = match result {
+      Ok(response) => panic!("{path} response trailer must be rejected, got response: {response}"),
+      Err(error) => error,
+    };
+
+    assert!(
+      error.to_string().contains("Forbidden trailer header"),
+      "unexpected error for {path}: {error}"
+    );
+    handle.join().expect("h2 peer thread");
+  }
 }
 
 #[test]


### PR DESCRIPTION
rttp_client h2c prior-knowledge request encoding now filters connection-specific and Connection-token headers, avoids regular trailer header emission, and includes regressions for outbound filtering plus peer response header/trailer boundaries.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1493/
work_kind: code_work
branch: hbx-1493-rttp-client-enforce-h2c-connection
base: main
commit: 8b903f5cc93d01fe2a1a342d307f99b489480ded
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1493/
    url: https://plane.kahub.in/endless/browse/HBX-1493/
    close_policy: link_only
```