### PR TITLE
feat: [rttp] Add bounded HTTP/1.1 h2c Upgrade server transition

### DIFF
--- a/rttp/src/server.rs
+++ b/rttp/src/server.rs
@@ -181,6 +181,30 @@ impl HttpServer {
       let request_closes_connection = request.closes_connection();
       let request_uses_http10_defaults = request.version() == "HTTP/1.0";
       let request_is_head = request.method() == "HEAD";
+      if let Some(settings_payload) = match h2c_upgrade_settings(&request) {
+        Ok(settings_payload) => settings_payload,
+        Err(err) if is_bad_request_error(&err) => {
+          self.normalize_connection_error(bad_request_response().write_to(reader.get_mut()))?;
+          served += 1;
+          break;
+        }
+        Err(err) => return Err(err),
+      } {
+        self.normalize_connection_error(write_h2c_upgrade_response(reader.get_mut()))?;
+        let buffered = reader.buffer().to_vec();
+        let stream = reader.into_inner().into_handoff_stream(buffered)?;
+        let handled = self.handle_http2_connection_with_initial(
+          stream,
+          request_limit - served,
+          handler,
+          Some(Http2InitialSettings {
+            payload: settings_payload,
+            acknowledge: false,
+            upgraded: true,
+          }),
+        )?;
+        return Ok(served + handled);
+      }
       let response = handler(request);
       let response_closes_connection = response.closes_connection();
       served += 1;
@@ -241,6 +265,30 @@ impl HttpServer {
       }
       Err(err) => return Err(err),
     };
+    if let Some(settings_payload) = match h2c_upgrade_settings(&request) {
+      Ok(settings_payload) => settings_payload,
+      Err(err) if is_bad_request_error(&err) => {
+        return self.normalize_connection_error(bad_request_response().write_to(reader.get_mut()));
+      }
+      Err(err) => return Err(err),
+    } {
+      self.normalize_connection_error(write_h2c_upgrade_response(reader.get_mut()))?;
+      let buffered = reader.buffer().to_vec();
+      let stream = reader.into_inner().into_handoff_stream(buffered)?;
+      let mut handler = Some(handler);
+      return self
+        .handle_http2_connection_with_initial(
+          stream,
+          1,
+          &mut |request| handler.take().expect("single h2 request handler")(request),
+          Some(Http2InitialSettings {
+            payload: settings_payload,
+            acknowledge: false,
+            upgraded: true,
+          }),
+        )
+        .map(|_| ());
+    }
     let request_is_head = request.method() == "HEAD";
     let response = handler(request);
     self.normalize_connection_error(response.write_to_with_default_connection_and_body(
@@ -272,6 +320,9 @@ impl HttpServer {
       }
       Err(err) => return Err(err),
     };
+    if h2c_upgrade_settings(&request).is_err() || h2c_upgrade_settings(&request)?.is_some() {
+      return self.normalize_connection_error(bad_request_response().write_to(reader.get_mut()));
+    }
     let request_is_head = request.method() == "HEAD";
     let body = RequestBodyReader::new(&mut reader, body_kind, self.read_timeout.is_some());
     let response = handler(request, body);
@@ -306,6 +357,10 @@ impl HttpServer {
       }
       Err(err) => return Err(err),
     };
+
+    if h2c_upgrade_settings(&request).is_err() || h2c_upgrade_settings(&request)?.is_some() {
+      return self.normalize_connection_error(bad_request_response().write_to(reader.get_mut()));
+    }
 
     let handoff = handler(request.clone());
     if !handoff.valid_for(&request) {
@@ -365,29 +420,54 @@ impl HttpServer {
 
   fn handle_http2_connection<F>(
     &self,
-    mut stream: TcpStream,
+    stream: TcpStream,
     request_limit: usize,
     handler: &mut F,
   ) -> io::Result<usize>
   where
     F: FnMut(Request) -> HttpResponse,
   {
-    let frame = self
-      .normalize_connection_error(read_http2_frame(&mut stream, HTTP2_DEFAULT_MAX_FRAME_SIZE))?;
-    if frame.frame_type != HTTP2_FRAME_SETTINGS
-      || frame.flags & HTTP2_FLAG_ACK == HTTP2_FLAG_ACK
-      || frame.stream_id != 0
+    self.handle_http2_connection_with_initial(stream, request_limit, handler, None)
+  }
+
+  fn handle_http2_connection_with_initial<S, F>(
+    &self,
+    mut stream: S,
+    request_limit: usize,
+    handler: &mut F,
+    initial_settings: Option<Http2InitialSettings>,
+  ) -> io::Result<usize>
+  where
+    S: Read + Write,
+    F: FnMut(Request) -> HttpResponse,
+  {
+    let (initial_payload, acknowledge_initial_settings, upgraded) = if let Some(initial_settings) =
+      initial_settings
     {
-      return Err(invalid_http2_settings_error());
-    }
-    validate_http2_settings_payload(&frame.payload)?;
+      (
+        initial_settings.payload,
+        initial_settings.acknowledge,
+        initial_settings.upgraded,
+      )
+    } else {
+      let frame = self
+        .normalize_connection_error(read_http2_frame(&mut stream, HTTP2_DEFAULT_MAX_FRAME_SIZE))?;
+      if frame.frame_type != HTTP2_FRAME_SETTINGS
+        || frame.flags & HTTP2_FLAG_ACK == HTTP2_FLAG_ACK
+        || frame.stream_id != 0
+      {
+        return Err(invalid_http2_settings_error());
+      }
+      (frame.payload, true, false)
+    };
+    validate_http2_settings_payload(&initial_payload)?;
     let mut peer_max_frame_size =
-      http2_settings_max_frame_size(&frame.payload).unwrap_or(HTTP2_DEFAULT_MAX_FRAME_SIZE);
-    let mut peer_initial_stream_send_window = http2_settings_initial_window_size(&frame.payload)
+      http2_settings_max_frame_size(&initial_payload).unwrap_or(HTTP2_DEFAULT_MAX_FRAME_SIZE);
+    let mut peer_initial_stream_send_window = http2_settings_initial_window_size(&initial_payload)
       .unwrap_or(HTTP2_DEFAULT_INITIAL_WINDOW_SIZE);
     let mut peer_header_table_size =
-      http2_settings_header_table_size(&frame.payload).unwrap_or(HTTP2_DEFAULT_HEADER_TABLE_SIZE);
-    let mut peer_enable_connect_protocol = http2_settings_enable_connect_protocol(&frame.payload);
+      http2_settings_header_table_size(&initial_payload).unwrap_or(HTTP2_DEFAULT_HEADER_TABLE_SIZE);
+    let mut peer_enable_connect_protocol = http2_settings_enable_connect_protocol(&initial_payload);
 
     self.normalize_connection_error(write_http2_frame(
       &mut stream,
@@ -396,18 +476,24 @@ impl HttpServer {
       0,
       &server_http2_settings_payload(request_limit),
     ))?;
-    self.normalize_connection_error(write_http2_frame(
-      &mut stream,
-      HTTP2_FRAME_SETTINGS,
-      HTTP2_FLAG_ACK,
-      0,
-      &[],
-    ))?;
+    if acknowledge_initial_settings {
+      self.normalize_connection_error(write_http2_frame(
+        &mut stream,
+        HTTP2_FRAME_SETTINGS,
+        HTTP2_FLAG_ACK,
+        0,
+        &[],
+      ))?;
+    }
     self.normalize_connection_error(stream.flush())?;
 
     let mut streams = Vec::<Http2RequestStream>::new();
     let mut reset_streams = Vec::<u32>::new();
-    let mut stream_ids = Http2ClientStreamIds::new();
+    let mut stream_ids = if upgraded {
+      Http2ClientStreamIds::after_http1_upgrade()
+    } else {
+      Http2ClientStreamIds::new()
+    };
     let mut connection_receive_window = HTTP2_DEFAULT_INITIAL_WINDOW_SIZE;
     let mut connection_send_window = Http2SendWindow::new(HTTP2_DEFAULT_INITIAL_WINDOW_SIZE);
     let mut request_header_decoder = Http2HeaderDecoder::new(HTTP2_DEFAULT_HEADER_TABLE_SIZE);
@@ -780,9 +866,29 @@ enum AcceptedConnection {
   Http2(TcpStream),
 }
 
+struct Http2InitialSettings {
+  payload: Vec<u8>,
+  acknowledge: bool,
+  upgraded: bool,
+}
+
 enum Http1Stream {
   Plain(TcpStream),
   Prefixed(HandoffStream),
+}
+
+impl Http1Stream {
+  fn into_handoff_stream(self, buffered: Vec<u8>) -> io::Result<HandoffStream> {
+    match self {
+      Self::Plain(stream) => Ok(HandoffStream::new(buffered, stream)),
+      Self::Prefixed(mut stream) => {
+        let mut combined = Vec::new();
+        stream.buffered.read_to_end(&mut combined)?;
+        combined.extend_from_slice(&buffered);
+        Ok(HandoffStream::new(combined, stream.stream))
+      }
+    }
+  }
 }
 
 impl Read for Http1Stream {
@@ -840,6 +946,13 @@ impl Http2ClientStreamIds {
     Self {
       max_opened: 0,
       closed: Vec::new(),
+    }
+  }
+
+  fn after_http1_upgrade() -> Self {
+    Self {
+      max_opened: 1,
+      closed: vec![1],
     }
   }
 
@@ -1084,7 +1197,7 @@ fn http2_data_payload_to_data(payload: &[u8], flags: u8) -> io::Result<&[u8]> {
   Ok(&data_and_padding[..data_and_padding.len() - pad_len])
 }
 
-fn read_http2_frame(stream: &mut TcpStream, max_frame_size: usize) -> io::Result<Http2Frame> {
+fn read_http2_frame<S: Read>(stream: &mut S, max_frame_size: usize) -> io::Result<Http2Frame> {
   let mut header = [0; 9];
   stream.read_exact(&mut header)?;
   let length = ((header[0] as usize) << 16) | ((header[1] as usize) << 8) | header[2] as usize;
@@ -1139,6 +1252,83 @@ fn validate_http2_settings_payload(payload: &[u8]) -> io::Result<()> {
   }
 
   Ok(())
+}
+
+fn h2c_upgrade_settings(request: &Request) -> io::Result<Option<Vec<u8>>> {
+  if !request
+    .header("Upgrade")
+    .is_some_and(|value| connection_header_has_token(Some(value), "h2c"))
+  {
+    return Ok(None);
+  }
+
+  if request.version() != "HTTP/1.1"
+    || request.method().eq_ignore_ascii_case("CONNECT")
+    || !request.connection_header_has_token("upgrade")
+    || !request.connection_header_has_token("http2-settings")
+    || request.headers_named("HTTP2-Settings").count() != 1
+    || !request.body().is_empty()
+  {
+    return Err(io::Error::new(
+      io::ErrorKind::InvalidData,
+      "invalid h2c upgrade request",
+    ));
+  }
+
+  let settings = request
+    .header("HTTP2-Settings")
+    .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "missing HTTP2-Settings header"))?;
+  let payload = decode_base64url_unpadded(settings.trim())?;
+  validate_http2_settings_payload(&payload)?;
+  Ok(Some(payload))
+}
+
+fn write_h2c_upgrade_response<S: Write>(stream: &mut S) -> io::Result<()> {
+  HttpResponse::new(101, "Switching Protocols")
+    .header("Connection", "Upgrade")
+    .header("Upgrade", "h2c")
+    .write_handoff_head_to(stream)
+}
+
+fn decode_base64url_unpadded(input: &str) -> io::Result<Vec<u8>> {
+  if input.as_bytes().contains(&b'=') || input.len() % 4 == 1 {
+    return Err(io::Error::new(
+      io::ErrorKind::InvalidData,
+      "invalid HTTP2-Settings header",
+    ));
+  }
+
+  let mut output = Vec::with_capacity((input.len() * 3) / 4);
+  for chunk in input.as_bytes().chunks(4) {
+    let mut value = 0u32;
+    for byte in chunk {
+      value = (value << 6) | base64url_value(*byte)? as u32;
+    }
+    let missing = 4 - chunk.len();
+    value <<= 6 * missing;
+    output.push(((value >> 16) & 0xff) as u8);
+    if chunk.len() >= 3 {
+      output.push(((value >> 8) & 0xff) as u8);
+    }
+    if chunk.len() == 4 {
+      output.push((value & 0xff) as u8);
+    }
+  }
+  Ok(output)
+}
+
+fn base64url_value(byte: u8) -> io::Result<u8> {
+  match byte {
+    b'A'..=b'Z' => Ok(byte - b'A'),
+    b'a'..=b'z' => Ok(byte - b'a' + 26),
+    b'0'..=b'9' => Ok(byte - b'0' + 52),
+    b'-' => Ok(62),
+    b'_' => Ok(63),
+    _ => Err(io::Error::new(
+      io::ErrorKind::InvalidData,
+      "invalid HTTP2-Settings header",
+    )),
+  }
 }
 
 fn http2_window_update_increment(payload: &[u8]) -> io::Result<u32> {
@@ -1307,8 +1497,8 @@ fn http2_closed_stream_error() -> io::Error {
   )
 }
 
-fn write_http2_frame(
-  stream: &mut TcpStream,
+fn write_http2_frame<S: Write>(
+  stream: &mut S,
   frame_type: u8,
   flags: u8,
   stream_id: u32,
@@ -1333,8 +1523,8 @@ fn write_http2_frame(
   stream.write_all(payload)
 }
 
-fn write_http2_window_update(
-  stream: &mut TcpStream,
+fn write_http2_window_update<S: Write>(
+  stream: &mut S,
   stream_id: u32,
   increment: usize,
 ) -> io::Result<()> {
@@ -1376,8 +1566,8 @@ fn server_http2_settings_payload(request_limit: usize) -> Vec<u8> {
   payload
 }
 
-fn write_http2_goaway(
-  stream: &mut TcpStream,
+fn write_http2_goaway<S: Write>(
+  stream: &mut S,
   last_stream_id: u32,
   error_code: u32,
 ) -> io::Result<()> {
@@ -2186,8 +2376,8 @@ enum Http2ResponseFlowControlRead {
   ResponseReset,
 }
 
-fn write_http2_response(
-  stream: &mut TcpStream,
+fn write_http2_response<S: Read + Write>(
+  stream: &mut S,
   stream_id: u32,
   response: &HttpResponse,
   write_body: bool,
@@ -2265,8 +2455,8 @@ fn write_http2_response(
   stream.flush()
 }
 
-fn read_http2_response_flow_control_frame(
-  stream: &mut TcpStream,
+fn read_http2_response_flow_control_frame<S: Read + Write>(
+  stream: &mut S,
   response_stream_id: u32,
   flow_control: &mut Http2ResponseFlowControl<'_>,
 ) -> io::Result<Http2ResponseFlowControlRead> {
@@ -2517,8 +2707,8 @@ fn read_http2_response_flow_control_frame(
   }
 }
 
-fn write_http2_header_block(
-  stream: &mut TcpStream,
+fn write_http2_header_block<S: Write>(
+  stream: &mut S,
   stream_id: u32,
   first_frame_flags: u8,
   block: &[u8],
@@ -3123,6 +3313,14 @@ impl Request {
       .iter()
       .filter(|(name, _)| name.eq_ignore_ascii_case("Connection"))
       .any(|(_, value)| connection_header_has_token(Some(value), token))
+  }
+
+  fn headers_named<'a>(&'a self, name: &'a str) -> impl Iterator<Item = &'a str> + 'a {
+    self
+      .headers
+      .iter()
+      .filter(move |(key, _)| key.eq_ignore_ascii_case(name))
+      .map(|(_, value)| value.as_str())
   }
 
   #[cfg(test)]

--- a/rttp/tests/http2_feature.rs
+++ b/rttp/tests/http2_feature.rs
@@ -173,6 +173,26 @@ fn h2_setting_value(payload: &[u8], id: u16) -> Option<u32> {
   })
 }
 
+fn base64url_encode_unpadded(bytes: &[u8]) -> String {
+  const ALPHABET: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+  let mut encoded = String::new();
+  for chunk in bytes.chunks(3) {
+    let first = chunk[0];
+    let second = *chunk.get(1).unwrap_or(&0);
+    let third = *chunk.get(2).unwrap_or(&0);
+    let value = ((first as u32) << 16) | ((second as u32) << 8) | third as u32;
+    encoded.push(ALPHABET[((value >> 18) & 0x3f) as usize] as char);
+    encoded.push(ALPHABET[((value >> 12) & 0x3f) as usize] as char);
+    if chunk.len() >= 2 {
+      encoded.push(ALPHABET[((value >> 6) & 0x3f) as usize] as char);
+    }
+    if chunk.len() == 3 {
+      encoded.push(ALPHABET[(value & 0x3f) as usize] as char);
+    }
+  }
+  encoded
+}
+
 fn h2_literal_indexed_name(name_index: u8, value: &[u8]) -> Vec<u8> {
   assert!(value.len() < 128);
   let mut encoded = vec![name_index, value.len() as u8];
@@ -441,6 +461,41 @@ fn complete_h2_server_handshake_with_settings(stream: &mut TcpStream, payload: &
   write_h2_frame(stream, H2_FRAME_SETTINGS, H2_FLAG_ACK, 0, &[]);
 }
 
+fn complete_h2c_upgrade(stream: &mut TcpStream, authority: &str, settings_payload: &[u8]) {
+  let settings = base64url_encode_unpadded(settings_payload);
+  let request = format!(
+    "GET /upgrade HTTP/1.1\r\n\
+     Host: {authority}\r\n\
+     Connection: keep-alive, HTTP2-Settings, Upgrade\r\n\
+     Upgrade: h2c\r\n\
+     HTTP2-Settings: {settings}\r\n\
+     \r\n"
+  );
+  stream
+    .write_all(request.as_bytes())
+    .expect("write h2c upgrade request");
+
+  let mut response = Vec::new();
+  let mut byte = [0; 1];
+  while !response.ends_with(b"\r\n\r\n") {
+    stream
+      .read_exact(&mut byte)
+      .expect("read h2c upgrade response");
+    response.push(byte[0]);
+  }
+  let response = String::from_utf8(response).expect("utf8 upgrade response");
+  assert!(response.starts_with("HTTP/1.1 101 Switching Protocols\r\n"));
+  assert!(response.contains("\r\nConnection: Upgrade\r\n"));
+  assert!(response.contains("\r\nUpgrade: h2c\r\n"));
+
+  let settings = read_h2_frame(stream);
+  assert_eq!(H2_FRAME_SETTINGS, settings.frame_type);
+  assert_eq!(0, settings.flags);
+  assert_eq!(0, settings.stream_id);
+
+  write_h2_frame(stream, H2_FRAME_SETTINGS, H2_FLAG_ACK, 0, &[]);
+}
+
 fn assert_malformed_settings_rejected_before_handler(
   initial_payload: &[u8],
   initial_flags: u8,
@@ -492,6 +547,55 @@ fn assert_malformed_settings_rejected_before_handler(
   assert!(
     result.is_err(),
     "malformed SETTINGS should reject connection"
+  );
+  assert!(rx.try_recv().is_err(), "handler must not be called");
+}
+
+fn assert_malformed_h2c_upgrade_rejected_before_handler(http2_settings: &str) {
+  let server = rttp::Http::server("127.0.0.1:0")
+    .expect("bind server")
+    .with_read_timeout(Some(Duration::from_secs(2)))
+    .with_write_timeout(Some(Duration::from_secs(2)));
+  let addr = server.local_addr().expect("server addr");
+  let (tx, rx) = mpsc::channel();
+
+  let handle = thread::spawn(move || {
+    server.accept_one(|_| {
+      tx.send(()).expect("send unexpected handler call");
+      HttpResponse::ok("unexpected")
+    })
+  });
+
+  let mut stream = TcpStream::connect(addr).expect("connect h2c upgrade server");
+  stream
+    .set_read_timeout(Some(Duration::from_secs(2)))
+    .expect("set client read timeout");
+  let request = format!(
+    "GET /upgrade HTTP/1.1\r\n\
+     Host: {addr}\r\n\
+     Connection: Upgrade, HTTP2-Settings\r\n\
+     Upgrade: h2c\r\n\
+     HTTP2-Settings: {http2_settings}\r\n\
+     \r\n"
+  );
+  stream
+    .write_all(request.as_bytes())
+    .expect("write malformed h2c upgrade request");
+  stream
+    .shutdown(std::net::Shutdown::Write)
+    .expect("shutdown client write");
+
+  let mut response = String::new();
+  stream.read_to_string(&mut response).expect("read response");
+  assert_eq!(
+    "HTTP/1.1 400 Bad Request\r\nContent-Length: 11\r\nConnection: close\r\n\r\nBad Request",
+    response
+  );
+
+  let result = handle.join().expect("server thread");
+  assert!(
+    result.is_ok(),
+    "malformed h2c upgrade should be handled as 400"
   );
   assert!(rx.try_recv().is_err(), "handler must not be called");
 }
@@ -1568,6 +1672,63 @@ fn prior_knowledge_server_acknowledges_valid_settings_payload_and_serves_request
   assert_eq!(b"settings accepted", response_body.payload.as_slice());
 
   handle.join().expect("server thread");
+}
+
+#[test]
+fn h2c_upgrade_server_transitions_to_bounded_http2_loop_on_same_socket() {
+  let server = rttp::Http::server("127.0.0.1:0")
+    .expect("bind server")
+    .with_read_timeout(Some(Duration::from_secs(2)))
+    .with_write_timeout(Some(Duration::from_secs(2)));
+  let addr = server.local_addr().expect("server addr");
+
+  let handle = thread::spawn(move || {
+    server
+      .accept_one(|request| {
+        assert_eq!("HTTP/2", request.version());
+        assert_eq!("GET", request.method());
+        assert_eq!("/settings", request.target());
+        HttpResponse::ok("h2c upgrade served")
+      })
+      .expect("serve h2c upgrade request")
+  });
+
+  let mut stream = TcpStream::connect(addr).expect("connect h2c upgrade server");
+  stream
+    .set_read_timeout(Some(Duration::from_secs(2)))
+    .expect("set client read timeout");
+  let mut settings_payload = Vec::new();
+  settings_payload.extend_from_slice(&h2_setting(H2_SETTINGS_ENABLE_PUSH, 0));
+  settings_payload.extend_from_slice(&h2_setting(H2_SETTINGS_MAX_FRAME_SIZE, 16_384));
+  complete_h2c_upgrade(&mut stream, &addr.to_string(), &settings_payload);
+
+  write_h2_frame(
+    &mut stream,
+    H2_FRAME_HEADERS,
+    H2_FLAG_END_HEADERS | H2_FLAG_END_STREAM,
+    3,
+    &h2_get_headers(b"/settings", addr.to_string().as_bytes()),
+  );
+
+  let response_headers = read_h2_frame(&mut stream);
+  assert_eq!(H2_FRAME_HEADERS, response_headers.frame_type);
+  assert_eq!(3, response_headers.stream_id);
+  let response_body = read_h2_frame(&mut stream);
+  assert_eq!(H2_FRAME_DATA, response_body.frame_type);
+  assert_eq!(H2_FLAG_END_STREAM, response_body.flags);
+  assert_eq!(3, response_body.stream_id);
+  assert_eq!(b"h2c upgrade served", response_body.payload.as_slice());
+
+  handle.join().expect("server thread");
+}
+
+#[test]
+fn h2c_upgrade_rejects_malformed_http2_settings_before_handler_dispatch() {
+  assert_malformed_h2c_upgrade_rejected_before_handler("%%%");
+  assert_malformed_h2c_upgrade_rejected_before_handler(&base64url_encode_unpadded(&h2_setting(
+    H2_SETTINGS_ENABLE_PUSH,
+    2,
+  )));
 }
 
 #[test]


### PR DESCRIPTION
Added bounded server-side HTTP/1.1 h2c upgrade support with settings validation, same-socket HTTP/2 transition, malformed-upgrade rejection, and focused regression coverage.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1544/
work_kind: code_work
branch: hbx-1544-rttp-add-bounded-http-1
base: main
commit: 707ed754d226be3170e7a429adbbd83d4b42f283
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1544/
    url: https://plane.kahub.in/endless/browse/HBX-1544/
    close_policy: link_only
```