### PR TITLE
feat: [rttp] Add cross-crate h2c GOAWAY shutdown matrix

### DIFF
--- a/rttp/src/server.rs
+++ b/rttp/src/server.rs
@@ -410,8 +410,11 @@ impl HttpServer {
     let mut accepted_stream_count = 0;
     let mut last_accepted_stream_id = 0;
     let mut graceful_goaway_sent = false;
+    let mut peer_goaway_received = false;
 
-    while served < request_limit && (!graceful_goaway_sent || !streams.is_empty()) {
+    while served < request_limit
+      && ((!graceful_goaway_sent && !peer_goaway_received) || !streams.is_empty())
+    {
       let frame = match self.normalize_connection_error(read_http2_frame(&mut stream)) {
         Ok(frame) => frame,
         Err(err)
@@ -511,7 +514,9 @@ impl HttpServer {
           if streams
             .iter()
             .all(|request_stream| request_stream.stream_id != id)
-            && (graceful_goaway_sent || served.saturating_add(streams.len()) >= request_limit)
+            && (graceful_goaway_sent
+              || peer_goaway_received
+              || served.saturating_add(streams.len()) >= request_limit)
           {
             self.normalize_connection_error(write_http2_frame(
               &mut stream,
@@ -653,7 +658,10 @@ impl HttpServer {
         (HTTP2_FRAME_RST_STREAM, id) => {
           validate_http2_rst_stream_frame(id, &frame.payload)?;
         }
-        (HTTP2_FRAME_GOAWAY, 0) => break,
+        (HTTP2_FRAME_GOAWAY, id) => {
+          validate_http2_goaway_frame(id, &frame.payload)?;
+          peer_goaway_received = true;
+        }
         (HTTP2_FRAME_WINDOW_UPDATE, _) => {
           let increment = http2_window_update_increment(&frame.payload)?;
           if frame.stream_id == 0 {
@@ -1124,6 +1132,16 @@ fn validate_http2_rst_stream_frame(stream_id: u32, payload: &[u8]) -> io::Result
     return Err(io::Error::new(
       io::ErrorKind::InvalidData,
       "invalid HTTP/2 RST_STREAM frame",
+    ));
+  }
+  Ok(())
+}
+
+fn validate_http2_goaway_frame(stream_id: u32, payload: &[u8]) -> io::Result<()> {
+  if stream_id != 0 || payload.len() < 8 {
+    return Err(io::Error::new(
+      io::ErrorKind::InvalidData,
+      "invalid HTTP/2 GOAWAY frame",
     ));
   }
   Ok(())

--- a/rttp/tests/http2_feature.rs
+++ b/rttp/tests/http2_feature.rs
@@ -1012,6 +1012,20 @@ fn cross_crate_h2c_server_goaway_rejects_new_streams_and_drains_accepted_streams
   );
   write_h2_frame(
     &mut stream,
+    H2_FRAME_GOAWAY,
+    0,
+    0,
+    &[0, 0, 0, 3, 0, 0, 0, 0],
+  );
+  write_h2_frame(
+    &mut stream,
+    H2_FRAME_GOAWAY,
+    0,
+    0,
+    &[0, 0, 0, 3, 0, 0, 0, 0],
+  );
+  write_h2_frame(
+    &mut stream,
     H2_FRAME_DATA,
     H2_FLAG_END_STREAM,
     1,
@@ -1043,6 +1057,60 @@ fn cross_crate_h2c_server_goaway_rejects_new_streams_and_drains_accepted_streams
     rx.try_recv().is_err(),
     "new streams after GOAWAY must not be dispatched"
   );
+}
+
+#[test]
+fn cross_crate_h2c_prior_knowledge_client_server_goaway_shutdown_matrix() {
+  let server = rttp::Http::server("127.0.0.1:0")
+    .expect("bind server")
+    .with_read_timeout(Some(Duration::from_secs(2)))
+    .with_write_timeout(Some(Duration::from_secs(2)));
+  let addr = server.local_addr().expect("server addr");
+  let (tx, rx) = mpsc::channel();
+
+  let handle = thread::spawn(move || {
+    server
+      .serve_requests(1, |request| {
+        tx.send(request.target().to_string())
+          .expect("send h2c shutdown matrix target");
+        HttpResponse::ok(format!("served {}", request.target()))
+      })
+      .expect("serve h2c shutdown matrix request");
+  });
+
+  let mut client = rttp::Http::client();
+  let response = client
+    .get()
+    .url(format!("http://{}/before-goaway", addr))
+    .emit_http2_prior_knowledge()
+    .expect("request accepted before server GOAWAY");
+
+  assert_eq!(200, response.code());
+  assert_eq!("HTTP/2", response.version());
+  assert_eq!("served /before-goaway", response.body().string().unwrap());
+  assert_eq!(
+    "/before-goaway",
+    rx.recv().expect("receive h2c shutdown matrix target")
+  );
+
+  let error = client
+    .get()
+    .url(format!("http://{}/after-goaway", addr))
+    .emit_http2_prior_knowledge()
+    .expect_err("closed h2c prior-knowledge client must refuse a replacement request");
+  assert!(
+    error
+      .to_string()
+      .to_ascii_lowercase()
+      .contains("connection is closed"),
+    "unexpected closed-client error: {error}"
+  );
+  assert!(
+    rx.try_recv().is_err(),
+    "closed client must not dispatch a replacement request after GOAWAY"
+  );
+
+  handle.join().expect("server thread");
 }
 
 #[test]

--- a/rttp_client/src/http2.rs
+++ b/rttp_client/src/http2.rs
@@ -314,18 +314,30 @@ fn apply_settings_before_opening_request(
 }
 
 fn pending_frame_available(stream: &mut TcpStream) -> error::Result<bool> {
-  stream.set_nonblocking(true).map_err(error::request)?;
+  let previous_timeout = stream.read_timeout().map_err(error::request)?;
+  stream
+    .set_read_timeout(Some(Duration::from_millis(10)))
+    .map_err(error::request)?;
   let mut byte = [0];
   let peeked = loop {
     match stream.peek(&mut byte) {
       Ok(0) => break Ok(false),
       Ok(_) => break Ok(true),
-      Err(err) if err.kind() == io::ErrorKind::WouldBlock => break Ok(false),
+      Err(err)
+        if matches!(
+          err.kind(),
+          io::ErrorKind::WouldBlock | io::ErrorKind::TimedOut
+        ) =>
+      {
+        break Ok(false);
+      }
       Err(err) if err.kind() == io::ErrorKind::Interrupted => continue,
       Err(err) => break Err(error::response(err)),
     }
   };
-  let restore_result = stream.set_nonblocking(false).map_err(error::request);
+  let restore_result = stream
+    .set_read_timeout(previous_timeout)
+    .map_err(error::request);
   match (peeked, restore_result) {
     (Ok(available), Ok(())) => Ok(available),
     (Err(err), Ok(())) => Err(err),


### PR DESCRIPTION
Added cross-crate h2c GOAWAY shutdown coverage and fixed bounded h2c shutdown handling so accepted streams drain, new streams are refused, repeated GOAWAY is idempotent, and immediate pre-open GOAWAY is detected reliably.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1520/
work_kind: code_work
branch: hbx-1520-rttp-add-cross-crate-h2c
base: main
commit: f41ff33ecf32a7e0a47d136d508f8f9e73267173
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1520/
    url: https://plane.kahub.in/endless/browse/HBX-1520/
    close_policy: link_only
```