### PR TITLE
feat: [rttp] Add bounded HTTP/1.1 If-Range evaluator helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,10 +342,18 @@ only the selected body bytes. For an unsatisfied range,
 `416 Range Not Satisfiable` with `Content-Range: bytes */length` and an empty
 body.
 
+For conditional range requests, `Request::evaluate_if_range(&metadata,
+entity_length)` composes caller-provided `HttpConditionalMetadata` with the
+existing single-range parser. Matching strong ETags or exact HTTP-date
+`Last-Modified` validators return `PartialContent(HttpByteRange)`;
+non-matching, weak, invalid, or metadata-missing validators return
+`FullResponse`; guarded unsatisfied ranges return `RangeNotSatisfiable`.
+Application code still chooses the final `200`, `206`, or `416` response.
+
 Multipart ranges are intentionally not generated: RTTP does not serialize
 `multipart/byteranges` or pick a multipart response for multiple requested
-ranges. `If-Range`, filesystem path normalization, MIME detection, ETag,
-Last-Modified, cache behavior, authorization, directory indexes, and dotfile
+ranges. Filesystem path normalization, MIME detection, ETag or Last-Modified
+generation, cache behavior, authorization, directory indexes, and dotfile
 visibility remain caller-owned policy before choosing `200`, `206`, or `416`.
 
 ### Bounded HTTP/1.1 conditional requests
@@ -509,7 +517,7 @@ TLS or async accept loops.
 | HTTP/1.1 request parsing | Required `Host` validation, origin-form, absolute-form, asterisk-form `OPTIONS`, authority-form `CONNECT`, fixed and chunked bodies, chunk extensions, `Expect: 100-continue`, and obsolete line folding rejection | Intended for local tests and simple embedded use, not full RFC coverage |
 | HTTP/1.1 connection handling | Bounded sequential `serve_requests`, keep-alive and close behavior for HTTP/1.1 and HTTP/1.0, pipelined request boundaries, malformed request rejection before handler dispatch | Blocking listener only; no async accept loop |
 | HTTP/1.1 response framing | Automatic `Content-Length`, explicit chunked responses, bodyless `HEAD`, `101`, `204`, and `304`, response trailers after the terminating chunk | No server TLS |
-| Byte ranges | `HttpByteRange` parses one `bytes` range and `HttpResponse::partial_content`/`range_not_satisfiable` serialize `206`/`416` with `Content-Range` | No multipart range serialization, `If-Range` evaluation, filesystem serving, or static-file policy |
+| Byte ranges | `HttpByteRange` parses one `bytes` range, `Request::evaluate_if_range` gates it with caller-provided strong ETag or exact HTTP-date metadata, and `HttpResponse::partial_content`/`range_not_satisfiable` serialize `206`/`416` with `Content-Range` | No multipart range serialization, filesystem serving, MIME detection, cache storage, or automatic static-file policy |
 | Conditional requests | `Request::evaluate_conditional`, `evaluate_conditional_request`, `HttpConditionalMetadata`, and `HttpEntityTag` evaluate bounded HTTP/1.1 validators; `HttpResponse::not_modified` and `precondition_failed` serialize `304` and `412` outcomes | No cache storage, static-file serving policy, automatic revalidation, or cache-control engine |
 | Upgrade and tunnel targets | `CONNECT` authority-form requests are accepted as HTTP requests; `HttpResponse::upgrade` can hand an upgraded socket to caller code after a matching request | The server does not implement the upgraded protocol after handoff |
 | Trailers | Chunked request trailers are preserved on `Request`; malformed, oversized, forbidden, and pseudo-header trailers are rejected; response trailers can be serialized for chunked responses | Application metadata trailers are allowed; trailer names that affect connection state, routing, authentication/cookies, framing, or payload processing are rejected |

--- a/rttp/README.md
+++ b/rttp/README.md
@@ -68,12 +68,23 @@ and sends only the selected body bytes. Use
 it returns `416 Range Not Satisfiable` with
 `Content-Range: bytes */length` and an empty body.
 
+For conditional range requests, build `HttpConditionalMetadata` from the
+selected representation and call `Request::evaluate_if_range(&metadata,
+entity_length)` or `HttpRequest::evaluate_if_range(&metadata, entity_length)`.
+The helper returns `PartialContent(HttpByteRange)` when the request can use the
+parsed single byte range, `RangeNotSatisfiable` when the guarded range is
+outside the representation, or `FullResponse` when there is no `Range` header
+or an `If-Range` validator is absent, invalid, weak, stale, or missing from the
+caller-provided metadata. Strong ETags use strong comparison, and HTTP-date
+validators require an exact `Last-Modified` match at HTTP-date second
+precision.
+
 Multipart byte ranges are intentionally not serialized: RTTP does not generate
 `multipart/byteranges` responses or choose a response for multiple requested
-ranges. `If-Range` is not evaluated by the server helper, and there is no
-built-in filesystem serving, path normalization, MIME selection, ETag,
-Last-Modified, cache, authorization, directory-index, or dotfile policy. Those
-remain application decisions before choosing `200`, `206`, or `416`.
+ranges. There is no built-in filesystem serving, path normalization, MIME
+selection, ETag or Last-Modified generation, cache, authorization,
+directory-index, or dotfile policy. Those remain application decisions before
+choosing `200`, `206`, or `416`.
 
 ## Bounded HTTP/1.1 conditional requests
 

--- a/rttp/src/server.rs
+++ b/rttp/src/server.rs
@@ -3336,6 +3336,14 @@ impl Request {
     evaluate_conditional_request(self, metadata)
   }
 
+  pub fn evaluate_if_range(
+    &self,
+    metadata: &HttpConditionalMetadata,
+    entity_length: usize,
+  ) -> Result<HttpIfRangeRequestOutcome, HttpByteRangeError> {
+    evaluate_if_range_request(self, metadata, entity_length)
+  }
+
   fn connection_header_has_token(&self, token: &str) -> bool {
     self
       .headers
@@ -3807,6 +3815,66 @@ pub fn evaluate_conditional_request(
   HttpConditionalRequestOutcome::Proceed
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum HttpIfRangeRequestOutcome {
+  FullResponse,
+  PartialContent(HttpByteRange),
+  RangeNotSatisfiable,
+}
+
+pub fn evaluate_if_range_request(
+  request: &Request,
+  metadata: &HttpConditionalMetadata,
+  entity_length: usize,
+) -> Result<HttpIfRangeRequestOutcome, HttpByteRangeError> {
+  evaluate_if_range_headers(
+    request.header("Range"),
+    request.header("If-Range"),
+    metadata,
+    entity_length,
+  )
+}
+
+fn evaluate_if_range_headers(
+  range_header: Option<&str>,
+  if_range: Option<&str>,
+  metadata: &HttpConditionalMetadata,
+  entity_length: usize,
+) -> Result<HttpIfRangeRequestOutcome, HttpByteRangeError> {
+  let Some(range_header) = range_header else {
+    return Ok(HttpIfRangeRequestOutcome::FullResponse);
+  };
+
+  if let Some(if_range) = if_range {
+    if !if_range_matches(if_range, metadata) {
+      return Ok(HttpIfRangeRequestOutcome::FullResponse);
+    }
+  }
+
+  match HttpByteRange::parse(range_header, entity_length) {
+    Ok(range) => Ok(HttpIfRangeRequestOutcome::PartialContent(range)),
+    Err(HttpByteRangeError::UnsatisfiedRange) => Ok(HttpIfRangeRequestOutcome::RangeNotSatisfiable),
+    Err(error) => Err(error),
+  }
+}
+
+fn if_range_matches(if_range: &str, metadata: &HttpConditionalMetadata) -> bool {
+  if let Ok(candidate) = HttpEntityTag::parse(if_range) {
+    return metadata
+      .entity_tag
+      .as_ref()
+      .is_some_and(|current| current.strong_matches(&candidate));
+  }
+
+  let Ok(candidate) = httpdate::parse_http_date(if_range) else {
+    return false;
+  };
+
+  metadata
+    .last_modified
+    .is_some_and(|last_modified| http_date_seconds_equal(last_modified, candidate))
+}
+
 fn request_if_match_matches(request: &Request, metadata: &HttpConditionalMetadata) -> Option<bool> {
   request_entity_tag_validator_matches(request, "If-Match", metadata, EntityTagComparison::Strong)
 }
@@ -3872,6 +3940,16 @@ fn http_date_seconds_after(left: SystemTime, right: SystemTime) -> bool {
   ) {
     (Ok(left), Ok(right)) => left.as_secs() > right.as_secs(),
     _ => left > right,
+  }
+}
+
+fn http_date_seconds_equal(left: SystemTime, right: SystemTime) -> bool {
+  match (
+    left.duration_since(UNIX_EPOCH),
+    right.duration_since(UNIX_EPOCH),
+  ) {
+    (Ok(left), Ok(right)) => left.as_secs() == right.as_secs(),
+    _ => left == right,
   }
 }
 
@@ -4165,6 +4243,19 @@ impl HttpRequest {
 
   pub fn body(&self) -> &[u8] {
     &self.body
+  }
+
+  pub fn evaluate_if_range(
+    &self,
+    metadata: &HttpConditionalMetadata,
+    entity_length: usize,
+  ) -> Result<HttpIfRangeRequestOutcome, HttpByteRangeError> {
+    evaluate_if_range_headers(
+      self.header("Range"),
+      self.header("If-Range"),
+      metadata,
+      entity_length,
+    )
   }
 }
 

--- a/rttp/tests/test_server_models.rs
+++ b/rttp/tests/test_server_models.rs
@@ -1,4 +1,11 @@
-use rttp::server::{HttpByteRange, HttpByteRangeError, HttpRequest, HttpResponse};
+use rttp::server::{
+  HttpByteRange, HttpByteRangeError, HttpConditionalMetadata, HttpEntityTag,
+  HttpIfRangeRequestOutcome, HttpRequest, HttpResponse,
+};
+
+fn parse_request(raw: &str) -> HttpRequest {
+  HttpRequest::parse(raw.as_bytes()).expect("request should parse")
+}
 
 #[test]
 fn parses_http_request_target_headers_and_body() {
@@ -425,6 +432,152 @@ fn serializes_range_not_satisfiable_response() {
     )
     .as_bytes(),
     response.to_bytes().as_slice()
+  );
+}
+
+#[test]
+fn if_range_allows_partial_content_for_matching_strong_etag() {
+  let request = parse_request(concat!(
+    "GET /asset HTTP/1.1\r\n",
+    "Host: example.test\r\n",
+    "Range: bytes=2-5\r\n",
+    "If-Range: \"abc123\"\r\n",
+    "\r\n"
+  ));
+  let metadata = HttpConditionalMetadata::new().entity_tag(HttpEntityTag::strong("abc123"));
+
+  assert_eq!(
+    Ok(HttpIfRangeRequestOutcome::PartialContent(
+      HttpByteRange::new(2, 5)
+    )),
+    request.evaluate_if_range(&metadata, 10)
+  );
+}
+
+#[test]
+fn if_range_falls_back_to_full_response_for_non_matching_or_weak_etag() {
+  for if_range in [r#""other""#, r#"W/"abc123""#] {
+    let request = parse_request(&format!(
+      concat!(
+        "GET /asset HTTP/1.1\r\n",
+        "Host: example.test\r\n",
+        "Range: bytes=2-5\r\n",
+        "If-Range: {if_range}\r\n",
+        "\r\n"
+      ),
+      if_range = if_range
+    ));
+    let metadata = HttpConditionalMetadata::new().entity_tag(HttpEntityTag::strong("abc123"));
+
+    assert_eq!(
+      Ok(HttpIfRangeRequestOutcome::FullResponse),
+      request.evaluate_if_range(&metadata, 10)
+    );
+  }
+}
+
+#[test]
+fn if_range_allows_partial_content_for_exact_http_date_match() {
+  let request = parse_request(concat!(
+    "GET /asset HTTP/1.1\r\n",
+    "Host: example.test\r\n",
+    "Range: bytes=7-\r\n",
+    "If-Range: Sun, 06 Nov 1994 08:49:37 GMT\r\n",
+    "\r\n"
+  ));
+  let metadata = HttpConditionalMetadata::new().last_modified(
+    httpdate::parse_http_date("Sun, 06 Nov 1994 08:49:37 GMT").expect("metadata date"),
+  );
+
+  assert_eq!(
+    Ok(HttpIfRangeRequestOutcome::PartialContent(
+      HttpByteRange::new(7, 9)
+    )),
+    request.evaluate_if_range(&metadata, 10)
+  );
+}
+
+#[test]
+fn if_range_falls_back_to_full_response_for_stale_invalid_or_missing_validator_metadata() {
+  for (if_range, metadata) in [
+    (
+      "Sun, 06 Nov 1994 08:49:36 GMT",
+      HttpConditionalMetadata::new().last_modified(
+        httpdate::parse_http_date("Sun, 06 Nov 1994 08:49:37 GMT").expect("metadata date"),
+      ),
+    ),
+    ("not a validator", HttpConditionalMetadata::new()),
+    (r#""abc123""#, HttpConditionalMetadata::new()),
+  ] {
+    let request = parse_request(&format!(
+      concat!(
+        "GET /asset HTTP/1.1\r\n",
+        "Host: example.test\r\n",
+        "Range: bytes=2-5\r\n",
+        "If-Range: {if_range}\r\n",
+        "\r\n"
+      ),
+      if_range = if_range
+    ));
+
+    assert_eq!(
+      Ok(HttpIfRangeRequestOutcome::FullResponse),
+      request.evaluate_if_range(&metadata, 10)
+    );
+  }
+}
+
+#[test]
+fn if_range_without_if_range_header_uses_existing_range_parser_outcomes() {
+  let partial = parse_request(concat!(
+    "GET /asset HTTP/1.1\r\n",
+    "Host: example.test\r\n",
+    "Range: bytes=-4\r\n",
+    "\r\n"
+  ));
+  let unsatisfied = parse_request(concat!(
+    "GET /asset HTTP/1.1\r\n",
+    "Host: example.test\r\n",
+    "Range: bytes=10-\r\n",
+    "\r\n"
+  ));
+  let invalid = parse_request(concat!(
+    "GET /asset HTTP/1.1\r\n",
+    "Host: example.test\r\n",
+    "Range: bytes=5-2\r\n",
+    "\r\n"
+  ));
+  let metadata = HttpConditionalMetadata::new();
+
+  assert_eq!(
+    Ok(HttpIfRangeRequestOutcome::PartialContent(
+      HttpByteRange::new(6, 9)
+    )),
+    partial.evaluate_if_range(&metadata, 10)
+  );
+  assert_eq!(
+    Ok(HttpIfRangeRequestOutcome::RangeNotSatisfiable),
+    unsatisfied.evaluate_if_range(&metadata, 10)
+  );
+  assert_eq!(
+    Err(HttpByteRangeError::InvalidRange),
+    invalid.evaluate_if_range(&metadata, 10)
+  );
+}
+
+#[test]
+fn if_range_without_range_header_falls_back_to_full_response() {
+  let request = parse_request(concat!(
+    "GET /asset HTTP/1.1\r\n",
+    "Host: example.test\r\n",
+    "If-Range: \"abc123\"\r\n",
+    "\r\n"
+  ));
+  let metadata = HttpConditionalMetadata::new().entity_tag(HttpEntityTag::strong("abc123"));
+
+  assert_eq!(
+    Ok(HttpIfRangeRequestOutcome::FullResponse),
+    request.evaluate_if_range(&metadata, 10)
   );
 }
 


### PR DESCRIPTION
Adds bounded server-side If-Range evaluation helpers for rttp with strong ETag and exact HTTP-date matching, caller-controlled fallback outcomes, tests, and documentation updates.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1569/
work_kind: code_work
branch: hbx-1569-rttp-add-bounded-http-1
base: main
commit: 559b6ac0d761f2dd042a6536f634800db9d3f6c9
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1569/
    url: https://plane.kahub.in/endless/browse/HBX-1569/
    close_policy: link_only
```