### PR TITLE
feat: [rttp] Document bounded HTTP/1.1 conditional request behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,28 @@ with the generic header API for cases outside those helpers.
 evaluate `If-Range`, retry range requests, or apply client cache validation
 policy.
 
+### Bounded HTTP/1.1 conditional requests
+
+`HttpClient` can emit common conditional validators with
+`if_none_match(etag)`, `if_match(etag)`, `if_modified_since(http_date)`, and
+`if_unmodified_since(http_date)`. The ETag helpers accept one validator per
+call: `*`, a strong tag such as `"abc"`, or a weak tag such as `W/"abc"`.
+Comma-separated validator lists remain available through the generic `header`
+API. The date helpers require values that parse as HTTP-date values before a
+socket is opened.
+
+Responses expose conditional metadata with `Response::is_not_modified()` for
+`304 Not Modified`, `Response::is_precondition_failed()` for
+`412 Precondition Failed`, `Response::etag()`, and
+`Response::last_modified()`. `304` responses are handled as bodyless even if
+misleading body framing is present; `412` remains an ordinary response status
+for the caller to handle.
+
+These helpers do not add cache storage, automatic revalidation, `If-Range`
+handling, or a cache-control engine. RTTP only emits bounded request headers
+and exposes response metadata; cache persistence and validation policy remain
+application-owned.
+
 ### Bounded trailer behavior
 
 Trailer support is explicit and bounded by protocol path. On the client,
@@ -114,6 +136,7 @@ gain additional HTTP/2 header-block handling.
 | Upgrade and tunnel handoff | `CONNECT` returns the tunnel socket after a successful `200`; `upgrade()` returns the socket after `101 Switching Protocols` and skips interim `1xx` responses | Upgraded protocols are handed to the caller and are not parsed by `rttp_client` |
 | Redirects | Auto-redirect covers 301, 302, 303, 307, and 308 method/body behavior, relative and absolute `Location` resolution, same- and cross-authority header handling, loop detection, and redirect bounds | Redirects are HTTP client behavior, not a browser policy implementation |
 | Byte ranges | `range`, `range_from`, and `range_suffix` emit single HTTP/1.1 `bytes` ranges; `Response::content_range`, `is_partial_content`, and `is_range_not_satisfiable` expose `206` and `416` metadata | No automatic `If-Range`, multipart range generation, retry, or cache validation policy |
+| Conditional requests | `if_none_match`, `if_match`, `if_modified_since`, and `if_unmodified_since` emit bounded HTTP/1.1 validators; `Response::is_not_modified`, `is_precondition_failed`, `etag`, and `last_modified` expose `304`/`412` metadata | One ETag validator per helper call, no `If-Range`, no cache storage, no automatic revalidation, and no cache-control engine |
 | Trailers | Chunked response trailers are exposed for blocking and async APIs; streaming chunked uploads can send declared request trailers | Application metadata trailers such as `X-Trace` are allowed; pseudo-header, connection-specific, routing, authentication/cookie, and framing trailer fields are rejected |
 | Bounded h2c client | With `http2`, direct `socket2` h2c sends GET, HEAD, bodyless DELETE, OPTIONS, or TRACE, buffered POST, PUT, or PATCH requests, and opt-in RFC 8441 extended CONNECT request HEADERS via `http2_extended_connect`, opens at most one request stream, supports prior-knowledge with `emit_http2_prior_knowledge`, supports explicit HTTP/1.1 `Upgrade: h2c` negotiation with `emit_http2_upgrade`, advertises `SETTINGS_ENABLE_PUSH = 0`, advertises `SETTINGS_ENABLE_CONNECT_PROTOCOL = 1` only for the explicit extended CONNECT path, validates received `SETTINGS_ENABLE_PUSH` values as only `0` or `1`, honors initial peer `SETTINGS_MAX_CONCURRENT_STREAMS` by failing before request HEADERS when the peer allows zero streams, honors peer-advertised `SETTINGS_MAX_HEADER_LIST_SIZE` request metadata limits, accepts only legal `SETTINGS_MAX_FRAME_SIZE` values from 16,384 through 16,777,215 bytes, splits outbound HEADERS, DATA, and trailers to the active peer frame-size limit, rejects oversized inbound frames when a configured local frame-size limit is exceeded, bounds HPACK dynamic table use with `SETTINGS_HEADER_TABLE_SIZE`, strips HTTP/1.x connection-specific request fields before emission, rejects connection-specific peer response fields, suppresses HEAD response bodies, treats `RST_STREAM` on the active stream as a bounded reset/cancellation signal, acknowledges valid PING frames with matching opaque data, DATA bodies, trailers, HPACK static Huffman strings, bounded large header blocks, padded incoming frames, `GOAWAY` shutdown boundaries, PRIORITY metadata validation without scheduling, HTTP/2-allowed unknown/extension frame ignoring inside this bounded path, reserved stream-id high-bit normalization, and conservative DATA flow control | Ordinary `CONNECT`, header-configured `:protocol` metadata, non-h2c HTTP/1.1 `Upgrade` handoff requests, and proxies are rejected deterministically, and `PUSH_PROMISE`/server push is rejected instead of managed; bounded direct h2c only, with no public cancellation callback API, no dynamic policy API, no extension callback API, no full extension negotiation, TLS ALPN, external h2 integration, proxy tunneling to h2, proxy h2, tunnel handoff, connection pooling, persistent HTTP/2 session management, automatic retry, server push, full stream state machine, unbounded multiplex scheduling, general multiplexing, priority scheduling, request bodies or trailers for extended CONNECT, or request bodies for GET, HEAD, DELETE, OPTIONS, or TRACE |
 
@@ -325,6 +348,35 @@ ranges. `If-Range`, filesystem path normalization, MIME detection, ETag,
 Last-Modified, cache behavior, authorization, directory indexes, and dotfile
 visibility remain caller-owned policy before choosing `200`, `206`, or `416`.
 
+### Bounded HTTP/1.1 conditional requests
+
+The server exposes conditional request primitives for applications that already
+know the selected representation. Use `HttpConditionalMetadata` with
+`HttpEntityTag::strong("tag")` or `HttpEntityTag::weak("tag")` and optional
+`last_modified(SystemTime)`, then call
+`Request::evaluate_conditional(&metadata)` or
+`evaluate_conditional_request(&request, &metadata)`.
+
+The evaluator returns `Proceed`, `NotModified`, or `PreconditionFailed`.
+`If-Match` uses strong ETag comparison and takes precedence over
+`If-Unmodified-Since`; `If-None-Match` uses weak ETag comparison and takes
+precedence over `If-Modified-Since`. Matching `If-None-Match` validators return
+`304 Not Modified` behavior for `GET` and `HEAD`, and `412 Precondition Failed`
+behavior for other methods. HTTP-date validators are used only when they parse
+as HTTP-date values, and `Last-Modified` comparisons are made at second
+precision.
+
+Use `HttpResponse::not_modified(&metadata)` to serialize a bodyless `304` with
+available `ETag` and `Last-Modified` validators. Use
+`HttpResponse::precondition_failed()` for `412`; application code can still add
+its own headers or body when desired. A `Proceed` outcome means the handler
+should send its normal representation response.
+
+The helper scope is intentionally bounded. RTTP does not choose ETags, read or
+serve files, implement static-file serving policy, store cached responses,
+automatically revalidate stale entries, or provide a full cache-control engine.
+Those remain application policy around the validator helpers.
+
 The server is intentionally small: it handles blocking HTTP/1.x request parsing
 for local tests and simple embedded use. It accepts fixed `Content-Length` and
 chunked request bodies, exposes chunked request trailers, applies bounded
@@ -458,6 +510,7 @@ TLS or async accept loops.
 | HTTP/1.1 connection handling | Bounded sequential `serve_requests`, keep-alive and close behavior for HTTP/1.1 and HTTP/1.0, pipelined request boundaries, malformed request rejection before handler dispatch | Blocking listener only; no async accept loop |
 | HTTP/1.1 response framing | Automatic `Content-Length`, explicit chunked responses, bodyless `HEAD`, `101`, `204`, and `304`, response trailers after the terminating chunk | No server TLS |
 | Byte ranges | `HttpByteRange` parses one `bytes` range and `HttpResponse::partial_content`/`range_not_satisfiable` serialize `206`/`416` with `Content-Range` | No multipart range serialization, `If-Range` evaluation, filesystem serving, or static-file policy |
+| Conditional requests | `Request::evaluate_conditional`, `evaluate_conditional_request`, `HttpConditionalMetadata`, and `HttpEntityTag` evaluate bounded HTTP/1.1 validators; `HttpResponse::not_modified` and `precondition_failed` serialize `304` and `412` outcomes | No cache storage, static-file serving policy, automatic revalidation, or cache-control engine |
 | Upgrade and tunnel targets | `CONNECT` authority-form requests are accepted as HTTP requests; `HttpResponse::upgrade` can hand an upgraded socket to caller code after a matching request | The server does not implement the upgraded protocol after handoff |
 | Trailers | Chunked request trailers are preserved on `Request`; malformed, oversized, forbidden, and pseudo-header trailers are rejected; response trailers can be serialized for chunked responses | Application metadata trailers are allowed; trailer names that affect connection state, routing, authentication/cookies, framing, or payload processing are rejected |
 | Bounded h2c server | The same `socket2` listener detects the HTTP/2 prior-knowledge preface or a valid HTTP/1.1 `Upgrade: h2c` request with `HTTP2-Settings`, validates SETTINGS including legal `SETTINGS_ENABLE_PUSH` and `SETTINGS_ENABLE_CONNECT_PROTOCOL` values of only `0` or `1` and legal `SETTINGS_MAX_FRAME_SIZE` values from 16,384 through 16,777,215 bytes, dispatches RFC 8441 extended CONNECT only after `SETTINGS_ENABLE_CONNECT_PROTOCOL = 1` has been negotiated, exposes negotiated extended CONNECT as a normal `Request` with method `CONNECT`, version `HTTP/2`, target from `:path`, `host` from `:authority`, and `Request::extended_connect_protocol()` from `:protocol`, advertises the default 16,384-byte `SETTINGS_MAX_FRAME_SIZE`, rejects inbound frames above the active local limit, splits outbound HEADERS, DATA, and trailers to the active peer frame-size limit, advertises `SETTINGS_MAX_CONCURRENT_STREAMS` from the bounded active stream allowance, enforces that allowance before dispatching new streams, advertises and enforces a conservative `SETTINGS_MAX_HEADER_LIST_SIZE` for inbound request metadata, bounds HPACK dynamic table use with `SETTINGS_HEADER_TABLE_SIZE`, serves bounded streams including bodyless DELETE, OPTIONS, TRACE, and negotiated extended CONNECT, handles HEAD without response DATA, rejects connection-specific request fields before handler dispatch, strips connection-specific response fields during h2c serialization, treats `RST_STREAM` as a bounded reset/cancellation signal for the affected stream, acknowledges valid PING frames with matching opaque data, accepts padded HEADERS/DATA/trailers without exposing padding, handles HPACK Huffman fields and bounded CONTINUATION header blocks, emits `GOAWAY` with the last completed stream id at bounded shutdown, validates and ignores valid PRIORITY metadata, ignores HTTP/2-allowed unknown/extension frames inside this bounded path, normalizes reserved stream-id high bits, and applies conservative DATA flow control | Ordinary `CONNECT`, missing-negotiation `:protocol`, non-CONNECT `:protocol`, malformed h2c Upgrade, request bodies on h2c Upgrade, and `PUSH_PROMISE` are rejected deterministically before handler dispatch; HTTP/1.1 `CONNECT` and non-h2c `Upgrade` remain separate handoff paths; bounded h2c only, with no public cancellation callback API, no dynamic policy API, no extension callback API, no full extension negotiation, TLS ALPN, external h2 integration, full WebSocket-over-h2, proxy h2, tunnel handoff, connection pooling, persistent multiplex sessions, persistent HTTP/2 session management, automatic retry, server push, full RFC 8441 support, full stream state machine, unbounded multiplexing, unbounded multiplex scheduling, general multiplexing, general tunnel scheduling, priority scheduling, or full HTTP/2 server feature set |

--- a/rttp/README.md
+++ b/rttp/README.md
@@ -75,6 +75,39 @@ built-in filesystem serving, path normalization, MIME selection, ETag,
 Last-Modified, cache, authorization, directory-index, or dotfile policy. Those
 remain application decisions before choosing `200`, `206`, or `416`.
 
+## Bounded HTTP/1.1 conditional requests
+
+The server exposes validator evaluation helpers, not a static-file or cache
+policy engine. Build representation metadata with
+`HttpConditionalMetadata::new().entity_tag(HttpEntityTag::strong("tag"))` or
+`HttpEntityTag::weak("tag")`, optionally add `last_modified(SystemTime)`, and
+evaluate a request with `Request::evaluate_conditional(&metadata)` or
+`evaluate_conditional_request(&request, &metadata)`.
+
+Evaluation returns `HttpConditionalRequestOutcome::Proceed`,
+`NotModified`, or `PreconditionFailed`. `If-Match` uses strong ETag comparison
+and takes precedence over `If-Unmodified-Since`; a failed match returns
+`PreconditionFailed`. `If-None-Match` uses weak ETag comparison and takes
+precedence over `If-Modified-Since`; a match returns `NotModified` for `GET`
+or `HEAD` and `PreconditionFailed` for other methods. `If-Modified-Since` and
+`If-Unmodified-Since` are evaluated only when their HTTP-date values parse
+successfully, and last-modified comparisons are performed at HTTP-date second
+precision.
+
+Use `HttpResponse::not_modified(&metadata)` for `304 Not Modified`; it adds
+available `ETag` and `Last-Modified` validators and serializes without a
+message body. Use `HttpResponse::precondition_failed()` for
+`412 Precondition Failed`; it returns an empty response unless application code
+adds its own headers or body. Applications remain responsible for the normal
+successful `200` response when evaluation returns `Proceed`.
+
+ETag comparison is deliberately scoped to the supplied representation metadata.
+The helpers do not pick entity tags, read files, check authorization, choose a
+static-file policy, store cached responses, perform automatic revalidation, or
+implement a full cache-control engine. Invalid conditional headers that cannot
+be parsed as the bounded helper syntax are ignored by the evaluation helper
+rather than rejected before handler code.
+
 ## Bounded trailer behavior
 
 HTTP/1.1 server trailer support remains chunked-scope only. Chunked request
@@ -268,6 +301,7 @@ scheduling, or async accept loops.
 | HTTP/1.1 connection handling | Bounded sequential `serve_requests`, keep-alive and close behavior for HTTP/1.1 and HTTP/1.0, pipelined request boundaries, malformed request rejection before handler dispatch | Blocking listener only; no async accept loop |
 | HTTP/1.1 response framing | Automatic `Content-Length`, explicit chunked responses, bodyless `HEAD`, `101`, `204`, and `304`, response trailers after the terminating chunk | No server TLS |
 | Byte ranges | `HttpByteRange` parses one `bytes` range and `HttpResponse::partial_content`/`range_not_satisfiable` serialize `206`/`416` with `Content-Range` | No multipart range serialization, `If-Range` evaluation, filesystem serving, or static-file policy |
+| Conditional requests | `Request::evaluate_conditional`, `evaluate_conditional_request`, `HttpConditionalMetadata`, and `HttpEntityTag` evaluate bounded HTTP/1.1 validators; `HttpResponse::not_modified` and `precondition_failed` serialize `304` and `412` outcomes | No cache storage, static-file serving policy, automatic revalidation, or cache-control engine |
 | Upgrade and tunnel targets | `CONNECT` authority-form requests are accepted as HTTP requests; `HttpResponse::upgrade` can hand an upgraded socket to caller code after a matching request | The server does not implement the upgraded protocol after handoff |
 | Trailers | Chunked request trailers are preserved on `Request`; malformed, oversized, forbidden, and pseudo-header trailers are rejected; response trailers can be serialized for chunked responses | Application metadata trailers are allowed; trailer names that affect connection state, routing, authentication/cookies, framing, or payload processing are rejected |
 | Bounded h2c server | The same `socket2` listener detects the HTTP/2 prior-knowledge preface or a valid HTTP/1.1 `Upgrade: h2c` request with `HTTP2-Settings`, validates SETTINGS including legal `SETTINGS_ENABLE_PUSH` and `SETTINGS_ENABLE_CONNECT_PROTOCOL` values of only `0` or `1` and legal `SETTINGS_MAX_FRAME_SIZE` values from 16,384 through 16,777,215 bytes, dispatches RFC 8441 extended CONNECT only after `SETTINGS_ENABLE_CONNECT_PROTOCOL = 1` has been negotiated, exposes negotiated extended CONNECT as a normal `Request` with method `CONNECT`, version `HTTP/2`, target from `:path`, `host` from `:authority`, and `Request::extended_connect_protocol()` from `:protocol`, advertises the default 16,384-byte `SETTINGS_MAX_FRAME_SIZE`, rejects inbound frames above the active local limit, splits outbound HEADERS, DATA, and trailers to the active peer frame-size limit, advertises `SETTINGS_MAX_CONCURRENT_STREAMS` from the bounded active stream allowance, enforces that allowance before dispatching new streams, advertises and enforces a conservative `SETTINGS_MAX_HEADER_LIST_SIZE` for inbound request metadata, bounds HPACK dynamic table use with `SETTINGS_HEADER_TABLE_SIZE`, serves bounded streams including bodyless DELETE, OPTIONS, TRACE, and negotiated extended CONNECT, handles HEAD without response DATA, rejects connection-specific request fields before handler dispatch, strips connection-specific response fields during h2c serialization, treats `RST_STREAM` as a bounded reset/cancellation signal for the affected stream, acknowledges valid PING frames with matching opaque data, accepts padded HEADERS/DATA/trailers without exposing padding, handles HPACK Huffman fields and bounded CONTINUATION header blocks, emits `GOAWAY` with the last completed stream id at bounded shutdown, validates and ignores valid PRIORITY metadata, ignores HTTP/2-allowed unknown/extension frames inside this bounded path, normalizes reserved stream-id high bits, and applies conservative DATA flow control | Ordinary `CONNECT`, missing-negotiation `:protocol`, non-CONNECT `:protocol`, malformed h2c Upgrade, request bodies on h2c Upgrade, and `PUSH_PROMISE` are rejected deterministically before handler dispatch; HTTP/1.1 `CONNECT` and non-h2c `Upgrade` remain separate handoff paths; bounded h2c only, with no public cancellation callback API, no dynamic policy API, no extension callback API, no full extension negotiation, TLS ALPN, external h2 integration, full WebSocket-over-h2, proxy h2, tunnel handoff, connection pooling, persistent multiplex sessions, persistent HTTP/2 session management, automatic retry, server push, full RFC 8441 support, full stream state machine, unbounded multiplexing, unbounded multiplex scheduling, general multiplexing, general tunnel scheduling, priority scheduling, or full HTTP/2 server feature set |

--- a/rttp_client/README.md
+++ b/rttp_client/README.md
@@ -52,6 +52,36 @@ range requests, or apply cache validation policy on the client side. Multiple
 ranges can only be sent by manually setting the header, and any server response
 is then parsed as an ordinary HTTP response.
 
+## Bounded HTTP/1.1 conditional requests
+
+`HttpClient` includes bounded helpers for the common conditional request
+validators: `if_none_match(etag)`, `if_match(etag)`,
+`if_modified_since(http_date)`, and `if_unmodified_since(http_date)`. The ETag
+helpers accept one validator at a time: `*`, a strong tag such as `"abc"`, or a
+weak tag such as `W/"abc"`. They reject comma-separated lists and obviously
+malformed tag syntax before opening a socket; callers that need validator
+lists or non-helper behavior can still use the generic `header` API.
+
+The date helpers validate that the supplied value parses as an HTTP-date before
+emission and then write the value as provided. They do not normalize date text
+or choose a validator policy for the request. `If-Range` remains outside these
+helpers.
+
+Conditional responses are exposed through response metadata helpers.
+`Response::is_not_modified()` identifies `304 Not Modified`,
+`Response::is_precondition_failed()` identifies `412 Precondition Failed`,
+`Response::etag()` returns the response `ETag` field when present, and
+`Response::last_modified()` returns the response `Last-Modified` field when
+present. A `304` response is treated as bodyless even if misleading framing
+headers are present, so the connection remains framed for the next response.
+`412` is surfaced as a normal response status and body/framing rules remain the
+server's responsibility.
+
+RTTP does not provide cache storage, automatic revalidation, or a
+cache-control engine. Client conditional helpers only set request headers and
+expose response metadata; applications decide when to persist validators, when
+to revalidate, and how to interpret cache directives.
+
 ## Bounded trailer behavior
 
 Trailer support is explicit and bounded by protocol path. Use
@@ -121,6 +151,7 @@ header-block model.
 | Upgrade and tunnel handoff | `CONNECT` returns the tunnel socket after a successful `200`; `upgrade()` returns the socket after `101 Switching Protocols` and skips interim `1xx` responses | Upgraded protocols are handed to the caller and are not parsed by `rttp_client` |
 | Redirects | Auto-redirect covers 301, 302, 303, 307, and 308 method/body behavior, relative and absolute `Location` resolution, same- and cross-authority header handling, loop detection, and redirect bounds | Redirects are HTTP client behavior, not a browser policy implementation |
 | Byte ranges | `range`, `range_from`, and `range_suffix` emit single HTTP/1.1 `bytes` ranges; `Response::content_range`, `is_partial_content`, and `is_range_not_satisfiable` expose `206` and `416` metadata | No automatic `If-Range`, multipart range generation, retry, or cache validation policy |
+| Conditional requests | `if_none_match`, `if_match`, `if_modified_since`, and `if_unmodified_since` emit bounded HTTP/1.1 validators; `Response::is_not_modified`, `is_precondition_failed`, `etag`, and `last_modified` expose `304`/`412` metadata | One ETag validator per helper call, no `If-Range`, no cache storage, no automatic revalidation, and no cache-control engine |
 | Trailers | Chunked response trailers are exposed for blocking and async APIs; streaming chunked uploads can send declared request trailers | Application metadata trailers such as `X-Trace` are allowed; pseudo-header, connection-specific, routing, authentication/cookie, and framing trailer fields are rejected |
 | Bounded h2c client | With `http2`, direct `socket2` h2c sends GET, HEAD, bodyless DELETE, OPTIONS, or TRACE, buffered POST, PUT, or PATCH requests, and opt-in RFC 8441 extended CONNECT request HEADERS via `http2_extended_connect`, opens at most one request stream, supports prior-knowledge with `emit_http2_prior_knowledge`, supports explicit HTTP/1.1 `Upgrade: h2c` negotiation with `emit_http2_upgrade`, advertises `SETTINGS_ENABLE_PUSH = 0`, advertises `SETTINGS_ENABLE_CONNECT_PROTOCOL = 1` only for the explicit extended CONNECT path, validates received `SETTINGS_ENABLE_PUSH` values as only `0` or `1`, honors initial peer `SETTINGS_MAX_CONCURRENT_STREAMS` by failing before request HEADERS when the peer allows zero streams, honors peer-advertised `SETTINGS_MAX_HEADER_LIST_SIZE` request metadata limits, accepts only legal `SETTINGS_MAX_FRAME_SIZE` values from 16,384 through 16,777,215 bytes, splits outbound HEADERS, DATA, and trailers to the active peer frame-size limit, rejects oversized inbound frames when a configured local frame-size limit is exceeded, bounds HPACK dynamic table use with `SETTINGS_HEADER_TABLE_SIZE`, strips HTTP/1.x connection-specific request fields before emission, rejects connection-specific peer response fields, suppresses HEAD response bodies, treats `RST_STREAM` on the active stream as a bounded reset/cancellation signal, acknowledges valid PING frames with matching opaque data, DATA bodies, trailers, HPACK static Huffman strings, bounded large header blocks, padded incoming frames, `GOAWAY` shutdown boundaries, PRIORITY metadata validation without scheduling, HTTP/2-allowed unknown/extension frame ignoring inside this bounded path, reserved stream-id high-bit normalization, and conservative DATA flow control | Ordinary `CONNECT`, header-configured `:protocol` metadata, non-h2c HTTP/1.1 `Upgrade` handoff requests, and proxies are rejected deterministically, and `PUSH_PROMISE`/server push is rejected instead of managed; bounded direct h2c only, with no public cancellation callback API, no dynamic policy API, no extension callback API, no full extension negotiation, TLS ALPN, external h2 integration, proxy tunneling to h2, proxy h2, tunnel handoff, connection pooling, persistent HTTP/2 session management, automatic retry, server push, full stream state machine, unbounded multiplex scheduling, general multiplexing, priority scheduling, request bodies or trailers for extended CONNECT, or request bodies for GET, HEAD, DELETE, OPTIONS, or TRACE |
 


### PR DESCRIPTION
Documented bounded HTTP/1.1 conditional request behavior and limitations across root, server, and client READMEs. Verification passed with targeted conditional tests for `rttp_client` and `rttp`.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1566/
work_kind: code_work
branch: hbx-1566-rttp-document-bounded-http-1
base: main
commit: cc46f9f22c26cd30c3dd355924bb4e7ddaedf9cf
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1566/
    url: https://plane.kahub.in/endless/browse/HBX-1566/
    close_policy: link_only
```