### PR TITLE
feat: [rttp] Document bounded HTTP/1.1 Range and Partial Content behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,23 @@ HTTP/1.x chunked responses are decoded by the client, and response trailers are
 available through `Response::trailers`, `Response::trailer`, and
 `Response::trailer_value`.
 
+### Bounded HTTP/1.1 byte ranges
+
+`HttpClient` can emit single `bytes` ranges with bounded helpers:
+`range(start, end)` writes `Range: bytes=start-end`, `range_from(start)` writes
+`Range: bytes=start-`, and `range_suffix(length)` writes
+`Range: bytes=-length`. The helpers reject inverted closed ranges and a zero
+suffix before opening a socket. Callers can still set a manual `Range` header
+with the generic header API for cases outside those helpers.
+
+`206 Partial Content` and `416 Range Not Satisfiable` are visible through
+`Response::is_partial_content()` and `Response::is_range_not_satisfiable()`.
+`Response::content_range()` parses `Content-Range` into `ContentRange`, using
+`start` and `end` for satisfiable ranges such as `bytes 10-19/200`, and no
+`start` or `end` for unsatisfied ranges such as `bytes */200`. RTTP does not
+evaluate `If-Range`, retry range requests, or apply client cache validation
+policy.
+
 ### Bounded trailer behavior
 
 Trailer support is explicit and bounded by protocol path. On the client,
@@ -96,6 +113,7 @@ gain additional HTTP/2 header-block handling.
 | HTTP/1.1 request emission | Origin-form requests, absolute-form proxy requests, `CONNECT`, `HEAD`, fixed bodies, streaming chunked uploads, and `Expect: 100-continue` | SOCKS handshakes are delegated to the `socks` crate |
 | Upgrade and tunnel handoff | `CONNECT` returns the tunnel socket after a successful `200`; `upgrade()` returns the socket after `101 Switching Protocols` and skips interim `1xx` responses | Upgraded protocols are handed to the caller and are not parsed by `rttp_client` |
 | Redirects | Auto-redirect covers 301, 302, 303, 307, and 308 method/body behavior, relative and absolute `Location` resolution, same- and cross-authority header handling, loop detection, and redirect bounds | Redirects are HTTP client behavior, not a browser policy implementation |
+| Byte ranges | `range`, `range_from`, and `range_suffix` emit single HTTP/1.1 `bytes` ranges; `Response::content_range`, `is_partial_content`, and `is_range_not_satisfiable` expose `206` and `416` metadata | No automatic `If-Range`, multipart range generation, retry, or cache validation policy |
 | Trailers | Chunked response trailers are exposed for blocking and async APIs; streaming chunked uploads can send declared request trailers | Application metadata trailers such as `X-Trace` are allowed; pseudo-header, connection-specific, routing, authentication/cookie, and framing trailer fields are rejected |
 | Bounded h2c client | With `http2`, direct `socket2` h2c sends GET, HEAD, bodyless DELETE, OPTIONS, or TRACE, buffered POST, PUT, or PATCH requests, and opt-in RFC 8441 extended CONNECT request HEADERS via `http2_extended_connect`, opens at most one request stream, supports prior-knowledge with `emit_http2_prior_knowledge`, supports explicit HTTP/1.1 `Upgrade: h2c` negotiation with `emit_http2_upgrade`, advertises `SETTINGS_ENABLE_PUSH = 0`, advertises `SETTINGS_ENABLE_CONNECT_PROTOCOL = 1` only for the explicit extended CONNECT path, validates received `SETTINGS_ENABLE_PUSH` values as only `0` or `1`, honors initial peer `SETTINGS_MAX_CONCURRENT_STREAMS` by failing before request HEADERS when the peer allows zero streams, honors peer-advertised `SETTINGS_MAX_HEADER_LIST_SIZE` request metadata limits, accepts only legal `SETTINGS_MAX_FRAME_SIZE` values from 16,384 through 16,777,215 bytes, splits outbound HEADERS, DATA, and trailers to the active peer frame-size limit, rejects oversized inbound frames when a configured local frame-size limit is exceeded, bounds HPACK dynamic table use with `SETTINGS_HEADER_TABLE_SIZE`, strips HTTP/1.x connection-specific request fields before emission, rejects connection-specific peer response fields, suppresses HEAD response bodies, treats `RST_STREAM` on the active stream as a bounded reset/cancellation signal, acknowledges valid PING frames with matching opaque data, DATA bodies, trailers, HPACK static Huffman strings, bounded large header blocks, padded incoming frames, `GOAWAY` shutdown boundaries, PRIORITY metadata validation without scheduling, HTTP/2-allowed unknown/extension frame ignoring inside this bounded path, reserved stream-id high-bit normalization, and conservative DATA flow control | Ordinary `CONNECT`, header-configured `:protocol` metadata, non-h2c HTTP/1.1 `Upgrade` handoff requests, and proxies are rejected deterministically, and `PUSH_PROMISE`/server push is rejected instead of managed; bounded direct h2c only, with no public cancellation callback API, no dynamic policy API, no extension callback API, no full extension negotiation, TLS ALPN, external h2 integration, proxy tunneling to h2, proxy h2, tunnel handoff, connection pooling, persistent HTTP/2 session management, automatic retry, server push, full stream state machine, unbounded multiplex scheduling, general multiplexing, priority scheduling, request bodies or trailers for extended CONNECT, or request bodies for GET, HEAD, DELETE, OPTIONS, or TRACE |
 
@@ -279,6 +297,34 @@ of an automatic `Content-Length`; response trailers added with
 `Trailer` response header when advertising which trailer fields will follow.
 The listener path uses `socket2`.
 
+### Bounded HTTP/1.1 byte ranges
+
+The server provides range parsing and response constructors for applications
+that choose to support partial content. It does not automatically serve files
+or decide static-file policy. Application code should inspect `Range`, choose
+the representation and entity length, and pass the header to
+`HttpByteRange::parse(range_header, entity_length)`.
+
+Supported request forms are a single `bytes=start-end`, `bytes=start-`, or
+`bytes=-suffix` range. Open-ended ranges are clipped to the representation
+length, suffix ranges require a nonzero suffix, unsupported units return
+`UnsupportedUnit`, comma-separated ranges return `MultipleRanges`, malformed
+or inverted ranges return `InvalidRange`, and ranges beyond the entity return
+`UnsatisfiedRange`.
+
+For a satisfiable range, `HttpResponse::partial_content(body, range)` returns
+`206 Partial Content`, adds `Content-Range: bytes start-end/length`, and sends
+only the selected body bytes. For an unsatisfied range,
+`HttpResponse::range_not_satisfiable(entity_length)` returns
+`416 Range Not Satisfiable` with `Content-Range: bytes */length` and an empty
+body.
+
+Multipart ranges are intentionally not generated: RTTP does not serialize
+`multipart/byteranges` or pick a multipart response for multiple requested
+ranges. `If-Range`, filesystem path normalization, MIME detection, ETag,
+Last-Modified, cache behavior, authorization, directory indexes, and dotfile
+visibility remain caller-owned policy before choosing `200`, `206`, or `416`.
+
 The server is intentionally small: it handles blocking HTTP/1.x request parsing
 for local tests and simple embedded use. It accepts fixed `Content-Length` and
 chunked request bodies, exposes chunked request trailers, applies bounded
@@ -411,6 +457,7 @@ TLS or async accept loops.
 | HTTP/1.1 request parsing | Required `Host` validation, origin-form, absolute-form, asterisk-form `OPTIONS`, authority-form `CONNECT`, fixed and chunked bodies, chunk extensions, `Expect: 100-continue`, and obsolete line folding rejection | Intended for local tests and simple embedded use, not full RFC coverage |
 | HTTP/1.1 connection handling | Bounded sequential `serve_requests`, keep-alive and close behavior for HTTP/1.1 and HTTP/1.0, pipelined request boundaries, malformed request rejection before handler dispatch | Blocking listener only; no async accept loop |
 | HTTP/1.1 response framing | Automatic `Content-Length`, explicit chunked responses, bodyless `HEAD`, `101`, `204`, and `304`, response trailers after the terminating chunk | No server TLS |
+| Byte ranges | `HttpByteRange` parses one `bytes` range and `HttpResponse::partial_content`/`range_not_satisfiable` serialize `206`/`416` with `Content-Range` | No multipart range serialization, `If-Range` evaluation, filesystem serving, or static-file policy |
 | Upgrade and tunnel targets | `CONNECT` authority-form requests are accepted as HTTP requests; `HttpResponse::upgrade` can hand an upgraded socket to caller code after a matching request | The server does not implement the upgraded protocol after handoff |
 | Trailers | Chunked request trailers are preserved on `Request`; malformed, oversized, forbidden, and pseudo-header trailers are rejected; response trailers can be serialized for chunked responses | Application metadata trailers are allowed; trailer names that affect connection state, routing, authentication/cookies, framing, or payload processing are rejected |
 | Bounded h2c server | The same `socket2` listener detects the HTTP/2 prior-knowledge preface or a valid HTTP/1.1 `Upgrade: h2c` request with `HTTP2-Settings`, validates SETTINGS including legal `SETTINGS_ENABLE_PUSH` and `SETTINGS_ENABLE_CONNECT_PROTOCOL` values of only `0` or `1` and legal `SETTINGS_MAX_FRAME_SIZE` values from 16,384 through 16,777,215 bytes, dispatches RFC 8441 extended CONNECT only after `SETTINGS_ENABLE_CONNECT_PROTOCOL = 1` has been negotiated, exposes negotiated extended CONNECT as a normal `Request` with method `CONNECT`, version `HTTP/2`, target from `:path`, `host` from `:authority`, and `Request::extended_connect_protocol()` from `:protocol`, advertises the default 16,384-byte `SETTINGS_MAX_FRAME_SIZE`, rejects inbound frames above the active local limit, splits outbound HEADERS, DATA, and trailers to the active peer frame-size limit, advertises `SETTINGS_MAX_CONCURRENT_STREAMS` from the bounded active stream allowance, enforces that allowance before dispatching new streams, advertises and enforces a conservative `SETTINGS_MAX_HEADER_LIST_SIZE` for inbound request metadata, bounds HPACK dynamic table use with `SETTINGS_HEADER_TABLE_SIZE`, serves bounded streams including bodyless DELETE, OPTIONS, TRACE, and negotiated extended CONNECT, handles HEAD without response DATA, rejects connection-specific request fields before handler dispatch, strips connection-specific response fields during h2c serialization, treats `RST_STREAM` as a bounded reset/cancellation signal for the affected stream, acknowledges valid PING frames with matching opaque data, accepts padded HEADERS/DATA/trailers without exposing padding, handles HPACK Huffman fields and bounded CONTINUATION header blocks, emits `GOAWAY` with the last completed stream id at bounded shutdown, validates and ignores valid PRIORITY metadata, ignores HTTP/2-allowed unknown/extension frames inside this bounded path, normalizes reserved stream-id high bits, and applies conservative DATA flow control | Ordinary `CONNECT`, missing-negotiation `:protocol`, non-CONNECT `:protocol`, malformed h2c Upgrade, request bodies on h2c Upgrade, and `PUSH_PROMISE` are rejected deterministically before handler dispatch; HTTP/1.1 `CONNECT` and non-h2c `Upgrade` remain separate handoff paths; bounded h2c only, with no public cancellation callback API, no dynamic policy API, no extension callback API, no full extension negotiation, TLS ALPN, external h2 integration, full WebSocket-over-h2, proxy h2, tunnel handoff, connection pooling, persistent multiplex sessions, persistent HTTP/2 session management, automatic retry, server push, full RFC 8441 support, full stream state machine, unbounded multiplexing, unbounded multiplex scheduling, general multiplexing, general tunnel scheduling, priority scheduling, or full HTTP/2 server feature set |

--- a/rttp/README.md
+++ b/rttp/README.md
@@ -46,6 +46,35 @@ zero-size chunk, and can be inspected before serialization with
 `HttpResponse::trailers` or `HttpResponse::trailer_value`. Add a `Trailer`
 response header when advertising which trailer fields will follow.
 
+## Bounded HTTP/1.1 byte ranges
+
+The server exposes byte-range primitives, not an automatic static-file server.
+Applications that want range support should read the request `Range` header,
+decide whether it applies to the selected representation, and call
+`HttpByteRange::parse(range_header, entity_length)`.
+
+`HttpByteRange::parse` supports one `bytes` range at a time:
+`bytes=start-end`, `bytes=start-`, and `bytes=-suffix`. Closed ranges must have
+`start <= end`; open-ended ranges are clipped to the entity length; suffix
+ranges must request at least one byte. Unsupported units return
+`UnsupportedUnit`, comma-separated ranges return `MultipleRanges`, malformed
+or inverted ranges return `InvalidRange`, and ranges outside the entity return
+`UnsatisfiedRange`.
+
+Use `HttpResponse::partial_content(body, range)` for a satisfiable range. It
+returns `206 Partial Content`, writes `Content-Range: bytes start-end/length`,
+and sends only the selected body bytes. Use
+`HttpResponse::range_not_satisfiable(entity_length)` for an unsatisfied range;
+it returns `416 Range Not Satisfiable` with
+`Content-Range: bytes */length` and an empty body.
+
+Multipart byte ranges are intentionally not serialized: RTTP does not generate
+`multipart/byteranges` responses or choose a response for multiple requested
+ranges. `If-Range` is not evaluated by the server helper, and there is no
+built-in filesystem serving, path normalization, MIME selection, ETag,
+Last-Modified, cache, authorization, directory-index, or dotfile policy. Those
+remain application decisions before choosing `200`, `206`, or `416`.
+
 ## Bounded trailer behavior
 
 HTTP/1.1 server trailer support remains chunked-scope only. Chunked request
@@ -238,6 +267,7 @@ scheduling, or async accept loops.
 | HTTP/1.1 request parsing | Required `Host` validation, origin-form, absolute-form, asterisk-form `OPTIONS`, authority-form `CONNECT`, fixed and chunked bodies, chunk extensions, `Expect: 100-continue`, and obsolete line folding rejection | Intended for local tests and simple embedded use, not full RFC coverage |
 | HTTP/1.1 connection handling | Bounded sequential `serve_requests`, keep-alive and close behavior for HTTP/1.1 and HTTP/1.0, pipelined request boundaries, malformed request rejection before handler dispatch | Blocking listener only; no async accept loop |
 | HTTP/1.1 response framing | Automatic `Content-Length`, explicit chunked responses, bodyless `HEAD`, `101`, `204`, and `304`, response trailers after the terminating chunk | No server TLS |
+| Byte ranges | `HttpByteRange` parses one `bytes` range and `HttpResponse::partial_content`/`range_not_satisfiable` serialize `206`/`416` with `Content-Range` | No multipart range serialization, `If-Range` evaluation, filesystem serving, or static-file policy |
 | Upgrade and tunnel targets | `CONNECT` authority-form requests are accepted as HTTP requests; `HttpResponse::upgrade` can hand an upgraded socket to caller code after a matching request | The server does not implement the upgraded protocol after handoff |
 | Trailers | Chunked request trailers are preserved on `Request`; malformed, oversized, forbidden, and pseudo-header trailers are rejected; response trailers can be serialized for chunked responses | Application metadata trailers are allowed; trailer names that affect connection state, routing, authentication/cookies, framing, or payload processing are rejected |
 | Bounded h2c server | The same `socket2` listener detects the HTTP/2 prior-knowledge preface or a valid HTTP/1.1 `Upgrade: h2c` request with `HTTP2-Settings`, validates SETTINGS including legal `SETTINGS_ENABLE_PUSH` and `SETTINGS_ENABLE_CONNECT_PROTOCOL` values of only `0` or `1` and legal `SETTINGS_MAX_FRAME_SIZE` values from 16,384 through 16,777,215 bytes, dispatches RFC 8441 extended CONNECT only after `SETTINGS_ENABLE_CONNECT_PROTOCOL = 1` has been negotiated, exposes negotiated extended CONNECT as a normal `Request` with method `CONNECT`, version `HTTP/2`, target from `:path`, `host` from `:authority`, and `Request::extended_connect_protocol()` from `:protocol`, advertises the default 16,384-byte `SETTINGS_MAX_FRAME_SIZE`, rejects inbound frames above the active local limit, splits outbound HEADERS, DATA, and trailers to the active peer frame-size limit, advertises `SETTINGS_MAX_CONCURRENT_STREAMS` from the bounded active stream allowance, enforces that allowance before dispatching new streams, advertises and enforces a conservative `SETTINGS_MAX_HEADER_LIST_SIZE` for inbound request metadata, bounds HPACK dynamic table use with `SETTINGS_HEADER_TABLE_SIZE`, serves bounded streams including bodyless DELETE, OPTIONS, TRACE, and negotiated extended CONNECT, handles HEAD without response DATA, rejects connection-specific request fields before handler dispatch, strips connection-specific response fields during h2c serialization, treats `RST_STREAM` as a bounded reset/cancellation signal for the affected stream, acknowledges valid PING frames with matching opaque data, accepts padded HEADERS/DATA/trailers without exposing padding, handles HPACK Huffman fields and bounded CONTINUATION header blocks, emits `GOAWAY` with the last completed stream id at bounded shutdown, validates and ignores valid PRIORITY metadata, ignores HTTP/2-allowed unknown/extension frames inside this bounded path, normalizes reserved stream-id high bits, and applies conservative DATA flow control | Ordinary `CONNECT`, missing-negotiation `:protocol`, non-CONNECT `:protocol`, malformed h2c Upgrade, request bodies on h2c Upgrade, and `PUSH_PROMISE` are rejected deterministically before handler dispatch; HTTP/1.1 `CONNECT` and non-h2c `Upgrade` remain separate handoff paths; bounded h2c only, with no public cancellation callback API, no dynamic policy API, no extension callback API, no full extension negotiation, TLS ALPN, external h2 integration, full WebSocket-over-h2, proxy h2, tunnel handoff, connection pooling, persistent multiplex sessions, persistent HTTP/2 session management, automatic retry, server push, full RFC 8441 support, full stream state machine, unbounded multiplexing, unbounded multiplex scheduling, general multiplexing, general tunnel scheduling, priority scheduling, or full HTTP/2 server feature set |
@@ -246,7 +276,12 @@ scheduling, or async accept loops.
 
 Enable the `client` feature to access `rttp::Http::client`, or enable `async`,
 `http2`, `tls-native`, `tls-rustls`, or `all` for the corresponding
-`rttp_client` capabilities. The `http2` feature exposes the bounded
+`rttp_client` capabilities. The client feature includes the bounded HTTP/1.1
+Range helpers from `rttp_client`: `range(start, end)`, `range_from(start)`, and
+`range_suffix(length)` set single `bytes` ranges, while `Response` exposes
+`is_partial_content()`, `is_range_not_satisfiable()`, and `content_range()` for
+`206` and `416` responses. Manual `Range` headers remain available through the
+generic header API. The `http2` feature exposes the bounded
 prior-knowledge h2c client path for GET, HEAD, bodyless DELETE, OPTIONS, or
 TRACE, and buffered POST, PUT, or PATCH requests. It opens at most one request
 stream, advertises `SETTINGS_ENABLE_PUSH = 0` so peers see server push

--- a/rttp_client/README.md
+++ b/rttp_client/README.md
@@ -27,6 +27,31 @@ HTTP/1.x chunked responses are decoded, and response trailers are exposed
 through `Response::trailers`, `Response::trailer`, and
 `Response::trailer_value` for both blocking and async request APIs.
 
+## Bounded HTTP/1.1 byte ranges
+
+`HttpClient` includes helpers for the single-range `bytes` forms RTTP keeps
+bounded: `range(start, end)` emits `Range: bytes=start-end`,
+`range_from(start)` emits `Range: bytes=start-`, and `range_suffix(length)`
+emits `Range: bytes=-length`. The helpers reject inverted closed ranges and a
+zero suffix length before a socket is opened. They are request-header helpers;
+manual `Range` headers remain available through `header(("Range", "..."))`
+when callers need behavior outside the helper validation.
+
+Partial-content responses are exposed through the normal `Response` API.
+`Response::is_partial_content()` identifies `206 Partial Content`, and
+`Response::content_range()` parses a `Content-Range` field such as
+`bytes 10-19/200` into a `ContentRange` with `unit`, `start`, `end`, and
+`complete_length` accessors. `Response::is_range_not_satisfiable()` identifies
+`416 Range Not Satisfiable`; an unsatisfied `Content-Range` such as
+`bytes */200` is exposed with no `start` or `end` and
+`ContentRange::is_unsatisfied() == true`. Response bodies and headers are still
+preserved normally for both `206` and `416`.
+
+RTTP does not synthesize multipart range requests, evaluate `If-Range`, retry
+range requests, or apply cache validation policy on the client side. Multiple
+ranges can only be sent by manually setting the header, and any server response
+is then parsed as an ordinary HTTP response.
+
 ## Bounded trailer behavior
 
 Trailer support is explicit and bounded by protocol path. Use
@@ -95,6 +120,7 @@ header-block model.
 | HTTP/1.1 request emission | Origin-form requests, absolute-form proxy requests, `CONNECT`, `HEAD`, fixed bodies, streaming chunked uploads, and `Expect: 100-continue` | SOCKS handshakes are delegated to the `socks` crate |
 | Upgrade and tunnel handoff | `CONNECT` returns the tunnel socket after a successful `200`; `upgrade()` returns the socket after `101 Switching Protocols` and skips interim `1xx` responses | Upgraded protocols are handed to the caller and are not parsed by `rttp_client` |
 | Redirects | Auto-redirect covers 301, 302, 303, 307, and 308 method/body behavior, relative and absolute `Location` resolution, same- and cross-authority header handling, loop detection, and redirect bounds | Redirects are HTTP client behavior, not a browser policy implementation |
+| Byte ranges | `range`, `range_from`, and `range_suffix` emit single HTTP/1.1 `bytes` ranges; `Response::content_range`, `is_partial_content`, and `is_range_not_satisfiable` expose `206` and `416` metadata | No automatic `If-Range`, multipart range generation, retry, or cache validation policy |
 | Trailers | Chunked response trailers are exposed for blocking and async APIs; streaming chunked uploads can send declared request trailers | Application metadata trailers such as `X-Trace` are allowed; pseudo-header, connection-specific, routing, authentication/cookie, and framing trailer fields are rejected |
 | Bounded h2c client | With `http2`, direct `socket2` h2c sends GET, HEAD, bodyless DELETE, OPTIONS, or TRACE, buffered POST, PUT, or PATCH requests, and opt-in RFC 8441 extended CONNECT request HEADERS via `http2_extended_connect`, opens at most one request stream, supports prior-knowledge with `emit_http2_prior_knowledge`, supports explicit HTTP/1.1 `Upgrade: h2c` negotiation with `emit_http2_upgrade`, advertises `SETTINGS_ENABLE_PUSH = 0`, advertises `SETTINGS_ENABLE_CONNECT_PROTOCOL = 1` only for the explicit extended CONNECT path, validates received `SETTINGS_ENABLE_PUSH` values as only `0` or `1`, honors initial peer `SETTINGS_MAX_CONCURRENT_STREAMS` by failing before request HEADERS when the peer allows zero streams, honors peer-advertised `SETTINGS_MAX_HEADER_LIST_SIZE` request metadata limits, accepts only legal `SETTINGS_MAX_FRAME_SIZE` values from 16,384 through 16,777,215 bytes, splits outbound HEADERS, DATA, and trailers to the active peer frame-size limit, rejects oversized inbound frames when a configured local frame-size limit is exceeded, bounds HPACK dynamic table use with `SETTINGS_HEADER_TABLE_SIZE`, strips HTTP/1.x connection-specific request fields before emission, rejects connection-specific peer response fields, suppresses HEAD response bodies, treats `RST_STREAM` on the active stream as a bounded reset/cancellation signal, acknowledges valid PING frames with matching opaque data, DATA bodies, trailers, HPACK static Huffman strings, bounded large header blocks, padded incoming frames, `GOAWAY` shutdown boundaries, PRIORITY metadata validation without scheduling, HTTP/2-allowed unknown/extension frame ignoring inside this bounded path, reserved stream-id high-bit normalization, and conservative DATA flow control | Ordinary `CONNECT`, header-configured `:protocol` metadata, non-h2c HTTP/1.1 `Upgrade` handoff requests, and proxies are rejected deterministically, and `PUSH_PROMISE`/server push is rejected instead of managed; bounded direct h2c only, with no public cancellation callback API, no dynamic policy API, no extension callback API, no full extension negotiation, TLS ALPN, external h2 integration, proxy tunneling to h2, proxy h2, tunnel handoff, connection pooling, persistent HTTP/2 session management, automatic retry, server push, full stream state machine, unbounded multiplex scheduling, general multiplexing, priority scheduling, request bodies or trailers for extended CONNECT, or request bodies for GET, HEAD, DELETE, OPTIONS, or TRACE |
 


### PR DESCRIPTION
Documented bounded HTTP/1.1 Range and Partial Content behavior for RTTP client and server APIs, including supported forms, response metadata exposure, 206/416 behavior, and explicit policy limitations.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1561/
work_kind: code_work
branch: hbx-1561-rttp-document-bounded-http-1
base: main
commit: b2d5f90276ce52ff1f57a961dca0dda0ec3cb9f2
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1561/
    url: https://plane.kahub.in/endless/browse/HBX-1561/
    close_policy: link_only
```