### PR TITLE
feat: [rttp] Document bounded HTTP/2 trailers behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,34 @@ HTTP/1.x chunked responses are decoded by the client, and response trailers are
 available through `Response::trailers`, `Response::trailer`, and
 `Response::trailer_value`.
 
+### Bounded trailer behavior
+
+Trailer support is explicit and bounded by protocol path. On the client,
+`HttpClient::trailer` configures request trailer fields. Those fields are sent
+for HTTP/1.1 only by `emit_streaming_chunked`; fixed-length HTTP/1.1 requests
+and buffered `emit` requests do not have an HTTP/1.1 trailer section. With the
+`http2` feature enabled, the same configured request trailers are sent as
+HTTP/2 trailing HEADERS by both `emit_http2_prior_knowledge` and the explicit
+`emit_http2_upgrade` h2c path after request DATA for buffered POST, PUT, and
+PATCH requests. The bounded h2c client rejects request trailers for
+`http2_extended_connect`, and the bodyless GET, HEAD, DELETE, OPTIONS, and
+TRACE paths cannot carry request DATA before trailers.
+
+Response trailers are read through the existing `Response` trailer accessors.
+For HTTP/1.1, RTTP exposes only trailers that arrive in a chunked response
+after the terminating zero-size chunk. For bounded h2c, peer response trailers
+arrive as trailing HEADERS on the active stream and are exposed through the
+same accessors. In both request and response directions, trailer names must be
+ordinary field names: HTTP/2 pseudo-headers and fields reserved for connection
+state, routing, authentication/cookies, transfer framing, or payload framing
+are rejected instead of passed to application code.
+
+HTTP/2 trailer support does not make the generic HTTP/1.1 `upgrade()` or
+`CONNECT` handoff paths parse trailers. The h2c Upgrade client path is opt-in
+through `emit_http2_upgrade` and replaces the initial HTTP/1.1 exchange with
+the bounded HTTP/2 stream model after `101 Switching Protocols`; non-h2c
+Upgrade handoffs remain caller-owned bytes.
+
 ### Tested client protocol coverage
 
 | area | tested coverage | limits |

--- a/rttp/README.md
+++ b/rttp/README.md
@@ -46,6 +46,30 @@ zero-size chunk, and can be inspected before serialization with
 `HttpResponse::trailers` or `HttpResponse::trailer_value`. Add a `Trailer`
 response header when advertising which trailer fields will follow.
 
+## Bounded trailer behavior
+
+HTTP/1.1 server trailer support remains chunked-scope only. Chunked request
+trailers are preserved on `Request` and can be read with `Request::trailers`
+or `Request::trailer`; fixed-length request bodies do not carry a trailer
+section. HTTP/1.1 response trailers are serialized only for chunked
+`HttpResponse` bodies when the response status permits a body.
+
+On the same listener, prior-knowledge h2c and valid `Upgrade: h2c` requests
+use HTTP/2 trailing HEADERS instead of HTTP/1.1 chunk trailers. Inbound
+application trailers such as `X-Trace`, `X-Upload-Status`, and
+`X-Upload-Checksum` are exposed on `Request` after bounded header-list and
+HPACK decoding. Outbound h2c response trailers come from
+`HttpResponse::trailer` and are emitted as trailing HEADERS after response
+DATA, split to the active peer frame-size limit. HTTP/2 pseudo-headers in
+trailers are rejected before handler dispatch, and trailer names reserved for
+connection state, routing, authentication/cookies, transfer framing, or
+payload processing are rejected.
+
+The h2c Upgrade path is only the bounded HTTP/2 path selected by a valid
+`Upgrade: h2c` request. Ordinary HTTP/1.1 `CONNECT` authority-form requests and
+non-h2c `HttpResponse::upgrade` handoffs remain separate caller-owned protocol
+paths; they are not trailer-parsed as HTTP/2 streams.
+
 The server currently parses blocking HTTP/1.x requests for local tests and
 simple embedded use. It supports fixed `Content-Length` and chunked request
 bodies, preserves chunked request trailers on `Request`, bounds request

--- a/rttp_client/README.md
+++ b/rttp_client/README.md
@@ -27,6 +27,34 @@ HTTP/1.x chunked responses are decoded, and response trailers are exposed
 through `Response::trailers`, `Response::trailer`, and
 `Response::trailer_value` for both blocking and async request APIs.
 
+## Bounded trailer behavior
+
+Trailer support is explicit and bounded by protocol path. Use
+`HttpClient::trailer` to configure request trailer fields. Those fields are
+sent for HTTP/1.1 only by `emit_streaming_chunked`; fixed-length HTTP/1.1
+requests and buffered `emit` requests do not have an HTTP/1.1 trailer section.
+With the `http2` feature enabled, the same configured request trailers are sent
+as HTTP/2 trailing HEADERS by both `emit_http2_prior_knowledge` and the
+explicit `emit_http2_upgrade` h2c path after request DATA for buffered POST,
+PUT, and PATCH requests. The bounded h2c client rejects request trailers for
+`http2_extended_connect`, and the bodyless GET, HEAD, DELETE, OPTIONS, and
+TRACE paths cannot carry request DATA before trailers.
+
+Response trailers are read through the existing `Response` trailer accessors.
+For HTTP/1.1, `rttp_client` exposes only trailers that arrive in a chunked
+response after the terminating zero-size chunk. For bounded h2c, peer response
+trailers arrive as trailing HEADERS on the active stream and are exposed
+through the same accessors. In both request and response directions, trailer
+names must be ordinary field names: HTTP/2 pseudo-headers and fields reserved
+for connection state, routing, authentication/cookies, transfer framing, or
+payload framing are rejected instead of passed to application code.
+
+HTTP/2 trailer support does not make the generic HTTP/1.1 `upgrade()` or
+`connect()` handoff paths parse trailers. The h2c Upgrade client path is opt-in
+through `emit_http2_upgrade` and replaces the initial HTTP/1.1 exchange with
+the bounded HTTP/2 stream model after `101 Switching Protocols`; non-h2c
+Upgrade handoffs remain caller-owned bytes.
+
 ## Tested protocol coverage
 
 | area | tested coverage | limits |


### PR DESCRIPTION
Documented bounded HTTP/2 trailer semantics across root, client, and server READMEs, including opt-in APIs, request/response trailer handling, h2c Upgrade and prior-knowledge behavior, invalid trailer rejection, and HTTP/1.1 chunked-only trailer scope. Focused HTTP/2 verification passed.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1551/
work_kind: code_work
branch: hbx-1551-rttp-document-bounded-http-2
base: main
commit: 82eb87dde03a565c2fab75b64d5d28b92b42daf2
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1551/
    url: https://plane.kahub.in/endless/browse/HBX-1551/
    close_policy: link_only
```