### PR TITLE
feat: [rttp_client] Honor h2c peer SETTINGS_MAX_HEADER_LIST_SIZE for request metadata

### DIFF
--- a/rttp_client/src/http2.rs
+++ b/rttp_client/src/http2.rs
@@ -338,7 +338,7 @@ fn write_request(
   request: &RawRequest<'_>,
   url: &Url,
   response_url: RoUrl,
-  peer_settings: PeerSettings,
+  mut peer_settings: PeerSettings,
 ) -> error::Result<Option<Response>> {
   if peer_settings.max_concurrent_streams == Some(0) {
     return Err(error::bad_response(
@@ -353,13 +353,7 @@ fn write_request(
   );
   let regular_header_fields = regular_headers(request.header());
   let trailer_fields = request_trailer_fields(request);
-  enforce_peer_header_list_size(
-    request,
-    url,
-    &regular_header_fields,
-    &trailer_fields,
-    peer_settings,
-  )?;
+  enforce_peer_request_header_list_size(request, url, &regular_header_fields, peer_settings)?;
   let mut dynamic_field_plan = Vec::new();
   dynamic_field_plan.extend(regular_header_fields.iter().cloned());
   dynamic_field_plan.extend(trailer_fields.iter().cloned());
@@ -393,12 +387,13 @@ fn write_request(
   )?;
   if !body.is_empty() {
     if let Some(response) =
-      write_data_frames(stream, body, peer_settings, has_trailers, response_url)?
+      write_data_frames(stream, body, &mut peer_settings, has_trailers, response_url)?
     {
       return Ok(Some(response));
     }
   }
   if has_trailers {
+    enforce_peer_trailer_header_list_size(&trailer_fields, peer_settings)?;
     let trailer_block = encode_request_trailers(
       &trailer_fields,
       &dynamic_field_plan,
@@ -416,11 +411,10 @@ fn write_request(
   stream.flush().map_err(error::request).map(|()| None)
 }
 
-fn enforce_peer_header_list_size(
+fn enforce_peer_request_header_list_size(
   request: &RawRequest<'_>,
   url: &Url,
   regular_header_fields: &[(String, String)],
-  trailer_fields: &[(String, String)],
   peer_settings: PeerSettings,
 ) -> error::Result<()> {
   let Some(max_header_list_size) = peer_settings.max_header_list_size else {
@@ -435,11 +429,29 @@ fn enforce_peer_header_list_size(
   for (name, value) in regular_header_fields {
     size = add_header_list_field_size(size, name, value)?;
   }
+  fail_if_header_list_size_exceeds_peer_bound(size, max_header_list_size)
+}
+
+fn enforce_peer_trailer_header_list_size(
+  trailer_fields: &[(String, String)],
+  peer_settings: PeerSettings,
+) -> error::Result<()> {
+  let Some(max_header_list_size) = peer_settings.max_header_list_size else {
+    return Ok(());
+  };
+
+  let mut size = 0usize;
   for (name, value) in trailer_fields {
     validate_request_trailer_field(name, value)?;
     size = add_header_list_field_size(size, name, value)?;
   }
+  fail_if_header_list_size_exceeds_peer_bound(size, max_header_list_size)
+}
 
+fn fail_if_header_list_size_exceeds_peer_bound(
+  size: usize,
+  max_header_list_size: usize,
+) -> error::Result<()> {
   if size > max_header_list_size {
     return Err(error::builder_with_message(
       "HTTP/2 peer SETTINGS_MAX_HEADER_LIST_SIZE exceeded by request metadata",
@@ -490,7 +502,7 @@ fn write_header_block_frames(
 fn write_data_frames(
   stream: &mut TcpStream,
   body: &[u8],
-  peer_settings: PeerSettings,
+  peer_settings: &mut PeerSettings,
   has_trailers: bool,
   url: RoUrl,
 ) -> error::Result<Option<Response>> {
@@ -510,6 +522,7 @@ fn write_data_frames(
         stream,
         &mut connection_send_window,
         &mut stream_send_window,
+        peer_settings,
         &mut current_initial_window_size,
         &mut current_max_frame_size,
         url.clone(),
@@ -543,6 +556,7 @@ fn read_until_send_window_available(
   stream: &mut TcpStream,
   connection_send_window: &mut SendWindow,
   stream_send_window: &mut SendWindow,
+  peer_settings: &mut PeerSettings,
   current_initial_window_size: &mut u32,
   current_max_frame_size: &mut usize,
   url: RoUrl,
@@ -564,6 +578,7 @@ fn read_until_send_window_available(
           stream,
           &frame,
           stream_send_window,
+          peer_settings,
           current_initial_window_size,
           current_max_frame_size,
         )?;
@@ -620,6 +635,7 @@ fn handle_settings_while_sending(
   stream: &mut TcpStream,
   frame: &Frame,
   stream_send_window: &mut SendWindow,
+  peer_settings: &mut PeerSettings,
   current_initial_window_size: &mut u32,
   current_max_frame_size: &mut usize,
 ) -> error::Result<()> {
@@ -637,6 +653,9 @@ fn handle_settings_while_sending(
   }
   if settings.max_frame_size_changed {
     *current_max_frame_size = settings.max_frame_size;
+  }
+  if settings.max_header_list_size.is_some() {
+    peer_settings.max_header_list_size = settings.max_header_list_size;
   }
   write_frame(stream, FRAME_SETTINGS, FLAG_ACK, 0, &[])?;
   stream.flush().map_err(error::request)

--- a/rttp_client/tests/http2_prior_knowledge.rs
+++ b/rttp_client/tests/http2_prior_knowledge.rs
@@ -30,6 +30,7 @@ const SETTING_ENABLE_PUSH: u16 = 0x2;
 const SETTING_MAX_CONCURRENT_STREAMS: u16 = 0x3;
 const SETTING_INITIAL_WINDOW_SIZE: u16 = 0x4;
 const SETTING_MAX_FRAME_SIZE: u16 = 0x5;
+const SETTING_MAX_HEADER_LIST_SIZE: u16 = 0x6;
 
 fn spawn_h2_prior_knowledge_peer() -> (SocketAddr, thread::JoinHandle<Vec<u8>>) {
   let listener = TcpListener::bind("127.0.0.1:0").expect("bind h2 peer");
@@ -1543,6 +1544,139 @@ fn prior_knowledge_accepts_subsequent_settings_with_max_concurrent_streams() {
   handle
     .join()
     .expect("subsequent max concurrent streams peer thread");
+}
+
+#[test]
+fn prior_knowledge_post_rejects_trailers_over_subsequent_max_header_list_size_before_headers() {
+  let listener = TcpListener::bind("127.0.0.1:0").expect("bind h2 peer");
+  let addr = listener.local_addr().expect("h2 peer addr");
+
+  let handle = thread::spawn(move || {
+    let (mut stream, _) = listener.accept().expect("accept h2 client");
+    complete_h2_handshake_without_request_with_settings(
+      &mut stream,
+      &settings_payload(SETTING_INITIAL_WINDOW_SIZE, 4),
+    );
+
+    let request_headers = read_frame(&mut stream);
+    assert_eq!(FRAME_HEADERS, request_headers.frame_type);
+    assert_eq!(FLAG_END_HEADERS, request_headers.flags);
+    assert_eq!(1, request_headers.stream_id);
+
+    let first_body = read_frame(&mut stream);
+    assert_eq!(FRAME_DATA, first_body.frame_type);
+    assert_eq!(0, first_body.flags);
+    assert_eq!(1, first_body.stream_id);
+    assert_eq!(b"hell", first_body.payload.as_slice());
+
+    write_frame(
+      &mut stream,
+      FRAME_SETTINGS,
+      0,
+      0,
+      &settings_payload(SETTING_MAX_HEADER_LIST_SIZE, 1),
+    );
+    let settings_ack = read_frame(&mut stream);
+    assert_eq!(FRAME_SETTINGS, settings_ack.frame_type);
+    assert_eq!(FLAG_ACK, settings_ack.flags);
+    assert_eq!(0, settings_ack.stream_id);
+    assert!(settings_ack.payload.is_empty());
+
+    write_frame(&mut stream, FRAME_WINDOW_UPDATE, 0, 1, &1_u32.to_be_bytes());
+    let final_body = read_frame(&mut stream);
+    assert_eq!(FRAME_DATA, final_body.frame_type);
+    assert_eq!(0, final_body.flags);
+    assert_eq!(1, final_body.stream_id);
+    assert_eq!(b"o", final_body.payload.as_slice());
+
+    stream
+      .set_read_timeout(Some(Duration::from_millis(200)))
+      .expect("set read timeout");
+    let next_frame = try_read_frame(&mut stream).expect("check for trailer headers");
+    assert!(
+      next_frame.is_none(),
+      "client must not send trailing HEADERS after smaller peer SETTINGS_MAX_HEADER_LIST_SIZE"
+    );
+  });
+
+  let err = HttpClient::new()
+    .post()
+    .url(format!("http://{}/later-max-header-list-size", addr))
+    .raw("hello")
+    .trailer(("X-Trace", "abc"))
+    .expect("configure request trailer")
+    .emit_http2_prior_knowledge()
+    .expect_err("trailer metadata over later max header list size must fail");
+
+  assert!(
+    err.to_string().contains("SETTINGS_MAX_HEADER_LIST_SIZE"),
+    "unexpected error: {err}"
+  );
+  handle
+    .join()
+    .expect("later max header list size peer thread");
+}
+
+#[test]
+fn prior_knowledge_post_allows_headers_and_trailers_each_under_initial_max_header_list_size() {
+  let listener = TcpListener::bind("127.0.0.1:0").expect("bind h2 peer");
+  let addr = listener.local_addr().expect("h2 peer addr");
+  let trailer_value = "a".repeat(300);
+  let expected_trailer_value = trailer_value.clone();
+
+  let handle = thread::spawn(move || {
+    let (mut stream, _) = listener.accept().expect("accept h2 client");
+    complete_h2_handshake_without_request_with_settings(
+      &mut stream,
+      &settings_payload(SETTING_MAX_HEADER_LIST_SIZE, 512),
+    );
+
+    let request_headers = read_frame(&mut stream);
+    assert_eq!(FRAME_HEADERS, request_headers.frame_type);
+    assert_eq!(FLAG_END_HEADERS, request_headers.flags);
+    assert_eq!(1, request_headers.stream_id);
+    assert!(
+      request_headers.payload.contains(&0x84),
+      "root request path should use the HPACK static :path / entry"
+    );
+
+    let body = read_frame(&mut stream);
+    assert_eq!(FRAME_DATA, body.frame_type);
+    assert_eq!(0, body.flags);
+    assert_eq!(1, body.stream_id);
+    assert_eq!(b"ok", body.payload.as_slice());
+
+    let request_trailers = read_frame(&mut stream);
+    assert_eq!(FRAME_HEADERS, request_trailers.frame_type);
+    assert_eq!(FLAG_END_HEADERS | FLAG_END_STREAM, request_trailers.flags);
+    assert_eq!(1, request_trailers.stream_id);
+    assert_eq!(
+      expected_trailer_value.as_bytes(),
+      find_header_value(&request_trailers.payload, b"x-t")
+        .expect("request trailer")
+        .value
+        .as_slice()
+    );
+
+    write_frame(&mut stream, FRAME_SETTINGS, FLAG_ACK, 0, &[]);
+    write_frame(&mut stream, FRAME_HEADERS, FLAG_END_HEADERS, 1, &[0x88]);
+    write_frame(&mut stream, FRAME_DATA, FLAG_END_STREAM, 1, b"accepted");
+  });
+
+  let response = HttpClient::new()
+    .post()
+    .url(format!("http://{}", addr))
+    .raw("ok")
+    .trailer(("X-T".to_string(), trailer_value))
+    .expect("configure request trailer")
+    .emit_http2_prior_knowledge()
+    .expect("metadata under peer max header list size should be sent");
+
+  assert_eq!(200, response.code());
+  assert_eq!("accepted", response.body().string().unwrap());
+  handle
+    .join()
+    .expect("under max header list size peer thread");
 }
 
 #[test]


### PR DESCRIPTION
Implemented h2c prior-knowledge enforcement for active peer `SETTINGS_MAX_HEADER_LIST_SIZE`, including later SETTINGS updates before trailers, with regression coverage and passing `rttp_client` http2 verification.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1508/
work_kind: code_work
branch: hbx-1508-rttp-client-honor-h2c-peer
base: main
commit: 6df5f6fb2977e6858a2997fcf148be2982fde2ce
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1508/
    url: https://plane.kahub.in/endless/browse/HBX-1508/
    close_policy: link_only
```