### PR TITLE
feat: [rttp] Advertise and enforce bounded h2c server concurrent stream limits

### DIFF
--- a/rttp/src/server.rs
+++ b/rttp/src/server.rs
@@ -30,9 +30,11 @@ const HTTP2_DEFAULT_INITIAL_WINDOW_SIZE: i32 = 65_535;
 const HTTP2_DEFAULT_HEADER_TABLE_SIZE: usize = 4096;
 const HTTP2_STATIC_TABLE_LEN: usize = 61;
 const HTTP2_SETTINGS_ENABLE_PUSH: u16 = 0x2;
+const HTTP2_SETTINGS_MAX_CONCURRENT_STREAMS: u16 = 0x3;
 const HTTP2_SETTINGS_INITIAL_WINDOW_SIZE: u16 = 0x4;
 const HTTP2_SETTINGS_MAX_FRAME_SIZE: u16 = 0x5;
 const HTTP2_ERROR_NO_ERROR: u32 = 0x0;
+const HTTP2_ERROR_PROTOCOL_ERROR: u32 = 0x1;
 
 pub struct HttpServer {
   listener: TcpListener,
@@ -384,7 +386,10 @@ impl HttpServer {
       HTTP2_FRAME_SETTINGS,
       0,
       0,
-      &[],
+      &http2_setting(
+        HTTP2_SETTINGS_MAX_CONCURRENT_STREAMS,
+        bounded_http2_max_concurrent_streams(request_limit),
+      ),
     ))?;
     self.normalize_connection_error(write_http2_frame(
       &mut stream,
@@ -498,6 +503,19 @@ impl HttpServer {
         (HTTP2_FRAME_HEADERS, id) if id != 0 => {
           let header_block_fragment =
             http2_headers_payload_to_header_block_fragment(&frame.payload, frame.flags)?;
+          if streams
+            .iter()
+            .all(|request_stream| request_stream.stream_id != id)
+            && served.saturating_add(streams.len()) >= request_limit
+          {
+            self.normalize_connection_error(write_http2_goaway(
+              &mut stream,
+              last_processed_stream_id,
+              HTTP2_ERROR_PROTOCOL_ERROR,
+            ))?;
+            self.normalize_connection_error(stream.flush())?;
+            return Err(http2_max_concurrent_streams_error());
+          }
           let request_stream = http2_request_stream(
             &mut streams,
             &mut stream_ids,
@@ -1125,6 +1143,17 @@ fn http2_settings_initial_window_size(payload: &[u8]) -> Option<i32> {
     })
 }
 
+fn bounded_http2_max_concurrent_streams(request_limit: usize) -> u32 {
+  u32::try_from(request_limit).unwrap_or(u32::MAX)
+}
+
+fn http2_setting(id: u16, value: u32) -> [u8; 6] {
+  let mut setting = [0; 6];
+  setting[..2].copy_from_slice(&id.to_be_bytes());
+  setting[2..].copy_from_slice(&value.to_be_bytes());
+  setting
+}
+
 fn invalid_http2_settings_error() -> io::Error {
   io::Error::new(io::ErrorKind::InvalidData, "invalid HTTP/2 SETTINGS frame")
 }
@@ -1140,6 +1169,13 @@ fn http2_closed_stream_error() -> io::Error {
   io::Error::new(
     io::ErrorKind::InvalidData,
     "HTTP/2 frame arrived after stream close",
+  )
+}
+
+fn http2_max_concurrent_streams_error() -> io::Error {
+  io::Error::new(
+    io::ErrorKind::InvalidData,
+    "HTTP/2 max concurrent streams exceeded",
   )
 }
 

--- a/rttp/tests/http2_feature.rs
+++ b/rttp/tests/http2_feature.rs
@@ -3820,30 +3820,35 @@ fn http2_feature_socket2_bounded_h2c_multiplexing_stops_at_request_limit() {
   write_h2_frame(
     &mut stream,
     H2_FRAME_HEADERS,
-    H2_FLAG_END_HEADERS,
-    1,
-    &h2_post_headers(b"/pending", addr.to_string().as_bytes()),
-  );
-  write_h2_frame(
-    &mut stream,
-    H2_FRAME_HEADERS,
     H2_FLAG_END_HEADERS | H2_FLAG_END_STREAM,
-    3,
+    1,
     &h2_get_headers(b"/ready", addr.to_string().as_bytes()),
   );
   stream.flush().expect("flush bounded h2 requests");
 
-  assert_eq!(vec![3], read_h2_end_stream_data_streams(&mut stream, 1, 8));
+  assert_eq!(vec![1], read_h2_end_stream_data_streams(&mut stream, 1, 8));
+  let shutdown = read_h2_frame(&mut stream);
+  assert_eq!(H2_FRAME_GOAWAY, shutdown.frame_type);
+  assert_eq!(0, shutdown.flags);
+  assert_eq!(0, shutdown.stream_id);
+  assert_eq!(8, shutdown.payload.len());
+  assert_eq!(
+    1,
+    u32::from_be_bytes(shutdown.payload[0..4].try_into().unwrap())
+  );
+  assert_eq!(
+    0,
+    u32::from_be_bytes(shutdown.payload[4..8].try_into().unwrap())
+  );
   assert_eq!(
     "/ready",
     rx.recv().expect("receive bounded h2 request target")
   );
 
-  drop(stream);
   handle.join().expect("server thread");
   assert!(
     rx.try_recv().is_err(),
-    "pending stream must not be dispatched after request limit"
+    "no additional stream must be dispatched after request limit"
   );
 }
 

--- a/rttp/tests/test_server.rs
+++ b/rttp/tests/test_server.rs
@@ -21,8 +21,10 @@ const H2_FRAME_CONTINUATION: u8 = 0x9;
 const H2_FLAG_END_STREAM: u8 = 0x1;
 const H2_FLAG_ACK: u8 = 0x1;
 const H2_FLAG_END_HEADERS: u8 = 0x4;
+const H2_SETTINGS_MAX_CONCURRENT_STREAMS: u16 = 0x3;
 const H2_SETTINGS_INITIAL_WINDOW_SIZE: u16 = 0x4;
 const H2_SETTINGS_MAX_FRAME_SIZE: u16 = 0x5;
+const H2_ERROR_PROTOCOL_ERROR: u32 = 0x1;
 
 #[derive(Debug)]
 struct H2Frame {
@@ -125,6 +127,27 @@ fn h2_goaway_last_stream_id(frame: &H2Frame) -> u32 {
     u32::from_be_bytes(frame.payload[4..8].try_into().unwrap())
   );
   u32::from_be_bytes(frame.payload[0..4].try_into().unwrap()) & 0x7fff_ffff
+}
+
+fn h2_goaway_error_code(frame: &H2Frame) -> u32 {
+  assert_eq!(H2_FRAME_GOAWAY, frame.frame_type);
+  assert_eq!(0, frame.flags);
+  assert_eq!(0, frame.stream_id);
+  assert_eq!(8, frame.payload.len());
+  u32::from_be_bytes(frame.payload[4..8].try_into().unwrap())
+}
+
+fn h2_setting_value(frame: &H2Frame, setting_id: u16) -> Option<u32> {
+  assert_eq!(H2_FRAME_SETTINGS, frame.frame_type);
+  assert_eq!(0, frame.flags);
+  assert_eq!(0, frame.stream_id);
+  assert_eq!(0, frame.payload.len() % 6);
+
+  frame.payload.chunks_exact(6).find_map(|setting| {
+    let id = u16::from_be_bytes(setting[..2].try_into().unwrap());
+    let value = u32::from_be_bytes(setting[2..].try_into().unwrap());
+    (id == setting_id).then_some(value)
+  })
 }
 
 fn h2_literal_indexed_name(name_index: u8, value: &[u8]) -> Vec<u8> {
@@ -337,6 +360,10 @@ fn complete_h2_server_handshake(stream: &mut TcpStream) {
 }
 
 fn complete_h2_server_handshake_with_settings(stream: &mut TcpStream, payload: &[u8]) {
+  let _ = read_h2_server_settings_during_handshake(stream, payload);
+}
+
+fn read_h2_server_settings_during_handshake(stream: &mut TcpStream, payload: &[u8]) -> H2Frame {
   stream.write_all(H2_PREFACE).expect("write h2 preface");
   write_h2_frame(stream, H2_FRAME_SETTINGS, 0, 0, payload);
 
@@ -351,6 +378,7 @@ fn complete_h2_server_handshake_with_settings(stream: &mut TcpStream, payload: &
   assert_eq!(0, settings_ack.stream_id);
 
   write_h2_frame(stream, H2_FRAME_SETTINGS, H2_FLAG_ACK, 0, &[]);
+  settings
 }
 
 fn assert_h2_header_block_split(
@@ -3411,6 +3439,36 @@ fn server_rejects_http2_prior_knowledge_pseudo_header_after_regular_header() {
 }
 
 #[test]
+fn server_advertises_bounded_http2_prior_knowledge_concurrent_stream_limit() {
+  let server = rttp::Http::server("127.0.0.1:0").expect("bind server");
+  let addr = server.local_addr().expect("server addr");
+
+  let handle = thread::spawn(move || {
+    server
+      .serve_requests(2, |_| HttpResponse::ok("unused"))
+      .expect_err("client closes before any h2 request")
+  });
+
+  let mut stream = TcpStream::connect(addr).expect("connect h2 server");
+  stream
+    .set_read_timeout(Some(Duration::from_secs(2)))
+    .expect("set h2 read timeout");
+  let settings = read_h2_server_settings_during_handshake(&mut stream, &[]);
+  assert_eq!(
+    Some(2),
+    h2_setting_value(&settings, H2_SETTINGS_MAX_CONCURRENT_STREAMS)
+  );
+  stream
+    .shutdown(std::net::Shutdown::Write)
+    .expect("shutdown h2 write");
+
+  assert_eq!(
+    ErrorKind::UnexpectedEof,
+    handle.join().expect("server thread").kind()
+  );
+}
+
+#[test]
 fn server_handles_multiple_interleaved_http2_streams_on_one_connection() {
   let server = rttp::Http::server("127.0.0.1:0").expect("bind server");
   let addr = server.local_addr().expect("server addr");
@@ -3476,6 +3534,125 @@ fn server_handles_multiple_interleaved_http2_streams_on_one_connection() {
   assert!(response_bodies.contains(&"response for /second".to_string()));
 
   handle.join().expect("server thread");
+}
+
+#[test]
+fn server_allows_http2_prior_knowledge_interleaving_up_to_advertised_stream_limit() {
+  let server = rttp::Http::server("127.0.0.1:0").expect("bind server");
+  let addr = server.local_addr().expect("server addr");
+  let (tx, rx) = mpsc::channel();
+
+  let handle = thread::spawn(move || {
+    server
+      .serve_requests(2, |request| {
+        tx.send(request.target().to_string())
+          .expect("send h2 target");
+        HttpResponse::ok(format!("response for {}", request.target()))
+      })
+      .expect("serve bounded h2 requests");
+  });
+
+  let mut stream = TcpStream::connect(addr).expect("connect h2 server");
+  stream
+    .set_read_timeout(Some(Duration::from_secs(2)))
+    .expect("set h2 read timeout");
+  let settings = read_h2_server_settings_during_handshake(&mut stream, &[]);
+  assert_eq!(
+    Some(2),
+    h2_setting_value(&settings, H2_SETTINGS_MAX_CONCURRENT_STREAMS)
+  );
+
+  write_h2_frame(
+    &mut stream,
+    H2_FRAME_HEADERS,
+    H2_FLAG_END_HEADERS,
+    1,
+    &h2_post_headers(b"/first", addr.to_string().as_bytes()),
+  );
+  write_h2_frame(
+    &mut stream,
+    H2_FRAME_HEADERS,
+    H2_FLAG_END_HEADERS,
+    3,
+    &h2_post_headers(b"/second", addr.to_string().as_bytes()),
+  );
+  write_h2_frame(&mut stream, H2_FRAME_DATA, H2_FLAG_END_STREAM, 3, b"two");
+  write_h2_frame(&mut stream, H2_FRAME_DATA, H2_FLAG_END_STREAM, 1, b"one");
+
+  let mut response_streams = Vec::new();
+  while response_streams.len() < 2 {
+    let frame = read_h2_frame(&mut stream);
+    if frame.frame_type == H2_FRAME_DATA && frame.flags & H2_FLAG_END_STREAM == H2_FLAG_END_STREAM {
+      response_streams.push(frame.stream_id);
+    }
+  }
+
+  assert_eq!(
+    vec!["/second", "/first"],
+    vec![
+      rx.recv().expect("first h2 target"),
+      rx.recv().expect("second h2 target"),
+    ]
+  );
+  assert!(response_streams.contains(&1));
+  assert!(response_streams.contains(&3));
+
+  handle.join().expect("server thread");
+}
+
+#[test]
+fn server_rejects_http2_prior_knowledge_streams_above_active_limit_before_handler() {
+  let server = rttp::Http::server("127.0.0.1:0")
+    .expect("bind server")
+    .with_read_timeout(Some(Duration::from_secs(2)));
+  let addr = server.local_addr().expect("server addr");
+  let (tx, rx) = mpsc::channel();
+
+  let handle = thread::spawn(move || {
+    server.serve_requests(2, |request| {
+      tx.send(request.target().to_string())
+        .expect("send unexpected h2 target");
+      HttpResponse::ok("unexpected")
+    })
+  });
+
+  let mut stream = TcpStream::connect(addr).expect("connect h2 server");
+  stream
+    .set_read_timeout(Some(Duration::from_secs(2)))
+    .expect("set h2 read timeout");
+  complete_h2_server_handshake(&mut stream);
+
+  write_h2_frame(
+    &mut stream,
+    H2_FRAME_HEADERS,
+    H2_FLAG_END_HEADERS,
+    1,
+    &h2_post_headers(b"/first", addr.to_string().as_bytes()),
+  );
+  write_h2_frame(
+    &mut stream,
+    H2_FRAME_HEADERS,
+    H2_FLAG_END_HEADERS,
+    3,
+    &h2_post_headers(b"/second", addr.to_string().as_bytes()),
+  );
+  write_h2_frame(
+    &mut stream,
+    H2_FRAME_HEADERS,
+    H2_FLAG_END_HEADERS | H2_FLAG_END_STREAM,
+    5,
+    &h2_get_headers(b"/over-limit", addr.to_string().as_bytes()),
+  );
+
+  let goaway = read_h2_frame(&mut stream);
+  assert_eq!(H2_ERROR_PROTOCOL_ERROR, h2_goaway_error_code(&goaway));
+
+  let error = handle
+    .join()
+    .expect("server thread")
+    .expect_err("over-limit h2 stream should reject connection");
+  assert_eq!(ErrorKind::InvalidData, error.kind());
+  assert!(rx.try_recv().is_err());
 }
 
 #[test]


### PR DESCRIPTION
Bounded prior-knowledge h2c concurrent stream limits are now advertised and enforced, with tests covering SETTINGS payload, allowed interleaving, and pre-handler over-limit rejection.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1504/
work_kind: code_work
branch: hbx-1504-rttp-advertise-and-enforce-bounded
base: main
commit: af24509221c91cff28486f87c40cb37031082b03
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1504/
    url: https://plane.kahub.in/endless/browse/HBX-1504/
    close_policy: link_only
```