### PR TITLE
feat: [rttp] Add cross-crate HTTP/1.1 h2c Upgrade matrix

### DIFF
--- a/rttp/src/server.rs
+++ b/rttp/src/server.rs
@@ -486,6 +486,16 @@ impl HttpServer {
       ))?;
     }
     self.normalize_connection_error(stream.flush())?;
+    if upgraded {
+      let mut preface = [0; HTTP2_CLIENT_PREFACE.len()];
+      self.normalize_connection_error(stream.read_exact(&mut preface))?;
+      if preface != *HTTP2_CLIENT_PREFACE {
+        return Err(io::Error::new(
+          io::ErrorKind::InvalidData,
+          "invalid HTTP/2 client preface after h2c upgrade",
+        ));
+      }
+    }
 
     let mut streams = Vec::<Http2RequestStream>::new();
     let mut reset_streams = Vec::<u32>::new();

--- a/rttp/tests/http2_feature.rs
+++ b/rttp/tests/http2_feature.rs
@@ -488,6 +488,10 @@ fn complete_h2c_upgrade(stream: &mut TcpStream, authority: &str, settings_payloa
   assert!(response.contains("\r\nConnection: Upgrade\r\n"));
   assert!(response.contains("\r\nUpgrade: h2c\r\n"));
 
+  stream
+    .write_all(H2_PREFACE)
+    .expect("write h2c upgraded client preface");
+
   let settings = read_h2_frame(stream);
   assert_eq!(H2_FRAME_SETTINGS, settings.frame_type);
   assert_eq!(0, settings.flags);
@@ -1729,6 +1733,201 @@ fn h2c_upgrade_rejects_malformed_http2_settings_before_handler_dispatch() {
     H2_SETTINGS_ENABLE_PUSH,
     2,
   )));
+}
+
+#[test]
+fn cross_crate_http11_h2c_upgrade_client_server_matrix() {
+  let server = rttp::Http::server("127.0.0.1:0")
+    .expect("bind cross-crate h2c upgrade server")
+    .with_read_timeout(Some(Duration::from_secs(2)))
+    .with_write_timeout(Some(Duration::from_secs(2)));
+  let addr = server.local_addr().expect("cross-crate h2c addr");
+
+  let handle = thread::spawn(move || {
+    server
+      .accept_one(|request| {
+        assert_eq!("HTTP/2", request.version());
+        assert_eq!("GET", request.method());
+        assert_eq!("/upgrade-matrix?mode=http11", request.target());
+        assert_eq!(Some(addr.to_string().as_str()), request.header("host"));
+        HttpResponse::ok("cross-crate h2c upgrade").header("x-cross-crate-path", "http11-upgrade")
+      })
+      .expect("serve cross-crate h2c upgrade request")
+  });
+
+  let response = HttpClient::new()
+    .get()
+    .url(format!("http://{}/upgrade-matrix?mode=http11", addr))
+    .emit_http2_upgrade()
+    .expect("cross-crate h2c upgrade response");
+
+  assert_eq!(200, response.code());
+  assert_eq!("HTTP/2", response.version());
+  assert_eq!(
+    Some(&"http11-upgrade".to_string()),
+    response.header_value("x-cross-crate-path")
+  );
+  assert_eq!("cross-crate h2c upgrade", response.body().string().unwrap());
+
+  handle.join().expect("cross-crate h2c upgrade thread");
+}
+
+#[test]
+fn cross_crate_http11_h2c_upgrade_rejects_invalid_or_missing_settings_before_dispatch() {
+  for request in [
+    format!(
+      "GET /bad-h2c HTTP/1.1\r\n\
+       Host: ignored\r\n\
+       Connection: Upgrade, HTTP2-Settings\r\n\
+       Upgrade: h2c\r\n\
+       HTTP2-Settings: {}\r\n\
+       \r\n",
+      base64url_encode_unpadded(&h2_setting(H2_SETTINGS_ENABLE_PUSH, 2))
+    ),
+    "GET /missing-h2c HTTP/1.1\r\n\
+     Host: ignored\r\n\
+     Connection: Upgrade, HTTP2-Settings\r\n\
+     Upgrade: h2c\r\n\
+     \r\n"
+      .to_string(),
+  ] {
+    let server = rttp::Http::server("127.0.0.1:0")
+      .expect("bind cross-crate h2c rejection server")
+      .with_read_timeout(Some(Duration::from_secs(2)))
+      .with_write_timeout(Some(Duration::from_secs(2)));
+    let addr = server.local_addr().expect("h2c rejection addr");
+    let (tx, rx) = mpsc::channel();
+
+    let handle = thread::spawn(move || {
+      server.accept_one(|_| {
+        tx.send(()).expect("send unexpected handler call");
+        HttpResponse::ok("unexpected")
+      })
+    });
+
+    let mut stream = TcpStream::connect(addr).expect("connect h2c rejection server");
+    stream
+      .set_read_timeout(Some(Duration::from_secs(2)))
+      .expect("set h2c rejection read timeout");
+    stream
+      .write_all(
+        request
+          .replace("Host: ignored", &format!("Host: {addr}"))
+          .as_bytes(),
+      )
+      .expect("write h2c rejection request");
+    stream
+      .shutdown(std::net::Shutdown::Write)
+      .expect("shutdown h2c rejection client write");
+
+    let mut response = String::new();
+    stream
+      .read_to_string(&mut response)
+      .expect("read h2c rejection response");
+    assert_eq!(
+      "HTTP/1.1 400 Bad Request\r\nContent-Length: 11\r\nConnection: close\r\n\r\nBad Request",
+      response
+    );
+
+    let result = handle.join().expect("h2c rejection server thread");
+    assert!(result.is_ok(), "invalid h2c upgrade must map to HTTP 400");
+    assert!(rx.try_recv().is_err(), "handler must not be dispatched");
+  }
+}
+
+#[test]
+fn cross_crate_http11_h2c_upgrade_detection_preserves_non_h2c_upgrade_handoff() {
+  let server = rttp::Http::server("127.0.0.1:0")
+    .expect("bind non-h2c upgrade handoff server")
+    .with_read_timeout(Some(Duration::from_secs(2)))
+    .with_write_timeout(Some(Duration::from_secs(2)));
+  let addr = server.local_addr().expect("non-h2c upgrade addr");
+
+  let handle = thread::spawn(move || {
+    server
+      .accept_one_handoff(|request| {
+        assert_eq!("GET", request.method());
+        assert_eq!("/chat", request.target());
+        assert_eq!(Some("websocket"), request.header("Upgrade"));
+        rttp::server::HttpHandoff::upgrade(
+          HttpResponse::new(101, "Switching Protocols")
+            .header("Connection", "Upgrade")
+            .header("Upgrade", "websocket"),
+          |mut stream| {
+            stream.write_all(b"server-websocket")?;
+            let mut client_bytes = [0u8; 16];
+            stream.read_exact(&mut client_bytes)?;
+            assert_eq!(b"client-websocket", &client_bytes);
+            Ok(())
+          },
+        )
+      })
+      .expect("serve non-h2c upgrade handoff")
+  });
+
+  let mut upgraded = HttpClient::new()
+    .url(format!("http://{}/chat", addr))
+    .header(("Connection", "Upgrade"))
+    .header(("Upgrade", "websocket"))
+    .upgrade()
+    .expect("non-h2c upgrade handoff");
+  assert_eq!(101, upgraded.response().code());
+  assert_eq!(
+    Some(&"websocket".to_string()),
+    upgraded.response().header_value("Upgrade")
+  );
+
+  let mut server_bytes = [0u8; 16];
+  upgraded
+    .stream_mut()
+    .read_exact(&mut server_bytes)
+    .expect("read non-h2c upgraded server bytes");
+  assert_eq!(b"server-websocket", &server_bytes);
+  upgraded
+    .stream_mut()
+    .write_all(b"client-websocket")
+    .expect("write non-h2c upgraded client bytes");
+
+  handle.join().expect("non-h2c upgrade handoff thread");
+}
+
+#[test]
+fn cross_crate_prior_knowledge_h2c_still_bypasses_http11_upgrade_path() {
+  let server = rttp::Http::server("127.0.0.1:0")
+    .expect("bind prior-knowledge regression server")
+    .with_read_timeout(Some(Duration::from_secs(2)))
+    .with_write_timeout(Some(Duration::from_secs(2)));
+  let addr = server
+    .local_addr()
+    .expect("prior-knowledge regression addr");
+
+  let handle = thread::spawn(move || {
+    server
+      .accept_one(|request| {
+        assert_eq!("HTTP/2", request.version());
+        assert_eq!("GET", request.method());
+        assert_eq!("/prior-knowledge-regression", request.target());
+        assert!(request.header("upgrade").is_none());
+        assert!(request.header("http2-settings").is_none());
+        HttpResponse::ok("prior knowledge unchanged")
+      })
+      .expect("serve prior-knowledge regression request")
+  });
+
+  let response = HttpClient::new()
+    .get()
+    .url(format!("http://{}/prior-knowledge-regression", addr))
+    .emit_http2_prior_knowledge()
+    .expect("prior-knowledge h2c regression response");
+
+  assert_eq!(200, response.code());
+  assert_eq!("HTTP/2", response.version());
+  assert_eq!(
+    "prior knowledge unchanged",
+    response.body().string().unwrap()
+  );
+
+  handle.join().expect("prior-knowledge regression thread");
 }
 
 #[test]

--- a/rttp_client/src/http2.rs
+++ b/rttp_client/src/http2.rs
@@ -31,6 +31,7 @@ const FLAG_PADDED: u8 = 0x8;
 const FLAG_PRIORITY: u8 = 0x20;
 
 const STREAM_ID: u32 = 1;
+const UPGRADED_STREAM_ID: u32 = 3;
 const SETTING_HEADER_TABLE_SIZE: u16 = 0x1;
 const SETTING_ENABLE_PUSH: u16 = 0x2;
 const SETTING_MAX_CONCURRENT_STREAMS: u16 = 0x3;
@@ -128,6 +129,7 @@ impl<'a> PriorKnowledgeClient<'a> {
       self.request.url().clone(),
       peer_settings,
       local_settings,
+      STREAM_ID,
     )? {
       Some(response) => response,
       None => read_single_stream_response(
@@ -135,6 +137,7 @@ impl<'a> PriorKnowledgeClient<'a> {
         self.request.url().clone(),
         !is_head,
         local_settings,
+        STREAM_ID,
       )?,
     };
     self.request.origin_mut().closed_set(true);
@@ -183,6 +186,7 @@ impl<'a> UpgradeClient<'a> {
       self.request.url().clone(),
       peer_settings,
       local_settings,
+      UPGRADED_STREAM_ID,
     )? {
       Some(response) => response,
       None => read_single_stream_response(
@@ -190,6 +194,7 @@ impl<'a> UpgradeClient<'a> {
         self.request.url().clone(),
         !is_head,
         local_settings,
+        UPGRADED_STREAM_ID,
       )?,
     };
     self.request.origin_mut().closed_set(true);
@@ -790,6 +795,7 @@ fn write_request(
   response_url: RoUrl,
   mut peer_settings: PeerSettings,
   local_settings: LocalSettings,
+  stream_id: u32,
 ) -> error::Result<Option<Response>> {
   if peer_settings.max_concurrent_streams == Some(0) {
     return Err(error::bad_response(
@@ -836,7 +842,7 @@ fn write_request(
   write_header_block_frames(
     stream,
     header_flags,
-    STREAM_ID,
+    stream_id,
     &header_block,
     peer_settings.max_frame_size,
   )?;
@@ -849,6 +855,7 @@ fn write_request(
       has_trailers,
       response_url,
       local_settings,
+      stream_id,
     )? {
       return Ok(Some(response));
     }
@@ -864,7 +871,7 @@ fn write_request(
     write_header_block_frames(
       stream,
       FLAG_END_STREAM,
-      STREAM_ID,
+      stream_id,
       &trailer_block,
       peer_settings.max_frame_size,
     )?;
@@ -980,6 +987,7 @@ fn write_data_frames(
   has_trailers: bool,
   url: RoUrl,
   local_settings: LocalSettings,
+  stream_id: u32,
 ) -> error::Result<Option<Response>> {
   let mut connection_send_window = SendWindow::new();
   let mut stream_send_window =
@@ -1003,6 +1011,7 @@ fn write_data_frames(
         &mut current_max_frame_size,
         url.clone(),
         local_settings,
+        stream_id,
       )? {
         return Ok(Some(response));
       }
@@ -1024,7 +1033,7 @@ fn write_data_frames(
     } else {
       0
     };
-    write_frame(stream, FRAME_DATA, flags, STREAM_ID, chunk)?;
+    write_frame(stream, FRAME_DATA, flags, stream_id, chunk)?;
   }
   Ok(None)
 }
@@ -1039,6 +1048,7 @@ fn read_until_send_window_available(
   current_max_frame_size: &mut usize,
   url: RoUrl,
   local_settings: LocalSettings,
+  stream_id: u32,
 ) -> error::Result<Option<Response>> {
   loop {
     let frame = read_frame(stream, local_settings)?;
@@ -1046,7 +1056,7 @@ fn read_until_send_window_available(
       (FRAME_WINDOW_UPDATE, 0) => {
         connection_send_window.increase(window_update_increment(&frame)?)?;
       }
-      (FRAME_WINDOW_UPDATE, STREAM_ID) => {
+      (FRAME_WINDOW_UPDATE, id) if id == stream_id => {
         stream_send_window.increase(window_update_increment(&frame)?)?;
       }
       (FRAME_WINDOW_UPDATE, _) => {
@@ -1069,7 +1079,7 @@ fn read_until_send_window_available(
       (FRAME_PUSH_PROMISE, _) => {
         reject_push_promise_frame(&frame)?;
       }
-      (FRAME_RST_STREAM, STREAM_ID) => {
+      (FRAME_RST_STREAM, id) if id == stream_id => {
         return Err(error::bad_response(format!(
           "HTTP/2 stream received RST_STREAM error code {}",
           rst_stream_error_code(&frame)?
@@ -1091,13 +1101,19 @@ fn read_until_send_window_available(
         return Err(error::bad_response("invalid HTTP/2 PING frame"));
       }
       (FRAME_GOAWAY, _) => {
-        if goaway_last_stream_id(&frame)? < STREAM_ID {
+        if goaway_last_stream_id(&frame)? < stream_id {
           return Err(error::bad_response("HTTP/2 connection received GOAWAY"));
         }
       }
-      (FRAME_HEADERS, STREAM_ID) | (FRAME_DATA, STREAM_ID) | (FRAME_CONTINUATION, STREAM_ID) => {
-        return read_single_stream_response_from_frame(stream, url, frame, local_settings)
-          .map(Some);
+      (FRAME_HEADERS, id) | (FRAME_DATA, id) | (FRAME_CONTINUATION, id) if id == stream_id => {
+        return read_single_stream_response_from_frame(
+          stream,
+          url,
+          frame,
+          local_settings,
+          stream_id,
+        )
+        .map(Some);
       }
       _ => {}
     }
@@ -1381,6 +1397,7 @@ fn read_single_stream_response(
   url: RoUrl,
   include_data_payload: bool,
   local_settings: LocalSettings,
+  stream_id: u32,
 ) -> error::Result<Response> {
   read_single_stream_response_with_first_frame(
     stream,
@@ -1388,6 +1405,7 @@ fn read_single_stream_response(
     None,
     include_data_payload,
     local_settings,
+    stream_id,
   )
 }
 
@@ -1396,8 +1414,16 @@ fn read_single_stream_response_from_frame(
   url: RoUrl,
   first_frame: Frame,
   local_settings: LocalSettings,
+  stream_id: u32,
 ) -> error::Result<Response> {
-  read_single_stream_response_with_first_frame(stream, url, Some(first_frame), true, local_settings)
+  read_single_stream_response_with_first_frame(
+    stream,
+    url,
+    Some(first_frame),
+    true,
+    local_settings,
+    stream_id,
+  )
 }
 
 fn read_single_stream_response_with_first_frame(
@@ -1406,6 +1432,7 @@ fn read_single_stream_response_with_first_frame(
   mut first_frame: Option<Frame>,
   include_data_payload: bool,
   local_settings: LocalSettings,
+  stream_id: u32,
 ) -> error::Result<Response> {
   let mut header_block = Vec::new();
   let mut headers = Vec::new();
@@ -1433,7 +1460,7 @@ fn read_single_stream_response_with_first_frame(
       },
     };
     if pending_header_block.is_some()
-      && (frame.frame_type != FRAME_CONTINUATION || frame.stream_id != STREAM_ID)
+      && (frame.frame_type != FRAME_CONTINUATION || frame.stream_id != stream_id)
     {
       return Err(error::bad_response(
         "expected HTTP/2 CONTINUATION frame for incomplete header block",
@@ -1447,7 +1474,7 @@ fn read_single_stream_response_with_first_frame(
           stream.flush().map_err(error::request)?;
         }
       }
-      (FRAME_HEADERS, STREAM_ID) => {
+      (FRAME_HEADERS, id) if id == stream_id => {
         let kind = if final_response_started || response_body_started {
           HeaderBlockKind::Trailers
         } else {
@@ -1475,7 +1502,7 @@ fn read_single_stream_response_with_first_frame(
           break;
         }
       }
-      (FRAME_CONTINUATION, STREAM_ID) => {
+      (FRAME_CONTINUATION, id) if id == stream_id => {
         let pending = pending_header_block.ok_or_else(|| {
           error::bad_response("unexpected HTTP/2 CONTINUATION frame without header block")
         })?;
@@ -1498,7 +1525,7 @@ fn read_single_stream_response_with_first_frame(
           }
         }
       }
-      (FRAME_DATA, STREAM_ID) => {
+      (FRAME_DATA, id) if id == stream_id => {
         let end_stream = frame.flags & FLAG_END_STREAM == FLAG_END_STREAM;
         let data = data_payload(&frame)?;
         response_body_started = true;
@@ -1509,7 +1536,7 @@ fn read_single_stream_response_with_first_frame(
         let connection_update = connection_receive_window.consume(frame.payload.len())?;
         if !end_stream && (stream_update > 0 || connection_update > 0) {
           if stream_update > 0 {
-            write_window_update_best_effort(stream, STREAM_ID, stream_update)?;
+            write_window_update_best_effort(stream, stream_id, stream_update)?;
             stream_receive_window.release(stream_update)?;
           }
           if connection_update > 0 {
@@ -1525,7 +1552,7 @@ fn read_single_stream_response_with_first_frame(
       (FRAME_WINDOW_UPDATE, 0) => {
         connection_send_window.increase(window_update_increment(&frame)?)?;
       }
-      (FRAME_WINDOW_UPDATE, STREAM_ID) => {
+      (FRAME_WINDOW_UPDATE, id) if id == stream_id => {
         stream_send_window.increase(window_update_increment(&frame)?)?;
       }
       (FRAME_WINDOW_UPDATE, _) => {
@@ -1537,7 +1564,7 @@ fn read_single_stream_response_with_first_frame(
       (FRAME_PUSH_PROMISE, _) => {
         reject_push_promise_frame(&frame)?;
       }
-      (FRAME_RST_STREAM, STREAM_ID) => {
+      (FRAME_RST_STREAM, id) if id == stream_id => {
         return Err(error::bad_response(format!(
           "HTTP/2 stream received RST_STREAM error code {}",
           rst_stream_error_code(&frame)?
@@ -1559,11 +1586,11 @@ fn read_single_stream_response_with_first_frame(
         return Err(error::bad_response("invalid HTTP/2 PING frame"));
       }
       (FRAME_GOAWAY, _) => {
-        if goaway_last_stream_id(&frame)? < STREAM_ID {
+        if goaway_last_stream_id(&frame)? < stream_id {
           return Err(error::bad_response("HTTP/2 connection received GOAWAY"));
         }
       }
-      (_, STREAM_ID) => {}
+      (_, id) if id == stream_id => {}
       (FRAME_CONTINUATION, _) => {
         return Err(error::bad_response(
           "unexpected HTTP/2 CONTINUATION frame without header block",

--- a/rttp_client/tests/http2_prior_knowledge.rs
+++ b/rttp_client/tests/http2_prior_knowledge.rs
@@ -149,7 +149,7 @@ fn http2_upgrade_sends_http11_upgrade_then_runs_single_h2_stream() {
     let request_headers = read_frame(&mut stream);
     assert_eq!(FRAME_HEADERS, request_headers.frame_type);
     assert_eq!(FLAG_END_STREAM | FLAG_END_HEADERS, request_headers.flags);
-    assert_eq!(1, request_headers.stream_id);
+    assert_eq!(3, request_headers.stream_id);
     assert_eq!(
       b"/upgrade?via=h2c",
       find_header_value(&request_headers.payload, b":path")
@@ -159,8 +159,8 @@ fn http2_upgrade_sends_http11_upgrade_then_runs_single_h2_stream() {
     );
 
     write_frame(&mut stream, FRAME_SETTINGS, FLAG_ACK, 0, &[]);
-    write_frame(&mut stream, FRAME_HEADERS, FLAG_END_HEADERS, 1, &[0x88]);
-    write_frame(&mut stream, FRAME_DATA, FLAG_END_STREAM, 1, b"h2c upgrade");
+    write_frame(&mut stream, FRAME_HEADERS, FLAG_END_HEADERS, 3, &[0x88]);
+    write_frame(&mut stream, FRAME_DATA, FLAG_END_STREAM, 3, b"h2c upgrade");
   });
 
   let response = HttpClient::new()


### PR DESCRIPTION
Cross-crate HTTP/1.1 h2c Upgrade coverage is in place, with server/client interop fixed for upgraded h2c preface handling and stream selection. Relevant HTTP/2 integration tests and formatting checks pass.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1545/
work_kind: code_work
branch: hbx-1545-rttp-add-cross-crate-http
base: main
commit: bee35095fc2cda34feabcb9a65c0b6fc629743ac
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1545/
    url: https://plane.kahub.in/endless/browse/HBX-1545/
    close_policy: link_only
```