### PR TITLE
feat: [rttp] Document h2c GOAWAY graceful shutdown boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,9 +94,16 @@ client path;
 prior-knowledge h2c `GOAWAY` is treated as a bounded shutdown signal: a
 response already completed before `GOAWAY` remains usable, an active stream
 continues only when the peer's `last-stream-id` includes it, and a lower
-boundary rejects the response deterministically. `RST_STREAM` is likewise
-bounded to this prior-knowledge h2c client path: a reset for the active stream
-is reported as response cancellation, while malformed reset frames are rejected
+boundary rejects the response deterministically. A `GOAWAY` received before
+stream 1 is opened is treated as request refusal and no request HEADERS are
+sent. RTTP returns that refusal to the caller instead of retrying on a new
+connection; callers that know a request is safe or idempotent must choose any
+retry policy themselves. This protocol shutdown boundary is distinct from a
+transport-level disconnect, read timeout, write timeout, or TCP reset, which
+is reported through the normal socket/error path without an HTTP/2
+`last-stream-id` boundary. `RST_STREAM` is likewise bounded to this
+prior-knowledge h2c client path: a reset for the active stream is reported as
+response cancellation, while malformed reset frames are rejected
 deterministically. RTTP does not expose a public cancellation callback API or
 retry the request automatically. `CONNECT`, RFC 8441 `:protocol` extended
 CONNECT metadata, HTTP/1.1 `Upgrade` handoff requests, and proxy tunneling are
@@ -222,7 +229,14 @@ are rejected deterministically before handler dispatch instead of attempting
 push state management.
 When the bounded prior-knowledge h2c server loop finishes, it sends `GOAWAY`
 with the last completed stream id so clients have a deterministic shutdown
-boundary for already processed streams.
+boundary for already processed streams. If the bounded request allowance is
+exhausted while additional streams are already open, the server first sends a
+graceful `GOAWAY` boundary and lets streams within that boundary finish; new
+streams outside the boundary are refused with `REFUSED_STREAM` and are not
+dispatched to the handler. If the peer closes the TCP connection, a read/write
+timeout fires, or the socket is reset before `GOAWAY` can be written, that is
+transport termination rather than an HTTP/2 graceful shutdown signal and no
+additional stream boundary is implied.
 Within that same prior-knowledge h2c server path, inbound `RST_STREAM` is a
 bounded reset/cancellation signal for the affected stream: reset request
 streams are not dispatched to handlers, and reset response streams stop within

--- a/rttp/README.md
+++ b/rttp/README.md
@@ -108,6 +108,14 @@ Responses are still written synchronously as requests complete. The bounded
 h2c path supports conservative DATA flow-control for prior-knowledge use. It
 uses `GOAWAY` as a bounded shutdown signal when the loop ends, reporting the
 last completed stream id so clients can apply a deterministic stream boundary.
+If the bounded request allowance is exhausted while additional streams are
+already open, the server first sends a graceful `GOAWAY` boundary and lets
+streams within that boundary finish; new streams outside the boundary are
+refused with `REFUSED_STREAM` and are not dispatched to the handler. If the
+peer closes the TCP connection, a read/write timeout fires, or the socket is
+reset before `GOAWAY` can be written, that is transport termination rather
+than an HTTP/2 graceful shutdown signal and no additional stream boundary is
+implied.
 Within that same prior-knowledge h2c server path, inbound `RST_STREAM` is a
 bounded reset/cancellation signal for the affected stream: reset request
 streams are not dispatched to handlers, and reset response streams stop within
@@ -174,7 +182,14 @@ deterministically instead of creating or tracking push state. HTTP/1.1
 `CONNECT` tunnel handoff remains a separate path; prior-knowledge h2c `GOAWAY`
 is treated as a bounded shutdown signal: completed responses remain usable,
 active responses continue only when the peer's `last-stream-id` includes the
-stream, and lower boundaries reject the response deterministically.
+stream, and lower boundaries reject the response deterministically. A
+`GOAWAY` received before stream 1 is opened is treated as request refusal and
+no request HEADERS are sent. RTTP returns that refusal to the caller instead
+of retrying on a new connection; callers that know a request is safe or
+idempotent must choose any retry policy themselves. This protocol shutdown
+boundary is distinct from a transport-level disconnect, read timeout, write
+timeout, or TCP reset, which is reported through the normal socket/error path
+without an HTTP/2 `last-stream-id` boundary.
 `RST_STREAM` is likewise bounded to this prior-knowledge h2c client path: a
 reset for the active stream is reported as response cancellation, while
 malformed reset frames are rejected deterministically. RTTP does not expose a

--- a/rttp_client/README.md
+++ b/rttp_client/README.md
@@ -92,7 +92,14 @@ HTTP/1.1 `CONNECT` tunnel handoff remains a separate client path;
 prior-knowledge h2c `GOAWAY` is treated as a bounded shutdown signal:
 completed responses remain usable, active responses continue only when the
 peer's `last-stream-id` includes the stream, and lower boundaries reject the
-response deterministically. `RST_STREAM` is likewise bounded to this
+response deterministically. A `GOAWAY` received before stream 1 is opened is
+treated as request refusal and no request HEADERS are sent. RTTP returns that
+refusal to the caller instead of retrying on a new connection; callers that
+know a request is safe or idempotent must choose any retry policy themselves.
+This protocol shutdown boundary is distinct from a transport-level
+disconnect, read timeout, write timeout, or TCP reset, which is reported
+through the normal socket/error path without an HTTP/2 `last-stream-id`
+boundary. `RST_STREAM` is likewise bounded to this
 prior-knowledge h2c client path: a reset for the active stream is reported as
 response cancellation, while malformed reset frames are rejected
 deterministically. RTTP does not expose a public cancellation callback API or

--- a/rttp_client/src/lib.rs
+++ b/rttp_client/src/lib.rs
@@ -13,9 +13,15 @@
 //! With the `http2` feature enabled, `emit_http2_prior_knowledge` sends a
 //! minimal prior-knowledge h2c request over a direct socket2 TCP connection.
 //! It decodes incoming padded HEADERS, DATA, and trailer frames without
-//! exposing padding bytes, including response HPACK dynamic table entries. TLS
-//! ALPN, proxy h2, full HTTP/2 multiplexing, and priority scheduling are not
-//! part of that single-stream path.
+//! exposing padding bytes, including response HPACK dynamic table entries.
+//! `GOAWAY` is treated as a protocol shutdown boundary: completed responses
+//! remain usable, an active stream may finish only when the peer's
+//! `last-stream-id` includes stream 1, and pre-stream `GOAWAY` refuses the
+//! request before request HEADERS are sent. RTTP reports those conditions to
+//! the caller and does not retry automatically; transport disconnects remain
+//! ordinary socket errors without an HTTP/2 stream boundary. TLS ALPN, proxy
+//! h2, full HTTP/2 multiplexing, and priority scheduling are not part of that
+//! single-stream path.
 //!
 //! ```rust,no_run
 //! use rttp_client::HttpClient;


### PR DESCRIPTION
Documented h2c GOAWAY graceful shutdown boundaries for client and server behavior, including retry/refusal semantics, in-flight streams, and protocol-vs-transport shutdown distinctions.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1521/
work_kind: code_work
branch: hbx-1521-rttp-document-h2c-goaway-graceful
base: main
commit: dfcabe1f3d769215a55168867e311c601cce4835
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1521/
    url: https://plane.kahub.in/endless/browse/HBX-1521/
    close_policy: link_only
```