### PR TITLE
feat: [rttp] Enforce h2c SETTINGS_MAX_FRAME_SIZE for request and response frames

### DIFF
--- a/rttp/src/server.rs
+++ b/rttp/src/server.rs
@@ -370,7 +370,8 @@ impl HttpServer {
   where
     F: FnMut(Request) -> HttpResponse,
   {
-    let frame = self.normalize_connection_error(read_http2_frame(&mut stream))?;
+    let frame = self
+      .normalize_connection_error(read_http2_frame(&mut stream, HTTP2_DEFAULT_MAX_FRAME_SIZE))?;
     if frame.frame_type != HTTP2_FRAME_SETTINGS
       || frame.flags & HTTP2_FLAG_ACK == HTTP2_FLAG_ACK
       || frame.stream_id != 0
@@ -415,7 +416,9 @@ impl HttpServer {
     while served < request_limit
       && ((!graceful_goaway_sent && !peer_goaway_received) || !streams.is_empty())
     {
-      let frame = match self.normalize_connection_error(read_http2_frame(&mut stream)) {
+      let frame = match self
+        .normalize_connection_error(read_http2_frame(&mut stream, HTTP2_DEFAULT_MAX_FRAME_SIZE))
+      {
         Ok(frame) => frame,
         Err(err)
           if err.kind() == io::ErrorKind::UnexpectedEof
@@ -1060,10 +1063,16 @@ fn http2_data_payload_to_data(payload: &[u8], flags: u8) -> io::Result<&[u8]> {
   Ok(&data_and_padding[..data_and_padding.len() - pad_len])
 }
 
-fn read_http2_frame(stream: &mut TcpStream) -> io::Result<Http2Frame> {
+fn read_http2_frame(stream: &mut TcpStream, max_frame_size: usize) -> io::Result<Http2Frame> {
   let mut header = [0; 9];
   stream.read_exact(&mut header)?;
   let length = ((header[0] as usize) << 16) | ((header[1] as usize) << 8) | header[2] as usize;
+  if length > max_frame_size {
+    return Err(io::Error::new(
+      io::ErrorKind::InvalidData,
+      "HTTP/2 frame payload exceeds active max frame size",
+    ));
+  }
   let mut payload = vec![0; length];
   stream.read_exact(&mut payload).map_err(|err| {
     if err.kind() == io::ErrorKind::UnexpectedEof {
@@ -1285,7 +1294,11 @@ fn write_http2_window_update(
 }
 
 fn server_http2_settings_payload(request_limit: usize) -> Vec<u8> {
-  let mut payload = Vec::with_capacity(12);
+  let mut payload = Vec::with_capacity(18);
+  payload.extend_from_slice(&http2_setting(
+    HTTP2_SETTINGS_MAX_FRAME_SIZE,
+    HTTP2_DEFAULT_MAX_FRAME_SIZE as u32,
+  ));
   payload.extend_from_slice(&http2_setting(
     HTTP2_SETTINGS_MAX_CONCURRENT_STREAMS,
     bounded_http2_max_concurrent_streams(request_limit),
@@ -2176,7 +2189,7 @@ fn read_http2_response_flow_control_frame(
   flow_control: &mut Http2ResponseFlowControl<'_>,
 ) -> io::Result<Http2ResponseFlowControlRead> {
   loop {
-    let frame = read_http2_frame(stream)?;
+    let frame = read_http2_frame(stream, HTTP2_DEFAULT_MAX_FRAME_SIZE)?;
     if let Some(stream_id) = active_http2_header_continuation_stream(flow_control.streams) {
       if frame.frame_type != HTTP2_FRAME_CONTINUATION || frame.stream_id != stream_id {
         return Err(io::Error::new(

--- a/rttp/tests/http2_feature.rs
+++ b/rttp/tests/http2_feature.rs
@@ -18,6 +18,7 @@ const H2_FRAME_PUSH_PROMISE: u8 = 0x5;
 const H2_FRAME_PING: u8 = 0x6;
 const H2_FRAME_GOAWAY: u8 = 0x7;
 const H2_FRAME_WINDOW_UPDATE: u8 = 0x8;
+const H2_FRAME_CONTINUATION: u8 = 0x9;
 const H2_FLAG_END_STREAM: u8 = 0x1;
 const H2_FLAG_ACK: u8 = 0x1;
 const H2_FLAG_END_HEADERS: u8 = 0x4;
@@ -29,6 +30,7 @@ const H2_SETTINGS_MAX_CONCURRENT_STREAMS: u16 = 0x3;
 const H2_SETTINGS_INITIAL_WINDOW_SIZE: u16 = 0x4;
 const H2_SETTINGS_MAX_FRAME_SIZE: u16 = 0x5;
 const H2_SETTINGS_ENABLE_CONNECT_PROTOCOL: u16 = 0x8;
+const H2_DEFAULT_MAX_FRAME_SIZE: usize = 16 * 1024;
 const H2_DEFAULT_INITIAL_WINDOW_SIZE: usize = 65_535;
 const H2_ERROR_CANCEL: u32 = 0x8;
 const H2_ERROR_REFUSED_STREAM: u32 = 0x7;
@@ -156,6 +158,18 @@ fn h2_setting(id: u16, value: u32) -> [u8; 6] {
   setting[..2].copy_from_slice(&id.to_be_bytes());
   setting[2..].copy_from_slice(&value.to_be_bytes());
   setting
+}
+
+fn h2_setting_value(payload: &[u8], id: u16) -> Option<u32> {
+  payload.chunks_exact(6).find_map(|setting| {
+    if u16::from_be_bytes([setting[0], setting[1]]) == id {
+      Some(u32::from_be_bytes([
+        setting[2], setting[3], setting[4], setting[5],
+      ]))
+    } else {
+      None
+    }
+  })
 }
 
 fn h2_literal_indexed_name(name_index: u8, value: &[u8]) -> Vec<u8> {
@@ -1479,6 +1493,251 @@ fn prior_knowledge_server_acknowledges_valid_settings_payload_and_serves_request
   assert_eq!(H2_FRAME_DATA, response_body.frame_type);
   assert_eq!(H2_FLAG_END_STREAM, response_body.flags);
   assert_eq!(b"settings accepted", response_body.payload.as_slice());
+
+  handle.join().expect("server thread");
+}
+
+#[test]
+fn prior_knowledge_server_advertises_conservative_max_frame_size() {
+  let server = rttp::Http::server("127.0.0.1:0")
+    .expect("bind server")
+    .with_read_timeout(Some(Duration::from_secs(2)))
+    .with_write_timeout(Some(Duration::from_secs(2)));
+  let addr = server.local_addr().expect("server addr");
+
+  let handle = thread::spawn(move || {
+    server
+      .accept_one(|request| {
+        assert_eq!("HTTP/2", request.version());
+        HttpResponse::ok("advertised max frame size")
+      })
+      .expect("serve h2 request")
+  });
+
+  let mut stream = TcpStream::connect(addr).expect("connect h2 server");
+  stream
+    .set_read_timeout(Some(Duration::from_secs(2)))
+    .expect("set client read timeout");
+  stream.write_all(H2_PREFACE).expect("write h2 preface");
+  write_h2_frame(&mut stream, H2_FRAME_SETTINGS, 0, 0, &[]);
+
+  let settings = read_h2_frame(&mut stream);
+  assert_eq!(H2_FRAME_SETTINGS, settings.frame_type);
+  assert_eq!(0, settings.flags);
+  assert_eq!(0, settings.stream_id);
+  assert_eq!(
+    Some(H2_DEFAULT_MAX_FRAME_SIZE as u32),
+    h2_setting_value(&settings.payload, H2_SETTINGS_MAX_FRAME_SIZE)
+  );
+
+  let settings_ack = read_h2_frame(&mut stream);
+  assert_eq!(H2_FRAME_SETTINGS, settings_ack.frame_type);
+  assert_eq!(H2_FLAG_ACK, settings_ack.flags);
+  assert_eq!(0, settings_ack.stream_id);
+
+  write_h2_frame(&mut stream, H2_FRAME_SETTINGS, H2_FLAG_ACK, 0, &[]);
+  write_h2_get_request(&mut stream, addr.to_string().as_bytes()).expect("write h2 request");
+  let response_headers = read_h2_frame(&mut stream);
+  assert_eq!(H2_FRAME_HEADERS, response_headers.frame_type);
+  let response_body = read_h2_frame(&mut stream);
+  assert_eq!(H2_FRAME_DATA, response_body.frame_type);
+  assert_eq!(
+    b"advertised max frame size",
+    response_body.payload.as_slice()
+  );
+
+  handle.join().expect("server thread");
+}
+
+#[test]
+fn prior_knowledge_server_rejects_inbound_frame_exceeding_active_max_before_handler() {
+  let server = rttp::Http::server("127.0.0.1:0")
+    .expect("bind server")
+    .with_read_timeout(Some(Duration::from_secs(2)))
+    .with_write_timeout(Some(Duration::from_secs(2)));
+  let addr = server.local_addr().expect("server addr");
+  let (tx, rx) = mpsc::channel();
+
+  let handle = thread::spawn(move || {
+    server.accept_one(|request| {
+      tx.send(request.target().to_string())
+        .expect("send unexpected oversized h2 request");
+      HttpResponse::ok("unexpected oversized frame")
+    })
+  });
+
+  let mut stream = TcpStream::connect(addr).expect("connect h2 server");
+  stream
+    .set_read_timeout(Some(Duration::from_millis(200)))
+    .expect("set client read timeout");
+  complete_h2_server_handshake_with_settings(&mut stream, &[]);
+  write_h2_frame(
+    &mut stream,
+    H2_FRAME_HEADERS,
+    H2_FLAG_END_HEADERS | H2_FLAG_END_STREAM,
+    1,
+    &vec![0x82; H2_DEFAULT_MAX_FRAME_SIZE + 1],
+  );
+  stream.flush().expect("flush oversized h2 frame");
+  let _ = try_read_h2_frame(&mut stream);
+  drop(stream);
+
+  let err = handle
+    .join()
+    .expect("server thread")
+    .expect_err("oversized inbound frame must reject the connection");
+  assert_eq!(io::ErrorKind::InvalidData, err.kind());
+  assert!(
+    err
+      .to_string()
+      .contains("HTTP/2 frame payload exceeds active max frame size"),
+    "unexpected oversized frame error: {err}"
+  );
+  assert!(
+    rx.try_recv().is_err(),
+    "oversized frame must not reach the handler"
+  );
+}
+
+#[test]
+fn prior_knowledge_server_uses_legal_peer_max_frame_size_update_for_response_data() {
+  let server = rttp::Http::server("127.0.0.1:0")
+    .expect("bind server")
+    .with_read_timeout(Some(Duration::from_secs(2)))
+    .with_write_timeout(Some(Duration::from_secs(2)));
+  let addr = server.local_addr().expect("server addr");
+
+  let handle = thread::spawn(move || {
+    server
+      .accept_one(|request| {
+        assert_eq!("/updated-response-frame-size", request.target());
+        HttpResponse::ok(vec![b'x'; 40_000])
+      })
+      .expect("serve h2 response using updated frame size")
+  });
+
+  let mut stream = TcpStream::connect(addr).expect("connect h2 server");
+  stream
+    .set_read_timeout(Some(Duration::from_secs(2)))
+    .expect("set client read timeout");
+  complete_h2_server_handshake_with_settings(&mut stream, &[]);
+  write_h2_frame(
+    &mut stream,
+    H2_FRAME_SETTINGS,
+    0,
+    0,
+    &h2_setting(H2_SETTINGS_MAX_FRAME_SIZE, 32_768),
+  );
+  let settings_ack = read_h2_frame(&mut stream);
+  assert_eq!(H2_FRAME_SETTINGS, settings_ack.frame_type);
+  assert_eq!(H2_FLAG_ACK, settings_ack.flags);
+  assert_eq!(0, settings_ack.stream_id);
+
+  write_h2_frame(
+    &mut stream,
+    H2_FRAME_HEADERS,
+    H2_FLAG_END_HEADERS | H2_FLAG_END_STREAM,
+    1,
+    &h2_get_headers(b"/updated-response-frame-size", addr.to_string().as_bytes()),
+  );
+  stream.flush().expect("flush h2 request");
+
+  let response_headers = read_h2_frame(&mut stream);
+  assert_eq!(H2_FRAME_HEADERS, response_headers.frame_type);
+  let mut data_lengths = Vec::new();
+  loop {
+    let frame = read_h2_frame(&mut stream);
+    if frame.frame_type != H2_FRAME_DATA {
+      continue;
+    }
+    assert!(frame.payload.len() <= 32_768);
+    data_lengths.push(frame.payload.len());
+    if frame.flags & H2_FLAG_END_STREAM == H2_FLAG_END_STREAM {
+      break;
+    }
+  }
+  assert!(
+    data_lengths
+      .iter()
+      .any(|len| *len > H2_DEFAULT_MAX_FRAME_SIZE),
+    "legal SETTINGS_MAX_FRAME_SIZE update should allow larger response DATA frames"
+  );
+  assert_eq!(40_000, data_lengths.iter().sum::<usize>());
+
+  handle.join().expect("server thread");
+}
+
+#[test]
+fn prior_knowledge_server_splits_response_trailing_headers_to_peer_max_frame_size() {
+  let server = rttp::Http::server("127.0.0.1:0")
+    .expect("bind server")
+    .with_read_timeout(Some(Duration::from_secs(2)))
+    .with_write_timeout(Some(Duration::from_secs(2)));
+  let addr = server.local_addr().expect("server addr");
+
+  let handle = thread::spawn(move || {
+    server
+      .accept_one(|request| {
+        assert_eq!("/large-trailers", request.target());
+        let mut response = HttpResponse::ok("body");
+        for index in 0..420 {
+          response = response.trailer(
+            format!("X-Trailer-{index}"),
+            format!("value-{index}-{}", "t".repeat(120)),
+          );
+        }
+        response
+      })
+      .expect("serve h2 response with large trailers")
+  });
+
+  let mut stream = TcpStream::connect(addr).expect("connect h2 server");
+  stream
+    .set_read_timeout(Some(Duration::from_secs(2)))
+    .expect("set client read timeout");
+  complete_h2_server_handshake_with_settings(
+    &mut stream,
+    &h2_setting(H2_SETTINGS_MAX_FRAME_SIZE, H2_DEFAULT_MAX_FRAME_SIZE as u32),
+  );
+  write_h2_frame(
+    &mut stream,
+    H2_FRAME_HEADERS,
+    H2_FLAG_END_HEADERS | H2_FLAG_END_STREAM,
+    1,
+    &h2_get_headers(b"/large-trailers", addr.to_string().as_bytes()),
+  );
+  stream.flush().expect("flush h2 request");
+
+  let response_headers = read_h2_frame(&mut stream);
+  assert_eq!(H2_FRAME_HEADERS, response_headers.frame_type);
+  let response_body = read_h2_frame(&mut stream);
+  assert_eq!(H2_FRAME_DATA, response_body.frame_type);
+  assert_eq!(b"body", response_body.payload.as_slice());
+  assert_eq!(0, response_body.flags & H2_FLAG_END_STREAM);
+
+  let first_trailer = read_h2_frame(&mut stream);
+  assert_eq!(H2_FRAME_HEADERS, first_trailer.frame_type);
+  assert_eq!(1, first_trailer.stream_id);
+  assert!(first_trailer.payload.len() <= H2_DEFAULT_MAX_FRAME_SIZE);
+  assert_eq!(H2_FLAG_END_STREAM, first_trailer.flags & H2_FLAG_END_STREAM);
+  assert_eq!(0, first_trailer.flags & H2_FLAG_END_HEADERS);
+
+  let mut saw_final_continuation = false;
+  for _ in 0..8 {
+    let frame = read_h2_frame(&mut stream);
+    assert_eq!(1, frame.stream_id);
+    assert!(frame.payload.len() <= H2_DEFAULT_MAX_FRAME_SIZE);
+    if frame.frame_type == H2_FRAME_CONTINUATION
+      && frame.flags & H2_FLAG_END_HEADERS == H2_FLAG_END_HEADERS
+    {
+      saw_final_continuation = true;
+      break;
+    }
+  }
+  assert!(
+    saw_final_continuation,
+    "large response trailers should be split with CONTINUATION frames"
+  );
 
   handle.join().expect("server thread");
 }

--- a/rttp/tests/test_server.rs
+++ b/rttp/tests/test_server.rs
@@ -25,6 +25,7 @@ const H2_SETTINGS_MAX_CONCURRENT_STREAMS: u16 = 0x3;
 const H2_SETTINGS_INITIAL_WINDOW_SIZE: u16 = 0x4;
 const H2_SETTINGS_MAX_FRAME_SIZE: u16 = 0x5;
 const H2_SETTINGS_MAX_HEADER_LIST_SIZE: u16 = 0x6;
+const H2_DEFAULT_MAX_FRAME_SIZE: usize = 16 * 1024;
 const H2_SERVER_MAX_HEADER_LIST_SIZE: u32 = 64 * 1024;
 const H2_ERROR_REFUSED_STREAM: u32 = 0x7;
 
@@ -44,6 +45,32 @@ fn write_h2_frame(
   payload: &[u8],
 ) {
   write_raw_h2_frame(stream, frame_type, flags, stream_id & 0x7fff_ffff, payload);
+}
+
+fn write_h2_header_block(stream: &mut TcpStream, stream_id: u32, end_stream: bool, block: &[u8]) {
+  if block.len() <= H2_DEFAULT_MAX_FRAME_SIZE {
+    let flags = H2_FLAG_END_HEADERS | if end_stream { H2_FLAG_END_STREAM } else { 0 };
+    write_h2_frame(stream, H2_FRAME_HEADERS, flags, stream_id, block);
+    return;
+  }
+
+  let mut chunks = block.chunks(H2_DEFAULT_MAX_FRAME_SIZE);
+  write_h2_frame(
+    stream,
+    H2_FRAME_HEADERS,
+    if end_stream { H2_FLAG_END_STREAM } else { 0 },
+    stream_id,
+    chunks.next().expect("first h2 header chunk"),
+  );
+
+  while let Some(chunk) = chunks.next() {
+    let flags = if chunks.len() == 0 {
+      H2_FLAG_END_HEADERS
+    } else {
+      0
+    };
+    write_h2_frame(stream, H2_FRAME_CONTINUATION, flags, stream_id, chunk);
+  }
 }
 
 fn write_raw_h2_frame(
@@ -117,6 +144,33 @@ fn h2_window_update_increment(frame: &H2Frame) -> u32 {
 
 fn h2_window_update(increment: u32) -> [u8; 4] {
   increment.to_be_bytes()
+}
+
+fn read_h2_window_updates_until(
+  stream: &mut TcpStream,
+  expected_connection_increment: u32,
+  expected_stream_increment: u32,
+  stream_id: u32,
+) {
+  let mut connection_increment = 0;
+  let mut stream_increment = 0;
+  for _ in 0..16 {
+    let update = read_h2_frame(stream);
+    assert_eq!(H2_FRAME_WINDOW_UPDATE, update.frame_type);
+    match update.stream_id {
+      0 => connection_increment += h2_window_update_increment(&update),
+      id if id == stream_id => stream_increment += h2_window_update_increment(&update),
+      id => panic!("unexpected WINDOW_UPDATE stream id {id}"),
+    }
+    if connection_increment == expected_connection_increment
+      && stream_increment == expected_stream_increment
+    {
+      return;
+    }
+  }
+  panic!(
+    "missing WINDOW_UPDATE totals: connection={connection_increment}, stream={stream_increment}"
+  );
 }
 
 fn h2_goaway_last_stream_id(frame: &H2Frame) -> u32 {
@@ -1760,23 +1814,11 @@ fn server_sends_http2_window_updates_while_consuming_large_request_body() {
   );
 
   let first_chunk = vec![b'a'; 65_535];
-  write_h2_frame(&mut stream, H2_FRAME_DATA, 0, 1, &first_chunk);
+  for chunk in first_chunk.chunks(H2_DEFAULT_MAX_FRAME_SIZE) {
+    write_h2_frame(&mut stream, H2_FRAME_DATA, 0, 1, chunk);
+  }
 
-  let first_update = read_h2_frame(&mut stream);
-  let second_update = read_h2_frame(&mut stream);
-  assert_eq!(
-    vec![(0, 65_535), (1, 65_535)],
-    vec![
-      (
-        first_update.stream_id,
-        h2_window_update_increment(&first_update)
-      ),
-      (
-        second_update.stream_id,
-        h2_window_update_increment(&second_update)
-      ),
-    ]
-  );
+  read_h2_window_updates_until(&mut stream, 65_535, 65_535, 1);
 
   write_h2_frame(&mut stream, H2_FRAME_DATA, 0, 1, b"tail");
   let trailers = h2_literal_new_name(b"x-large-body", b"complete");
@@ -1788,21 +1830,7 @@ fn server_sends_http2_window_updates_while_consuming_large_request_body() {
     &trailers,
   );
 
-  let tail_connection_update = read_h2_frame(&mut stream);
-  let tail_stream_update = read_h2_frame(&mut stream);
-  assert_eq!(
-    vec![(0, 4), (1, 4)],
-    vec![
-      (
-        tail_connection_update.stream_id,
-        h2_window_update_increment(&tail_connection_update)
-      ),
-      (
-        tail_stream_update.stream_id,
-        h2_window_update_increment(&tail_stream_update)
-      ),
-    ]
-  );
+  read_h2_window_updates_until(&mut stream, 4, 4, 1);
 
   let response_headers = read_h2_frame(&mut stream);
   assert_eq!(H2_FRAME_HEADERS, response_headers.frame_type);
@@ -3534,18 +3562,8 @@ fn server_rejects_http2_prior_knowledge_oversized_request_headers_before_handler
     2,
     &vec![b'a'; H2_SERVER_MAX_HEADER_LIST_SIZE as usize],
   ));
-  let split = headers.len() / 2;
-  write_h2_frame(&mut stream, H2_FRAME_HEADERS, 0, 1, &headers[..split]);
-  write_h2_frame(
-    &mut stream,
-    H2_FRAME_CONTINUATION,
-    H2_FLAG_END_HEADERS | H2_FLAG_END_STREAM,
-    1,
-    &headers[split..],
-  );
-  stream
-    .shutdown(std::net::Shutdown::Write)
-    .expect("shutdown h2 write");
+  write_h2_header_block(&mut stream, 1, true, &headers);
+  let _ = stream.shutdown(std::net::Shutdown::Write);
 
   let error = handle
     .join()


### PR DESCRIPTION
Adds socket2 h2c SETTINGS_MAX_FRAME_SIZE advertisement and inbound enforcement with coverage for request rejection, legal peer updates, and response frame splitting.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1524/
work_kind: code_work
branch: hbx-1524-rttp-enforce-h2c-settings-max
base: main
commit: dcf45c44d531965a2c62854a3adf13c4b51556c8
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1524/
    url: https://plane.kahub.in/endless/browse/HBX-1524/
    close_policy: link_only
```