### PR TITLE
feat: [rttp] Reject forbidden h2c request trailer fields before handler dispatch

### DIFF
--- a/rttp/src/server.rs
+++ b/rttp/src/server.rs
@@ -4472,6 +4472,7 @@ fn is_forbidden_trailer_name(name: &str) -> bool {
   matches!(
     name.to_ascii_lowercase().as_str(),
     "authorization"
+      | "cache-control"
       | "connection"
       | "content-encoding"
       | "content-length"
@@ -4479,8 +4480,11 @@ fn is_forbidden_trailer_name(name: &str) -> bool {
       | "content-type"
       | "cookie"
       | "host"
+      | "keep-alive"
+      | "max-forwards"
       | "proxy-authenticate"
       | "proxy-authorization"
+      | "proxy-connection"
       | "www-authenticate"
       | "set-cookie"
       | "te"

--- a/rttp/tests/test_server.rs
+++ b/rttp/tests/test_server.rs
@@ -2594,9 +2594,13 @@ fn server_rejects_http2_prior_knowledge_hpack_huffman_request_trailer_before_han
 #[test]
 fn server_rejects_http2_prior_knowledge_forbidden_request_trailer_name() {
   for name in [
+    b"cache-control".as_slice(),
+    b"max-forwards",
     b"content-length".as_slice(),
     b"transfer-encoding",
     b"connection",
+    b"keep-alive",
+    b"proxy-connection",
     b"host",
     b"te",
     b"trailer",


### PR DESCRIPTION
Hardened h2c request trailer validation so forbidden connection/request-control trailer fields are rejected before handler dispatch while valid application trailers remain available.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1499/
work_kind: code_work
branch: hbx-1499-rttp-reject-forbidden-h2c-request
base: main
commit: 78001c8fe08c159bbbb6d86505a4d2fd9af8ccfe
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1499/
    url: https://plane.kahub.in/endless/browse/HBX-1499/
    close_policy: link_only
```