### PR TITLE
feat: [rttp] Add cross-crate h2c SETTINGS_HEADER_TABLE_SIZE matrix

### DIFF
--- a/rttp/tests/http2_feature.rs
+++ b/rttp/tests/http2_feature.rs
@@ -7,7 +7,7 @@ use std::thread;
 use std::time::Duration;
 
 use rttp::server::HttpResponse;
-use rttp_client::HttpClient;
+use rttp_client::{Config, HttpClient};
 
 const H2_FRAME_DATA: u8 = 0x0;
 const H2_FRAME_HEADERS: u8 = 0x1;
@@ -4046,6 +4046,139 @@ fn rttp_client_http2_prior_knowledge_decodes_rttp_server_dynamic_response_evicti
   assert!(response.header_value("X-Evict-Trailer").is_none());
 
   handle.join().expect("server thread");
+}
+
+#[test]
+fn rttp_client_http2_prior_knowledge_settings_header_table_size_matrix_with_rttp_server() {
+  struct MatrixCase {
+    name: &'static str,
+    local_header_table_size: usize,
+    response_headers: Vec<(&'static str, &'static str)>,
+    response_trailers: Vec<(&'static str, &'static str)>,
+  }
+
+  let cases = [
+    MatrixCase {
+      name: "zero",
+      local_header_table_size: 0,
+      response_headers: vec![
+        ("X-Matrix-Zero", "repeatable-response-value"),
+        ("X-Matrix-Zero", "repeatable-response-value"),
+      ],
+      response_trailers: vec![
+        ("X-Matrix-Zero-Trailer", "repeatable-trailer-value"),
+        ("X-Matrix-Zero-Trailer", "repeatable-trailer-value"),
+      ],
+    },
+    MatrixCase {
+      name: "small-eviction",
+      local_header_table_size: 64,
+      response_headers: vec![
+        ("X-Matrix-One", "a"),
+        ("X-Matrix-Two", "b"),
+        ("X-Matrix-One", "a"),
+        ("X-Matrix-Two", "b"),
+      ],
+      response_trailers: vec![("X-Matrix-Trailer-One", "a"), ("X-Matrix-Trailer-Two", "b")],
+    },
+  ];
+
+  for case in cases {
+    let case_name = case.name;
+    let server = rttp::Http::server("127.0.0.1:0")
+      .expect("bind server")
+      .with_read_timeout(Some(Duration::from_secs(2)))
+      .with_write_timeout(Some(Duration::from_secs(2)));
+    let addr = server.local_addr().expect("server addr");
+    let request_field_name = format!("X-Matrix-Request-{}", case.name);
+    let request_trailer_name = request_field_name.clone();
+    let handler_request_field_name = request_field_name.clone();
+    let handler_request_trailer_name = request_trailer_name.clone();
+    let response_headers = case.response_headers.clone();
+    let response_trailers = case.response_trailers.clone();
+    let response_body = format!("matrix {}", case_name);
+    let expected_response_body = response_body.clone();
+
+    let handle = thread::spawn(move || {
+      server
+        .accept_one(move |request| {
+          assert_eq!("HTTP/2", request.version());
+          assert_eq!("POST", request.method());
+          assert_eq!(
+            format!("/settings-header-table-size/{}", case_name),
+            request.target()
+          );
+          assert_eq!(
+            Some("repeatable-request-value"),
+            request.header(&handler_request_field_name)
+          );
+          assert_eq!(b"matrix request body", request.body());
+          assert_eq!(
+            Some("repeatable-request-value"),
+            request.trailer(&handler_request_trailer_name)
+          );
+
+          let mut response = HttpResponse::ok(&response_body);
+          for (name, value) in &response_headers {
+            response = response.header(*name, *value);
+          }
+          for (name, _) in &response_trailers {
+            response = response.header("Trailer", *name);
+          }
+          for (name, value) in &response_trailers {
+            response = response.trailer(*name, *value);
+          }
+          response
+        })
+        .expect("serve header table size matrix request");
+    });
+
+    let config = Config::builder()
+      .http2_header_table_size(case.local_header_table_size)
+      .build();
+    let response = rttp_client::HttpClient::new()
+      .post()
+      .url(format!(
+        "http://{}/settings-header-table-size/{}",
+        addr, case_name
+      ))
+      .config(config)
+      .header((
+        request_field_name.clone(),
+        "repeatable-request-value".to_string(),
+      ))
+      .trailer((request_trailer_name, "repeatable-request-value".to_string()))
+      .expect("configure matrix request trailer")
+      .raw("matrix request body")
+      .emit_http2_prior_knowledge()
+      .expect("matrix h2 response");
+
+    assert_eq!("HTTP/2", response.version());
+    assert_eq!(200, response.code());
+    assert_eq!(expected_response_body, response.body().string().unwrap());
+    for (name, value) in case.response_headers {
+      assert!(
+        response
+          .header_values(name)
+          .iter()
+          .any(|actual| *actual == value),
+        "{name} response header value {value:?} missing for {} table",
+        case_name
+      );
+    }
+    for (name, value) in case.response_trailers {
+      assert!(
+        response
+          .trailer_values(name)
+          .iter()
+          .any(|actual| *actual == value),
+        "{name} response trailer value {value:?} missing for {} table",
+        case_name
+      );
+    }
+    assert!(response.header_value("Trailer").is_none());
+    handle.join().expect("server thread");
+  }
 }
 
 #[test]

--- a/rttp_client/src/config.rs
+++ b/rttp_client/src/config.rs
@@ -7,6 +7,7 @@ pub struct Config {
   verify_ssl_hostname: bool,
   verify_ssl_cert: bool,
   http2_max_frame_size: Option<usize>,
+  http2_header_table_size: Option<usize>,
 }
 
 impl Default for Config {
@@ -48,6 +49,9 @@ impl Config {
   pub fn http2_max_frame_size(&self) -> Option<usize> {
     self.http2_max_frame_size
   }
+  pub fn http2_header_table_size(&self) -> Option<usize> {
+    self.http2_header_table_size
+  }
 }
 
 #[derive(Clone, Debug)]
@@ -72,6 +76,7 @@ impl ConfigBuilder {
         verify_ssl_hostname: true,
         verify_ssl_cert: true,
         http2_max_frame_size: None,
+        http2_header_table_size: None,
       },
     }
   }
@@ -120,6 +125,15 @@ impl ConfigBuilder {
     self.config.http2_max_frame_size = Some(max_frame_size);
     self
   }
+  /// Configure the local h2c `SETTINGS_HEADER_TABLE_SIZE` value.
+  ///
+  /// This applies only to the bounded prior-knowledge h2c client path. The
+  /// value is advertised to the peer and bounds the HPACK dynamic table used
+  /// while decoding inbound response HEADERS and trailing HEADERS.
+  pub fn http2_header_table_size(&mut self, header_table_size: usize) -> &mut Self {
+    self.config.http2_header_table_size = Some(header_table_size);
+    self
+  }
 }
 
 impl AsRef<Config> for Config {
@@ -148,6 +162,7 @@ mod tests {
       .verify_ssl_hostname(false)
       .verify_ssl_cert(false)
       .http2_max_frame_size(16_384)
+      .http2_header_table_size(64)
       .build();
 
     assert_eq!(config.read_timeout(), 1234);
@@ -157,6 +172,7 @@ mod tests {
     assert!(!config.verify_ssl_hostname());
     assert!(!config.verify_ssl_cert());
     assert_eq!(Some(16_384), config.http2_max_frame_size());
+    assert_eq!(Some(64), config.http2_header_table_size());
   }
 
   #[test]
@@ -185,6 +201,10 @@ mod tests {
     assert_eq!(
       default_config.http2_max_frame_size(),
       builder_config.http2_max_frame_size()
+    );
+    assert_eq!(
+      default_config.http2_header_table_size(),
+      builder_config.http2_header_table_size()
     );
   }
 

--- a/rttp_client/src/http2.rs
+++ b/rttp_client/src/http2.rs
@@ -417,13 +417,21 @@ struct PeerSettings {
 
 #[derive(Clone, Copy)]
 struct LocalSettings {
+  header_table_size: usize,
+  header_table_size_configured: bool,
   max_frame_size: usize,
   max_frame_size_configured: bool,
 }
 
 impl LocalSettings {
   fn from_config(config: &Config) -> error::Result<Self> {
+    let configured_header_table_size = config.http2_header_table_size();
     let configured_max_frame_size = config.http2_max_frame_size();
+    if configured_header_table_size.is_some_and(|size| size > u32::MAX as usize) {
+      return Err(error::builder_with_message(
+        "invalid HTTP/2 SETTINGS_HEADER_TABLE_SIZE value",
+      ));
+    }
     let max_frame_size = configured_max_frame_size.unwrap_or(DEFAULT_MAX_FRAME_SIZE);
     if !(DEFAULT_MAX_FRAME_SIZE..=MAX_FRAME_SIZE_LIMIT).contains(&max_frame_size) {
       return Err(error::builder_with_message(
@@ -431,16 +439,28 @@ impl LocalSettings {
       ));
     }
     Ok(Self {
+      header_table_size: configured_header_table_size.unwrap_or(DEFAULT_HPACK_DYNAMIC_TABLE_SIZE),
+      header_table_size_configured: configured_header_table_size.is_some(),
       max_frame_size,
       max_frame_size_configured: configured_max_frame_size.is_some(),
     })
   }
 
   fn settings_payload(self) -> Vec<u8> {
-    if !self.max_frame_size_configured {
-      return Vec::new();
+    let mut payload = Vec::new();
+    if self.header_table_size_configured {
+      payload.extend_from_slice(&h2_setting(
+        SETTING_HEADER_TABLE_SIZE,
+        self.header_table_size as u32,
+      ));
     }
-    h2_setting(SETTING_MAX_FRAME_SIZE, self.max_frame_size as u32).to_vec()
+    if self.max_frame_size_configured {
+      payload.extend_from_slice(&h2_setting(
+        SETTING_MAX_FRAME_SIZE,
+        self.max_frame_size as u32,
+      ));
+    }
+    payload
   }
 }
 
@@ -1135,7 +1155,7 @@ fn read_single_stream_response_with_first_frame(
   let mut pending_header_block = None;
   let mut final_response_started = false;
   let mut response_body_started = false;
-  let mut hpack = HpackDecoder::new(DEFAULT_HPACK_DYNAMIC_TABLE_SIZE);
+  let mut hpack = HpackDecoder::new(local_settings.header_table_size);
   let mut connection_receive_window = ReceiveWindow::new();
   let mut stream_receive_window = ReceiveWindow::new();
   let mut connection_send_window = SendWindow::new();

--- a/rttp_client/tests/http2_prior_knowledge.rs
+++ b/rttp_client/tests/http2_prior_knowledge.rs
@@ -1766,6 +1766,93 @@ fn prior_knowledge_advertises_configured_legal_max_frame_size_boundaries() {
 }
 
 #[test]
+fn prior_knowledge_advertises_configured_header_table_size_boundaries() {
+  for header_table_size in [0, u32::MAX] {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind h2 peer");
+    let addr = listener.local_addr().expect("h2 peer addr");
+
+    let handle = thread::spawn(move || {
+      let (mut stream, _) = listener.accept().expect("accept h2 client");
+      let mut preface = [0; 24];
+      stream
+        .read_exact(&mut preface)
+        .expect("read client preface");
+      assert_eq!(b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n", &preface);
+
+      let client_settings = read_frame(&mut stream);
+      assert_eq!(FRAME_SETTINGS, client_settings.frame_type);
+      assert_eq!(0, client_settings.flags);
+      assert_eq!(0, client_settings.stream_id);
+      assert_eq!(
+        Some(header_table_size),
+        h2_setting_value(&client_settings.payload, SETTING_HEADER_TABLE_SIZE)
+      );
+
+      write_frame(&mut stream, FRAME_SETTINGS, 0, 0, &[]);
+      let client_settings_ack = read_frame(&mut stream);
+      assert_eq!(FRAME_SETTINGS, client_settings_ack.frame_type);
+      assert_eq!(FLAG_ACK, client_settings_ack.flags);
+      assert_eq!(0, client_settings_ack.stream_id);
+      assert!(client_settings_ack.payload.is_empty());
+
+      let request_headers = read_frame(&mut stream);
+      assert_eq!(FRAME_HEADERS, request_headers.frame_type);
+      assert_eq!(FLAG_END_STREAM | FLAG_END_HEADERS, request_headers.flags);
+      assert_eq!(1, request_headers.stream_id);
+
+      write_frame(&mut stream, FRAME_SETTINGS, FLAG_ACK, 0, &[]);
+      write_frame(&mut stream, FRAME_HEADERS, FLAG_END_HEADERS, 1, &[0x88]);
+      write_frame(&mut stream, FRAME_DATA, FLAG_END_STREAM, 1, b"ok");
+    });
+
+    let config = Config::builder()
+      .http2_header_table_size(header_table_size as usize)
+      .build();
+    let response = HttpClient::new()
+      .get()
+      .url(format!("http://{}/configured-header-table-size", addr))
+      .config(config)
+      .emit_http2_prior_knowledge()
+      .expect("configured legal header table size should work");
+
+    assert_eq!(200, response.code());
+    assert_eq!("ok", response.body().string().unwrap());
+    handle
+      .join()
+      .expect("configured header table size peer thread");
+  }
+}
+
+#[test]
+fn prior_knowledge_rejects_configured_header_table_size_above_wire_limit_before_connecting() {
+  let Some(header_table_size) = (u32::MAX as usize).checked_add(1) else {
+    return;
+  };
+  let listener = TcpListener::bind("127.0.0.1:0").expect("bind h2 peer");
+  listener
+    .set_nonblocking(true)
+    .expect("set h2 listener nonblocking");
+  let addr = listener.local_addr().expect("h2 peer addr");
+  let config = Config::builder()
+    .http2_header_table_size(header_table_size)
+    .build();
+
+  let err = HttpClient::new()
+    .get()
+    .url(format!("http://{}/illegal-header-table-size", addr))
+    .config(config)
+    .emit_http2_prior_knowledge()
+    .expect_err("illegal local SETTINGS_HEADER_TABLE_SIZE must fail");
+
+  assert!(err.is_builder());
+  assert!(err.to_string().contains("SETTINGS_HEADER_TABLE_SIZE"));
+  assert!(
+    listener.accept().is_err(),
+    "client must reject illegal local SETTINGS_HEADER_TABLE_SIZE before connecting"
+  );
+}
+
+#[test]
 fn prior_knowledge_rejects_configured_illegal_max_frame_size_boundaries_before_connecting() {
   for max_frame_size in [DEFAULT_MAX_FRAME_SIZE - 1, MAX_FRAME_SIZE_LIMIT + 1] {
     let listener = TcpListener::bind("127.0.0.1:0").expect("bind h2 peer");


### PR DESCRIPTION
Adds `rttp_client` local `SETTINGS_HEADER_TABLE_SIZE` configuration, applies it to response HPACK decoding, and covers zero/small table-size interoperability with the `rttp` h2c server.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1530/
work_kind: code_work
branch: hbx-1530-rttp-add-cross-crate-h2c
base: main
commit: 885b1523fde9ded1a54e1afaa85edb9ebe0c9145
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1530/
    url: https://plane.kahub.in/endless/browse/HBX-1530/
    close_policy: link_only
```