### PR TITLE
feat: [rttp] Document h2c SETTINGS_MAX_FRAME_SIZE boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ available through `Response::trailers`, `Response::trailer`, and
 | Upgrade and tunnel handoff | `CONNECT` returns the tunnel socket after a successful `200`; `upgrade()` returns the socket after `101 Switching Protocols` and skips interim `1xx` responses | Upgraded protocols are handed to the caller and are not parsed by `rttp_client` |
 | Redirects | Auto-redirect covers 301, 302, 303, 307, and 308 method/body behavior, relative and absolute `Location` resolution, same- and cross-authority header handling, loop detection, and redirect bounds | Redirects are HTTP client behavior, not a browser policy implementation |
 | Trailers | Chunked response trailers are exposed for blocking and async APIs; streaming chunked uploads can send declared request trailers | Application metadata trailers such as `X-Trace` are allowed; pseudo-header, connection-specific, routing, authentication/cookie, and framing trailer fields are rejected |
-| Prior-knowledge h2c | With `http2`, direct `socket2` h2c sends GET, HEAD, bodyless DELETE, OPTIONS, or TRACE, and buffered POST, PUT, or PATCH requests, opens at most one request stream, honors initial peer `SETTINGS_MAX_CONCURRENT_STREAMS` by failing before request HEADERS when the peer allows zero streams, honors peer-advertised `SETTINGS_MAX_HEADER_LIST_SIZE` request metadata limits, strips HTTP/1.x connection-specific request fields before emission, rejects connection-specific peer response fields, suppresses HEAD response bodies, treats `RST_STREAM` on the active stream as a bounded reset/cancellation signal, acknowledges valid PING frames with matching opaque data, DATA bodies, trailers, HPACK static Huffman strings, dynamic entries within peer settings, bounded large header blocks, padded incoming frames, `GOAWAY` shutdown boundaries, PRIORITY metadata validation without scheduling, HTTP/2-allowed unknown/extension frame ignoring inside this bounded path, reserved stream-id high-bit normalization, and conservative DATA flow control | `CONNECT`, RFC 8441 `:protocol` extended CONNECT metadata, and HTTP/1.1 `Upgrade` handoff requests are rejected deterministically before opening a client socket, and `PUSH_PROMISE`/server push is rejected instead of managed; bounded prior-knowledge h2c only, with no public cancellation callback API, no dynamic policy API, no extension callback API, full extension negotiation, TLS ALPN, external h2 integration, proxy tunneling to h2, proxy h2, tunnel handoff, connection pooling, persistent HTTP/2 session management, automatic retry, server push, full stream state machine, unbounded multiplex scheduling, general multiplexing, priority scheduling, or request bodies for GET, HEAD, DELETE, OPTIONS, or TRACE |
+| Prior-knowledge h2c | With `http2`, direct `socket2` h2c sends GET, HEAD, bodyless DELETE, OPTIONS, or TRACE, and buffered POST, PUT, or PATCH requests, opens at most one request stream, honors initial peer `SETTINGS_MAX_CONCURRENT_STREAMS` by failing before request HEADERS when the peer allows zero streams, honors peer-advertised `SETTINGS_MAX_HEADER_LIST_SIZE` request metadata limits, accepts only legal `SETTINGS_MAX_FRAME_SIZE` values from 16,384 through 16,777,215 bytes, splits outbound HEADERS, DATA, and trailers to the active peer frame-size limit, rejects oversized inbound frames when a configured local frame-size limit is exceeded, strips HTTP/1.x connection-specific request fields before emission, rejects connection-specific peer response fields, suppresses HEAD response bodies, treats `RST_STREAM` on the active stream as a bounded reset/cancellation signal, acknowledges valid PING frames with matching opaque data, DATA bodies, trailers, HPACK static Huffman strings, dynamic entries within peer settings, bounded large header blocks, padded incoming frames, `GOAWAY` shutdown boundaries, PRIORITY metadata validation without scheduling, HTTP/2-allowed unknown/extension frame ignoring inside this bounded path, reserved stream-id high-bit normalization, and conservative DATA flow control | `CONNECT`, RFC 8441 `:protocol` extended CONNECT metadata, and HTTP/1.1 `Upgrade` handoff requests are rejected deterministically before opening a client socket, and `PUSH_PROMISE`/server push is rejected instead of managed; bounded prior-knowledge h2c only, with no public cancellation callback API, no dynamic policy API, no extension callback API, full extension negotiation, TLS ALPN, external h2 integration, proxy tunneling to h2, proxy h2, tunnel handoff, connection pooling, persistent HTTP/2 session management, automatic retry, server push, full stream state machine, unbounded multiplex scheduling, general multiplexing, priority scheduling, or request bodies for GET, HEAD, DELETE, OPTIONS, or TRACE |
 
 With the `http2` feature enabled, `emit_http2_prior_knowledge` sends a bounded
 prior-knowledge h2c request over a direct socket2 TCP connection. It opens at
@@ -51,8 +51,17 @@ and buffered POST, PUT, or PATCH requests, including non-empty buffered request
 bodies as DATA frames for the write methods. GET, HEAD, DELETE, OPTIONS, and
 TRACE requests with bodies are rejected; HEAD, bodyless DELETE, OPTIONS, and
 TRACE requests do not send request DATA frames, and any HEAD response DATA
-frames are consumed without being exposed as a response body. Before encoding
-request HEADERS, this bounded h2c client path
+frames are consumed without being exposed as a response body. The client
+validates `SETTINGS_MAX_FRAME_SIZE` boundaries on both sides of the bounded
+h2c handshake. A configured local
+`http2_max_frame_size` is advertised only when set, must be in the legal
+HTTP/2 range of 16,384 through 16,777,215 bytes, and is used to reject inbound
+frame payloads larger than that active local limit. Peer-advertised
+`SETTINGS_MAX_FRAME_SIZE` values outside that same legal range reject the
+handshake. Legal peer values become the outbound frame boundary, so request
+HEADERS, DATA, and trailing HEADERS are split into frames no larger than the
+active peer limit while the client remains a single-stream prior-knowledge
+path. Before encoding request HEADERS, this bounded h2c client path
 strips HTTP/1.x connection-specific fields: `Connection`, `Keep-Alive`,
 `Proxy-Connection`, `Transfer-Encoding`, `Upgrade`, `TE`, `Trailer`, `Host`,
 and any field named by a `Connection` token. Peer response HEADERS are rejected
@@ -115,8 +124,8 @@ extension negotiation, external h2 integration, connection pooling, automatic
 retry, server push, full stream state machines, and full HTTP/2 features such
 as unbounded multiplex scheduling, general multiplexing, and priority
 scheduling are not part of that bounded prior-knowledge client path; RTTP also
-does not provide a dynamic policy API for changing those h2c metadata limits
-at runtime.
+does not provide a dynamic policy API for changing h2c frame-size or metadata
+limits at runtime.
 
 ```rust,no_run
 use rttp_client::HttpClient;
@@ -186,9 +195,12 @@ h2c streams once the open-stream count plus completed requests reaches that
 allowance. It also advertises and enforces a conservative
 `SETTINGS_MAX_HEADER_LIST_SIZE` for inbound request metadata; request HEADERS
 and trailing HEADERS can span CONTINUATION frames, but the decoded metadata
-remains bounded before handler dispatch. It preserves the same HEAD body
-suppression for prior-knowledge h2c
-responses.
+remains bounded before handler dispatch. The server advertises the default
+16,384-byte `SETTINGS_MAX_FRAME_SIZE`, rejects peer SETTINGS values outside the
+legal HTTP/2 range of 16,384 through 16,777,215 bytes, rejects inbound frames
+larger than the active local limit, and splits outbound response HEADERS, DATA,
+and trailing HEADERS to the active peer frame-size limit. It preserves the same
+HEAD body suppression for prior-knowledge h2c responses.
 Incoming padded HEADERS, DATA, and trailer frames are accepted without exposing
 padding bytes to handlers, and application trailers such as `X-Trace`,
 `X-Upload-Status`, and `X-Upload-Checksum` are preserved on `Request`.
@@ -254,7 +266,7 @@ management, full RFC 8441 support, and full HTTP/2 features such as unbounded
 multiplexing, unbounded multiplex scheduling, general multiplexing, server
 push, and priority scheduling remain outside this bounded prior-knowledge
 server path. RTTP does not expose a dynamic policy API for changing the h2c
-metadata limit at runtime.
+frame-size or metadata limit at runtime.
 
 It is not a full RFC-covering web server and still does not implement server
 TLS or async accept loops.
@@ -268,4 +280,4 @@ TLS or async accept loops.
 | HTTP/1.1 response framing | Automatic `Content-Length`, explicit chunked responses, bodyless `HEAD`, `101`, `204`, and `304`, response trailers after the terminating chunk | No server TLS |
 | Upgrade and tunnel targets | `CONNECT` authority-form requests are accepted as HTTP requests; `HttpResponse::upgrade` can hand an upgraded socket to caller code after a matching request | The server does not implement the upgraded protocol after handoff |
 | Trailers | Chunked request trailers are preserved on `Request`; malformed, oversized, forbidden, and pseudo-header trailers are rejected; response trailers can be serialized for chunked responses | Application metadata trailers are allowed; trailer names that affect connection state, routing, authentication/cookies, framing, or payload processing are rejected |
-| Prior-knowledge h2c | The same `socket2` listener detects the HTTP/2 preface, validates SETTINGS, advertises `SETTINGS_MAX_CONCURRENT_STREAMS` from the bounded active stream allowance, enforces that allowance before dispatching new streams, advertises and enforces a conservative `SETTINGS_MAX_HEADER_LIST_SIZE` for inbound request metadata, serves bounded prior-knowledge streams including bodyless DELETE, OPTIONS, and TRACE, handles HEAD without response DATA, rejects connection-specific request fields before handler dispatch, strips connection-specific response fields during h2c serialization, treats `RST_STREAM` as a bounded reset/cancellation signal for the affected stream, acknowledges valid PING frames with matching opaque data, accepts padded HEADERS/DATA/trailers without exposing padding, handles HPACK Huffman/dynamic fields and bounded CONTINUATION header blocks, emits `GOAWAY` with the last completed stream id at bounded shutdown, validates and ignores valid PRIORITY metadata, ignores HTTP/2-allowed unknown/extension frames inside this bounded path, normalizes reserved stream-id high bits, and applies conservative DATA flow control | Ordinary `CONNECT`, RFC 8441 extended `CONNECT`/`:protocol`, and `PUSH_PROMISE` are rejected deterministically before handler dispatch; HTTP/1.1 `CONNECT` and `Upgrade` remain separate handoff paths; bounded prior-knowledge h2c only, with no public cancellation callback API, no dynamic policy API, no extension callback API, full extension negotiation, TLS ALPN, external h2 integration, WebSocket over h2, proxy h2, tunnel handoff, connection pooling, persistent HTTP/2 session management, automatic retry, server push, full RFC 8441 support, full stream state machine, unbounded multiplexing, unbounded multiplex scheduling, general multiplexing, priority scheduling, or full HTTP/2 server feature set |
+| Prior-knowledge h2c | The same `socket2` listener detects the HTTP/2 preface, validates SETTINGS including legal `SETTINGS_MAX_FRAME_SIZE` values from 16,384 through 16,777,215 bytes, advertises the default 16,384-byte `SETTINGS_MAX_FRAME_SIZE`, rejects inbound frames above the active local limit, splits outbound HEADERS, DATA, and trailers to the active peer frame-size limit, advertises `SETTINGS_MAX_CONCURRENT_STREAMS` from the bounded active stream allowance, enforces that allowance before dispatching new streams, advertises and enforces a conservative `SETTINGS_MAX_HEADER_LIST_SIZE` for inbound request metadata, serves bounded prior-knowledge streams including bodyless DELETE, OPTIONS, and TRACE, handles HEAD without response DATA, rejects connection-specific request fields before handler dispatch, strips connection-specific response fields during h2c serialization, treats `RST_STREAM` as a bounded reset/cancellation signal for the affected stream, acknowledges valid PING frames with matching opaque data, accepts padded HEADERS/DATA/trailers without exposing padding, handles HPACK Huffman/dynamic fields and bounded CONTINUATION header blocks, emits `GOAWAY` with the last completed stream id at bounded shutdown, validates and ignores valid PRIORITY metadata, ignores HTTP/2-allowed unknown/extension frames inside this bounded path, normalizes reserved stream-id high bits, and applies conservative DATA flow control | Ordinary `CONNECT`, RFC 8441 extended `CONNECT`/`:protocol`, and `PUSH_PROMISE` are rejected deterministically before handler dispatch; HTTP/1.1 `CONNECT` and `Upgrade` remain separate handoff paths; bounded prior-knowledge h2c only, with no public cancellation callback API, no dynamic policy API, no extension callback API, full extension negotiation, TLS ALPN, external h2 integration, WebSocket over h2, proxy h2, tunnel handoff, connection pooling, persistent HTTP/2 session management, automatic retry, server push, full RFC 8441 support, full stream state machine, unbounded multiplexing, unbounded multiplex scheduling, general multiplexing, priority scheduling, or full HTTP/2 server feature set |

--- a/rttp/README.md
+++ b/rttp/README.md
@@ -62,7 +62,11 @@ allowance. The h2c path handles `HEAD` without writing response DATA frames.
 The server also advertises and enforces a conservative
 `SETTINGS_MAX_HEADER_LIST_SIZE` for inbound request metadata; request HEADERS
 and trailing HEADERS can span CONTINUATION frames, but decoded metadata remains
-bounded before handler dispatch.
+bounded before handler dispatch. It advertises the default 16,384-byte
+`SETTINGS_MAX_FRAME_SIZE`, rejects peer SETTINGS values outside the legal
+HTTP/2 range of 16,384 through 16,777,215 bytes, rejects inbound frames larger
+than the active local limit, and splits outbound response HEADERS, DATA, and
+trailing HEADERS to the active peer frame-size limit.
 Incoming padded HEADERS, DATA, and trailer frames are accepted without exposing
 padding bytes to handlers, and application trailers such as `X-Trace`,
 `X-Upload-Status`, and `X-Upload-Checksum` are preserved on `Request`.
@@ -146,7 +150,7 @@ push, and priority scheduling, or async accept loops.
 | HTTP/1.1 response framing | Automatic `Content-Length`, explicit chunked responses, bodyless `HEAD`, `101`, `204`, and `304`, response trailers after the terminating chunk | No server TLS |
 | Upgrade and tunnel targets | `CONNECT` authority-form requests are accepted as HTTP requests; `HttpResponse::upgrade` can hand an upgraded socket to caller code after a matching request | The server does not implement the upgraded protocol after handoff |
 | Trailers | Chunked request trailers are preserved on `Request`; malformed, oversized, forbidden, and pseudo-header trailers are rejected; response trailers can be serialized for chunked responses | Application metadata trailers are allowed; trailer names that affect connection state, routing, authentication/cookies, framing, or payload processing are rejected |
-| Prior-knowledge h2c | The same `socket2` listener detects the HTTP/2 preface, validates SETTINGS, advertises `SETTINGS_MAX_CONCURRENT_STREAMS` from the bounded active stream allowance, enforces that allowance before dispatching new streams, advertises and enforces a conservative `SETTINGS_MAX_HEADER_LIST_SIZE` for inbound request metadata, serves bounded prior-knowledge streams including bodyless DELETE, OPTIONS, and TRACE, handles HEAD without response DATA, rejects connection-specific request fields before handler dispatch, strips connection-specific response fields during h2c serialization, treats `RST_STREAM` as a bounded reset/cancellation signal for the affected stream, acknowledges valid PING frames with matching opaque data, accepts padded HEADERS/DATA/trailers without exposing padding, handles HPACK Huffman/dynamic fields and bounded CONTINUATION header blocks, emits `GOAWAY` with the last completed stream id at bounded shutdown, validates and ignores valid PRIORITY metadata, ignores HTTP/2-allowed unknown/extension frames inside this bounded path, normalizes reserved stream-id high bits, and applies conservative DATA flow control | Ordinary `CONNECT`, RFC 8441 extended `CONNECT`/`:protocol`, and `PUSH_PROMISE` are rejected deterministically before handler dispatch; HTTP/1.1 `CONNECT` and `Upgrade` remain separate handoff paths; bounded prior-knowledge h2c only, with no public cancellation callback API, no dynamic policy API, no extension callback API, full extension negotiation, TLS ALPN, external h2 integration, WebSocket over h2, proxy h2, tunnel handoff, connection pooling, persistent HTTP/2 session management, automatic retry, server push, full RFC 8441 support, full stream state machine, unbounded multiplexing, unbounded multiplex scheduling, general multiplexing, priority scheduling, or full HTTP/2 server feature set |
+| Prior-knowledge h2c | The same `socket2` listener detects the HTTP/2 preface, validates SETTINGS including legal `SETTINGS_MAX_FRAME_SIZE` values from 16,384 through 16,777,215 bytes, advertises the default 16,384-byte `SETTINGS_MAX_FRAME_SIZE`, rejects inbound frames above the active local limit, splits outbound HEADERS, DATA, and trailers to the active peer frame-size limit, advertises `SETTINGS_MAX_CONCURRENT_STREAMS` from the bounded active stream allowance, enforces that allowance before dispatching new streams, advertises and enforces a conservative `SETTINGS_MAX_HEADER_LIST_SIZE` for inbound request metadata, serves bounded prior-knowledge streams including bodyless DELETE, OPTIONS, and TRACE, handles HEAD without response DATA, rejects connection-specific request fields before handler dispatch, strips connection-specific response fields during h2c serialization, treats `RST_STREAM` as a bounded reset/cancellation signal for the affected stream, acknowledges valid PING frames with matching opaque data, accepts padded HEADERS/DATA/trailers without exposing padding, handles HPACK Huffman/dynamic fields and bounded CONTINUATION header blocks, emits `GOAWAY` with the last completed stream id at bounded shutdown, validates and ignores valid PRIORITY metadata, ignores HTTP/2-allowed unknown/extension frames inside this bounded path, normalizes reserved stream-id high bits, and applies conservative DATA flow control | Ordinary `CONNECT`, RFC 8441 extended `CONNECT`/`:protocol`, and `PUSH_PROMISE` are rejected deterministically before handler dispatch; HTTP/1.1 `CONNECT` and `Upgrade` remain separate handoff paths; bounded prior-knowledge h2c only, with no public cancellation callback API, no dynamic policy API, no extension callback API, full extension negotiation, TLS ALPN, external h2 integration, WebSocket over h2, proxy h2, tunnel handoff, connection pooling, persistent HTTP/2 session management, automatic retry, server push, full RFC 8441 support, full stream state machine, unbounded multiplexing, unbounded multiplex scheduling, general multiplexing, priority scheduling, or full HTTP/2 server feature set |
 
 ## Client feature
 
@@ -158,7 +162,13 @@ TRACE, and buffered POST, PUT, or PATCH requests. It opens at most one request
 stream and honors the peer's initial `SETTINGS_MAX_CONCURRENT_STREAMS` by
 failing before request HEADERS when the peer allows zero streams. The bounded
 client path also honors peer-advertised `SETTINGS_MAX_HEADER_LIST_SIZE` request
-metadata limits before sending request HEADERS or trailing HEADERS. It also
+metadata limits before sending request HEADERS or trailing HEADERS. It
+validates `SETTINGS_MAX_FRAME_SIZE` on both sides of the bounded h2c handshake:
+a configured local `http2_max_frame_size` is advertised only when set, must be
+in the legal HTTP/2 range of 16,384 through 16,777,215 bytes, and rejects
+inbound frame payloads above that active local limit; peer-advertised values
+outside the same range reject the handshake, while legal peer values are used
+to split outbound request HEADERS, DATA, and trailing HEADERS. It also
 includes rejection of request bodies for GET, HEAD, DELETE,
 OPTIONS, and TRACE, HEAD response body suppression, stripping of HTTP/1.x
 connection-specific request fields before h2c emission, rejection of
@@ -221,7 +231,8 @@ extension negotiation, external h2 integration, connection pooling, automatic
 retry, server push, full stream state machines, and full HTTP/2 features such
 as unbounded multiplex scheduling, general multiplexing, and priority
 scheduling remain outside that bounded prior-knowledge path. RTTP does not
-expose a dynamic policy API for changing h2c metadata limits at runtime.
+expose a dynamic policy API for changing h2c frame-size or metadata limits at
+runtime.
 
 Direct TCP client connections use `socket2`. SOCKS proxy handshakes remain
 delegated to the `socks` crate.

--- a/rttp/src/lib.rs
+++ b/rttp/src/lib.rs
@@ -1,3 +1,27 @@
+//! `rttp` wraps `rttp_client` behind optional client features and provides a
+//! small blocking HTTP server for local tests and simple embedded use.
+//!
+//! The server accepts HTTP/1.x on a `socket2` listener and also detects the
+//! HTTP/2 client preface for a bounded prior-knowledge h2c path. That h2c
+//! server path advertises the default 16,384-byte
+//! `SETTINGS_MAX_FRAME_SIZE`, accepts only legal peer
+//! `SETTINGS_MAX_FRAME_SIZE` values from 16,384 through 16,777,215 bytes,
+//! rejects inbound frame payloads above the active local limit, and splits
+//! outbound response HEADERS, DATA, and trailing HEADERS to the active peer
+//! frame-size limit. It remains a bounded prior-knowledge server path: it can
+//! accept multiple open streams only up to the advertised active-stream
+//! allowance, uses synchronous response writes, and does not provide full
+//! multiplex scheduling, persistent HTTP/2 session management, dynamic policy
+//! APIs, extension callbacks, TLS ALPN, server push, proxy h2, tunnel handoff,
+//! or a full HTTP/2 server feature set.
+//!
+//! With the `client` or `http2` feature enabled, the wrapper exposes the
+//! `rttp_client` bounded prior-knowledge h2c client behavior. The client opens
+//! at most one stream, validates the same legal `SETTINGS_MAX_FRAME_SIZE`
+//! range, splits outbound request HEADERS, DATA, and trailing HEADERS to the
+//! peer frame-size limit, and rejects inbound oversized frames when a local
+//! `http2_max_frame_size` is configured.
+
 pub struct Http {}
 
 pub mod server;

--- a/rttp_client/README.md
+++ b/rttp_client/README.md
@@ -36,7 +36,7 @@ through `Response::trailers`, `Response::trailer`, and
 | Upgrade and tunnel handoff | `CONNECT` returns the tunnel socket after a successful `200`; `upgrade()` returns the socket after `101 Switching Protocols` and skips interim `1xx` responses | Upgraded protocols are handed to the caller and are not parsed by `rttp_client` |
 | Redirects | Auto-redirect covers 301, 302, 303, 307, and 308 method/body behavior, relative and absolute `Location` resolution, same- and cross-authority header handling, loop detection, and redirect bounds | Redirects are HTTP client behavior, not a browser policy implementation |
 | Trailers | Chunked response trailers are exposed for blocking and async APIs; streaming chunked uploads can send declared request trailers | Application metadata trailers such as `X-Trace` are allowed; pseudo-header, connection-specific, routing, authentication/cookie, and framing trailer fields are rejected |
-| Prior-knowledge h2c | With `http2`, direct `socket2` h2c sends GET, HEAD, bodyless DELETE, OPTIONS, or TRACE, and buffered POST, PUT, or PATCH requests, opens at most one request stream, honors initial peer `SETTINGS_MAX_CONCURRENT_STREAMS` by failing before request HEADERS when the peer allows zero streams, honors peer-advertised `SETTINGS_MAX_HEADER_LIST_SIZE` request metadata limits, strips HTTP/1.x connection-specific request fields before emission, rejects connection-specific peer response fields, suppresses HEAD response bodies, treats `RST_STREAM` on the active stream as a bounded reset/cancellation signal, acknowledges valid PING frames with matching opaque data, DATA bodies, trailers, HPACK static Huffman strings, dynamic entries within peer settings, bounded large header blocks, padded incoming frames, `GOAWAY` shutdown boundaries, PRIORITY metadata validation without scheduling, HTTP/2-allowed unknown/extension frame ignoring inside this bounded path, reserved stream-id high-bit normalization, and conservative DATA flow control | `CONNECT`, RFC 8441 `:protocol` extended CONNECT metadata, and HTTP/1.1 `Upgrade` handoff requests are rejected deterministically before opening a client socket, and `PUSH_PROMISE`/server push is rejected instead of managed; bounded prior-knowledge h2c only, with no public cancellation callback API, no dynamic policy API, no extension callback API, full extension negotiation, TLS ALPN, external h2 integration, proxy tunneling to h2, proxy h2, tunnel handoff, connection pooling, persistent HTTP/2 session management, automatic retry, server push, full stream state machine, unbounded multiplex scheduling, general multiplexing, priority scheduling, or request bodies for GET, HEAD, DELETE, OPTIONS, or TRACE |
+| Prior-knowledge h2c | With `http2`, direct `socket2` h2c sends GET, HEAD, bodyless DELETE, OPTIONS, or TRACE, and buffered POST, PUT, or PATCH requests, opens at most one request stream, honors initial peer `SETTINGS_MAX_CONCURRENT_STREAMS` by failing before request HEADERS when the peer allows zero streams, honors peer-advertised `SETTINGS_MAX_HEADER_LIST_SIZE` request metadata limits, accepts only legal `SETTINGS_MAX_FRAME_SIZE` values from 16,384 through 16,777,215 bytes, splits outbound HEADERS, DATA, and trailers to the active peer frame-size limit, rejects oversized inbound frames when a configured local frame-size limit is exceeded, strips HTTP/1.x connection-specific request fields before emission, rejects connection-specific peer response fields, suppresses HEAD response bodies, treats `RST_STREAM` on the active stream as a bounded reset/cancellation signal, acknowledges valid PING frames with matching opaque data, DATA bodies, trailers, HPACK static Huffman strings, dynamic entries within peer settings, bounded large header blocks, padded incoming frames, `GOAWAY` shutdown boundaries, PRIORITY metadata validation without scheduling, HTTP/2-allowed unknown/extension frame ignoring inside this bounded path, reserved stream-id high-bit normalization, and conservative DATA flow control | `CONNECT`, RFC 8441 `:protocol` extended CONNECT metadata, and HTTP/1.1 `Upgrade` handoff requests are rejected deterministically before opening a client socket, and `PUSH_PROMISE`/server push is rejected instead of managed; bounded prior-knowledge h2c only, with no public cancellation callback API, no dynamic policy API, no extension callback API, full extension negotiation, TLS ALPN, external h2 integration, proxy tunneling to h2, proxy h2, tunnel handoff, connection pooling, persistent HTTP/2 session management, automatic retry, server push, full stream state machine, unbounded multiplex scheduling, general multiplexing, priority scheduling, or request bodies for GET, HEAD, DELETE, OPTIONS, or TRACE |
 
 With the `http2` feature enabled, `emit_http2_prior_knowledge` sends a bounded
 prior-knowledge h2c request over a direct socket2 TCP connection. It opens at
@@ -51,7 +51,16 @@ and buffered POST, PUT, or PATCH requests. Non-empty buffered request bodies
 are sent as DATA frames for the write methods; GET, HEAD, DELETE, OPTIONS, and
 TRACE requests with bodies are rejected. HEAD, bodyless DELETE, OPTIONS, and
 TRACE requests do not send request DATA frames, and any HEAD response DATA
-frames are consumed without being exposed as a response body. Before encoding
+frames are consumed without being exposed as a response body. The client
+validates `SETTINGS_MAX_FRAME_SIZE` boundaries on both sides of the bounded
+h2c handshake. A configured local `http2_max_frame_size` is advertised only
+when set, must be in the legal HTTP/2 range of 16,384 through 16,777,215
+bytes, and is used to reject inbound frame payloads larger than that active
+local limit. Peer-advertised `SETTINGS_MAX_FRAME_SIZE` values outside that
+same legal range reject the handshake. Legal peer values become the outbound
+frame boundary, so request HEADERS, DATA, and trailing HEADERS are split into
+frames no larger than the active peer limit while the client remains a
+single-stream prior-knowledge path. Before encoding
 request HEADERS, this bounded h2c path strips
 HTTP/1.x connection-specific fields: `Connection`, `Keep-Alive`,
 `Proxy-Connection`, `Transfer-Encoding`, `Upgrade`, `TE`, `Trailer`, `Host`,
@@ -113,7 +122,8 @@ extension negotiation, external h2 integration, connection pooling, automatic
 retry, server push, full stream state machines, and full HTTP/2 features such
 as unbounded multiplex scheduling, general multiplexing, and priority
 scheduling are not part of that bounded prior-knowledge client path. RTTP does
-not expose a dynamic policy API for changing h2c metadata limits at runtime.
+not expose a dynamic policy API for changing h2c frame-size or metadata limits
+at runtime.
 
 ## Examples
 

--- a/rttp_client/src/config.rs
+++ b/rttp_client/src/config.rs
@@ -107,6 +107,15 @@ impl ConfigBuilder {
     self.config.verify_ssl_cert = verify_ssl_cert;
     self
   }
+  /// Configure the local h2c `SETTINGS_MAX_FRAME_SIZE` value.
+  ///
+  /// This applies only to the bounded prior-knowledge h2c client path. Values
+  /// must be in the legal HTTP/2 range of 16,384 through 16,777,215 bytes; an
+  /// out-of-range value is rejected before a socket is opened. When set, the
+  /// value is advertised to the peer and inbound frame payloads above that
+  /// active local limit are rejected. Outbound request HEADERS, DATA, and
+  /// trailing HEADERS are still split to the peer's active
+  /// `SETTINGS_MAX_FRAME_SIZE`.
   pub fn http2_max_frame_size(&mut self, max_frame_size: usize) -> &mut Self {
     self.config.http2_max_frame_size = Some(max_frame_size);
     self

--- a/rttp_client/src/lib.rs
+++ b/rttp_client/src/lib.rs
@@ -4,14 +4,21 @@
 //! | name | comment |
 //! |------|---------|
 //! | async | Async request APIs |
-//! | http2 | Prior-knowledge h2c over direct `socket2` TCP connections |
+//! | http2 | Bounded prior-knowledge h2c over direct `socket2` TCP connections |
 //! | tls-native | HTTPS with `native-tls` |
 //! | tls-rustls | HTTPS with `rustls` |
 //!
 //! Direct TCP connections use `socket2`. SOCKS proxy handshakes remain delegated
 //! to the `socks` crate.
 //! With the `http2` feature enabled, `emit_http2_prior_knowledge` sends a
-//! minimal prior-knowledge h2c request over a direct socket2 TCP connection.
+//! bounded prior-knowledge h2c request over a direct socket2 TCP connection.
+//! It opens at most one stream and validates `SETTINGS_MAX_FRAME_SIZE` on both
+//! sides of the handshake. A configured local `http2_max_frame_size` is
+//! advertised only when set, must be in the legal HTTP/2 range of 16,384
+//! through 16,777,215 bytes, and rejects inbound frame payloads larger than
+//! that active local limit. Peer-advertised values outside the same range
+//! reject the handshake, while legal peer values are used to split outbound
+//! request HEADERS, DATA, and trailing HEADERS.
 //! It decodes incoming padded HEADERS, DATA, and trailer frames without
 //! exposing padding bytes, including response HPACK dynamic table entries.
 //! `GOAWAY` is treated as a protocol shutdown boundary: completed responses
@@ -20,8 +27,8 @@
 //! request before request HEADERS are sent. RTTP reports those conditions to
 //! the caller and does not retry automatically; transport disconnects remain
 //! ordinary socket errors without an HTTP/2 stream boundary. TLS ALPN, proxy
-//! h2, full HTTP/2 multiplexing, and priority scheduling are not part of that
-//! single-stream path.
+//! h2, full HTTP/2 multiplexing, dynamic policy APIs, and priority scheduling
+//! are not part of that single-stream path.
 //!
 //! ```rust,no_run
 //! use rttp_client::HttpClient;


### PR DESCRIPTION
Documented h2c SETTINGS_MAX_FRAME_SIZE boundaries for client and server docs, including legal limits, splitting, rejection behavior, and out-of-scope APIs.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1526/
work_kind: code_work
branch: hbx-1526-rttp-document-h2c-settings-max
base: main
commit: 36e5a96fb83df7dc513c068191f37fdd3ef741f2
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1526/
    url: https://plane.kahub.in/endless/browse/HBX-1526/
    close_policy: link_only
```