### PR TITLE
feat: [rttp] Document bounded HTTP/2 CONTINUATION behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,39 @@ through `emit_http2_upgrade` and replaces the initial HTTP/1.1 exchange with
 the bounded HTTP/2 stream model after `101 Switching Protocols`; non-h2c
 Upgrade handoffs remain caller-owned bytes.
 
+### Bounded HTTP/2 CONTINUATION behavior
+
+With the `http2` feature enabled, RTTP supports large HTTP/2 header blocks by
+splitting outbound HEADERS or trailing HEADERS into an initial HEADERS frame
+followed by CONTINUATION frames when the encoded HPACK block is larger than the
+active peer `SETTINGS_MAX_FRAME_SIZE`. The same bounded decoder reassembles
+inbound HEADERS plus CONTINUATION fragments before normal HPACK decoding and
+header-list validation. This applies to request headers, response headers, and
+trailing HEADERS on the bounded h2c paths.
+
+Frame-size settings remain frame limits, not metadata-size limits. A legal
+peer `SETTINGS_MAX_FRAME_SIZE` value from 16,384 through 16,777,215 bytes
+controls how RTTP fragments outbound header blocks, DATA, and trailing
+HEADERS. Inbound frames larger than the active local frame-size limit are
+rejected even if their decoded metadata would otherwise be acceptable. Decoded
+metadata is still bounded separately by `SETTINGS_MAX_HEADER_LIST_SIZE` and by
+the HPACK dynamic table limits documented for the client and server paths.
+
+CONTINUATION ordering is strict. Once a HEADERS frame starts a header block
+without `END_HEADERS`, only CONTINUATION frames for that same stream may appear
+until `END_HEADERS` closes the block. RTTP rejects orphan CONTINUATION frames,
+CONTINUATION on stream 0, CONTINUATION on the wrong stream, interleaved DATA or
+control frames before `END_HEADERS`, and EOF before a pending header block is
+closed. Rejected header-block ordering failures happen before handler dispatch
+or before a client response is returned.
+
+The behavior is the same h2c stream model after both entry points:
+`emit_http2_prior_knowledge` and explicit `emit_http2_upgrade` on the client,
+and HTTP/2 prior-knowledge preface detection or valid `Upgrade: h2c` on the
+server. Generic HTTP/1.1 `Upgrade`, `CONNECT`, proxy, TLS ALPN, server push,
+extension callback, persistent session, and unbounded multiplexing paths do not
+gain additional HTTP/2 header-block handling.
+
 ### Tested client protocol coverage
 
 | area | tested coverage | limits |

--- a/rttp/README.md
+++ b/rttp/README.md
@@ -70,6 +70,39 @@ The h2c Upgrade path is only the bounded HTTP/2 path selected by a valid
 non-h2c `HttpResponse::upgrade` handoffs remain separate caller-owned protocol
 paths; they are not trailer-parsed as HTTP/2 streams.
 
+## Bounded HTTP/2 CONTINUATION behavior
+
+The server supports large HTTP/2 header blocks on its bounded h2c paths.
+Inbound request HEADERS and trailing HEADERS may arrive as an initial HEADERS
+frame followed by CONTINUATION frames, and RTTP reassembles the complete HPACK
+block before decoding, header-list-size enforcement, trailer validation, and
+handler dispatch. Outbound response HEADERS and trailing HEADERS are split into
+HEADERS plus CONTINUATION frames when their encoded HPACK block exceeds the
+active peer `SETTINGS_MAX_FRAME_SIZE`.
+
+`SETTINGS_MAX_FRAME_SIZE` controls per-frame payload boundaries, not the total
+decoded metadata allowance. The server advertises the default 16,384-byte
+frame size, accepts only legal peer frame-size settings from 16,384 through
+16,777,215 bytes, rejects inbound frames above the active local limit, and uses
+the active peer limit to fragment response HEADERS, DATA, and trailing HEADERS.
+Decoded request metadata remains bounded by the advertised
+`SETTINGS_MAX_HEADER_LIST_SIZE`; HPACK dynamic table size controls compression
+state only.
+
+CONTINUATION ordering is enforced before application code sees a request. Once
+a request HEADERS frame starts a block without `END_HEADERS`, only
+CONTINUATION frames on that same stream may arrive until `END_HEADERS` closes
+the block. CONTINUATION on stream 0, orphan CONTINUATION frames,
+wrong-stream CONTINUATION frames, interleaved DATA or control frames before
+`END_HEADERS`, and EOF before the block is closed are rejected without handler
+dispatch.
+
+This behavior is shared by HTTP/2 prior-knowledge preface detection and the
+valid `Upgrade: h2c` server path after `101 Switching Protocols`. It does not
+apply to ordinary HTTP/1.1 `CONNECT`, non-h2c `HttpResponse::upgrade`
+handoffs, TLS ALPN, proxy h2, h2c tunnel handoff, server push, extension
+callbacks, persistent sessions, or unbounded multiplexing.
+
 The server currently parses blocking HTTP/1.x requests for local tests and
 simple embedded use. It supports fixed `Content-Length` and chunked request
 bodies, preserves chunked request trailers on `Request`, bounds request

--- a/rttp/src/lib.rs
+++ b/rttp/src/lib.rs
@@ -2,8 +2,9 @@
 //! small blocking HTTP server for local tests and simple embedded use.
 //!
 //! The server accepts HTTP/1.x on a `socket2` listener and also detects the
-//! HTTP/2 client preface for a bounded prior-knowledge h2c path. That h2c
-//! server path advertises the default 16,384-byte
+//! HTTP/2 client preface for bounded prior-knowledge h2c or a valid
+//! `Upgrade: h2c` request for the same bounded h2c handler. That h2c server
+//! path advertises the default 16,384-byte
 //! `SETTINGS_MAX_FRAME_SIZE`, accepts only legal peer
 //! `SETTINGS_MAX_FRAME_SIZE` values from 16,384 through 16,777,215 bytes,
 //! rejects inbound frame payloads above the active local limit, and splits
@@ -15,6 +16,13 @@
 //! dynamic table size updates may shrink that table, including to zero, but
 //! updates above 4,096 bytes are rejected. Those table-size boundaries affect
 //! HPACK compression state only, not trailer validation or request dispatch.
+//! Large request HEADERS and trailing HEADERS may arrive as HEADERS plus
+//! CONTINUATION fragments; the server reassembles the HPACK block before
+//! decoding and header-list validation. Outbound response HEADERS and trailing
+//! HEADERS are fragmented to the active peer frame-size limit. CONTINUATION
+//! ordering is strict: orphan CONTINUATION frames, stream-0 CONTINUATION,
+//! wrong-stream fragments, interleaved frames before `END_HEADERS`, and EOF
+//! before `END_HEADERS` are rejected before handler dispatch.
 //! Peer `SETTINGS_ENABLE_PUSH` values are validated as only `0` or `1`; any
 //! other value rejects the bounded h2c handshake. `PUSH_PROMISE` frames are
 //! rejected before handler dispatch, and this path does not implement
@@ -33,7 +41,12 @@
 //! received `SETTINGS_ENABLE_PUSH` values as only `0` or `1`, validates the
 //! same legal `SETTINGS_MAX_FRAME_SIZE` range, splits outbound request HEADERS,
 //! DATA, and trailing HEADERS to the peer frame-size limit, and rejects inbound
-//! oversized frames when a local `http2_max_frame_size` is configured. The peer's
+//! oversized frames when a local `http2_max_frame_size` is configured.
+//! Response HEADERS and trailing HEADERS may span CONTINUATION frames, which
+//! are reassembled before HPACK decoding and metadata validation. The client
+//! rejects orphan, wrong-stream, interrupted, or incomplete CONTINUATION
+//! sequences before returning a response.
+//! The peer's
 //! `SETTINGS_HEADER_TABLE_SIZE` bounds request dynamic indexing, including
 //! disabling request dynamic indexing at zero. Response decoding uses the
 //! locally advertised HPACK dynamic table limit, defaulting to 4,096 bytes

--- a/rttp_client/README.md
+++ b/rttp_client/README.md
@@ -55,6 +55,38 @@ through `emit_http2_upgrade` and replaces the initial HTTP/1.1 exchange with
 the bounded HTTP/2 stream model after `101 Switching Protocols`; non-h2c
 Upgrade handoffs remain caller-owned bytes.
 
+## Bounded HTTP/2 CONTINUATION behavior
+
+With the `http2` feature enabled, `rttp_client` supports large HTTP/2 header
+blocks by fragmenting outbound request HEADERS and trailing HEADERS into an
+initial HEADERS frame plus CONTINUATION frames whenever the encoded HPACK block
+exceeds the active peer `SETTINGS_MAX_FRAME_SIZE`. It reassembles inbound
+response HEADERS or trailing HEADERS that arrive as HEADERS plus CONTINUATION
+fragments before HPACK decoding, header-list-size enforcement, and trailer
+validation.
+
+The active frame-size limit controls only frame payload size. Legal peer
+`SETTINGS_MAX_FRAME_SIZE` values from 16,384 through 16,777,215 bytes become
+the outbound fragmentation boundary for request HEADERS, DATA, and trailing
+HEADERS. A configured local `http2_max_frame_size` advertises the client's
+inbound limit and causes larger inbound frame payloads to be rejected.
+`SETTINGS_MAX_HEADER_LIST_SIZE` and `SETTINGS_HEADER_TABLE_SIZE` remain the
+separate decoded-metadata and HPACK compression-state limits.
+
+CONTINUATION sequencing is enforced before a response is returned. After a
+response HEADERS frame starts a header block without `END_HEADERS`, the client
+requires the following frames for that pending block to be CONTINUATION frames
+on the same stream until `END_HEADERS`. Orphan CONTINUATION frames,
+wrong-stream CONTINUATION frames, interleaved non-CONTINUATION frames, and EOF
+before `END_HEADERS` are rejected deterministically.
+
+The same behavior applies to both bounded h2c client entry points:
+`emit_http2_prior_knowledge` and explicit `emit_http2_upgrade` after a valid
+`101 Switching Protocols` h2c negotiation. Generic HTTP/1.1 `upgrade()` and
+`connect()` handoffs, proxies, TLS ALPN, persistent sessions, server push,
+extension callbacks, and general multiplexing stay outside this bounded
+header-block model.
+
 ## Tested protocol coverage
 
 | area | tested coverage | limits |

--- a/rttp_client/src/lib.rs
+++ b/rttp_client/src/lib.rs
@@ -19,6 +19,13 @@
 //! that active local limit. Peer-advertised values outside the same range
 //! reject the handshake, while legal peer values are used to split outbound
 //! request HEADERS, DATA, and trailing HEADERS.
+//! Large outbound request HEADERS and trailing HEADERS are fragmented as
+//! HEADERS plus CONTINUATION frames when the encoded HPACK block exceeds the
+//! active peer frame-size limit. Inbound response HEADERS and trailing HEADERS
+//! may span CONTINUATION frames, which are reassembled before HPACK decoding
+//! and metadata validation. The client rejects orphan CONTINUATION frames,
+//! wrong-stream fragments, interleaved frames before `END_HEADERS`, and EOF
+//! before a pending header block closes.
 //! The client advertises `SETTINGS_ENABLE_PUSH = 0` so peers see server push
 //! disabled, validates received `SETTINGS_ENABLE_PUSH` values as only `0` or
 //! `1`, and rejects any incoming `PUSH_PROMISE` frame instead of creating or


### PR DESCRIPTION
Documented RTTP bounded HTTP/2 CONTINUATION behavior for client and server h2c paths, including fragmentation, frame-size boundaries, invalid ordering rejection, entry points, and operational limits.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1556/
work_kind: code_work
branch: hbx-1556-rttp-document-bounded-http-2
base: main
commit: 83af68e4956c92f8d7b2bd0f4740f1e99eac4da3
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1556/
    url: https://plane.kahub.in/endless/browse/HBX-1556/
    close_policy: link_only
```