### PR TITLE
feat: [rttp] Add bounded HTTP/1.1 conditional request evaluator helpers

### DIFF
--- a/rttp/Cargo.toml
+++ b/rttp/Cargo.toml
@@ -18,6 +18,7 @@ readme = "README.md"
 edition = "2021"
 
 [dependencies]
+httpdate = "1.0"
 socket2 = "0.5"
 
 rttp_client = { optional = true, path = "../rttp_client", features = [ "tls-native", "async" ] }

--- a/rttp/src/server.rs
+++ b/rttp/src/server.rs
@@ -3,7 +3,7 @@ use std::fmt;
 use std::io::{self, BufRead, BufReader, Cursor, Read, Write};
 use std::net::{SocketAddr, TcpListener, TcpStream, ToSocketAddrs};
 use std::sync::OnceLock;
-use std::time::Duration;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use socket2::{Domain, Protocol, Socket, Type};
 
@@ -3329,6 +3329,13 @@ impl Request {
     self.version == "HTTP/1.0" && !self.connection_header_has_token("keep-alive")
   }
 
+  pub fn evaluate_conditional(
+    &self,
+    metadata: &HttpConditionalMetadata,
+  ) -> HttpConditionalRequestOutcome {
+    evaluate_conditional_request(self, metadata)
+  }
+
   fn connection_header_has_token(&self, token: &str) -> bool {
     self
       .headers
@@ -3653,6 +3660,298 @@ impl Request {
       extended_connect_protocol: None,
     }
   }
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct HttpConditionalMetadata {
+  entity_tag: Option<HttpEntityTag>,
+  last_modified: Option<SystemTime>,
+}
+
+impl HttpConditionalMetadata {
+  pub fn new() -> Self {
+    Self::default()
+  }
+
+  pub fn entity_tag(mut self, entity_tag: HttpEntityTag) -> Self {
+    self.entity_tag = Some(entity_tag);
+    self
+  }
+
+  pub fn last_modified(mut self, last_modified: SystemTime) -> Self {
+    self.last_modified = Some(last_modified);
+    self
+  }
+
+  pub fn entity_tag_value(&self) -> Option<&HttpEntityTag> {
+    self.entity_tag.as_ref()
+  }
+
+  pub fn last_modified_value(&self) -> Option<SystemTime> {
+    self.last_modified
+  }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct HttpEntityTag {
+  weak: bool,
+  opaque_tag: String,
+}
+
+impl HttpEntityTag {
+  pub fn strong<S: AsRef<str>>(opaque_tag: S) -> Self {
+    Self::new(false, opaque_tag)
+  }
+
+  pub fn weak<S: AsRef<str>>(opaque_tag: S) -> Self {
+    Self::new(true, opaque_tag)
+  }
+
+  pub fn parse<S: AsRef<str>>(value: S) -> Result<Self, HttpEntityTagParseError> {
+    parse_entity_tag(value.as_ref().trim()).ok_or(HttpEntityTagParseError)
+  }
+
+  pub fn is_weak(&self) -> bool {
+    self.weak
+  }
+
+  pub fn opaque_tag(&self) -> &str {
+    &self.opaque_tag
+  }
+
+  pub fn header_value(&self) -> String {
+    let mut value = String::new();
+    if self.weak {
+      value.push_str("W/");
+    }
+    value.push('"');
+    value.push_str(&self.opaque_tag);
+    value.push('"');
+    value
+  }
+
+  fn new<S: AsRef<str>>(weak: bool, opaque_tag: S) -> Self {
+    let opaque_tag = opaque_tag.as_ref();
+    assert_valid_entity_tag_opaque_tag(opaque_tag);
+    Self {
+      weak,
+      opaque_tag: opaque_tag.to_string(),
+    }
+  }
+
+  fn strong_matches(&self, other: &Self) -> bool {
+    !self.weak && !other.weak && self.opaque_tag == other.opaque_tag
+  }
+
+  fn weak_matches(&self, other: &Self) -> bool {
+    self.opaque_tag == other.opaque_tag
+  }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct HttpEntityTagParseError;
+
+impl fmt::Display for HttpEntityTagParseError {
+  fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+    formatter.write_str("invalid entity tag")
+  }
+}
+
+impl Error for HttpEntityTagParseError {}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum HttpConditionalRequestOutcome {
+  Proceed,
+  NotModified,
+  PreconditionFailed,
+}
+
+pub fn evaluate_conditional_request(
+  request: &Request,
+  metadata: &HttpConditionalMetadata,
+) -> HttpConditionalRequestOutcome {
+  if let Some(matches) = request_if_match_matches(request, metadata) {
+    if !matches {
+      return HttpConditionalRequestOutcome::PreconditionFailed;
+    }
+  } else if let Some(if_unmodified_since) = request_http_date(request, "If-Unmodified-Since") {
+    if metadata
+      .last_modified
+      .is_some_and(|last_modified| http_date_seconds_after(last_modified, if_unmodified_since))
+    {
+      return HttpConditionalRequestOutcome::PreconditionFailed;
+    }
+  }
+
+  if let Some(matches) = request_if_none_match_matches(request, metadata) {
+    if matches {
+      if method_uses_not_modified_for_if_none_match(request.method()) {
+        return HttpConditionalRequestOutcome::NotModified;
+      }
+      return HttpConditionalRequestOutcome::PreconditionFailed;
+    }
+    return HttpConditionalRequestOutcome::Proceed;
+  }
+
+  if method_uses_not_modified_for_if_none_match(request.method()) {
+    if let Some(if_modified_since) = request_http_date(request, "If-Modified-Since") {
+      if metadata
+        .last_modified
+        .is_some_and(|last_modified| !http_date_seconds_after(last_modified, if_modified_since))
+      {
+        return HttpConditionalRequestOutcome::NotModified;
+      }
+    }
+  }
+
+  HttpConditionalRequestOutcome::Proceed
+}
+
+fn request_if_match_matches(request: &Request, metadata: &HttpConditionalMetadata) -> Option<bool> {
+  request_entity_tag_validator_matches(request, "If-Match", metadata, EntityTagComparison::Strong)
+}
+
+fn request_if_none_match_matches(
+  request: &Request,
+  metadata: &HttpConditionalMetadata,
+) -> Option<bool> {
+  request_entity_tag_validator_matches(
+    request,
+    "If-None-Match",
+    metadata,
+    EntityTagComparison::Weak,
+  )
+}
+
+fn request_entity_tag_validator_matches(
+  request: &Request,
+  header_name: &str,
+  metadata: &HttpConditionalMetadata,
+  comparison: EntityTagComparison,
+) -> Option<bool> {
+  let mut saw_header = false;
+  let mut saw_valid_validator = false;
+
+  for value in request.headers_named(header_name) {
+    saw_header = true;
+    for validator in EntityTagValidatorList::parse(value)? {
+      saw_valid_validator = true;
+      match validator {
+        EntityTagValidator::Any => return Some(true),
+        EntityTagValidator::Tag(candidate) => {
+          let Some(current) = metadata.entity_tag.as_ref() else {
+            continue;
+          };
+          let matches = match comparison {
+            EntityTagComparison::Strong => current.strong_matches(&candidate),
+            EntityTagComparison::Weak => current.weak_matches(&candidate),
+          };
+          if matches {
+            return Some(true);
+          }
+        }
+      }
+    }
+  }
+
+  if saw_header && saw_valid_validator {
+    Some(false)
+  } else {
+    None
+  }
+}
+
+fn request_http_date(request: &Request, header_name: &str) -> Option<SystemTime> {
+  httpdate::parse_http_date(request.header(header_name)?).ok()
+}
+
+fn http_date_seconds_after(left: SystemTime, right: SystemTime) -> bool {
+  match (
+    left.duration_since(UNIX_EPOCH),
+    right.duration_since(UNIX_EPOCH),
+  ) {
+    (Ok(left), Ok(right)) => left.as_secs() > right.as_secs(),
+    _ => left > right,
+  }
+}
+
+fn method_uses_not_modified_for_if_none_match(method: &str) -> bool {
+  method.eq_ignore_ascii_case("GET") || method.eq_ignore_ascii_case("HEAD")
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum EntityTagComparison {
+  Strong,
+  Weak,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum EntityTagValidator {
+  Any,
+  Tag(HttpEntityTag),
+}
+
+struct EntityTagValidatorList {
+  validators: Vec<EntityTagValidator>,
+}
+
+impl EntityTagValidatorList {
+  fn parse(value: &str) -> Option<Self> {
+    let value = value.trim();
+    if value == "*" {
+      return Some(Self {
+        validators: vec![EntityTagValidator::Any],
+      });
+    }
+
+    let mut validators = Vec::new();
+    for part in value.split(',') {
+      validators.push(EntityTagValidator::Tag(parse_entity_tag(part.trim())?));
+    }
+    if validators.is_empty() {
+      None
+    } else {
+      Some(Self { validators })
+    }
+  }
+}
+
+impl IntoIterator for EntityTagValidatorList {
+  type Item = EntityTagValidator;
+  type IntoIter = std::vec::IntoIter<EntityTagValidator>;
+
+  fn into_iter(self) -> Self::IntoIter {
+    self.validators.into_iter()
+  }
+}
+
+fn parse_entity_tag(value: &str) -> Option<HttpEntityTag> {
+  let (weak, value) = if let Some(rest) = value.strip_prefix("W/") {
+    (true, rest)
+  } else {
+    (false, value)
+  };
+  let opaque_tag = value.strip_prefix('"')?.strip_suffix('"')?;
+  if !is_valid_entity_tag_opaque_tag(opaque_tag) {
+    return None;
+  }
+  Some(HttpEntityTag {
+    weak,
+    opaque_tag: opaque_tag.to_string(),
+  })
+}
+
+fn assert_valid_entity_tag_opaque_tag(opaque_tag: &str) {
+  assert!(
+    is_valid_entity_tag_opaque_tag(opaque_tag),
+    "entity tag opaque value must be valid for an HTTP ETag header"
+  );
+}
+
+fn is_valid_entity_tag_opaque_tag(opaque_tag: &str) -> bool {
+  opaque_tag
+    .bytes()
+    .all(|byte| matches!(byte, b'\x21' | b'\x23'..=b'\x7e' | b'\x80'..=b'\xff'))
 }
 
 pub struct RequestBodyReader<'a, R: BufRead> {
@@ -4024,6 +4323,21 @@ impl HttpResponse {
   pub fn range_not_satisfiable(entity_length: usize) -> Self {
     Self::new(416, "Range Not Satisfiable")
       .header("Content-Range", format!("bytes */{entity_length}"))
+  }
+
+  pub fn not_modified(metadata: &HttpConditionalMetadata) -> Self {
+    let mut response = Self::new(304, "Not Modified");
+    if let Some(entity_tag) = metadata.entity_tag_value() {
+      response = response.header("ETag", entity_tag.header_value());
+    }
+    if let Some(last_modified) = metadata.last_modified_value() {
+      response = response.header("Last-Modified", httpdate::fmt_http_date(last_modified));
+    }
+    response
+  }
+
+  pub fn precondition_failed() -> Self {
+    Self::new(412, "Precondition Failed")
   }
 
   pub fn header<N: AsRef<str>, V: AsRef<str>>(mut self, name: N, value: V) -> Self {

--- a/rttp/tests/test_server.rs
+++ b/rttp/tests/test_server.rs
@@ -2,9 +2,11 @@ use std::io::{self, ErrorKind, Read, Write};
 use std::net::{SocketAddr, TcpListener, TcpStream};
 use std::sync::mpsc;
 use std::thread;
-use std::time::Duration;
+use std::time::{Duration, UNIX_EPOCH};
 
-use rttp::server::{HttpResponse, Request};
+use rttp::server::{
+  HttpConditionalMetadata, HttpConditionalRequestOutcome, HttpEntityTag, HttpResponse, Request,
+};
 use rttp_client::{Config, HttpClient};
 
 const H2_PREFACE: &[u8; 24] = b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n";
@@ -6812,6 +6814,173 @@ fn server_keeps_304_connection_framed_for_following_request() {
 }
 
 #[test]
+fn conditional_request_helpers_evaluate_if_none_match_get_as_not_modified() {
+  let metadata = HttpConditionalMetadata::new()
+    .entity_tag(HttpEntityTag::strong("abc"))
+    .last_modified(UNIX_EPOCH + Duration::from_secs(784_111_777));
+
+  let outcome = conditional_outcome_for(
+    concat!(
+      "GET /cached HTTP/1.1\r\n",
+      "Host: localhost\r\n",
+      "If-None-Match: W/\"different\", \"abc\"\r\n",
+      "\r\n",
+    ),
+    metadata,
+  );
+
+  assert_eq!(HttpConditionalRequestOutcome::NotModified, outcome);
+}
+
+#[test]
+fn conditional_request_helpers_evaluate_if_none_match_unsafe_method_as_precondition_failed() {
+  let metadata = HttpConditionalMetadata::new().entity_tag(HttpEntityTag::strong("abc"));
+
+  let outcome = conditional_outcome_for(
+    concat!(
+      "PUT /cached HTTP/1.1\r\n",
+      "Host: localhost\r\n",
+      "If-None-Match: *\r\n",
+      "Content-Length: 0\r\n",
+      "\r\n",
+    ),
+    metadata,
+  );
+
+  assert_eq!(HttpConditionalRequestOutcome::PreconditionFailed, outcome);
+}
+
+#[test]
+fn conditional_request_helpers_evaluate_if_match_with_strong_comparison() {
+  let metadata = HttpConditionalMetadata::new().entity_tag(HttpEntityTag::strong("abc"));
+
+  let weak_match = conditional_outcome_for(
+    concat!(
+      "GET /cached HTTP/1.1\r\n",
+      "Host: localhost\r\n",
+      "If-Match: W/\"abc\"\r\n",
+      "\r\n",
+    ),
+    metadata.clone(),
+  );
+  let strong_match = conditional_outcome_for(
+    concat!(
+      "GET /cached HTTP/1.1\r\n",
+      "Host: localhost\r\n",
+      "If-Match: \"abc\"\r\n",
+      "\r\n",
+    ),
+    metadata,
+  );
+
+  assert_eq!(
+    HttpConditionalRequestOutcome::PreconditionFailed,
+    weak_match
+  );
+  assert_eq!(HttpConditionalRequestOutcome::Proceed, strong_match);
+}
+
+#[test]
+fn conditional_request_helpers_evaluate_http_dates_and_precedence() {
+  let metadata = HttpConditionalMetadata::new()
+    .entity_tag(HttpEntityTag::strong("abc"))
+    .last_modified(UNIX_EPOCH + Duration::from_secs(784_111_777));
+
+  let stale_if_unmodified_since = conditional_outcome_for(
+    concat!(
+      "GET /cached HTTP/1.1\r\n",
+      "Host: localhost\r\n",
+      "If-Unmodified-Since: Sun, 06 Nov 1994 08:49:36 GMT\r\n",
+      "\r\n",
+    ),
+    metadata.clone(),
+  );
+  let fresh_if_modified_since = conditional_outcome_for(
+    concat!(
+      "GET /cached HTTP/1.1\r\n",
+      "Host: localhost\r\n",
+      "If-Modified-Since: Sun, 06 Nov 1994 08:49:37 GMT\r\n",
+      "\r\n",
+    ),
+    metadata.clone(),
+  );
+  let if_none_match_takes_precedence = conditional_outcome_for(
+    concat!(
+      "GET /cached HTTP/1.1\r\n",
+      "Host: localhost\r\n",
+      "If-None-Match: \"different\"\r\n",
+      "If-Modified-Since: Sun, 06 Nov 1994 08:49:37 GMT\r\n",
+      "\r\n",
+    ),
+    metadata,
+  );
+
+  assert_eq!(
+    HttpConditionalRequestOutcome::PreconditionFailed,
+    stale_if_unmodified_since
+  );
+  assert_eq!(
+    HttpConditionalRequestOutcome::NotModified,
+    fresh_if_modified_since
+  );
+  assert_eq!(
+    HttpConditionalRequestOutcome::Proceed,
+    if_none_match_takes_precedence
+  );
+}
+
+#[test]
+fn conditional_request_helpers_compare_http_dates_at_second_precision() {
+  let metadata = HttpConditionalMetadata::new()
+    .last_modified(UNIX_EPOCH + Duration::from_secs(784_111_777) + Duration::from_millis(500));
+
+  let outcome = conditional_outcome_for(
+    concat!(
+      "GET /cached HTTP/1.1\r\n",
+      "Host: localhost\r\n",
+      "If-Modified-Since: Sun, 06 Nov 1994 08:49:37 GMT\r\n",
+      "\r\n",
+    ),
+    metadata,
+  );
+
+  assert_eq!(HttpConditionalRequestOutcome::NotModified, outcome);
+}
+
+#[test]
+fn conditional_response_helpers_include_available_validators_and_preserve_304_framing() {
+  let metadata = HttpConditionalMetadata::new()
+    .entity_tag(HttpEntityTag::weak("abc"))
+    .last_modified(UNIX_EPOCH + Duration::from_secs(784_111_777));
+  let mut not_modified = Vec::new();
+  let mut precondition_failed = Vec::new();
+
+  HttpResponse::not_modified(&metadata)
+    .body("ignored")
+    .write_to(&mut not_modified)
+    .expect("serialize 304 response");
+  HttpResponse::precondition_failed()
+    .write_to(&mut precondition_failed)
+    .expect("serialize 412 response");
+
+  assert_eq!(
+    concat!(
+      "HTTP/1.1 304 Not Modified\r\n",
+      "ETag: W/\"abc\"\r\n",
+      "Last-Modified: Sun, 06 Nov 1994 08:49:37 GMT\r\n",
+      "Connection: close\r\n",
+      "\r\n",
+    )
+    .as_bytes(),
+    not_modified.as_slice()
+  );
+  assert_eq!(
+    b"HTTP/1.1 412 Precondition Failed\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+    precondition_failed.as_slice()
+  );
+}
+
+#[test]
 fn server_keeps_chunked_response_framed_for_following_request() {
   let server = rttp::Http::server("127.0.0.1:0").expect("bind server");
   let addr = server.local_addr().expect("server addr");
@@ -7264,4 +7433,28 @@ fn send_request(addr: std::net::SocketAddr, request: &[u8]) -> String {
   let mut response = String::new();
   stream.read_to_string(&mut response).expect("read response");
   response
+}
+
+fn conditional_outcome_for(
+  request: &str,
+  metadata: HttpConditionalMetadata,
+) -> HttpConditionalRequestOutcome {
+  let server = rttp::Http::server("127.0.0.1:0").expect("bind server");
+  let addr = server.local_addr().expect("server addr");
+  let (tx, rx) = mpsc::channel();
+
+  let handle = thread::spawn(move || {
+    server
+      .accept_one(|request| {
+        let outcome = request.evaluate_conditional(&metadata);
+        tx.send(outcome).expect("send conditional outcome");
+        HttpResponse::ok("")
+      })
+      .expect("serve one request");
+  });
+
+  let _response = send_request(addr, request.as_bytes());
+  let outcome = rx.recv().expect("receive conditional outcome");
+  handle.join().expect("server thread");
+  outcome
 }


### PR DESCRIPTION
Added bounded server-side HTTP/1.1 conditional request evaluator helpers with validator metadata, ETag/date evaluation, and 304/412 response constructors.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1564/
work_kind: code_work
branch: hbx-1564-rttp-add-bounded-http-1
base: main
commit: ff38dfe9a737000295ec4e9877f7858f104fb07e
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1564/
    url: https://plane.kahub.in/endless/browse/HBX-1564/
    close_policy: link_only
```