### PR TITLE
feat: [rttp_client] Add bounded HTTP/1.1 conditional request helpers

### DIFF
--- a/rttp_client/src/client.rs
+++ b/rttp_client/src/client.rs
@@ -218,6 +218,36 @@ impl HttpClient {
     Ok(self.header(("Range", format!("bytes=-{}", suffix).as_str())))
   }
 
+  /// Set a single entity-tag validator, `If-None-Match: <etag>`.
+  ///
+  /// Accepts `*`, a strong entity tag such as `"abc"`, or a weak entity tag
+  /// such as `W/"abc"`. Use `header` directly for multiple validators.
+  pub fn if_none_match<S: AsRef<str>>(&mut self, etag: S) -> error::Result<&mut Self> {
+    let etag = validate_single_etag(etag.as_ref())?;
+    Ok(self.header(Header::new("If-None-Match", etag)))
+  }
+
+  /// Set a single entity-tag validator, `If-Match: <etag>`.
+  ///
+  /// Accepts `*`, a strong entity tag such as `"abc"`, or a weak entity tag
+  /// such as `W/"abc"`. Use `header` directly for multiple validators.
+  pub fn if_match<S: AsRef<str>>(&mut self, etag: S) -> error::Result<&mut Self> {
+    let etag = validate_single_etag(etag.as_ref())?;
+    Ok(self.header(Header::new("If-Match", etag)))
+  }
+
+  /// Set an HTTP-date modification validator, `If-Modified-Since: <http-date>`.
+  pub fn if_modified_since<S: AsRef<str>>(&mut self, http_date: S) -> error::Result<&mut Self> {
+    let http_date = validate_http_date(http_date.as_ref())?;
+    Ok(self.header(Header::new("If-Modified-Since", http_date)))
+  }
+
+  /// Set an HTTP-date modification validator, `If-Unmodified-Since: <http-date>`.
+  pub fn if_unmodified_since<S: AsRef<str>>(&mut self, http_date: S) -> error::Result<&mut Self> {
+    let http_date = validate_http_date(http_date.as_ref())?;
+    Ok(self.header(Header::new("If-Unmodified-Since", http_date)))
+  }
+
   /// Set request content type
   pub fn content_type<S: AsRef<str>>(&mut self, content_type: S) -> &mut Self {
     self.header(("Content-Type", content_type.as_ref()))
@@ -471,6 +501,48 @@ fn validate_request_trailer_header(name: &str, value: &str) -> error::Result<()>
     ));
   }
   Ok(())
+}
+
+fn validate_single_etag(etag: &str) -> error::Result<&str> {
+  let etag = etag.trim();
+  if etag == "*" {
+    return Ok(etag);
+  }
+  if etag.contains(',') {
+    return Err(error::builder_with_message(
+      "conditional entity-tag helper accepts one validator; use header() for lists",
+    ));
+  }
+
+  let opaque_tag = etag.strip_prefix("W/").unwrap_or(etag);
+  let Some(inner) = opaque_tag
+    .strip_prefix('"')
+    .and_then(|value| value.strip_suffix('"'))
+  else {
+    return Err(error::builder_with_message(
+      "conditional entity-tag must be *, \"tag\", or W/\"tag\"",
+    ));
+  };
+
+  if inner
+    .as_bytes()
+    .iter()
+    .any(|byte| matches!(*byte, b'"' | b'\r' | b'\n') || *byte < 0x21 || *byte == 0x7f)
+  {
+    return Err(error::builder_with_message(
+      "conditional entity-tag contains invalid characters",
+    ));
+  }
+
+  Ok(etag)
+}
+
+fn validate_http_date(http_date: &str) -> error::Result<&str> {
+  let http_date = http_date.trim();
+  httpdate::parse_http_date(http_date).map_err(|_| {
+    error::builder_with_message("conditional modification time must be a valid HTTP-date")
+  })?;
+  Ok(http_date)
 }
 
 fn is_forbidden_request_trailer_name(name: &str) -> bool {

--- a/rttp_client/src/response/response.rs
+++ b/rttp_client/src/response/response.rs
@@ -42,6 +42,14 @@ impl Response {
     self.code() == 416
   }
 
+  pub fn is_not_modified(&self) -> bool {
+    self.code() == 304
+  }
+
+  pub fn is_precondition_failed(&self) -> bool {
+    self.code() == 412
+  }
+
   pub fn is_redirect(&self) -> bool {
     matches!(self.code(), 301 | 302 | 303 | 307 | 308)
   }
@@ -76,6 +84,14 @@ impl Response {
 
   pub fn location(&self) -> Option<&String> {
     self.header_value("location")
+  }
+
+  pub fn etag(&self) -> Option<&String> {
+    self.header_value("etag")
+  }
+
+  pub fn last_modified(&self) -> Option<&String> {
+    self.header_value("last-modified")
   }
 
   pub fn content_range(&self) -> Option<ContentRange> {

--- a/rttp_client/tests/test_raw_request_capture.rs
+++ b/rttp_client/tests/test_raw_request_capture.rs
@@ -267,6 +267,113 @@ fn manual_range_header_remains_available_as_escape_hatch() {
 }
 
 #[test]
+fn conditional_request_helpers_emit_validator_headers() {
+  let request = capture_request(|base_url| {
+    client()
+      .get()
+      .url(format!("{}/asset", base_url))
+      .if_none_match(r#""abc123""#)
+      .expect("etag should be accepted")
+      .if_modified_since("Sun, 06 Nov 1994 08:49:37 GMT")
+      .expect("http date should be accepted")
+      .emit()
+      .expect("request should succeed");
+  });
+  let request = request_text(&request);
+
+  assert_eq!(Some(r#""abc123""#), header_value(&request, "If-None-Match"));
+  assert_eq!(
+    Some("Sun, 06 Nov 1994 08:49:37 GMT"),
+    header_value(&request, "If-Modified-Since")
+  );
+
+  let request = capture_request(|base_url| {
+    client()
+      .put()
+      .url(format!("{}/asset", base_url))
+      .if_match(r#"W/"weak-tag""#)
+      .expect("weak etag syntax should be accepted")
+      .if_unmodified_since("Sun, 06 Nov 1994 08:49:37 GMT")
+      .expect("http date should be accepted")
+      .emit()
+      .expect("request should succeed");
+  });
+  let request = request_text(&request);
+
+  assert_eq!(Some(r#"W/"weak-tag""#), header_value(&request, "If-Match"));
+  assert_eq!(
+    Some("Sun, 06 Nov 1994 08:49:37 GMT"),
+    header_value(&request, "If-Unmodified-Since")
+  );
+}
+
+#[test]
+fn conditional_request_helpers_reject_obvious_malformed_inputs_before_connecting() {
+  let request = capture_optional_request(|base_url| {
+    let mut client = client();
+    let error = client
+      .get()
+      .url(format!("{}/asset", base_url))
+      .if_none_match("abc123")
+      .expect_err("unquoted etag should be rejected");
+
+    assert!(error.is_builder());
+  });
+  assert!(
+    request.is_empty(),
+    "malformed etag helper should not open a socket"
+  );
+
+  let request = capture_optional_request(|base_url| {
+    let mut client = client();
+    let error = client
+      .get()
+      .url(format!("{}/asset", base_url))
+      .if_match(r#""one", "two""#)
+      .expect_err("etag lists should stay on manual header escape hatch");
+
+    assert!(error.is_builder());
+  });
+  assert!(
+    request.is_empty(),
+    "malformed etag helper should not open a socket"
+  );
+
+  let request = capture_optional_request(|base_url| {
+    let mut client = client();
+    let error = client
+      .get()
+      .url(format!("{}/asset", base_url))
+      .if_modified_since("not a date")
+      .expect_err("invalid http date should be rejected");
+
+    assert!(error.is_builder());
+  });
+  assert!(
+    request.is_empty(),
+    "malformed http date helper should not open a socket"
+  );
+}
+
+#[test]
+fn manual_conditional_headers_remain_available_as_escape_hatch() {
+  let request = capture_request(|base_url| {
+    client()
+      .get()
+      .url(format!("{}/asset", base_url))
+      .header(("If-None-Match", r#""one", "two""#))
+      .emit()
+      .expect("request should succeed");
+  });
+  let request = request_text(&request);
+
+  assert_eq!(
+    Some(r#""one", "two""#),
+    header_value(&request, "If-None-Match")
+  );
+}
+
+#[test]
 fn streaming_fixed_framing_does_not_leak_into_later_emit() {
   let (addr, handle) = spawn_streaming_then_capture_server();
   let mut client = client();

--- a/rttp_client/tests/test_response.rs
+++ b/rttp_client/tests/test_response.rs
@@ -168,6 +168,48 @@ fn test_parse_range_not_satisfiable_metadata_preserves_body_and_headers() {
 }
 
 #[test]
+fn test_parse_conditional_response_metadata() {
+  let s = concat!(
+    "HTTP/1.1 304 Not Modified\r\n",
+    "ETag: \"abc123\"\r\n",
+    "Last-Modified: Sun, 06 Nov 1994 08:49:37 GMT\r\n",
+    "Content-Length: 0\r\n",
+    "\r\n"
+  );
+  let response = Response::new(
+    RoUrl::with("https://example.test/asset"),
+    s.as_bytes().to_vec(),
+  )
+  .expect("parse not modified response");
+
+  assert!(response.is_not_modified());
+  assert!(!response.is_precondition_failed());
+  assert_eq!(Some(&"\"abc123\"".to_string()), response.etag());
+  assert_eq!(
+    Some(&"Sun, 06 Nov 1994 08:49:37 GMT".to_string()),
+    response.last_modified()
+  );
+
+  let s = concat!(
+    "HTTP/1.1 412 Precondition Failed\r\n",
+    "ETag: W/\"stale\"\r\n",
+    "Content-Length: 5\r\n",
+    "\r\n",
+    "stale"
+  );
+  let response = Response::new(
+    RoUrl::with("https://example.test/asset"),
+    s.as_bytes().to_vec(),
+  )
+  .expect("parse precondition failed response");
+
+  assert!(!response.is_not_modified());
+  assert!(response.is_precondition_failed());
+  assert_eq!(Some(&"W/\"stale\"".to_string()), response.etag());
+  assert_eq!(None, response.last_modified());
+}
+
+#[test]
 fn test_parse_response_rejects_header_without_colon() {
   let s = concat!(
     "HTTP/1.1 200 OK\r\n",


### PR DESCRIPTION
Added bounded HTTP/1.1 conditional request helpers and response inspection helpers for ETag and modification-time validation without adding cache policy or automatic revalidation behavior.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1563/
work_kind: code_work
branch: hbx-1563-rttp-client-add-bounded-http
base: main
commit: 6b308a5b5cb98ed2cf13d3ac6971d07a24f024e2
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1563/
    url: https://plane.kahub.in/endless/browse/HBX-1563/
    close_policy: link_only
```