### PR TITLE
feat: [rttp_client] Add bounded h2c RFC 8441 extended CONNECT client path

### DIFF
--- a/rttp/README.md
+++ b/rttp/README.md
@@ -193,7 +193,10 @@ bounded local response dynamic table decoding, bounded large header blocks via
 CONTINUATION frames, padded incoming response frames, and conservative DATA
 flow-control for single-stream prior-knowledge use. Any received
 `SETTINGS_ENABLE_PUSH` value other than `0` or `1` rejects the bounded h2c
-handshake. Valid response PRIORITY
+handshake. The explicit `http2_extended_connect(protocol)` request mode
+advertises `SETTINGS_ENABLE_CONNECT_PROTOCOL = 1` and emits `:method CONNECT`
+with `:protocol`, `:scheme`, `:authority`, and `:path` on the same bounded
+single-stream path. Valid response PRIORITY
 frames and HEADERS priority fields are validated and ignored as metadata;
 malformed priority metadata is rejected, and no priority scheduling is
 performed. Valid PING frames are acknowledged with PING ACK frames that carry
@@ -247,15 +250,16 @@ connection-specific, routing, authentication/cookie, and framing fields such
 as `Authorization`, `Connection`, `Content-Length`, `Cookie`, `Host`,
 `Keep-Alive`, `Proxy-Authenticate`, `Proxy-Authorization`,
 `Proxy-Connection`, `Set-Cookie`, `TE`, `Trailer`, `Transfer-Encoding`,
-`Upgrade`, and `WWW-Authenticate`. `CONNECT`, RFC 8441 `:protocol` extended
-CONNECT metadata, HTTP/1.1 `Upgrade` handoff requests, and proxy tunneling are
-rejected before a client socket is opened. HTTP/1.1 `CONNECT` tunnel handoff
-and `Upgrade` remain separate client handoff paths; this h2c path does not
-provide WebSocket over h2, proxy h2, tunnel handoff, persistent HTTP/2
-sessions, or full RFC 8441 support. TLS ALPN, extension callback APIs, full
-extension negotiation, external h2 integration, connection pooling, automatic
-retry, server push, full stream state machines, and full HTTP/2 features such
-as unbounded multiplex scheduling, general multiplexing, and priority
+`Upgrade`, and `WWW-Authenticate`. Ordinary `CONNECT`, header-configured RFC
+8441 `:protocol` metadata, HTTP/1.1 `Upgrade` handoff requests, proxy
+tunneling, extended CONNECT request bodies, and extended CONNECT request
+trailers are rejected before a client socket is opened. HTTP/1.1 `CONNECT`
+tunnel handoff and `Upgrade` remain separate client handoff paths; this h2c
+path does not provide proxy h2, tunnel handoff, persistent HTTP/2 sessions, or
+full RFC 8441 support. TLS ALPN, extension callback APIs, full extension
+negotiation, external h2 integration, connection pooling, automatic retry,
+server push, full stream state machines, and full HTTP/2 features such as
+unbounded multiplex scheduling, general multiplexing, and priority
 scheduling remain outside that bounded prior-knowledge path. RTTP does not
 expose a dynamic policy API for changing h2c frame-size or metadata limits at
 runtime.

--- a/rttp_client/README.md
+++ b/rttp_client/README.md
@@ -36,7 +36,7 @@ through `Response::trailers`, `Response::trailer`, and
 | Upgrade and tunnel handoff | `CONNECT` returns the tunnel socket after a successful `200`; `upgrade()` returns the socket after `101 Switching Protocols` and skips interim `1xx` responses | Upgraded protocols are handed to the caller and are not parsed by `rttp_client` |
 | Redirects | Auto-redirect covers 301, 302, 303, 307, and 308 method/body behavior, relative and absolute `Location` resolution, same- and cross-authority header handling, loop detection, and redirect bounds | Redirects are HTTP client behavior, not a browser policy implementation |
 | Trailers | Chunked response trailers are exposed for blocking and async APIs; streaming chunked uploads can send declared request trailers | Application metadata trailers such as `X-Trace` are allowed; pseudo-header, connection-specific, routing, authentication/cookie, and framing trailer fields are rejected |
-| Prior-knowledge h2c | With `http2`, direct `socket2` h2c sends GET, HEAD, bodyless DELETE, OPTIONS, or TRACE, and buffered POST, PUT, or PATCH requests, opens at most one request stream, advertises `SETTINGS_ENABLE_PUSH = 0`, validates received `SETTINGS_ENABLE_PUSH` values as only `0` or `1`, honors initial peer `SETTINGS_MAX_CONCURRENT_STREAMS` by failing before request HEADERS when the peer allows zero streams, honors peer-advertised `SETTINGS_MAX_HEADER_LIST_SIZE` request metadata limits, accepts only legal `SETTINGS_MAX_FRAME_SIZE` values from 16,384 through 16,777,215 bytes, splits outbound HEADERS, DATA, and trailers to the active peer frame-size limit, rejects oversized inbound frames when a configured local frame-size limit is exceeded, bounds HPACK dynamic table use with `SETTINGS_HEADER_TABLE_SIZE`, strips HTTP/1.x connection-specific request fields before emission, rejects connection-specific peer response fields, suppresses HEAD response bodies, treats `RST_STREAM` on the active stream as a bounded reset/cancellation signal, acknowledges valid PING frames with matching opaque data, DATA bodies, trailers, HPACK static Huffman strings, bounded large header blocks, padded incoming frames, `GOAWAY` shutdown boundaries, PRIORITY metadata validation without scheduling, HTTP/2-allowed unknown/extension frame ignoring inside this bounded path, reserved stream-id high-bit normalization, and conservative DATA flow control | `CONNECT`, RFC 8441 `:protocol` extended CONNECT metadata, and HTTP/1.1 `Upgrade` handoff requests are rejected deterministically before opening a client socket, and `PUSH_PROMISE`/server push is rejected instead of managed; bounded prior-knowledge h2c only, with no public cancellation callback API, no dynamic policy API, no extension callback API, no full extension negotiation, TLS ALPN, external h2 integration, proxy tunneling to h2, proxy h2, tunnel handoff, connection pooling, persistent HTTP/2 session management, automatic retry, server push, full stream state machine, unbounded multiplex scheduling, general multiplexing, priority scheduling, or request bodies for GET, HEAD, DELETE, OPTIONS, or TRACE |
+| Prior-knowledge h2c | With `http2`, direct `socket2` h2c sends GET, HEAD, bodyless DELETE, OPTIONS, or TRACE, buffered POST, PUT, or PATCH requests, and opt-in RFC 8441 extended CONNECT request HEADERS via `http2_extended_connect`, opens at most one request stream, advertises `SETTINGS_ENABLE_PUSH = 0`, advertises `SETTINGS_ENABLE_CONNECT_PROTOCOL = 1` only for the explicit extended CONNECT path, validates received `SETTINGS_ENABLE_PUSH` values as only `0` or `1`, honors initial peer `SETTINGS_MAX_CONCURRENT_STREAMS` by failing before request HEADERS when the peer allows zero streams, honors peer-advertised `SETTINGS_MAX_HEADER_LIST_SIZE` request metadata limits, accepts only legal `SETTINGS_MAX_FRAME_SIZE` values from 16,384 through 16,777,215 bytes, splits outbound HEADERS, DATA, and trailers to the active peer frame-size limit, rejects oversized inbound frames when a configured local frame-size limit is exceeded, bounds HPACK dynamic table use with `SETTINGS_HEADER_TABLE_SIZE`, strips HTTP/1.x connection-specific request fields before emission, rejects connection-specific peer response fields, suppresses HEAD response bodies, treats `RST_STREAM` on the active stream as a bounded reset/cancellation signal, acknowledges valid PING frames with matching opaque data, DATA bodies, trailers, HPACK static Huffman strings, bounded large header blocks, padded incoming frames, `GOAWAY` shutdown boundaries, PRIORITY metadata validation without scheduling, HTTP/2-allowed unknown/extension frame ignoring inside this bounded path, reserved stream-id high-bit normalization, and conservative DATA flow control | Ordinary `CONNECT`, header-configured `:protocol` metadata, and HTTP/1.1 `Upgrade` handoff requests are rejected deterministically before opening a client socket, and `PUSH_PROMISE`/server push is rejected instead of managed; bounded prior-knowledge h2c only, with no public cancellation callback API, no dynamic policy API, no extension callback API, no full extension negotiation, TLS ALPN, external h2 integration, proxy tunneling to h2, proxy h2, tunnel handoff, connection pooling, persistent HTTP/2 session management, automatic retry, server push, full stream state machine, unbounded multiplex scheduling, general multiplexing, priority scheduling, request bodies or trailers for extended CONNECT, or request bodies for GET, HEAD, DELETE, OPTIONS, or TRACE |
 
 With the `http2` feature enabled, `emit_http2_prior_knowledge` sends a bounded
 prior-knowledge h2c request over a direct socket2 TCP connection. It opens at
@@ -47,14 +47,18 @@ HEADERS are sent. It also honors the peer's advertised
 and trailing HEADERS must stay within that peer boundary before emission, while
 peers that do not advertise the setting keep the bounded direct-client default.
 It supports GET, HEAD, bodyless DELETE, OPTIONS, or TRACE,
-and buffered POST, PUT, or PATCH requests. Non-empty buffered request bodies
-are sent as DATA frames for the write methods; GET, HEAD, DELETE, OPTIONS, and
-TRACE requests with bodies are rejected. HEAD, bodyless DELETE, OPTIONS, and
-TRACE requests do not send request DATA frames, and any HEAD response DATA
-frames are consumed without being exposed as a response body. The client
-advertises `SETTINGS_ENABLE_PUSH = 0` in its initial SETTINGS frame so peers
-see server push disabled, and it validates received `SETTINGS_ENABLE_PUSH`
-values as only `0` or `1`; any other value rejects the bounded h2c handshake.
+buffered POST, PUT, or PATCH requests, and an explicit
+`http2_extended_connect(protocol)` request mode. Non-empty buffered request
+bodies are sent as DATA frames for the write methods; GET, HEAD, DELETE,
+OPTIONS, TRACE, and extended CONNECT requests with bodies are rejected. HEAD,
+bodyless DELETE, OPTIONS, TRACE, and extended CONNECT requests do not send
+request DATA frames, and any HEAD response DATA frames are consumed without
+being exposed as a response body. The client advertises
+`SETTINGS_ENABLE_PUSH = 0` in its initial SETTINGS frame so peers see server
+push disabled, and it advertises `SETTINGS_ENABLE_CONNECT_PROTOCOL = 1` only
+when `http2_extended_connect` is used. It validates received
+`SETTINGS_ENABLE_PUSH` values as only `0` or `1`; any other value rejects the
+bounded h2c handshake.
 The client validates `SETTINGS_MAX_FRAME_SIZE` boundaries on both sides of the
 bounded h2c handshake. A configured local `http2_max_frame_size` is advertised
 only when set, must be in the legal HTTP/2 range of 16,384 through 16,777,215
@@ -127,18 +131,21 @@ boundary. `RST_STREAM` is likewise bounded to this
 prior-knowledge h2c client path: a reset for the active stream is reported as
 response cancellation, while malformed reset frames are rejected
 deterministically. RTTP does not expose a public cancellation callback API or
-retry the request automatically. `CONNECT`, RFC 8441 `:protocol` extended
-CONNECT metadata, HTTP/1.1 `Upgrade` handoff requests, and proxy tunneling are
-rejected before a client socket is opened. HTTP/1.1 `CONNECT` tunnel handoff
-and `Upgrade` remain separate client handoff paths; this h2c path does not
-provide WebSocket over h2, proxy h2, tunnel handoff, persistent HTTP/2
-sessions, or full RFC 8441 support. TLS ALPN, extension callback APIs, full
-extension negotiation, external h2 integration, connection pooling, automatic
-retry, server push, full stream state machines, and full HTTP/2 features such
-as unbounded multiplex scheduling, general multiplexing, and priority
-scheduling are not part of that bounded prior-knowledge client path. RTTP does
-not expose a dynamic policy API for changing h2c frame-size or metadata limits
-at runtime.
+retry the request automatically. Ordinary `CONNECT`, header-configured RFC
+8441 `:protocol` metadata, HTTP/1.1 `Upgrade` handoff requests, and proxy
+tunneling are rejected before a client socket is opened. The explicit
+`http2_extended_connect(protocol)` mode emits `:method CONNECT` with
+`:protocol`, `:scheme`, `:authority`, and `:path`, but remains a bounded
+single-stream request/response path without request bodies, request trailers,
+or upgraded socket handoff. HTTP/1.1 `CONNECT` tunnel handoff and `Upgrade`
+remain separate client handoff paths; this h2c path does not provide proxy h2,
+tunnel handoff, persistent HTTP/2 sessions, or full RFC 8441 support. TLS
+ALPN, extension callback APIs, full extension negotiation, external h2
+integration, connection pooling, automatic retry, server push, full stream
+state machines, and full HTTP/2 features such as unbounded multiplex
+scheduling, general multiplexing, and priority scheduling are not part of that
+bounded prior-knowledge client path. RTTP does not expose a dynamic policy API
+for changing h2c frame-size or metadata limits at runtime.
 
 ## Examples
 

--- a/rttp_client/src/client.rs
+++ b/rttp_client/src/client.rs
@@ -116,6 +116,19 @@ impl HttpClient {
     self
   }
 
+  /// Use RFC 8441 extended CONNECT on the bounded prior-knowledge h2c path.
+  ///
+  /// This is only honored by `emit_http2_prior_knowledge` with the `http2`
+  /// feature enabled. The request is emitted as `:method CONNECT` and includes
+  /// the configured `:protocol` pseudo-header.
+  #[cfg(feature = "http2")]
+  pub fn http2_extended_connect<S: AsRef<str>>(&mut self, protocol: S) -> &mut Self {
+    self
+      .request
+      .http2_extended_connect_protocol_set(protocol.as_ref());
+    self
+  }
+
   /// Set HTTP authentication. Supports Basic Auth and Bearer Token.
   ///
   /// # Examples

--- a/rttp_client/src/http2.rs
+++ b/rttp_client/src/http2.rs
@@ -36,6 +36,7 @@ const SETTING_MAX_CONCURRENT_STREAMS: u16 = 0x3;
 const SETTING_INITIAL_WINDOW_SIZE: u16 = 0x4;
 const SETTING_MAX_FRAME_SIZE: u16 = 0x5;
 const SETTING_MAX_HEADER_LIST_SIZE: u16 = 0x6;
+const SETTING_ENABLE_CONNECT_PROTOCOL: u16 = 0x8;
 const DEFAULT_INITIAL_WINDOW_SIZE: i64 = 65_535;
 const DEFAULT_MAX_FRAME_SIZE: usize = 16 * 1024;
 const MAX_FRAME_SIZE_LIMIT: usize = 16_777_215;
@@ -98,14 +99,35 @@ impl<'a> PriorKnowledgeClient<'a> {
 
   pub fn get(mut self) -> error::Result<Response> {
     let method = self.request.origin().method();
+    let extended_connect_protocol = self
+      .request
+      .origin()
+      .http2_extended_connect_protocol()
+      .as_deref();
     let is_head = method.eq_ignore_ascii_case("HEAD");
     let is_delete = method.eq_ignore_ascii_case("DELETE");
     let is_options = method.eq_ignore_ascii_case("OPTIONS");
     let is_trace = method.eq_ignore_ascii_case("TRACE");
-    if requires_http2_connect_semantics(&self.request) {
+    if has_http2_upgrade_handoff(&self.request)
+      || has_header_configured_extended_connect_protocol(&self.request)
+      || (extended_connect_protocol.is_none() && method.eq_ignore_ascii_case("CONNECT"))
+    {
       return Err(error::builder_with_message(
         "HTTP/2 prior-knowledge CONNECT or extended CONNECT is unsupported",
       ));
+    }
+    if let Some(protocol) = extended_connect_protocol {
+      validate_extended_connect_protocol(protocol)?;
+      if self.request.body().is_some() {
+        return Err(error::builder_with_message(
+          "HTTP/2 extended CONNECT cannot send a request body",
+        ));
+      }
+      if !self.request.origin().trailers().is_empty() {
+        return Err(error::builder_with_message(
+          "HTTP/2 extended CONNECT cannot send request trailers",
+        ));
+      }
     }
     if (method.eq_ignore_ascii_case("GET") || is_head) && self.request.body().is_some() {
       return Err(error::builder_with_message(
@@ -127,7 +149,7 @@ impl<'a> PriorKnowledgeClient<'a> {
         "HTTP/2 prior-knowledge TRACE cannot send a request body",
       ));
     }
-    if !is_supported_request_method(method) {
+    if extended_connect_protocol.is_none() && !is_supported_request_method(method) {
       return Err(error::builder_with_message(
         "HTTP/2 prior-knowledge client supports GET, HEAD, bodyless DELETE, OPTIONS, or TRACE, and buffered POST, PUT, or PATCH",
       ));
@@ -138,7 +160,10 @@ impl<'a> PriorKnowledgeClient<'a> {
       return Err(error::url_bad_scheme(url));
     }
 
-    let local_settings = LocalSettings::from_config(self.request.origin().config())?;
+    let local_settings = LocalSettings::from_config(
+      self.request.origin().config(),
+      extended_connect_protocol.is_some(),
+    )?;
     let mut stream = connect_tcp_stream(addr(&url)?, self.request.origin().config())?;
     write_connection_preface(&mut stream, local_settings)?;
     let mut peer_settings = read_settings_and_ack(&mut stream, local_settings)?;
@@ -164,17 +189,34 @@ impl<'a> PriorKnowledgeClient<'a> {
   }
 }
 
-fn requires_http2_connect_semantics(request: &RawRequest<'_>) -> bool {
-  request.origin().method().eq_ignore_ascii_case("CONNECT")
-    || request.origin().headers().iter().any(|header| {
-      header.name().eq_ignore_ascii_case(":protocol")
-        || header.name().eq_ignore_ascii_case("upgrade")
-    })
+fn has_http2_upgrade_handoff(request: &RawRequest<'_>) -> bool {
+  request
+    .origin()
+    .headers()
+    .iter()
+    .any(|header| header.name().eq_ignore_ascii_case("upgrade"))
+}
+
+fn has_header_configured_extended_connect_protocol(request: &RawRequest<'_>) -> bool {
+  request
+    .origin()
+    .headers()
+    .iter()
+    .any(|header| header.name().eq_ignore_ascii_case(":protocol"))
     || request
       .header()
       .lines()
       .skip(1)
       .any(|line| line.trim_start().starts_with(":protocol:"))
+}
+
+fn validate_extended_connect_protocol(protocol: &str) -> error::Result<()> {
+  if is_http_token(protocol) {
+    return Ok(());
+  }
+  Err(error::builder_with_message(
+    "Invalid HTTP/2 extended CONNECT protocol",
+  ))
 }
 
 fn is_supported_request_method(method: &str) -> bool {
@@ -421,10 +463,11 @@ struct LocalSettings {
   header_table_size_configured: bool,
   max_frame_size: usize,
   max_frame_size_configured: bool,
+  enable_connect_protocol: bool,
 }
 
 impl LocalSettings {
-  fn from_config(config: &Config) -> error::Result<Self> {
+  fn from_config(config: &Config, enable_connect_protocol: bool) -> error::Result<Self> {
     let configured_header_table_size = config.http2_header_table_size();
     let configured_max_frame_size = config.http2_max_frame_size();
     if configured_header_table_size.is_some_and(|size| size > u32::MAX as usize) {
@@ -443,12 +486,16 @@ impl LocalSettings {
       header_table_size_configured: configured_header_table_size.is_some(),
       max_frame_size,
       max_frame_size_configured: configured_max_frame_size.is_some(),
+      enable_connect_protocol,
     })
   }
 
   fn settings_payload(self) -> Vec<u8> {
     let mut payload = Vec::new();
     payload.extend_from_slice(&h2_setting(SETTING_ENABLE_PUSH, 0));
+    if self.enable_connect_protocol {
+      payload.extend_from_slice(&h2_setting(SETTING_ENABLE_CONNECT_PROTOCOL, 1));
+    }
     if self.header_table_size_configured {
       payload.extend_from_slice(&h2_setting(
         SETTING_HEADER_TABLE_SIZE,
@@ -579,6 +626,10 @@ fn write_request(
   let header_block = encode_request_headers(
     request,
     url,
+    request
+      .origin()
+      .http2_extended_connect_protocol()
+      .as_deref(),
     &regular_header_fields,
     &dynamic_field_plan,
     &mut dynamic_field_position,
@@ -645,7 +696,19 @@ fn enforce_peer_request_header_list_size(
   };
 
   let mut size = 0usize;
-  size = add_header_list_field_size(size, ":method", request.origin().method())?;
+  let extended_connect_protocol = request
+    .origin()
+    .http2_extended_connect_protocol()
+    .as_deref();
+  let method = if extended_connect_protocol.is_some() {
+    "CONNECT"
+  } else {
+    request.origin().method()
+  };
+  size = add_header_list_field_size(size, ":method", method)?;
+  if let Some(protocol) = extended_connect_protocol {
+    size = add_header_list_field_size(size, ":protocol", protocol)?;
+  }
   size = add_header_list_field_size(size, ":scheme", url.scheme())?;
   size = add_header_list_field_size(size, ":path", &request_target(url))?;
   size = add_header_list_field_size(size, ":authority", &authority(url)?)?;
@@ -905,13 +968,22 @@ fn handle_settings_while_sending(
 fn encode_request_headers(
   request: &RawRequest<'_>,
   url: &Url,
+  extended_connect_protocol: Option<&str>,
   regular_header_fields: &[(String, String)],
   dynamic_field_plan: &[(String, String)],
   dynamic_field_position: &mut usize,
   hpack: &mut RequestHpackEncoder,
 ) -> error::Result<Vec<u8>> {
   let mut block = Vec::new();
-  encode_method(&mut block, request.origin().method())?;
+  let method = if extended_connect_protocol.is_some() {
+    "CONNECT"
+  } else {
+    request.origin().method()
+  };
+  encode_method(&mut block, method)?;
+  if let Some(protocol) = extended_connect_protocol {
+    encode_literal_new_name_without_indexing(&mut block, b":protocol", protocol.as_bytes())?;
+  }
   if url.scheme() == "http" {
     block.push(0x86);
   } else {

--- a/rttp_client/src/request/request.rs
+++ b/rttp_client/src/request/request.rs
@@ -26,6 +26,7 @@ pub struct Request {
   raw: Option<String>,
   binary: Vec<u8>,
   proxy: Option<Proxy>,
+  http2_extended_connect_protocol: Option<String>,
 }
 
 #[allow(dead_code)]
@@ -47,6 +48,7 @@ impl Request {
       raw: None,
       binary: vec![],
       proxy: None,
+      http2_extended_connect_protocol: None,
     }
   }
 
@@ -95,6 +97,9 @@ impl Request {
   pub fn proxy(&self) -> &Option<Proxy> {
     &self.proxy
   }
+  pub fn http2_extended_connect_protocol(&self) -> &Option<String> {
+    &self.http2_extended_connect_protocol
+  }
 
   pub(crate) fn closed_mut(&mut self) -> &mut bool {
     &mut self.closed
@@ -140,6 +145,9 @@ impl Request {
   }
   pub(crate) fn proxy_mut(&mut self) -> &mut Option<Proxy> {
     &mut self.proxy
+  }
+  pub(crate) fn http2_extended_connect_protocol_mut(&mut self) -> &mut Option<String> {
+    &mut self.http2_extended_connect_protocol
   }
 
   pub(crate) fn closed_set(&mut self, closed: bool) -> &mut Self {
@@ -200,6 +208,13 @@ impl Request {
   }
   pub(crate) fn proxy_set(&mut self, proxy: Proxy) -> &mut Self {
     self.proxy = Some(proxy);
+    self
+  }
+  pub(crate) fn http2_extended_connect_protocol_set<S: AsRef<str>>(
+    &mut self,
+    protocol: S,
+  ) -> &mut Self {
+    self.http2_extended_connect_protocol = Some(protocol.as_ref().into());
     self
   }
 

--- a/rttp_client/tests/http2_prior_knowledge.rs
+++ b/rttp_client/tests/http2_prior_knowledge.rs
@@ -32,6 +32,7 @@ const SETTING_MAX_CONCURRENT_STREAMS: u16 = 0x3;
 const SETTING_INITIAL_WINDOW_SIZE: u16 = 0x4;
 const SETTING_MAX_FRAME_SIZE: u16 = 0x5;
 const SETTING_MAX_HEADER_LIST_SIZE: u16 = 0x6;
+const SETTING_ENABLE_CONNECT_PROTOCOL: u16 = 0x8;
 const DEFAULT_MAX_FRAME_SIZE: usize = 16 * 1024;
 const MAX_FRAME_SIZE_LIMIT: usize = 16_777_215;
 
@@ -332,6 +333,156 @@ fn prior_knowledge_upgrade_handoff_is_rejected_before_connecting() {
   assert!(
     matches!(listener.accept(), Err(ref err) if err.kind() == io::ErrorKind::WouldBlock),
     "prior-knowledge upgrade handoff must not open a server connection"
+  );
+}
+
+#[test]
+fn extended_connect_sends_enable_connect_protocol_and_pseudo_headers() {
+  let listener = TcpListener::bind("127.0.0.1:0").expect("bind h2 peer");
+  let addr = listener.local_addr().expect("h2 peer addr");
+
+  let handle = thread::spawn(move || {
+    let (mut stream, _) = listener.accept().expect("accept h2 client");
+    stream
+      .set_read_timeout(Some(Duration::from_millis(200)))
+      .expect("set h2 peer read timeout");
+    let mut preface = [0; 24];
+    stream
+      .read_exact(&mut preface)
+      .expect("read client preface");
+    assert_eq!(b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n", &preface);
+
+    let client_settings = read_frame(&mut stream);
+    assert_eq!(FRAME_SETTINGS, client_settings.frame_type);
+    assert_eq!(0, client_settings.stream_id);
+    assert_client_advertises_enable_push_disabled(&client_settings);
+    assert_eq!(
+      Some(1),
+      h2_setting_value(&client_settings.payload, SETTING_ENABLE_CONNECT_PROTOCOL)
+    );
+
+    write_frame(&mut stream, FRAME_SETTINGS, 0, 0, &[]);
+
+    let client_settings_ack = read_frame(&mut stream);
+    assert_eq!(FRAME_SETTINGS, client_settings_ack.frame_type);
+    assert_eq!(FLAG_ACK, client_settings_ack.flags);
+    assert_eq!(0, client_settings_ack.stream_id);
+    assert_eq!(0, client_settings_ack.payload.len());
+
+    let request_headers = read_frame(&mut stream);
+    assert_eq!(FRAME_HEADERS, request_headers.frame_type);
+    assert_eq!(FLAG_END_STREAM | FLAG_END_HEADERS, request_headers.flags);
+    assert_eq!(1, request_headers.stream_id);
+    assert_eq!(
+      b"CONNECT",
+      find_header_value(&request_headers.payload, b":method")
+        .expect("request method")
+        .value
+        .as_slice()
+    );
+    assert_eq!(
+      b"websocket",
+      find_header_value(&request_headers.payload, b":protocol")
+        .expect("request protocol")
+        .value
+        .as_slice()
+    );
+    assert!(
+      request_headers.payload.contains(&0x86),
+      "extended CONNECT request must send :scheme http"
+    );
+    assert_eq!(
+      addr.to_string().as_bytes(),
+      find_header_value(&request_headers.payload, b":authority")
+        .expect("request authority")
+        .value
+        .as_slice()
+    );
+    assert_eq!(
+      b"/chat?room=blue",
+      find_header_value(&request_headers.payload, b":path")
+        .expect("request path")
+        .value
+        .as_slice()
+    );
+    assert!(
+      try_read_frame(&mut stream)
+        .expect("check for unexpected extended CONNECT body")
+        .is_none(),
+      "extended CONNECT request must not send DATA frames"
+    );
+
+    write_frame(&mut stream, FRAME_SETTINGS, FLAG_ACK, 0, &[]);
+    write_frame(&mut stream, FRAME_HEADERS, FLAG_END_HEADERS, 1, &[0x88]);
+    write_frame(&mut stream, FRAME_DATA, FLAG_END_STREAM, 1, b"connected");
+  });
+
+  let response = HttpClient::new()
+    .http2_extended_connect("websocket")
+    .url(format!("http://{}/chat?room=blue", addr))
+    .emit_http2_prior_knowledge()
+    .expect("h2 extended CONNECT response");
+
+  assert_eq!(200, response.code());
+  assert_eq!("HTTP/2", response.version());
+  assert_eq!("connected", response.body().string().unwrap());
+
+  handle.join().expect("h2 extended CONNECT peer thread");
+}
+
+#[test]
+fn extended_connect_rejects_request_body_before_connecting() {
+  let listener = TcpListener::bind("127.0.0.1:0").expect("bind h2 peer");
+  listener
+    .set_nonblocking(true)
+    .expect("set listener nonblocking");
+  let addr = listener.local_addr().expect("h2 peer addr");
+
+  let err = HttpClient::new()
+    .http2_extended_connect("websocket")
+    .url(format!("http://{}/chat", addr))
+    .raw("unsupported body")
+    .emit_http2_prior_knowledge()
+    .expect_err("extended CONNECT with a body must be rejected");
+
+  assert!(err.is_builder());
+  assert!(
+    err
+      .to_string()
+      .contains("HTTP/2 extended CONNECT cannot send a request body"),
+    "unexpected error: {err}"
+  );
+  assert!(
+    matches!(listener.accept(), Err(ref err) if err.kind() == io::ErrorKind::WouldBlock),
+    "extended CONNECT with a body must not open a server connection"
+  );
+}
+
+#[test]
+fn extended_connect_with_proxy_is_rejected_before_connecting() {
+  let listener = TcpListener::bind("127.0.0.1:0").expect("bind h2 peer");
+  listener
+    .set_nonblocking(true)
+    .expect("set listener nonblocking");
+  let addr = listener.local_addr().expect("h2 peer addr");
+
+  let err = HttpClient::new()
+    .http2_extended_connect("websocket")
+    .url(format!("http://{}/chat", addr))
+    .proxy(Proxy::http("127.0.0.1", 8080))
+    .emit_http2_prior_knowledge()
+    .expect_err("extended CONNECT with proxy must be rejected");
+
+  assert!(err.is_builder());
+  assert!(
+    err
+      .to_string()
+      .contains("HTTP/2 prior-knowledge client does not support proxies"),
+    "unexpected error: {err}"
+  );
+  assert!(
+    matches!(listener.accept(), Err(ref err) if err.kind() == io::ErrorKind::WouldBlock),
+    "extended CONNECT with proxy must not open a server connection"
   );
 }
 


### PR DESCRIPTION
Adds an explicit bounded h2c RFC 8441 extended CONNECT client path while preserving existing rejection boundaries and documenting the new opt-in behavior.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1538/
work_kind: code_work
branch: hbx-1538-rttp-client-add-bounded-h2c
base: main
commit: a55cbca9ddc9ef917b5046fa66676134b3890c52
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1538/
    url: https://plane.kahub.in/endless/browse/HBX-1538/
    close_policy: link_only
```