### PR TITLE
feat: [rttp_client] Add bounded HTTP/1.1 Range request and partial-response helpers

### DIFF
--- a/rttp_client/src/client.rs
+++ b/rttp_client/src/client.rs
@@ -193,6 +193,31 @@ impl HttpClient {
     self.header(("Cookie", cookie.as_ref()))
   }
 
+  /// Set a single bounded byte range request header, `Range: bytes=start-end`.
+  pub fn range(&mut self, start: u64, end: u64) -> error::Result<&mut Self> {
+    if start > end {
+      return Err(error::builder_with_message(
+        "byte range start cannot be greater than end",
+      ));
+    }
+    Ok(self.header(("Range", format!("bytes={}-{}", start, end).as_str())))
+  }
+
+  /// Set a single open-ended byte range request header, `Range: bytes=start-`.
+  pub fn range_from(&mut self, start: u64) -> &mut Self {
+    self.header(("Range", format!("bytes={}-", start).as_str()))
+  }
+
+  /// Set a single suffix byte range request header, `Range: bytes=-suffix`.
+  pub fn range_suffix(&mut self, suffix: u64) -> error::Result<&mut Self> {
+    if suffix == 0 {
+      return Err(error::builder_with_message(
+        "byte range suffix length must be greater than zero",
+      ));
+    }
+    Ok(self.header(("Range", format!("bytes=-{}", suffix).as_str())))
+  }
+
   /// Set request content type
   pub fn content_type<S: AsRef<str>>(&mut self, content_type: S) -> &mut Self {
     self.header(("Content-Type", content_type.as_ref()))

--- a/rttp_client/src/response/response.rs
+++ b/rttp_client/src/response/response.rs
@@ -34,6 +34,14 @@ impl Response {
     self.code() == 200
   }
 
+  pub fn is_partial_content(&self) -> bool {
+    self.code() == 206
+  }
+
+  pub fn is_range_not_satisfiable(&self) -> bool {
+    self.code() == 416
+  }
+
   pub fn is_redirect(&self) -> bool {
     matches!(self.code(), 301 | 302 | 303 | 307 | 308)
   }
@@ -68,6 +76,12 @@ impl Response {
 
   pub fn location(&self) -> Option<&String> {
     self.header_value("location")
+  }
+
+  pub fn content_range(&self) -> Option<ContentRange> {
+    self
+      .header_value("content-range")
+      .and_then(|value| ContentRange::parse(value))
   }
 
   pub fn headers(&self) -> &Vec<Header> {
@@ -158,6 +172,76 @@ impl fmt::Display for Response {
   fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
     fmt::Display::fmt(&self.raw, formatter)
   }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ContentRange {
+  unit: String,
+  start: Option<u64>,
+  end: Option<u64>,
+  complete_length: Option<u64>,
+}
+
+impl ContentRange {
+  pub fn parse(value: impl AsRef<str>) -> Option<Self> {
+    let value = value.as_ref().trim();
+    let (unit, range_and_length) = value.split_once(' ')?;
+    if unit.is_empty() {
+      return None;
+    }
+
+    let (range, complete_length) = range_and_length.split_once('/')?;
+    let complete_length = parse_complete_length(complete_length)?;
+    if range == "*" {
+      return Some(Self {
+        unit: unit.to_string(),
+        start: None,
+        end: None,
+        complete_length,
+      });
+    }
+
+    let (start, end) = range.split_once('-')?;
+    let start = start.parse::<u64>().ok()?;
+    let end = end.parse::<u64>().ok()?;
+    if start > end {
+      return None;
+    }
+
+    Some(Self {
+      unit: unit.to_string(),
+      start: Some(start),
+      end: Some(end),
+      complete_length,
+    })
+  }
+
+  pub fn unit(&self) -> &str {
+    &self.unit
+  }
+
+  pub fn start(&self) -> Option<u64> {
+    self.start
+  }
+
+  pub fn end(&self) -> Option<u64> {
+    self.end
+  }
+
+  pub fn complete_length(&self) -> Option<u64> {
+    self.complete_length
+  }
+
+  pub fn is_unsatisfied(&self) -> bool {
+    self.start.is_none() && self.end.is_none()
+  }
+}
+
+fn parse_complete_length(value: &str) -> Option<Option<u64>> {
+  if value == "*" {
+    return Some(None);
+  }
+  value.parse::<u64>().ok().map(Some)
 }
 
 #[derive(Clone)]

--- a/rttp_client/src/response/response.rs
+++ b/rttp_client/src/response/response.rs
@@ -81,7 +81,7 @@ impl Response {
   pub fn content_range(&self) -> Option<ContentRange> {
     self
       .header_value("content-range")
-      .and_then(|value| ContentRange::parse(value))
+      .and_then(ContentRange::parse)
   }
 
   pub fn headers(&self) -> &Vec<Header> {

--- a/rttp_client/tests/test_raw_request_capture.rs
+++ b/rttp_client/tests/test_raw_request_capture.rs
@@ -179,6 +179,94 @@ fn get_with_query_parameters_sends_request_target_without_body() {
 }
 
 #[test]
+fn range_helpers_emit_single_byte_range_headers() {
+  let bounded = capture_request(|base_url| {
+    client()
+      .get()
+      .url(format!("{}/asset", base_url))
+      .range(10, 19)
+      .expect("bounded range should be accepted")
+      .emit()
+      .expect("request should succeed");
+  });
+  let bounded = request_text(&bounded);
+  assert_eq!(Some("bytes=10-19"), header_value(&bounded, "Range"));
+
+  let open_ended = capture_request(|base_url| {
+    client()
+      .get()
+      .url(format!("{}/asset", base_url))
+      .range_from(20)
+      .emit()
+      .expect("request should succeed");
+  });
+  let open_ended = request_text(&open_ended);
+  assert_eq!(Some("bytes=20-"), header_value(&open_ended, "Range"));
+
+  let suffix = capture_request(|base_url| {
+    client()
+      .get()
+      .url(format!("{}/asset", base_url))
+      .range_suffix(128)
+      .expect("suffix range should be accepted")
+      .emit()
+      .expect("request should succeed");
+  });
+  let suffix = request_text(&suffix);
+  assert_eq!(Some("bytes=-128"), header_value(&suffix, "Range"));
+}
+
+#[test]
+fn range_helper_rejects_malformed_inputs_before_connecting() {
+  let request = capture_optional_request(|base_url| {
+    let mut client = client();
+    let error = client
+      .get()
+      .url(format!("{}/asset", base_url))
+      .range(20, 10)
+      .expect_err("inverted range should be rejected");
+
+    assert!(error.is_builder());
+  });
+
+  assert!(
+    request.is_empty(),
+    "malformed range helper should not open a socket"
+  );
+
+  let request = capture_optional_request(|base_url| {
+    let mut client = client();
+    let error = client
+      .get()
+      .url(format!("{}/asset", base_url))
+      .range_suffix(0)
+      .expect_err("empty suffix range should be rejected");
+
+    assert!(error.is_builder());
+  });
+
+  assert!(
+    request.is_empty(),
+    "malformed suffix helper should not open a socket"
+  );
+}
+
+#[test]
+fn manual_range_header_remains_available_as_escape_hatch() {
+  let request = capture_request(|base_url| {
+    client()
+      .get()
+      .url(format!("{}/asset", base_url))
+      .header(("Range", "bytes=5-9"))
+      .emit()
+      .expect("request should succeed");
+  });
+  let request = request_text(&request);
+
+  assert_eq!(Some("bytes=5-9"), header_value(&request, "Range"));
+}
+
+#[test]
 fn streaming_fixed_framing_does_not_leak_into_later_emit() {
   let (addr, handle) = spawn_streaming_then_capture_server();
   let mut client = client();

--- a/rttp_client/tests/test_response.rs
+++ b/rttp_client/tests/test_response.rs
@@ -107,6 +107,67 @@ fn test_parse_response_preserves_duplicate_headers_with_case_insensitive_lookup(
 }
 
 #[test]
+fn test_parse_partial_content_range_metadata() {
+  let s = concat!(
+    "HTTP/1.1 206 Partial Content\r\n",
+    "Content-Range: bytes 10-19/200\r\n",
+    "Content-Length: 10\r\n",
+    "\r\n",
+    "0123456789"
+  );
+  let response = Response::new(
+    RoUrl::with("https://example.test/asset"),
+    s.as_bytes().to_vec(),
+  )
+  .expect("parse partial content response");
+  let content_range = response
+    .content_range()
+    .expect("partial content response should expose content range");
+
+  assert!(response.is_partial_content());
+  assert!(!response.is_range_not_satisfiable());
+  assert_eq!("bytes", content_range.unit());
+  assert_eq!(Some(10), content_range.start());
+  assert_eq!(Some(19), content_range.end());
+  assert_eq!(Some(200), content_range.complete_length());
+  assert!(!content_range.is_unsatisfied());
+  assert_eq!("0123456789", response.body().string().unwrap());
+}
+
+#[test]
+fn test_parse_range_not_satisfiable_metadata_preserves_body_and_headers() {
+  let s = concat!(
+    "HTTP/1.1 416 Range Not Satisfiable\r\n",
+    "Content-Range: bytes */200\r\n",
+    "Content-Type: text/plain\r\n",
+    "Content-Length: 17\r\n",
+    "\r\n",
+    "range unavailable"
+  );
+  let response = Response::new(
+    RoUrl::with("https://example.test/asset"),
+    s.as_bytes().to_vec(),
+  )
+  .expect("parse range not satisfiable response");
+  let content_range = response
+    .content_range()
+    .expect("416 response should expose unsatisfied content range");
+
+  assert!(!response.is_partial_content());
+  assert!(response.is_range_not_satisfiable());
+  assert_eq!("bytes", content_range.unit());
+  assert_eq!(None, content_range.start());
+  assert_eq!(None, content_range.end());
+  assert_eq!(Some(200), content_range.complete_length());
+  assert!(content_range.is_unsatisfied());
+  assert_eq!(
+    Some(&"text/plain".to_string()),
+    response.header_value("Content-Type")
+  );
+  assert_eq!("range unavailable", response.body().string().unwrap());
+}
+
+#[test]
 fn test_parse_response_rejects_header_without_colon() {
   let s = concat!(
     "HTTP/1.1 200 OK\r\n",


### PR DESCRIPTION
Adds client-side single byte-range request helpers and response-side Content-Range inspection for partial and unsatisfied range responses, with tests covering header emission, invalid helper rejection before connection, manual Range headers, and 206/416 metadata preservation.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1558/
work_kind: code_work
branch: hbx-1558-rttp-client-add-bounded-http
base: main
commit: 9d064bc2ceca0aee645cecd09759c4e6ae9eebab
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1558/
    url: https://plane.kahub.in/endless/browse/HBX-1558/
    close_policy: link_only
```