### PR TITLE
feat: [rttp_client] Honor h2c GOAWAY no-new-stream boundaries

### DIFF
--- a/rttp_client/src/http2.rs
+++ b/rttp_client/src/http2.rs
@@ -140,7 +140,8 @@ impl<'a> PriorKnowledgeClient<'a> {
 
     let mut stream = connect_tcp_stream(addr(&url)?, self.request.origin().config())?;
     write_connection_preface(&mut stream)?;
-    let peer_settings = read_settings_and_ack(&mut stream)?;
+    let mut peer_settings = read_settings_and_ack(&mut stream)?;
+    reject_goaway_before_opening_request_stream(&mut stream, &mut peer_settings)?;
     let response = match write_request(
       &mut stream,
       &self.request,
@@ -224,6 +225,114 @@ where
   })))
 }
 
+fn reject_goaway_before_opening_request_stream(
+  stream: &mut TcpStream,
+  peer_settings: &mut PeerSettings,
+) -> error::Result<()> {
+  while pending_frame_available(stream)? {
+    let frame = read_frame(stream)?;
+    match (frame.frame_type, frame.stream_id) {
+      (FRAME_GOAWAY, _) => {
+        if goaway_last_stream_id(&frame)? < STREAM_ID {
+          return Err(error::request(io::Error::new(
+            io::ErrorKind::ConnectionAborted,
+            "HTTP/2 connection received GOAWAY before opening request stream; no new streams may be created on this connection",
+          )));
+        }
+      }
+      (FRAME_SETTINGS, _) => {
+        validate_settings_frame(&frame)?;
+        if frame.flags & FLAG_ACK == 0 {
+          apply_settings_before_opening_request(peer_settings, &frame.payload)?;
+          write_frame(stream, FRAME_SETTINGS, FLAG_ACK, 0, &[])?;
+          stream.flush().map_err(error::request)?;
+        }
+      }
+      (FRAME_PING, 0) => {
+        if frame.payload.len() != 8 {
+          return Err(error::bad_response("invalid HTTP/2 PING frame"));
+        }
+        if frame.flags & FLAG_ACK == 0 {
+          write_frame(stream, FRAME_PING, FLAG_ACK, 0, &frame.payload)?;
+          stream.flush().map_err(error::request)?;
+        }
+      }
+      (FRAME_PING, _) => {
+        return Err(error::bad_response("invalid HTTP/2 PING frame"));
+      }
+      (FRAME_WINDOW_UPDATE, _) => {
+        window_update_increment(&frame)?;
+      }
+      (FRAME_PRIORITY, _) => {
+        validate_priority_frame(&frame)?;
+      }
+      (FRAME_PUSH_PROMISE, _) => {
+        reject_push_promise_frame(&frame)?;
+      }
+      (FRAME_RST_STREAM, _) => {
+        rst_stream_error_code(&frame)?;
+      }
+      (FRAME_CONTINUATION, _) => {
+        return Err(error::bad_response(
+          "unexpected HTTP/2 CONTINUATION frame without header block",
+        ));
+      }
+      (_, 0) => {}
+      _ => {
+        return Err(error::bad_response(
+          "HTTP/2 peer sent stream frame before request stream was opened",
+        ));
+      }
+    }
+  }
+  Ok(())
+}
+
+fn apply_settings_before_opening_request(
+  peer_settings: &mut PeerSettings,
+  payload: &[u8],
+) -> error::Result<()> {
+  let settings = validate_settings_payload(payload)?;
+  if settings.header_table_size_changed {
+    peer_settings.header_table_size = settings.header_table_size;
+  }
+  if settings.max_concurrent_streams_changed {
+    peer_settings.max_concurrent_streams = settings.max_concurrent_streams;
+  }
+  if settings.initial_window_size_changed {
+    peer_settings.initial_window_size = settings.initial_window_size;
+    peer_settings.initial_window_size_changed = true;
+  }
+  if settings.max_frame_size_changed {
+    peer_settings.max_frame_size = settings.max_frame_size;
+    peer_settings.max_frame_size_changed = true;
+  }
+  if settings.max_header_list_size.is_some() {
+    peer_settings.max_header_list_size = settings.max_header_list_size;
+  }
+  Ok(())
+}
+
+fn pending_frame_available(stream: &mut TcpStream) -> error::Result<bool> {
+  stream.set_nonblocking(true).map_err(error::request)?;
+  let mut byte = [0];
+  let peeked = loop {
+    match stream.peek(&mut byte) {
+      Ok(0) => break Ok(false),
+      Ok(_) => break Ok(true),
+      Err(err) if err.kind() == io::ErrorKind::WouldBlock => break Ok(false),
+      Err(err) if err.kind() == io::ErrorKind::Interrupted => continue,
+      Err(err) => break Err(error::response(err)),
+    }
+  };
+  let restore_result = stream.set_nonblocking(false).map_err(error::request);
+  match (peeked, restore_result) {
+    (Ok(available), Ok(())) => Ok(available),
+    (Err(err), Ok(())) => Err(err),
+    (_, Err(err)) => Err(err),
+  }
+}
+
 fn timeout_duration(name: &'static str, millis: u64) -> error::Result<Duration> {
   if millis == 0 {
     return Err(error::request(io::Error::new(
@@ -269,7 +378,9 @@ fn read_settings_and_ack(stream: &mut TcpStream) -> error::Result<PeerSettings> 
 #[derive(Clone, Copy)]
 struct PeerSettings {
   header_table_size: usize,
+  header_table_size_changed: bool,
   max_concurrent_streams: Option<u32>,
+  max_concurrent_streams_changed: bool,
   initial_window_size: u32,
   initial_window_size_changed: bool,
   max_frame_size: usize,
@@ -284,7 +395,9 @@ fn validate_settings_payload(payload: &[u8]) -> error::Result<PeerSettings> {
 
   let mut settings = PeerSettings {
     header_table_size: DEFAULT_HPACK_DYNAMIC_TABLE_SIZE,
+    header_table_size_changed: false,
     max_concurrent_streams: None,
+    max_concurrent_streams_changed: false,
     initial_window_size: DEFAULT_INITIAL_WINDOW_SIZE as u32,
     initial_window_size_changed: false,
     max_frame_size: DEFAULT_MAX_FRAME_SIZE,
@@ -295,7 +408,10 @@ fn validate_settings_payload(payload: &[u8]) -> error::Result<PeerSettings> {
     let identifier = u16::from_be_bytes([setting[0], setting[1]]);
     let value = u32::from_be_bytes([setting[2], setting[3], setting[4], setting[5]]);
     match identifier {
-      SETTING_HEADER_TABLE_SIZE => settings.header_table_size = value as usize,
+      SETTING_HEADER_TABLE_SIZE => {
+        settings.header_table_size = value as usize;
+        settings.header_table_size_changed = true;
+      }
       SETTING_ENABLE_PUSH => {
         if value > 1 {
           return Err(error::bad_response(
@@ -303,7 +419,10 @@ fn validate_settings_payload(payload: &[u8]) -> error::Result<PeerSettings> {
           ));
         }
       }
-      SETTING_MAX_CONCURRENT_STREAMS => settings.max_concurrent_streams = Some(value),
+      SETTING_MAX_CONCURRENT_STREAMS => {
+        settings.max_concurrent_streams = Some(value);
+        settings.max_concurrent_streams_changed = true;
+      }
       SETTING_INITIAL_WINDOW_SIZE => {
         if value > MAX_INITIAL_WINDOW_SIZE {
           return Err(error::bad_response(

--- a/rttp_client/tests/http2_prior_knowledge.rs
+++ b/rttp_client/tests/http2_prior_knowledge.rs
@@ -1429,6 +1429,62 @@ fn prior_knowledge_get_rejects_zero_peer_max_concurrent_streams_before_headers()
 }
 
 #[test]
+fn prior_knowledge_get_rejects_goaway_before_opening_request_stream() {
+  let listener = TcpListener::bind("127.0.0.1:0").expect("bind h2 peer");
+  let addr = listener.local_addr().expect("h2 peer addr");
+
+  let handle = thread::spawn(move || {
+    let (mut stream, _) = listener.accept().expect("accept h2 client");
+    let mut preface = [0; 24];
+    stream
+      .read_exact(&mut preface)
+      .expect("read client preface");
+    assert_eq!(b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n", &preface);
+
+    let client_settings = read_frame(&mut stream);
+    assert_eq!(FRAME_SETTINGS, client_settings.frame_type);
+    assert_eq!(0, client_settings.stream_id);
+    assert_eq!(0, client_settings.payload.len());
+
+    write_frame(&mut stream, FRAME_SETTINGS, 0, 0, &[]);
+    write_frame(&mut stream, FRAME_GOAWAY, 0, 0, &[0, 0, 0, 0, 0, 0, 0, 0]);
+
+    let client_settings_ack = read_frame(&mut stream);
+    assert_eq!(FRAME_SETTINGS, client_settings_ack.frame_type);
+    assert_eq!(FLAG_ACK, client_settings_ack.flags);
+    assert_eq!(0, client_settings_ack.stream_id);
+    assert_eq!(0, client_settings_ack.payload.len());
+
+    stream
+      .set_read_timeout(Some(Duration::from_millis(200)))
+      .expect("set read timeout");
+    let next_frame = try_read_frame(&mut stream).expect("check for refused request HEADERS");
+    assert!(
+      next_frame.is_none(),
+      "client must not open a request stream after GOAWAY last_stream_id=0"
+    );
+  });
+
+  let err = HttpClient::new()
+    .get()
+    .url(format!("http://{}/goaway-before-request", addr))
+    .emit_http2_prior_knowledge()
+    .expect_err("GOAWAY before request assignment must refuse the request");
+
+  assert!(
+    err
+      .to_string()
+      .contains("HTTP/2 connection received GOAWAY before opening request stream"),
+    "unexpected error: {err}"
+  );
+  assert!(
+    err.to_string().contains("no new streams"),
+    "unexpected error: {err}"
+  );
+  handle.join().expect("pre-request goaway peer thread");
+}
+
+#[test]
 fn prior_knowledge_put_and_patch_send_body_data_frames() {
   for method in ["PUT", "PATCH"] {
     let request_header_block = emit_prior_knowledge_body_request(method);


### PR DESCRIPTION
Client-side h2c prior-knowledge GOAWAY boundaries are now enforced before request stream assignment, with focused regression coverage and full workspace verification passing.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1518/
work_kind: code_work
branch: hbx-1518-rttp-client-honor-h2c-goaway
base: main
commit: bfca37bbf74ebbbdc656e0223f99eecb71a5b962
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1518/
    url: https://plane.kahub.in/endless/browse/HBX-1518/
    close_policy: link_only
```