### PR TITLE
feat: [rttp] Add cross-crate h2c header list size matrix

### DIFF
--- a/rttp/tests/http2_feature.rs
+++ b/rttp/tests/http2_feature.rs
@@ -2705,6 +2705,120 @@ fn rttp_client_http2_prior_knowledge_request_trailer_boundary_matrix_round_trips
 }
 
 #[test]
+fn rttp_client_http2_prior_knowledge_header_list_size_matrix_respects_socket2_server_bound() {
+  struct HeaderListCase {
+    name: &'static str,
+    path: &'static str,
+    header_value_len: usize,
+    trailer_value_len: usize,
+    expect_success: bool,
+  }
+
+  for case in [
+    HeaderListCase {
+      name: "under-advertised-bound",
+      path: "/bounded-header-list/under",
+      header_value_len: 1024,
+      trailer_value_len: 1024,
+      expect_success: true,
+    },
+    HeaderListCase {
+      name: "over-advertised-bound",
+      path: "/bounded-header-list/over",
+      header_value_len: 64 * 1024,
+      trailer_value_len: 1024,
+      expect_success: false,
+    },
+  ] {
+    let server = rttp::Http::server("127.0.0.1:0")
+      .expect("bind server")
+      .with_read_timeout(Some(Duration::from_secs(2)))
+      .with_write_timeout(Some(Duration::from_secs(2)));
+    let addr = server.local_addr().expect("server addr");
+    let (tx, rx) = mpsc::channel();
+
+    let handle = thread::spawn(move || {
+      let result = server.accept_one(|request| {
+        tx.send((
+          request.method().to_string(),
+          request.version().to_string(),
+          request.target().to_string(),
+          request.header("x-boundary-header").map(str::to_string),
+          request.trailer("x-boundary-trailer").map(str::to_string),
+        ))
+        .expect("send parsed bounded h2 request metadata");
+        HttpResponse::ok(format!("accepted {}", case.name))
+      });
+
+      if case.expect_success {
+        result.expect("serve bounded h2 request metadata");
+      } else {
+        let error = result.expect_err("oversized h2 metadata should close before dispatch");
+        assert!(
+          matches!(
+            error.kind(),
+            io::ErrorKind::UnexpectedEof | io::ErrorKind::TimedOut | io::ErrorKind::ConnectionReset
+          ),
+          "unexpected server error for {}: {error}",
+          case.name
+        );
+      }
+    });
+
+    let header_value = "h".repeat(case.header_value_len);
+    let expected_header_value = header_value.clone();
+    let trailer_value = "t".repeat(case.trailer_value_len);
+    let expected_trailer_value = trailer_value.clone();
+    let response = rttp_client::HttpClient::new()
+      .post()
+      .url(format!("http://{}{}", addr, case.path))
+      .header(("X-Boundary-Header".to_string(), header_value))
+      .trailer(("X-Boundary-Trailer".to_string(), trailer_value))
+      .expect("configure bounded request trailer")
+      .raw("bounded metadata body")
+      .emit_http2_prior_knowledge();
+
+    if case.expect_success {
+      let response = response.expect("bounded h2 metadata response");
+      assert_eq!("HTTP/2", response.version(), "{}", case.name);
+      assert_eq!(
+        format!("accepted {}", case.name),
+        response.body().string().unwrap(),
+        "{}",
+        case.name
+      );
+      assert_eq!(
+        (
+          "POST".to_string(),
+          "HTTP/2".to_string(),
+          case.path.to_string(),
+          Some(expected_header_value),
+          Some(expected_trailer_value),
+        ),
+        rx.recv().expect("receive parsed bounded h2 metadata"),
+        "{}",
+        case.name
+      );
+    } else {
+      let error = response.expect_err("oversized h2 metadata should be rejected");
+      assert!(
+        error
+          .to_string()
+          .contains("HTTP/2 peer SETTINGS_MAX_HEADER_LIST_SIZE"),
+        "unexpected client error for {}: {error}",
+        case.name
+      );
+      assert!(
+        rx.recv_timeout(Duration::from_millis(200)).is_err(),
+        "oversized h2 metadata must not dispatch to the socket2 server handler"
+      );
+    }
+
+    handle.join().expect("server thread");
+  }
+}
+
+#[test]
 fn rttp_client_http2_prior_knowledge_head_interoperates_with_socket2_h2c_server_matrix() {
   struct HeadCase {
     name: &'static str,

--- a/rttp_client/src/http2.rs
+++ b/rttp_client/src/http2.rs
@@ -35,6 +35,7 @@ const SETTING_ENABLE_PUSH: u16 = 0x2;
 const SETTING_MAX_CONCURRENT_STREAMS: u16 = 0x3;
 const SETTING_INITIAL_WINDOW_SIZE: u16 = 0x4;
 const SETTING_MAX_FRAME_SIZE: u16 = 0x5;
+const SETTING_MAX_HEADER_LIST_SIZE: u16 = 0x6;
 const DEFAULT_INITIAL_WINDOW_SIZE: i64 = 65_535;
 const DEFAULT_MAX_FRAME_SIZE: usize = 16 * 1024;
 const MAX_FRAME_SIZE_LIMIT: usize = 16_777_215;
@@ -260,6 +261,7 @@ struct PeerSettings {
   initial_window_size_changed: bool,
   max_frame_size: usize,
   max_frame_size_changed: bool,
+  max_header_list_size: Option<usize>,
 }
 
 fn validate_settings_payload(payload: &[u8]) -> error::Result<PeerSettings> {
@@ -274,6 +276,7 @@ fn validate_settings_payload(payload: &[u8]) -> error::Result<PeerSettings> {
     initial_window_size_changed: false,
     max_frame_size: DEFAULT_MAX_FRAME_SIZE,
     max_frame_size_changed: false,
+    max_header_list_size: None,
   };
   for setting in payload.chunks_exact(6) {
     let identifier = u16::from_be_bytes([setting[0], setting[1]]);
@@ -307,6 +310,7 @@ fn validate_settings_payload(payload: &[u8]) -> error::Result<PeerSettings> {
         settings.max_frame_size = value;
         settings.max_frame_size_changed = true;
       }
+      SETTING_MAX_HEADER_LIST_SIZE => settings.max_header_list_size = Some(value as usize),
       _ => {}
     }
   }
@@ -349,6 +353,13 @@ fn write_request(
   );
   let regular_header_fields = regular_headers(request.header());
   let trailer_fields = request_trailer_fields(request);
+  enforce_peer_header_list_size(
+    request,
+    url,
+    &regular_header_fields,
+    &trailer_fields,
+    peer_settings,
+  )?;
   let mut dynamic_field_plan = Vec::new();
   dynamic_field_plan.extend(regular_header_fields.iter().cloned());
   dynamic_field_plan.extend(trailer_fields.iter().cloned());
@@ -403,6 +414,46 @@ fn write_request(
     )?;
   }
   stream.flush().map_err(error::request).map(|()| None)
+}
+
+fn enforce_peer_header_list_size(
+  request: &RawRequest<'_>,
+  url: &Url,
+  regular_header_fields: &[(String, String)],
+  trailer_fields: &[(String, String)],
+  peer_settings: PeerSettings,
+) -> error::Result<()> {
+  let Some(max_header_list_size) = peer_settings.max_header_list_size else {
+    return Ok(());
+  };
+
+  let mut size = 0usize;
+  size = add_header_list_field_size(size, ":method", request.origin().method())?;
+  size = add_header_list_field_size(size, ":scheme", url.scheme())?;
+  size = add_header_list_field_size(size, ":path", &request_target(url))?;
+  size = add_header_list_field_size(size, ":authority", &authority(url)?)?;
+  for (name, value) in regular_header_fields {
+    size = add_header_list_field_size(size, name, value)?;
+  }
+  for (name, value) in trailer_fields {
+    validate_request_trailer_field(name, value)?;
+    size = add_header_list_field_size(size, name, value)?;
+  }
+
+  if size > max_header_list_size {
+    return Err(error::builder_with_message(
+      "HTTP/2 peer SETTINGS_MAX_HEADER_LIST_SIZE exceeded by request metadata",
+    ));
+  }
+  Ok(())
+}
+
+fn add_header_list_field_size(size: usize, name: &str, value: &str) -> error::Result<usize> {
+  size
+    .checked_add(name.len())
+    .and_then(|size| size.checked_add(value.len()))
+    .and_then(|size| size.checked_add(32))
+    .ok_or_else(|| error::builder_with_message("HTTP/2 request header list size overflow"))
 }
 
 fn write_header_block_frames(


### PR DESCRIPTION
RTTP h2c now advertises and enforces request header-list bounds across client and socket2 server, with cross-crate matrix coverage for under-bound success and oversized deterministic rejection.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1510/
work_kind: code_work
branch: hbx-1510-rttp-add-cross-crate-h2c
base: main
commit: ad1d11a4e938ef944c4a32b970ace70abda361c8
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1510/
    url: https://plane.kahub.in/endless/browse/HBX-1510/
    close_policy: link_only
```