### PR TITLE
feat: [rttp] Add cross-crate h2c SETTINGS_MAX_FRAME_SIZE matrix

### DIFF
--- a/rttp/tests/test_server.rs
+++ b/rttp/tests/test_server.rs
@@ -5,7 +5,7 @@ use std::thread;
 use std::time::Duration;
 
 use rttp::server::{HttpResponse, Request};
-use rttp_client::HttpClient;
+use rttp_client::{Config, HttpClient};
 
 const H2_PREFACE: &[u8; 24] = b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n";
 const H2_FRAME_DATA: u8 = 0x0;
@@ -26,6 +26,7 @@ const H2_SETTINGS_INITIAL_WINDOW_SIZE: u16 = 0x4;
 const H2_SETTINGS_MAX_FRAME_SIZE: u16 = 0x5;
 const H2_SETTINGS_MAX_HEADER_LIST_SIZE: u16 = 0x6;
 const H2_DEFAULT_MAX_FRAME_SIZE: usize = 16 * 1024;
+const H2_MAX_FRAME_SIZE_LIMIT: usize = 16_777_215;
 const H2_SERVER_MAX_HEADER_LIST_SIZE: u32 = 64 * 1024;
 const H2_ERROR_REFUSED_STREAM: u32 = 0x7;
 
@@ -789,6 +790,74 @@ fn server_accepts_http2_prior_knowledge_get_and_writes_single_stream_response() 
       .map(|value| value.as_str())
   );
   assert_eq!("hello over h2", response.body().string().unwrap());
+
+  handle.join().expect("server thread");
+}
+
+#[test]
+fn rttp_client_h2c_max_frame_size_interoperates_with_socket2_server_matrix() {
+  let min_response_body = vec![b's'; H2_DEFAULT_MAX_FRAME_SIZE * 2 + 7];
+  let min_request_body = vec![b'c'; H2_DEFAULT_MAX_FRAME_SIZE * 2 + 11];
+  let server = rttp::Http::server("127.0.0.1:0")
+    .expect("bind server")
+    .with_read_timeout(Some(Duration::from_secs(2)))
+    .with_write_timeout(Some(Duration::from_secs(2)));
+  let addr = server.local_addr().expect("server addr");
+  let (tx, rx) = mpsc::channel();
+  let min_response_body_for_server = min_response_body.clone();
+  let min_request_body_for_client = min_request_body.clone();
+
+  let handle = thread::spawn(move || {
+    server
+      .serve_requests(2, move |request| match request.target() {
+        "/min-split" => {
+          tx.send((
+            request.target().to_string(),
+            request.body().len(),
+            request.body().first().copied(),
+            request.body().last().copied(),
+          ))
+          .expect("send min split request details");
+          HttpResponse::ok(min_response_body_for_server.clone())
+        }
+        "/max-single" => HttpResponse::ok(vec![b'm'; H2_DEFAULT_MAX_FRAME_SIZE + 19]),
+        target => panic!("unexpected h2c target {target}"),
+      })
+      .expect("serve h2c max-frame-size matrix");
+  });
+
+  let min_response = HttpClient::new()
+    .post()
+    .url(format!("http://{}/min-split", addr))
+    .binary(min_request_body_for_client)
+    .emit_http2_prior_knowledge()
+    .expect("min legal max-frame-size h2c response");
+  assert_eq!("HTTP/2", min_response.version());
+  assert_eq!(min_response_body, min_response.body().binary());
+  assert_eq!(
+    (
+      "/min-split".to_string(),
+      min_request_body.len(),
+      Some(b'c'),
+      Some(b'c')
+    ),
+    rx.recv().expect("receive min split request")
+  );
+
+  let max_frame_config = Config::builder()
+    .http2_max_frame_size(H2_MAX_FRAME_SIZE_LIMIT)
+    .build();
+  let max_response = HttpClient::new()
+    .get()
+    .url(format!("http://{}/max-single", addr))
+    .config(max_frame_config)
+    .emit_http2_prior_knowledge()
+    .expect("max legal max-frame-size h2c response");
+  assert_eq!("HTTP/2", max_response.version());
+  assert_eq!(
+    vec![b'm'; H2_DEFAULT_MAX_FRAME_SIZE + 19],
+    max_response.body().binary()
+  );
 
   handle.join().expect("server thread");
 }

--- a/rttp_client/src/config.rs
+++ b/rttp_client/src/config.rs
@@ -6,6 +6,7 @@ pub struct Config {
   max_redirect: u32,
   verify_ssl_hostname: bool,
   verify_ssl_cert: bool,
+  http2_max_frame_size: Option<usize>,
 }
 
 impl Default for Config {
@@ -44,6 +45,9 @@ impl Config {
   pub fn verify_ssl_hostname(&self) -> bool {
     self.verify_ssl_hostname
   }
+  pub fn http2_max_frame_size(&self) -> Option<usize> {
+    self.http2_max_frame_size
+  }
 }
 
 #[derive(Clone, Debug)]
@@ -67,6 +71,7 @@ impl ConfigBuilder {
         max_redirect: 0,
         verify_ssl_hostname: true,
         verify_ssl_cert: true,
+        http2_max_frame_size: None,
       },
     }
   }
@@ -102,6 +107,10 @@ impl ConfigBuilder {
     self.config.verify_ssl_cert = verify_ssl_cert;
     self
   }
+  pub fn http2_max_frame_size(&mut self, max_frame_size: usize) -> &mut Self {
+    self.config.http2_max_frame_size = Some(max_frame_size);
+    self
+  }
 }
 
 impl AsRef<Config> for Config {
@@ -129,6 +138,7 @@ mod tests {
       .max_redirect(5)
       .verify_ssl_hostname(false)
       .verify_ssl_cert(false)
+      .http2_max_frame_size(16_384)
       .build();
 
     assert_eq!(config.read_timeout(), 1234);
@@ -137,6 +147,7 @@ mod tests {
     assert_eq!(config.max_redirect(), 5);
     assert!(!config.verify_ssl_hostname());
     assert!(!config.verify_ssl_cert());
+    assert_eq!(Some(16_384), config.http2_max_frame_size());
   }
 
   #[test]
@@ -161,6 +172,10 @@ mod tests {
     assert_eq!(
       default_config.verify_ssl_cert(),
       builder_config.verify_ssl_cert()
+    );
+    assert_eq!(
+      default_config.http2_max_frame_size(),
+      builder_config.http2_max_frame_size()
     );
   }
 

--- a/rttp_client/src/http2.rs
+++ b/rttp_client/src/http2.rs
@@ -138,19 +138,26 @@ impl<'a> PriorKnowledgeClient<'a> {
       return Err(error::url_bad_scheme(url));
     }
 
+    let local_settings = LocalSettings::from_config(self.request.origin().config())?;
     let mut stream = connect_tcp_stream(addr(&url)?, self.request.origin().config())?;
-    write_connection_preface(&mut stream)?;
-    let mut peer_settings = read_settings_and_ack(&mut stream)?;
-    reject_goaway_before_opening_request_stream(&mut stream, &mut peer_settings)?;
+    write_connection_preface(&mut stream, local_settings)?;
+    let mut peer_settings = read_settings_and_ack(&mut stream, local_settings)?;
+    reject_goaway_before_opening_request_stream(&mut stream, &mut peer_settings, local_settings)?;
     let response = match write_request(
       &mut stream,
       &self.request,
       &url,
       self.request.url().clone(),
       peer_settings,
+      local_settings,
     )? {
       Some(response) => response,
-      None => read_single_stream_response(&mut stream, self.request.url().clone(), !is_head)?,
+      None => read_single_stream_response(
+        &mut stream,
+        self.request.url().clone(),
+        !is_head,
+        local_settings,
+      )?,
     };
     self.request.origin_mut().closed_set(true);
     Ok(response)
@@ -228,9 +235,10 @@ where
 fn reject_goaway_before_opening_request_stream(
   stream: &mut TcpStream,
   peer_settings: &mut PeerSettings,
+  local_settings: LocalSettings,
 ) -> error::Result<()> {
   while pending_frame_available(stream)? {
-    let frame = read_frame(stream)?;
+    let frame = read_frame(stream, local_settings)?;
     match (frame.frame_type, frame.stream_id) {
       (FRAME_GOAWAY, _) => {
         if goaway_last_stream_id(&frame)? < STREAM_ID {
@@ -355,15 +363,22 @@ fn timeout_duration(name: &'static str, millis: u64) -> error::Result<Duration> 
   Ok(Duration::from_millis(millis))
 }
 
-fn write_connection_preface(stream: &mut TcpStream) -> error::Result<()> {
+fn write_connection_preface(
+  stream: &mut TcpStream,
+  local_settings: LocalSettings,
+) -> error::Result<()> {
   stream.write_all(CLIENT_PREFACE).map_err(error::request)?;
-  write_frame(stream, FRAME_SETTINGS, 0, 0, &[])?;
+  let payload = local_settings.settings_payload();
+  write_frame(stream, FRAME_SETTINGS, 0, 0, &payload)?;
   stream.flush().map_err(error::request)
 }
 
-fn read_settings_and_ack(stream: &mut TcpStream) -> error::Result<PeerSettings> {
+fn read_settings_and_ack(
+  stream: &mut TcpStream,
+  local_settings: LocalSettings,
+) -> error::Result<PeerSettings> {
   loop {
-    let frame = read_frame(stream)?;
+    let frame = read_frame(stream, local_settings)?;
     if frame.frame_type != FRAME_SETTINGS {
       return Err(error::bad_response(
         "HTTP/2 peer did not start with a SETTINGS frame",
@@ -398,6 +413,42 @@ struct PeerSettings {
   max_frame_size: usize,
   max_frame_size_changed: bool,
   max_header_list_size: Option<usize>,
+}
+
+#[derive(Clone, Copy)]
+struct LocalSettings {
+  max_frame_size: usize,
+  max_frame_size_configured: bool,
+}
+
+impl LocalSettings {
+  fn from_config(config: &Config) -> error::Result<Self> {
+    let configured_max_frame_size = config.http2_max_frame_size();
+    let max_frame_size = configured_max_frame_size.unwrap_or(DEFAULT_MAX_FRAME_SIZE);
+    if !(DEFAULT_MAX_FRAME_SIZE..=MAX_FRAME_SIZE_LIMIT).contains(&max_frame_size) {
+      return Err(error::builder_with_message(
+        "invalid HTTP/2 SETTINGS_MAX_FRAME_SIZE value",
+      ));
+    }
+    Ok(Self {
+      max_frame_size,
+      max_frame_size_configured: configured_max_frame_size.is_some(),
+    })
+  }
+
+  fn settings_payload(self) -> Vec<u8> {
+    if !self.max_frame_size_configured {
+      return Vec::new();
+    }
+    h2_setting(SETTING_MAX_FRAME_SIZE, self.max_frame_size as u32).to_vec()
+  }
+}
+
+fn h2_setting(id: u16, value: u32) -> [u8; 6] {
+  let mut setting = [0; 6];
+  setting[..2].copy_from_slice(&id.to_be_bytes());
+  setting[2..].copy_from_slice(&value.to_be_bytes());
+  setting
 }
 
 fn validate_settings_payload(payload: &[u8]) -> error::Result<PeerSettings> {
@@ -483,6 +534,7 @@ fn write_request(
   url: &Url,
   response_url: RoUrl,
   mut peer_settings: PeerSettings,
+  local_settings: LocalSettings,
 ) -> error::Result<Option<Response>> {
   if peer_settings.max_concurrent_streams == Some(0) {
     return Err(error::bad_response(
@@ -530,9 +582,14 @@ fn write_request(
     peer_settings.max_frame_size,
   )?;
   if !body.is_empty() {
-    if let Some(response) =
-      write_data_frames(stream, body, &mut peer_settings, has_trailers, response_url)?
-    {
+    if let Some(response) = write_data_frames(
+      stream,
+      body,
+      &mut peer_settings,
+      has_trailers,
+      response_url,
+      local_settings,
+    )? {
       return Ok(Some(response));
     }
   }
@@ -649,6 +706,7 @@ fn write_data_frames(
   peer_settings: &mut PeerSettings,
   has_trailers: bool,
   url: RoUrl,
+  local_settings: LocalSettings,
 ) -> error::Result<Option<Response>> {
   let mut connection_send_window = SendWindow::new();
   let mut stream_send_window =
@@ -670,6 +728,7 @@ fn write_data_frames(
         &mut current_initial_window_size,
         &mut current_max_frame_size,
         url.clone(),
+        local_settings,
       )? {
         return Ok(Some(response));
       }
@@ -704,9 +763,10 @@ fn read_until_send_window_available(
   current_initial_window_size: &mut u32,
   current_max_frame_size: &mut usize,
   url: RoUrl,
+  local_settings: LocalSettings,
 ) -> error::Result<Option<Response>> {
   loop {
-    let frame = read_frame(stream)?;
+    let frame = read_frame(stream, local_settings)?;
     match (frame.frame_type, frame.stream_id) {
       (FRAME_WINDOW_UPDATE, 0) => {
         connection_send_window.increase(window_update_increment(&frame)?)?;
@@ -760,7 +820,8 @@ fn read_until_send_window_available(
         }
       }
       (FRAME_HEADERS, STREAM_ID) | (FRAME_DATA, STREAM_ID) | (FRAME_CONTINUATION, STREAM_ID) => {
-        return read_single_stream_response_from_frame(stream, url, frame).map(Some);
+        return read_single_stream_response_from_frame(stream, url, frame, local_settings)
+          .map(Some);
       }
       _ => {}
     }
@@ -1025,16 +1086,24 @@ fn read_single_stream_response(
   stream: &mut TcpStream,
   url: RoUrl,
   include_data_payload: bool,
+  local_settings: LocalSettings,
 ) -> error::Result<Response> {
-  read_single_stream_response_with_first_frame(stream, url, None, include_data_payload)
+  read_single_stream_response_with_first_frame(
+    stream,
+    url,
+    None,
+    include_data_payload,
+    local_settings,
+  )
 }
 
 fn read_single_stream_response_from_frame(
   stream: &mut TcpStream,
   url: RoUrl,
   first_frame: Frame,
+  local_settings: LocalSettings,
 ) -> error::Result<Response> {
-  read_single_stream_response_with_first_frame(stream, url, Some(first_frame), true)
+  read_single_stream_response_with_first_frame(stream, url, Some(first_frame), true, local_settings)
 }
 
 fn read_single_stream_response_with_first_frame(
@@ -1042,6 +1111,7 @@ fn read_single_stream_response_with_first_frame(
   url: RoUrl,
   mut first_frame: Option<Frame>,
   include_data_payload: bool,
+  local_settings: LocalSettings,
 ) -> error::Result<Response> {
   let mut header_block = Vec::new();
   let mut headers = Vec::new();
@@ -1060,7 +1130,7 @@ fn read_single_stream_response_with_first_frame(
   loop {
     let frame = match first_frame.take() {
       Some(frame) => frame,
-      None => match read_frame(stream) {
+      None => match read_frame(stream, local_settings) {
         Ok(frame) => frame,
         Err(err) if pending_header_block.is_some() && is_unexpected_eof(&err) => {
           return Err(error::bad_response("incomplete HTTP/2 header block"));
@@ -1483,10 +1553,15 @@ struct Frame {
   payload: Vec<u8>,
 }
 
-fn read_frame(stream: &mut TcpStream) -> error::Result<Frame> {
+fn read_frame(stream: &mut TcpStream, local_settings: LocalSettings) -> error::Result<Frame> {
   let mut header = [0; 9];
   stream.read_exact(&mut header).map_err(error::response)?;
   let length = ((header[0] as usize) << 16) | ((header[1] as usize) << 8) | header[2] as usize;
+  if local_settings.max_frame_size_configured && length > local_settings.max_frame_size {
+    return Err(error::bad_response(
+      "HTTP/2 frame payload exceeds active max frame size",
+    ));
+  }
   let mut payload = vec![0; length];
   stream.read_exact(&mut payload).map_err(error::response)?;
   Ok(Frame {

--- a/rttp_client/tests/http2_prior_knowledge.rs
+++ b/rttp_client/tests/http2_prior_knowledge.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 
 use rttp_client::types::Header;
 use rttp_client::types::Proxy;
-use rttp_client::HttpClient;
+use rttp_client::{Config, HttpClient};
 
 const FRAME_DATA: u8 = 0x0;
 const FRAME_HEADERS: u8 = 0x1;
@@ -32,6 +32,8 @@ const SETTING_MAX_CONCURRENT_STREAMS: u16 = 0x3;
 const SETTING_INITIAL_WINDOW_SIZE: u16 = 0x4;
 const SETTING_MAX_FRAME_SIZE: u16 = 0x5;
 const SETTING_MAX_HEADER_LIST_SIZE: u16 = 0x6;
+const DEFAULT_MAX_FRAME_SIZE: usize = 16 * 1024;
+const MAX_FRAME_SIZE_LIMIT: usize = 16_777_215;
 
 fn spawn_h2_prior_knowledge_peer() -> (SocketAddr, thread::JoinHandle<Vec<u8>>) {
   let listener = TcpListener::bind("127.0.0.1:0").expect("bind h2 peer");
@@ -1625,6 +1627,150 @@ fn prior_knowledge_rejects_initial_settings_with_invalid_max_frame_size() {
 
   assert!(err.to_string().contains("SETTINGS_MAX_FRAME_SIZE"));
   handle.join().expect("invalid max frame size peer thread");
+}
+
+#[test]
+fn prior_knowledge_advertises_configured_legal_max_frame_size_boundaries() {
+  for max_frame_size in [DEFAULT_MAX_FRAME_SIZE, MAX_FRAME_SIZE_LIMIT] {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind h2 peer");
+    let addr = listener.local_addr().expect("h2 peer addr");
+
+    let handle = thread::spawn(move || {
+      let (mut stream, _) = listener.accept().expect("accept h2 client");
+      let mut preface = [0; 24];
+      stream
+        .read_exact(&mut preface)
+        .expect("read client preface");
+      assert_eq!(b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n", &preface);
+
+      let client_settings = read_frame(&mut stream);
+      assert_eq!(FRAME_SETTINGS, client_settings.frame_type);
+      assert_eq!(0, client_settings.flags);
+      assert_eq!(0, client_settings.stream_id);
+      assert_eq!(
+        Some(max_frame_size as u32),
+        h2_setting_value(&client_settings.payload, SETTING_MAX_FRAME_SIZE)
+      );
+
+      write_frame(&mut stream, FRAME_SETTINGS, 0, 0, &[]);
+      let client_settings_ack = read_frame(&mut stream);
+      assert_eq!(FRAME_SETTINGS, client_settings_ack.frame_type);
+      assert_eq!(FLAG_ACK, client_settings_ack.flags);
+      assert_eq!(0, client_settings_ack.stream_id);
+      assert!(client_settings_ack.payload.is_empty());
+
+      let request_headers = read_frame(&mut stream);
+      assert_eq!(FRAME_HEADERS, request_headers.frame_type);
+      assert_eq!(FLAG_END_STREAM | FLAG_END_HEADERS, request_headers.flags);
+      assert_eq!(1, request_headers.stream_id);
+
+      write_frame(&mut stream, FRAME_SETTINGS, FLAG_ACK, 0, &[]);
+      write_frame(&mut stream, FRAME_HEADERS, FLAG_END_HEADERS, 1, &[0x88]);
+      write_frame(&mut stream, FRAME_DATA, FLAG_END_STREAM, 1, b"ok");
+    });
+
+    let config = Config::builder()
+      .http2_max_frame_size(max_frame_size)
+      .build();
+    let response = HttpClient::new()
+      .get()
+      .url(format!("http://{}/configured-max-frame-size", addr))
+      .config(config)
+      .emit_http2_prior_knowledge()
+      .expect("configured legal max frame size should work");
+
+    assert_eq!(200, response.code());
+    assert_eq!("ok", response.body().string().unwrap());
+    handle
+      .join()
+      .expect("configured max frame size peer thread");
+  }
+}
+
+#[test]
+fn prior_knowledge_rejects_configured_illegal_max_frame_size_boundaries_before_connecting() {
+  for max_frame_size in [DEFAULT_MAX_FRAME_SIZE - 1, MAX_FRAME_SIZE_LIMIT + 1] {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind h2 peer");
+    listener
+      .set_nonblocking(true)
+      .expect("set h2 listener nonblocking");
+    let addr = listener.local_addr().expect("h2 peer addr");
+    let config = Config::builder()
+      .http2_max_frame_size(max_frame_size)
+      .build();
+
+    let err = HttpClient::new()
+      .get()
+      .url(format!("http://{}/illegal-max-frame-size", addr))
+      .config(config)
+      .emit_http2_prior_knowledge()
+      .expect_err("illegal local SETTINGS_MAX_FRAME_SIZE must fail");
+
+    assert!(err.is_builder());
+    assert!(err.to_string().contains("SETTINGS_MAX_FRAME_SIZE"));
+    assert!(
+      listener.accept().is_err(),
+      "client must reject illegal local SETTINGS_MAX_FRAME_SIZE before connecting"
+    );
+  }
+}
+
+#[test]
+fn prior_knowledge_rejects_oversized_inbound_frame_above_configured_max_frame_size() {
+  let listener = TcpListener::bind("127.0.0.1:0").expect("bind h2 peer");
+  let addr = listener.local_addr().expect("h2 peer addr");
+
+  let handle = thread::spawn(move || {
+    let (mut stream, _) = listener.accept().expect("accept h2 client");
+    let mut preface = [0; 24];
+    stream
+      .read_exact(&mut preface)
+      .expect("read client preface");
+    assert_eq!(b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n", &preface);
+
+    let client_settings = read_frame(&mut stream);
+    assert_eq!(
+      Some(DEFAULT_MAX_FRAME_SIZE as u32),
+      h2_setting_value(&client_settings.payload, SETTING_MAX_FRAME_SIZE)
+    );
+
+    write_frame(&mut stream, FRAME_SETTINGS, 0, 0, &[]);
+    let client_settings_ack = read_frame(&mut stream);
+    assert_eq!(FRAME_SETTINGS, client_settings_ack.frame_type);
+    assert_eq!(FLAG_ACK, client_settings_ack.flags);
+
+    let request_headers = read_frame(&mut stream);
+    assert_eq!(FRAME_HEADERS, request_headers.frame_type);
+    assert_eq!(1, request_headers.stream_id);
+
+    write_frame(&mut stream, FRAME_SETTINGS, FLAG_ACK, 0, &[]);
+    write_frame(&mut stream, FRAME_HEADERS, FLAG_END_HEADERS, 1, &[0x88]);
+    write_frame(
+      &mut stream,
+      FRAME_DATA,
+      FLAG_END_STREAM,
+      1,
+      &vec![b'x'; DEFAULT_MAX_FRAME_SIZE + 1],
+    );
+  });
+
+  let config = Config::builder()
+    .http2_max_frame_size(DEFAULT_MAX_FRAME_SIZE)
+    .build();
+  let err = HttpClient::new()
+    .get()
+    .url(format!("http://{}/oversized-inbound-frame", addr))
+    .config(config)
+    .emit_http2_prior_knowledge()
+    .expect_err("oversized inbound HTTP/2 frame must fail");
+
+  assert!(
+    err
+      .to_string()
+      .contains("frame payload exceeds active max frame size"),
+    "unexpected error: {err}"
+  );
+  handle.join().expect("oversized inbound peer thread");
 }
 
 #[test]
@@ -3705,6 +3851,14 @@ fn settings_payload(identifier: u16, value: u32) -> Vec<u8> {
   payload.extend_from_slice(&identifier.to_be_bytes());
   payload.extend_from_slice(&value.to_be_bytes());
   payload
+}
+
+fn h2_setting_value(payload: &[u8], identifier: u16) -> Option<u32> {
+  payload.chunks_exact(6).find_map(|setting| {
+    let id = u16::from_be_bytes([setting[0], setting[1]]);
+    let value = u32::from_be_bytes([setting[2], setting[3], setting[4], setting[5]]);
+    (id == identifier).then_some(value)
+  })
 }
 
 fn h2_literal_new_name(name: &[u8], value: &[u8]) -> Vec<u8> {


### PR DESCRIPTION
Adds configurable h2c SETTINGS_MAX_FRAME_SIZE support and verifies cross-crate client/server behavior for legal boundaries, DATA splitting, and configured oversized inbound frame rejection.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1525/
work_kind: code_work
branch: hbx-1525-rttp-add-cross-crate-h2c
base: main
commit: d1a9f2e40de137f83c3d015d8dce671a6a9f778a
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1525/
    url: https://plane.kahub.in/endless/browse/HBX-1525/
    close_policy: link_only
```