### PR TITLE
feat: [rttp_client] Add bounded HTTP/1.1 Cache-Control response helpers

### DIFF
--- a/rttp_client/src/response/response.rs
+++ b/rttp_client/src/response/response.rs
@@ -100,6 +100,14 @@ impl Response {
       .and_then(ContentRange::parse)
   }
 
+  pub fn cache_control(&self) -> error::Result<Option<CacheControl>> {
+    let values = self.header_values("cache-control");
+    if values.is_empty() {
+      return Ok(None);
+    }
+    CacheControl::parse_values(values.into_iter().map(String::as_str)).map(Some)
+  }
+
   pub fn headers(&self) -> &Vec<Header> {
     self.raw.headers_get()
   }
@@ -258,6 +266,342 @@ fn parse_complete_length(value: &str) -> Option<Option<u64>> {
     return Some(None);
   }
   value.parse::<u64>().ok().map(Some)
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct CacheControl {
+  no_cache: bool,
+  no_cache_fields: Vec<String>,
+  no_store: bool,
+  max_age: Option<u64>,
+  s_maxage: Option<u64>,
+  private: bool,
+  private_fields: Vec<String>,
+  public: bool,
+  must_revalidate: bool,
+  proxy_revalidate: bool,
+  immutable: bool,
+  stale_while_revalidate: Option<u64>,
+  stale_if_error: Option<u64>,
+  extensions: Vec<CacheControlExtension>,
+}
+
+impl CacheControl {
+  pub fn parse(value: impl AsRef<str>) -> error::Result<Self> {
+    Self::parse_values([value.as_ref()])
+  }
+
+  fn parse_values<'a, I>(values: I) -> error::Result<Self>
+  where
+    I: IntoIterator<Item = &'a str>,
+  {
+    let mut cache_control = Self::default();
+    for value in values {
+      for directive in split_cache_control_directives(value)? {
+        cache_control.apply_directive(&directive)?;
+      }
+    }
+    Ok(cache_control)
+  }
+
+  fn apply_directive(&mut self, directive: &str) -> error::Result<()> {
+    let (name, value, value_was_quoted) = match directive.split_once('=') {
+      Some((name, value)) => {
+        let value = value.trim();
+        (
+          name.trim(),
+          Some(parse_directive_value(value)?),
+          value.starts_with('"'),
+        )
+      }
+      None => (directive.trim(), None, false),
+    };
+    if !is_token(name) {
+      return Err(error::bad_response("Invalid Cache-Control directive"));
+    }
+
+    match name.to_ascii_lowercase().as_str() {
+      "no-cache" => {
+        self.no_cache = true;
+        if let Some(value) = value {
+          self.no_cache_fields = split_field_names(&value);
+        }
+      }
+      "no-store" => self.no_store = true,
+      "max-age" => {
+        self.max_age = Some(parse_delta_seconds(
+          name,
+          value.as_deref(),
+          value_was_quoted,
+        )?)
+      }
+      "s-maxage" => {
+        self.s_maxage = Some(parse_delta_seconds(
+          name,
+          value.as_deref(),
+          value_was_quoted,
+        )?)
+      }
+      "private" => {
+        self.private = true;
+        if let Some(value) = value {
+          self.private_fields = split_field_names(&value);
+        }
+      }
+      "public" => self.public = true,
+      "must-revalidate" => self.must_revalidate = true,
+      "proxy-revalidate" => self.proxy_revalidate = true,
+      "immutable" => self.immutable = true,
+      "stale-while-revalidate" => {
+        self.stale_while_revalidate = Some(parse_delta_seconds(
+          name,
+          value.as_deref(),
+          value_was_quoted,
+        )?)
+      }
+      "stale-if-error" => {
+        self.stale_if_error = Some(parse_delta_seconds(
+          name,
+          value.as_deref(),
+          value_was_quoted,
+        )?)
+      }
+      _ => self
+        .extensions
+        .push(CacheControlExtension::new(name, value.as_deref())),
+    }
+    Ok(())
+  }
+
+  pub fn no_cache(&self) -> bool {
+    self.no_cache
+  }
+
+  pub fn no_cache_fields(&self) -> Vec<&str> {
+    self.no_cache_fields.iter().map(String::as_str).collect()
+  }
+
+  pub fn no_store(&self) -> bool {
+    self.no_store
+  }
+
+  pub fn max_age(&self) -> Option<u64> {
+    self.max_age
+  }
+
+  pub fn s_maxage(&self) -> Option<u64> {
+    self.s_maxage
+  }
+
+  pub fn private(&self) -> bool {
+    self.private
+  }
+
+  pub fn private_fields(&self) -> Vec<&str> {
+    self.private_fields.iter().map(String::as_str).collect()
+  }
+
+  pub fn public(&self) -> bool {
+    self.public
+  }
+
+  pub fn must_revalidate(&self) -> bool {
+    self.must_revalidate
+  }
+
+  pub fn proxy_revalidate(&self) -> bool {
+    self.proxy_revalidate
+  }
+
+  pub fn immutable(&self) -> bool {
+    self.immutable
+  }
+
+  pub fn stale_while_revalidate(&self) -> Option<u64> {
+    self.stale_while_revalidate
+  }
+
+  pub fn stale_if_error(&self) -> Option<u64> {
+    self.stale_if_error
+  }
+
+  pub fn extensions(&self) -> &[CacheControlExtension] {
+    &self.extensions
+  }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CacheControlExtension {
+  name: String,
+  value: Option<String>,
+}
+
+impl CacheControlExtension {
+  fn new(name: &str, value: Option<&str>) -> Self {
+    Self {
+      name: name.to_string(),
+      value: value.map(ToString::to_string),
+    }
+  }
+
+  pub fn name(&self) -> &str {
+    &self.name
+  }
+
+  pub fn value(&self) -> Option<&str> {
+    self.value.as_deref()
+  }
+}
+
+fn split_cache_control_directives(value: &str) -> error::Result<Vec<String>> {
+  let mut directives = Vec::new();
+  let mut current = String::new();
+  let mut in_quote = false;
+  let mut escaped = false;
+
+  for ch in value.chars() {
+    if escaped {
+      current.push(ch);
+      escaped = false;
+      continue;
+    }
+
+    match ch {
+      '\\' if in_quote => {
+        current.push(ch);
+        escaped = true;
+      }
+      '"' => {
+        current.push(ch);
+        in_quote = !in_quote;
+      }
+      ',' if !in_quote => {
+        push_directive(&mut directives, &current)?;
+        current.clear();
+      }
+      _ => current.push(ch),
+    }
+  }
+
+  if in_quote || escaped {
+    return Err(error::bad_response("Malformed Cache-Control quoted-string"));
+  }
+  push_directive(&mut directives, &current)?;
+  Ok(directives)
+}
+
+fn push_directive(directives: &mut Vec<String>, directive: &str) -> error::Result<()> {
+  let directive = directive.trim();
+  if directive.is_empty() {
+    return Err(error::bad_response("Invalid Cache-Control directive"));
+  }
+  directives.push(directive.to_string());
+  Ok(())
+}
+
+fn parse_directive_value(value: &str) -> error::Result<String> {
+  if let Some(value) = value.strip_prefix('"') {
+    return parse_quoted_string(value);
+  }
+  if value.contains('"') || value.is_empty() {
+    return Err(error::bad_response("Invalid Cache-Control directive value"));
+  }
+  Ok(value.to_string())
+}
+
+fn parse_quoted_string(value: &str) -> error::Result<String> {
+  let mut chars = value.chars();
+  let mut parsed = String::new();
+  let mut closed = false;
+
+  while let Some(ch) = chars.next() {
+    match ch {
+      '"' => {
+        closed = true;
+        break;
+      }
+      '\\' => {
+        let Some(escaped) = chars.next() else {
+          return Err(error::bad_response("Malformed Cache-Control quoted-string"));
+        };
+        if !is_quoted_pair_char(escaped) {
+          return Err(error::bad_response("Malformed Cache-Control quoted-string"));
+        }
+        parsed.push(escaped);
+      }
+      _ if is_qdtext(ch) => parsed.push(ch),
+      _ => return Err(error::bad_response("Malformed Cache-Control quoted-string")),
+    }
+  }
+
+  if !closed || chars.any(|ch| !ch.is_ascii_whitespace()) {
+    return Err(error::bad_response("Malformed Cache-Control quoted-string"));
+  }
+  Ok(parsed)
+}
+
+fn parse_delta_seconds(
+  name: &str,
+  value: Option<&str>,
+  value_was_quoted: bool,
+) -> error::Result<u64> {
+  let Some(value) = value else {
+    return Err(error::bad_response(format!(
+      "Missing Cache-Control {name} delta-seconds"
+    )));
+  };
+  if value_was_quoted || value.is_empty() || !value.chars().all(|ch| ch.is_ascii_digit()) {
+    return Err(error::bad_response(format!(
+      "Invalid Cache-Control {name} delta-seconds"
+    )));
+  }
+  value
+    .parse::<u64>()
+    .map_err(|_| error::bad_response(format!("Invalid Cache-Control {name} delta-seconds")))
+}
+
+fn split_field_names(value: &str) -> Vec<String> {
+  value
+    .split(',')
+    .map(str::trim)
+    .filter(|field| !field.is_empty())
+    .map(ToString::to_string)
+    .collect()
+}
+
+fn is_token(value: &str) -> bool {
+  !value.is_empty() && value.bytes().all(is_token_byte)
+}
+
+fn is_token_byte(byte: u8) -> bool {
+  matches!(
+    byte,
+    b'!' | b'#'
+      | b'$'
+      | b'%'
+      | b'&'
+      | b'\''
+      | b'*'
+      | b'+'
+      | b'-'
+      | b'.'
+      | b'^'
+      | b'_'
+      | b'`'
+      | b'|'
+      | b'~'
+      | b'0'..=b'9'
+      | b'A'..=b'Z'
+      | b'a'..=b'z'
+  )
+}
+
+fn is_qdtext(ch: char) -> bool {
+  matches!(ch, '\t' | ' ' | '!' | '#'..='[' | ']'..='~') || ('\u{80}'..='\u{ff}').contains(&ch)
+}
+
+fn is_quoted_pair_char(ch: char) -> bool {
+  matches!(ch, '\t' | ' '..='~') || ('\u{80}'..='\u{ff}').contains(&ch)
 }
 
 #[derive(Clone)]

--- a/rttp_client/tests/test_response.rs
+++ b/rttp_client/tests/test_response.rs
@@ -210,6 +210,79 @@ fn test_parse_conditional_response_metadata() {
 }
 
 #[test]
+fn test_parse_cache_control_response_directives() {
+  let s = concat!(
+    "HTTP/1.1 200 OK\r\n",
+    "Cache-Control: no-cache=\"Set-Cookie, Authorization\", no-store, max-age=60\r\n",
+    "Cache-Control: s-maxage=120, private=\"X-User\", public, must-revalidate\r\n",
+    "Cache-Control: proxy-revalidate, immutable, stale-while-revalidate=30, stale-if-error=90\r\n",
+    "Cache-Control: community=\"u=1, tier=gold\", ext-token\r\n",
+    "Content-Length: 2\r\n",
+    "\r\n",
+    "OK"
+  );
+  let response = Response::new(RoUrl::with("https://example.test"), s.as_bytes().to_vec())
+    .expect("parse cache-control response");
+
+  let cache_control = response
+    .cache_control()
+    .expect("valid cache-control should parse")
+    .expect("cache-control header should be present");
+
+  assert!(cache_control.no_cache());
+  assert_eq!(
+    vec!["Set-Cookie", "Authorization"],
+    cache_control.no_cache_fields()
+  );
+  assert!(cache_control.no_store());
+  assert_eq!(Some(60), cache_control.max_age());
+  assert_eq!(Some(120), cache_control.s_maxage());
+  assert!(cache_control.private());
+  assert_eq!(vec!["X-User"], cache_control.private_fields());
+  assert!(cache_control.public());
+  assert!(cache_control.must_revalidate());
+  assert!(cache_control.proxy_revalidate());
+  assert!(cache_control.immutable());
+  assert_eq!(Some(30), cache_control.stale_while_revalidate());
+  assert_eq!(Some(90), cache_control.stale_if_error());
+  assert_eq!(2, cache_control.extensions().len());
+  assert_eq!("community", cache_control.extensions()[0].name());
+  assert_eq!(
+    Some("u=1, tier=gold"),
+    cache_control.extensions()[0].value()
+  );
+  assert_eq!("ext-token", cache_control.extensions()[1].name());
+  assert_eq!(None, cache_control.extensions()[1].value());
+}
+
+#[test]
+fn test_parse_cache_control_rejects_invalid_helper_values_without_rejecting_response() {
+  let invalid_values = [
+    "max-age=-1",
+    "s-maxage=abc",
+    "stale-while-revalidate=1.5",
+    "stale-if-error=\"60\"",
+    "private=\"unterminated",
+    "extension=\"bad\\\"",
+  ];
+
+  for value in invalid_values {
+    let raw = format!("HTTP/1.1 200 OK\r\nCache-Control: {value}\r\nContent-Length: 2\r\n\r\nOK");
+    let response = Response::new(RoUrl::with("https://example.test"), raw.into_bytes())
+      .expect("raw response remains usable");
+
+    assert!(
+      response.cache_control().is_err(),
+      "cache-control helper should reject {value:?}"
+    );
+    assert_eq!(
+      Some(&value.to_string()),
+      response.header_value("Cache-Control")
+    );
+  }
+}
+
+#[test]
 fn test_parse_response_rejects_header_without_colon() {
   let s = concat!(
     "HTTP/1.1 200 OK\r\n",


### PR DESCRIPTION
Adds bounded `Cache-Control` response helper parsing in `rttp_client`, including structured common directives, extension preservation, and strict helper-level rejection of malformed numeric or quoted values. Existing response behavior and raw header access remain unchanged.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1573/
work_kind: code_work
branch: hbx-1573-rttp-client-add-bounded-http
base: main
commit: 6e0f94610b7d76ec8c6d737302bbd425e9074602
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1573/
    url: https://plane.kahub.in/endless/browse/HBX-1573/
    close_policy: link_only
```