### PR TITLE
feat: [rttp_client] Honor h2c SETTINGS_HEADER_TABLE_SIZE for request HPACK

### DIFF
--- a/rttp_client/src/http2.rs
+++ b/rttp_client/src/http2.rs
@@ -586,6 +586,7 @@ fn write_request(
       stream,
       body,
       &mut peer_settings,
+      &mut hpack,
       has_trailers,
       response_url,
       local_settings,
@@ -704,6 +705,7 @@ fn write_data_frames(
   stream: &mut TcpStream,
   body: &[u8],
   peer_settings: &mut PeerSettings,
+  hpack: &mut RequestHpackEncoder,
   has_trailers: bool,
   url: RoUrl,
   local_settings: LocalSettings,
@@ -725,6 +727,7 @@ fn write_data_frames(
         &mut connection_send_window,
         &mut stream_send_window,
         peer_settings,
+        hpack,
         &mut current_initial_window_size,
         &mut current_max_frame_size,
         url.clone(),
@@ -760,6 +763,7 @@ fn read_until_send_window_available(
   connection_send_window: &mut SendWindow,
   stream_send_window: &mut SendWindow,
   peer_settings: &mut PeerSettings,
+  hpack: &mut RequestHpackEncoder,
   current_initial_window_size: &mut u32,
   current_max_frame_size: &mut usize,
   url: RoUrl,
@@ -783,6 +787,7 @@ fn read_until_send_window_available(
           &frame,
           stream_send_window,
           peer_settings,
+          hpack,
           current_initial_window_size,
           current_max_frame_size,
         )?;
@@ -841,6 +846,7 @@ fn handle_settings_while_sending(
   frame: &Frame,
   stream_send_window: &mut SendWindow,
   peer_settings: &mut PeerSettings,
+  hpack: &mut RequestHpackEncoder,
   current_initial_window_size: &mut u32,
   current_max_frame_size: &mut usize,
 ) -> error::Result<()> {
@@ -859,6 +865,14 @@ fn handle_settings_while_sending(
   if settings.max_frame_size_changed {
     peer_settings.max_frame_size = settings.max_frame_size;
     *current_max_frame_size = settings.max_frame_size;
+  }
+  if settings.header_table_size_changed {
+    peer_settings.header_table_size = settings.header_table_size;
+    hpack.set_max_size(
+      settings
+        .header_table_size
+        .min(DEFAULT_HPACK_DYNAMIC_TABLE_SIZE),
+    );
   }
   if settings.max_header_list_size.is_some() {
     peer_settings.max_header_list_size = settings.max_header_list_size;
@@ -1767,6 +1781,11 @@ impl RequestHpackEncoder {
 
     self.dynamic_entries.insert(0, (name, value));
     self.current_size += entry_size;
+    self.evict_to_capacity();
+  }
+
+  fn set_max_size(&mut self, max_size: usize) {
+    self.max_size = max_size;
     self.evict_to_capacity();
   }
 

--- a/rttp_client/tests/http2_prior_knowledge.rs
+++ b/rttp_client/tests/http2_prior_knowledge.rs
@@ -1343,6 +1343,84 @@ fn prior_knowledge_post_uses_later_max_frame_size_for_request_trailers() {
 }
 
 #[test]
+fn prior_knowledge_post_applies_later_zero_header_table_size_before_trailers() {
+  let listener = TcpListener::bind("127.0.0.1:0").expect("bind h2 peer");
+  let addr = listener.local_addr().expect("h2 peer addr");
+
+  let handle = thread::spawn(move || {
+    let (mut stream, _) = listener.accept().expect("accept h2 client");
+    complete_h2_handshake_without_request_with_settings(
+      &mut stream,
+      &settings_payload(SETTING_INITIAL_WINDOW_SIZE, 5),
+    );
+
+    let request_headers = read_frame(&mut stream);
+    assert_eq!(FRAME_HEADERS, request_headers.frame_type);
+    assert_eq!(FLAG_END_HEADERS, request_headers.flags);
+    assert_eq!(1, request_headers.stream_id);
+
+    let first_body = read_frame(&mut stream);
+    assert_eq!(FRAME_DATA, first_body.frame_type);
+    assert_eq!(0, first_body.flags);
+    assert_eq!(1, first_body.stream_id);
+    assert_eq!(b"abcde", first_body.payload.as_slice());
+
+    write_frame(
+      &mut stream,
+      FRAME_SETTINGS,
+      0,
+      0,
+      &settings_payload(SETTING_HEADER_TABLE_SIZE, 0),
+    );
+    let settings_ack = read_frame(&mut stream);
+    assert_eq!(FRAME_SETTINGS, settings_ack.frame_type);
+    assert_eq!(FLAG_ACK, settings_ack.flags);
+    assert_eq!(0, settings_ack.stream_id);
+    assert!(settings_ack.payload.is_empty());
+
+    write_frame(&mut stream, FRAME_WINDOW_UPDATE, 0, 1, &1_u32.to_be_bytes());
+
+    let final_body = read_frame(&mut stream);
+    assert_eq!(FRAME_DATA, final_body.frame_type);
+    assert_eq!(0, final_body.flags);
+    assert_eq!(1, final_body.stream_id);
+    assert_eq!(b"f", final_body.payload.as_slice());
+
+    let request_trailers = read_frame(&mut stream);
+    assert_eq!(FRAME_HEADERS, request_trailers.frame_type);
+    assert_eq!(FLAG_END_HEADERS | FLAG_END_STREAM, request_trailers.flags);
+    assert_eq!(1, request_trailers.stream_id);
+
+    write_frame(&mut stream, FRAME_HEADERS, FLAG_END_HEADERS, 1, &[0x88]);
+    write_frame(&mut stream, FRAME_DATA, FLAG_END_STREAM, 1, b"ok");
+
+    (request_headers.payload, request_trailers.payload)
+  });
+
+  let response = HttpClient::new()
+    .post()
+    .url(format!("http://{}/later-zero-table-size", addr))
+    .header(("X-Repeat", "same-value"))
+    .trailer(("X-Repeat", "same-value"))
+    .expect("configure repeated request trailer")
+    .raw("abcdef")
+    .emit_http2_prior_knowledge()
+    .expect("h2 POST response");
+
+  assert_eq!(200, response.code());
+  assert_eq!("ok", response.body().string().unwrap());
+
+  let (request_header_block, request_trailer_block) = handle.join().expect("h2 peer thread");
+  assert_eq!(1, literal_with_indexing_fields(&request_header_block));
+  assert_eq!(0, dynamic_indexed_fields(&request_trailer_block));
+  assert_eq!(0, literal_with_indexing_fields(&request_trailer_block));
+  assert!(
+    find_literal_new_name_value(&request_trailer_block, b"x-repeat").is_some(),
+    "later zero-sized peer table should make repeated trailer fall back to a literal"
+  );
+}
+
+#[test]
 fn prior_knowledge_get_splits_large_request_headers_at_peer_max_frame_size() {
   let listener = TcpListener::bind("127.0.0.1:0").expect("bind h2 peer");
   let addr = listener.local_addr().expect("h2 peer addr");


### PR DESCRIPTION
Implemented request HPACK resizing for later h2c `SETTINGS_HEADER_TABLE_SIZE` updates and verified the HTTP/2 prior-knowledge client behavior.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1528/
work_kind: code_work
branch: hbx-1528-rttp-client-honor-h2c-settings
base: main
commit: 69191aa180f0ce9066e26f50f798d7ce7d0210d1
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1528/
    url: https://plane.kahub.in/endless/browse/HBX-1528/
    close_policy: link_only
```