### PR TITLE
feat: [rttp_client] Add bounded HTTP/1.1 If-Range request helpers

### DIFF
--- a/rttp_client/README.md
+++ b/rttp_client/README.md
@@ -47,6 +47,14 @@ Partial-content responses are exposed through the normal `Response` API.
 `ContentRange::is_unsatisfied() == true`. Response bodies and headers are still
 preserved normally for both `206` and `416`.
 
+`If-Range` is available as a bounded request helper for the two validator forms
+that compose with these range helpers: `if_range_etag(etag)` emits a single
+strong entity tag validator, and `if_range_date(http_date)` emits an HTTP-date
+validator. The ETag helper rejects weak tags, `*`, lists, and malformed tag
+syntax before opening a socket; the date helper requires a parseable HTTP-date.
+Manual `If-Range` headers remain available through `header(("If-Range", "..."))`
+when callers need values outside the helper validation.
+
 RTTP does not synthesize multipart range requests, evaluate `If-Range`, retry
 range requests, or apply cache validation policy on the client side. Multiple
 ranges can only be sent by manually setting the header, and any server response
@@ -64,8 +72,9 @@ lists or non-helper behavior can still use the generic `header` API.
 
 The date helpers validate that the supplied value parses as an HTTP-date before
 emission and then write the value as provided. They do not normalize date text
-or choose a validator policy for the request. `If-Range` remains outside these
-helpers.
+or choose a validator policy for the request. `If-Range` uses its own helpers
+because it is intended to compose with range requests and permits only strong
+entity tags or HTTP-date validators.
 
 Conditional responses are exposed through response metadata helpers.
 `Response::is_not_modified()` identifies `304 Not Modified`,
@@ -150,8 +159,8 @@ header-block model.
 | HTTP/1.1 request emission | Origin-form requests, absolute-form proxy requests, `CONNECT`, `HEAD`, fixed bodies, streaming chunked uploads, and `Expect: 100-continue` | SOCKS handshakes are delegated to the `socks` crate |
 | Upgrade and tunnel handoff | `CONNECT` returns the tunnel socket after a successful `200`; `upgrade()` returns the socket after `101 Switching Protocols` and skips interim `1xx` responses | Upgraded protocols are handed to the caller and are not parsed by `rttp_client` |
 | Redirects | Auto-redirect covers 301, 302, 303, 307, and 308 method/body behavior, relative and absolute `Location` resolution, same- and cross-authority header handling, loop detection, and redirect bounds | Redirects are HTTP client behavior, not a browser policy implementation |
-| Byte ranges | `range`, `range_from`, and `range_suffix` emit single HTTP/1.1 `bytes` ranges; `Response::content_range`, `is_partial_content`, and `is_range_not_satisfiable` expose `206` and `416` metadata | No automatic `If-Range`, multipart range generation, retry, or cache validation policy |
-| Conditional requests | `if_none_match`, `if_match`, `if_modified_since`, and `if_unmodified_since` emit bounded HTTP/1.1 validators; `Response::is_not_modified`, `is_precondition_failed`, `etag`, and `last_modified` expose `304`/`412` metadata | One ETag validator per helper call, no `If-Range`, no cache storage, no automatic revalidation, and no cache-control engine |
+| Byte ranges | `range`, `range_from`, `range_suffix`, `if_range_etag`, and `if_range_date` emit bounded HTTP/1.1 range request metadata; `Response::content_range`, `is_partial_content`, and `is_range_not_satisfiable` expose `206` and `416` metadata | No automatic `If-Range`, multipart range generation, retry, or cache validation policy |
+| Conditional requests | `if_none_match`, `if_match`, `if_modified_since`, and `if_unmodified_since` emit bounded HTTP/1.1 validators; `Response::is_not_modified`, `is_precondition_failed`, `etag`, and `last_modified` expose `304`/`412` metadata | One ETag validator per helper call, `If-Range` is range-scoped, no cache storage, no automatic revalidation, and no cache-control engine |
 | Trailers | Chunked response trailers are exposed for blocking and async APIs; streaming chunked uploads can send declared request trailers | Application metadata trailers such as `X-Trace` are allowed; pseudo-header, connection-specific, routing, authentication/cookie, and framing trailer fields are rejected |
 | Bounded h2c client | With `http2`, direct `socket2` h2c sends GET, HEAD, bodyless DELETE, OPTIONS, or TRACE, buffered POST, PUT, or PATCH requests, and opt-in RFC 8441 extended CONNECT request HEADERS via `http2_extended_connect`, opens at most one request stream, supports prior-knowledge with `emit_http2_prior_knowledge`, supports explicit HTTP/1.1 `Upgrade: h2c` negotiation with `emit_http2_upgrade`, advertises `SETTINGS_ENABLE_PUSH = 0`, advertises `SETTINGS_ENABLE_CONNECT_PROTOCOL = 1` only for the explicit extended CONNECT path, validates received `SETTINGS_ENABLE_PUSH` values as only `0` or `1`, honors initial peer `SETTINGS_MAX_CONCURRENT_STREAMS` by failing before request HEADERS when the peer allows zero streams, honors peer-advertised `SETTINGS_MAX_HEADER_LIST_SIZE` request metadata limits, accepts only legal `SETTINGS_MAX_FRAME_SIZE` values from 16,384 through 16,777,215 bytes, splits outbound HEADERS, DATA, and trailers to the active peer frame-size limit, rejects oversized inbound frames when a configured local frame-size limit is exceeded, bounds HPACK dynamic table use with `SETTINGS_HEADER_TABLE_SIZE`, strips HTTP/1.x connection-specific request fields before emission, rejects connection-specific peer response fields, suppresses HEAD response bodies, treats `RST_STREAM` on the active stream as a bounded reset/cancellation signal, acknowledges valid PING frames with matching opaque data, DATA bodies, trailers, HPACK static Huffman strings, bounded large header blocks, padded incoming frames, `GOAWAY` shutdown boundaries, PRIORITY metadata validation without scheduling, HTTP/2-allowed unknown/extension frame ignoring inside this bounded path, reserved stream-id high-bit normalization, and conservative DATA flow control | Ordinary `CONNECT`, header-configured `:protocol` metadata, non-h2c HTTP/1.1 `Upgrade` handoff requests, and proxies are rejected deterministically, and `PUSH_PROMISE`/server push is rejected instead of managed; bounded direct h2c only, with no public cancellation callback API, no dynamic policy API, no extension callback API, no full extension negotiation, TLS ALPN, external h2 integration, proxy tunneling to h2, proxy h2, tunnel handoff, connection pooling, persistent HTTP/2 session management, automatic retry, server push, full stream state machine, unbounded multiplex scheduling, general multiplexing, priority scheduling, request bodies or trailers for extended CONNECT, or request bodies for GET, HEAD, DELETE, OPTIONS, or TRACE |
 

--- a/rttp_client/src/client.rs
+++ b/rttp_client/src/client.rs
@@ -218,6 +218,21 @@ impl HttpClient {
     Ok(self.header(("Range", format!("bytes=-{}", suffix).as_str())))
   }
 
+  /// Set an `If-Range` validator with a single strong entity tag.
+  ///
+  /// `If-Range` only permits strong entity-tag validators. Use `header`
+  /// directly for manual values that intentionally bypass this helper.
+  pub fn if_range_etag<S: AsRef<str>>(&mut self, etag: S) -> error::Result<&mut Self> {
+    let etag = validate_single_strong_etag(etag.as_ref())?;
+    Ok(self.header(Header::new("If-Range", etag)))
+  }
+
+  /// Set an `If-Range` validator with an HTTP-date.
+  pub fn if_range_date<S: AsRef<str>>(&mut self, http_date: S) -> error::Result<&mut Self> {
+    let http_date = validate_http_date(http_date.as_ref())?;
+    Ok(self.header(Header::new("If-Range", http_date)))
+  }
+
   /// Set a single entity-tag validator, `If-None-Match: <etag>`.
   ///
   /// Accepts `*`, a strong entity tag such as `"abc"`, or a weak entity tag
@@ -534,6 +549,16 @@ fn validate_single_etag(etag: &str) -> error::Result<&str> {
     ));
   }
 
+  Ok(etag)
+}
+
+fn validate_single_strong_etag(etag: &str) -> error::Result<&str> {
+  let etag = validate_single_etag(etag)?;
+  if etag == "*" || etag.starts_with("W/") {
+    return Err(error::builder_with_message(
+      "If-Range entity-tag helper accepts only a single strong entity tag",
+    ));
+  }
   Ok(etag)
 }
 

--- a/rttp_client/tests/test_raw_request_capture.rs
+++ b/rttp_client/tests/test_raw_request_capture.rs
@@ -308,6 +308,91 @@ fn conditional_request_helpers_emit_validator_headers() {
 }
 
 #[test]
+fn if_range_helpers_emit_single_validator_headers() {
+  let request = capture_request(|base_url| {
+    client()
+      .get()
+      .url(format!("{}/asset", base_url))
+      .range(10, 19)
+      .expect("bounded range should be accepted")
+      .if_range_etag(r#""abc123""#)
+      .expect("strong etag should be accepted")
+      .emit()
+      .expect("request should succeed");
+  });
+  let request = request_text(&request);
+
+  assert_eq!(Some("bytes=10-19"), header_value(&request, "Range"));
+  assert_eq!(Some(r#""abc123""#), header_value(&request, "If-Range"));
+
+  let request = capture_request(|base_url| {
+    client()
+      .get()
+      .url(format!("{}/asset", base_url))
+      .range_from(20)
+      .if_range_date("Sun, 06 Nov 1994 08:49:37 GMT")
+      .expect("http date should be accepted")
+      .emit()
+      .expect("request should succeed");
+  });
+  let request = request_text(&request);
+
+  assert_eq!(Some("bytes=20-"), header_value(&request, "Range"));
+  assert_eq!(
+    Some("Sun, 06 Nov 1994 08:49:37 GMT"),
+    header_value(&request, "If-Range")
+  );
+}
+
+#[test]
+fn if_range_helpers_reject_obvious_malformed_inputs_before_connecting() {
+  let request = capture_optional_request(|base_url| {
+    let mut client = client();
+    let error = client
+      .get()
+      .url(format!("{}/asset", base_url))
+      .if_range_etag(r#"W/"weak-tag""#)
+      .expect_err("weak etag should be rejected for If-Range");
+
+    assert!(error.is_builder());
+  });
+  assert!(
+    request.is_empty(),
+    "malformed If-Range etag helper should not open a socket"
+  );
+
+  let request = capture_optional_request(|base_url| {
+    let mut client = client();
+    let error = client
+      .get()
+      .url(format!("{}/asset", base_url))
+      .if_range_etag("*")
+      .expect_err("wildcard etag should be rejected for If-Range");
+
+    assert!(error.is_builder());
+  });
+  assert!(
+    request.is_empty(),
+    "malformed If-Range etag helper should not open a socket"
+  );
+
+  let request = capture_optional_request(|base_url| {
+    let mut client = client();
+    let error = client
+      .get()
+      .url(format!("{}/asset", base_url))
+      .if_range_date("not a date")
+      .expect_err("invalid http date should be rejected");
+
+    assert!(error.is_builder());
+  });
+  assert!(
+    request.is_empty(),
+    "malformed If-Range date helper should not open a socket"
+  );
+}
+
+#[test]
 fn conditional_request_helpers_reject_obvious_malformed_inputs_before_connecting() {
   let request = capture_optional_request(|base_url| {
     let mut client = client();
@@ -370,6 +455,21 @@ fn manual_conditional_headers_remain_available_as_escape_hatch() {
   assert_eq!(
     Some(r#""one", "two""#),
     header_value(&request, "If-None-Match")
+  );
+
+  let request = capture_request(|base_url| {
+    client()
+      .get()
+      .url(format!("{}/asset", base_url))
+      .header(("If-Range", r#"W/"manual-weak""#))
+      .emit()
+      .expect("request should succeed");
+  });
+  let request = request_text(&request);
+
+  assert_eq!(
+    Some(r#"W/"manual-weak""#),
+    header_value(&request, "If-Range")
   );
 }
 


### PR DESCRIPTION
Adds bounded `rttp_client` HTTP/1.1 `If-Range` helpers for strong ETag and HTTP-date validators, with pre-connect validation, manual header escape hatch preservation, tests, and documentation updates.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1568/
work_kind: code_work
branch: hbx-1568-rttp-client-add-bounded-http
base: main
commit: 8300593021a0f16e4bb17b93fed3e204e3c98f9c
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1568/
    url: https://plane.kahub.in/endless/browse/HBX-1568/
    close_policy: link_only
```