### PR TITLE
feat: [rttp] Add cross-crate HTTP/1.1 Cache-Control matrix

### DIFF
--- a/rttp/tests/http11_compliance_matrix.rs
+++ b/rttp/tests/http11_compliance_matrix.rs
@@ -4,7 +4,7 @@ use std::sync::mpsc;
 use std::thread;
 use std::time::Duration;
 
-use rttp::server::{HttpRequest, HttpResponse};
+use rttp::server::{HttpRequest, HttpRequestCacheControl, HttpResponse, HttpResponseCacheControl};
 use rttp_http11_test_fixtures as fixtures;
 
 #[derive(Debug)]
@@ -34,6 +34,113 @@ fn header_value<'a>(head: &'a str, name: &str) -> Option<&'a str> {
     .map(|(_, value)| value.trim())
 }
 
+fn cache_control_request(values: &[&str]) -> Vec<u8> {
+  let mut request = String::from("GET /matrix/cache-control HTTP/1.1\r\nHost: example.test\r\n");
+  for value in values {
+    request.push_str("Cache-Control: ");
+    request.push_str(value);
+    request.push_str("\r\n");
+  }
+  request.push_str("\r\n");
+  request.into_bytes()
+}
+
+fn cache_control_response(values: &[&str]) -> HttpResponse {
+  values
+    .iter()
+    .fold(HttpResponse::new(200, "OK"), |response, value| {
+      response.header("Cache-Control", value)
+    })
+}
+
+fn assert_request_cache_control(
+  name: &str,
+  cache_control: HttpRequestCacheControl,
+  expected: &fixtures::cache_control::RequestCase,
+) {
+  assert_eq!(expected.no_cache, cache_control.no_cache(), "{name}");
+  assert_eq!(expected.no_store, cache_control.no_store(), "{name}");
+  assert_eq!(expected.max_age, cache_control.max_age(), "{name}");
+  assert_eq!(expected.max_stale, cache_control.max_stale(), "{name}");
+  assert_eq!(expected.min_fresh, cache_control.min_fresh(), "{name}");
+  assert_eq!(
+    expected.no_transform,
+    cache_control.no_transform(),
+    "{name}"
+  );
+  assert_eq!(
+    expected.only_if_cached,
+    cache_control.only_if_cached(),
+    "{name}"
+  );
+  assert_eq!(
+    expected.extensions.len(),
+    cache_control.extensions().len(),
+    "{name}"
+  );
+  for ((expected_name, expected_value), observed) in
+    expected.extensions.iter().zip(cache_control.extensions())
+  {
+    assert_eq!(*expected_name, observed.name(), "{name}");
+    assert_eq!(*expected_value, observed.value(), "{name}");
+  }
+}
+
+fn assert_response_cache_control(
+  name: &str,
+  cache_control: HttpResponseCacheControl,
+  expected: &fixtures::cache_control::ResponseCase,
+) {
+  assert_eq!(expected.no_cache, cache_control.no_cache(), "{name}");
+  assert_eq!(
+    expected.no_cache_fields,
+    cache_control.no_cache_fields().as_slice(),
+    "{name}"
+  );
+  assert_eq!(expected.no_store, cache_control.no_store(), "{name}");
+  assert_eq!(expected.max_age, cache_control.max_age(), "{name}");
+  assert_eq!(expected.s_maxage, cache_control.s_maxage(), "{name}");
+  assert_eq!(expected.private, cache_control.private(), "{name}");
+  assert_eq!(
+    expected.private_fields,
+    cache_control.private_fields().as_slice(),
+    "{name}"
+  );
+  assert_eq!(expected.public, cache_control.public(), "{name}");
+  assert_eq!(
+    expected.must_revalidate,
+    cache_control.must_revalidate(),
+    "{name}"
+  );
+  assert_eq!(
+    expected.proxy_revalidate,
+    cache_control.proxy_revalidate(),
+    "{name}"
+  );
+  assert_eq!(expected.immutable, cache_control.immutable(), "{name}");
+  assert_eq!(
+    expected.stale_while_revalidate,
+    cache_control.stale_while_revalidate(),
+    "{name}"
+  );
+  assert_eq!(
+    expected.stale_if_error,
+    cache_control.stale_if_error(),
+    "{name}"
+  );
+  assert_eq!(
+    expected.extensions.len(),
+    cache_control.extensions().len(),
+    "{name}"
+  );
+  for ((expected_name, expected_value), observed) in
+    expected.extensions.iter().zip(cache_control.extensions())
+  {
+    assert_eq!(*expected_name, observed.name(), "{name}");
+    assert_eq!(*expected_value, observed.value(), "{name}");
+  }
+}
+
 #[test]
 fn model_parser_accepts_shared_fixed_length_request_fixture() {
   let fixture = fixtures::request::fixed_length_post();
@@ -46,6 +153,165 @@ fn model_parser_accepts_shared_fixed_length_request_fixture() {
   assert_eq!(fixture.version, request.version());
   assert_eq!(Some(fixture.host), request.header("host"));
   assert_eq!(fixture.body, request.body());
+}
+
+#[test]
+fn model_parser_accepts_shared_cache_control_request_matrix() {
+  for case in fixtures::cache_control::request_cases() {
+    let request =
+      HttpRequest::parse(&cache_control_request(case.values)).expect("request should parse");
+    let cache_control = request
+      .cache_control()
+      .unwrap_or_else(|err| panic!("{} cache-control should parse: {err}", case.name))
+      .unwrap_or_else(|| panic!("{} should include Cache-Control", case.name));
+
+    assert_request_cache_control(case.name, cache_control, case);
+  }
+}
+
+#[test]
+fn model_parser_cache_control_helper_rejects_shared_invalid_request_matrix() {
+  for case in fixtures::cache_control::invalid_request_cases() {
+    let request =
+      HttpRequest::parse(&cache_control_request(&[case.value])).expect("request should parse");
+
+    assert!(
+      request.cache_control().is_err(),
+      "{} helper should reject invalid Cache-Control",
+      case.name
+    );
+    assert_eq!(
+      Some(case.value),
+      request.header("Cache-Control"),
+      "{}",
+      case.name
+    );
+  }
+}
+
+#[test]
+fn model_parser_cache_control_helper_enforces_shared_bounds() {
+  let too_many_directives = fixtures::cache_control::too_many_directives_value();
+  let request = HttpRequest::parse(&cache_control_request(&[&too_many_directives]))
+    .expect("request should parse");
+
+  assert!(
+    request.cache_control().is_err(),
+    "too many request Cache-Control directives helper should reject invalid Cache-Control"
+  );
+  assert_eq!(
+    Some(too_many_directives.as_str()),
+    request.header("Cache-Control"),
+    "too many request Cache-Control directives"
+  );
+
+  let oversized_value = fixtures::cache_control::oversized_value();
+  assert!(
+    HttpRequestCacheControl::parse(&oversized_value).is_err(),
+    "oversized request Cache-Control value helper should reject invalid Cache-Control"
+  );
+}
+
+#[test]
+fn live_socket2_server_accepts_shared_cache_control_request_matrix() {
+  for case in fixtures::cache_control::request_cases() {
+    let server = rttp::Http::server("127.0.0.1:0").expect("bind server");
+    let addr = server.local_addr().expect("server addr");
+    let (tx, rx) = mpsc::channel();
+
+    let handle = thread::spawn(move || {
+      server
+        .accept_one(|request| {
+          let cache_control = request
+            .cache_control()
+            .expect("cache-control should parse")
+            .expect("cache-control header should be present");
+          tx.send(cache_control).expect("send cache-control");
+          HttpResponse::ok("accepted")
+        })
+        .expect("serve one request");
+    });
+
+    let mut stream = TcpStream::connect(addr).expect("connect server");
+    stream
+      .write_all(&cache_control_request(case.values))
+      .expect(case.name);
+    stream.shutdown(Shutdown::Write).expect("shutdown write");
+
+    let mut response = String::new();
+    stream.read_to_string(&mut response).expect("read response");
+
+    assert!(response.starts_with("HTTP/1.1 200 OK"), "{}", case.name);
+    assert_request_cache_control(case.name, rx.recv().expect("cache-control"), case);
+
+    handle.join().expect("server thread");
+  }
+}
+
+#[test]
+fn server_response_helper_accepts_shared_cache_control_response_matrix() {
+  for case in fixtures::cache_control::response_cases() {
+    let response = cache_control_response(case.values);
+    let cache_control = response
+      .cache_control()
+      .unwrap_or_else(|err| panic!("{} cache-control should parse: {err}", case.name))
+      .unwrap_or_else(|| panic!("{} should include Cache-Control", case.name));
+
+    assert_response_cache_control(case.name, cache_control, case);
+  }
+}
+
+#[test]
+fn server_response_cache_control_helper_rejects_shared_invalid_response_matrix() {
+  for case in fixtures::cache_control::invalid_response_cases() {
+    let response = cache_control_response(&[case.value]);
+
+    assert!(
+      response.cache_control().is_err(),
+      "{} helper should reject invalid Cache-Control",
+      case.name
+    );
+  }
+}
+
+#[test]
+fn server_response_cache_control_helper_enforces_shared_bounds() {
+  for (name, value) in [
+    (
+      "too many response Cache-Control directives",
+      fixtures::cache_control::too_many_directives_value(),
+    ),
+    (
+      "oversized response Cache-Control value",
+      fixtures::cache_control::oversized_value(),
+    ),
+  ] {
+    let response = cache_control_response(&[&value]);
+
+    assert!(
+      response.cache_control().is_err(),
+      "{name} helper should reject invalid Cache-Control"
+    );
+  }
+}
+
+#[test]
+fn server_cache_control_matrix_keeps_cache_engine_non_goals_explicit() {
+  let request = HttpRequest::parse(
+    b"GET /matrix/cache-control-non-goals HTTP/1.1\r\nHost: example.test\r\nETag: \"client\"\r\n\r\n",
+  )
+  .expect("request without Cache-Control should parse");
+  let response = HttpResponse::ok("OK").header("ETag", "\"representation\"");
+
+  assert!(request
+    .cache_control()
+    .expect("missing header is valid")
+    .is_none());
+  assert!(response
+    .cache_control()
+    .expect("missing header is valid")
+    .is_none());
+  assert_eq!(Some("\"client\""), request.header("ETag"));
 }
 
 #[test]

--- a/rttp_client/src/response/response.rs
+++ b/rttp_client/src/response/response.rs
@@ -6,6 +6,9 @@ use crate::error;
 use crate::response::raw_response::RawResponse;
 use crate::types::{Cookie, Header, RoUrl};
 
+const MAX_CACHE_CONTROL_VALUE_BYTES: usize = 64 * 1024;
+const MAX_CACHE_CONTROL_DIRECTIVES: usize = 256;
+
 #[derive(Clone)]
 pub struct Response {
   raw: RawResponse,
@@ -296,8 +299,13 @@ impl CacheControl {
     I: IntoIterator<Item = &'a str>,
   {
     let mut cache_control = Self::default();
+    let mut directive_count = 0usize;
     for value in values {
       for directive in split_cache_control_directives(value)? {
+        directive_count += 1;
+        if directive_count > MAX_CACHE_CONTROL_DIRECTIVES {
+          return Err(error::bad_response("Too many Cache-Control directives"));
+        }
         cache_control.apply_directive(&directive)?;
       }
     }
@@ -454,6 +462,12 @@ impl CacheControlExtension {
 }
 
 fn split_cache_control_directives(value: &str) -> error::Result<Vec<String>> {
+  if value.len() > MAX_CACHE_CONTROL_VALUE_BYTES {
+    return Err(error::bad_response(
+      "Cache-Control header value is too large",
+    ));
+  }
+
   let mut directives = Vec::new();
   let mut current = String::new();
   let mut in_quote = false;
@@ -494,6 +508,9 @@ fn push_directive(directives: &mut Vec<String>, directive: &str) -> error::Resul
   let directive = directive.trim();
   if directive.is_empty() {
     return Err(error::bad_response("Invalid Cache-Control directive"));
+  }
+  if directives.len() >= MAX_CACHE_CONTROL_DIRECTIVES {
+    return Err(error::bad_response("Too many Cache-Control directives"));
   }
   directives.push(directive.to_string());
   Ok(())

--- a/rttp_client/tests/http11_compliance_matrix.rs
+++ b/rttp_client/tests/http11_compliance_matrix.rs
@@ -17,6 +17,17 @@ fn client() -> HttpClient {
   HttpClient::new()
 }
 
+fn cache_control_response(values: &[&str]) -> Vec<u8> {
+  let mut response = String::from("HTTP/1.1 200 OK\r\n");
+  for value in values {
+    response.push_str("Cache-Control: ");
+    response.push_str(value);
+    response.push_str("\r\n");
+  }
+  response.push_str("Content-Length: 2\r\n\r\nOK");
+  response.into_bytes()
+}
+
 const RANGE_BODY: &[u8] = b"0123456789abcdef";
 const CONDITIONAL_LAST_MODIFIED: &str = "Sun, 06 Nov 1994 08:49:37 GMT";
 const CONDITIONAL_STALE_DATE: &str = "Sun, 06 Nov 1994 08:49:36 GMT";
@@ -246,12 +257,160 @@ fn assert_observed_if_range(
   );
 }
 
+fn assert_response_cache_control(
+  name: &str,
+  response: rttp_client::response::Response,
+  expected: &fixtures::cache_control::ResponseCase,
+) {
+  let cache_control = response
+    .cache_control()
+    .unwrap_or_else(|err| panic!("{name} cache-control should parse: {err}"))
+    .unwrap_or_else(|| panic!("{name} should include Cache-Control"));
+
+  assert_eq!(expected.no_cache, cache_control.no_cache(), "{name}");
+  assert_eq!(
+    expected.no_cache_fields,
+    cache_control.no_cache_fields().as_slice(),
+    "{name}"
+  );
+  assert_eq!(expected.no_store, cache_control.no_store(), "{name}");
+  assert_eq!(expected.max_age, cache_control.max_age(), "{name}");
+  assert_eq!(expected.s_maxage, cache_control.s_maxage(), "{name}");
+  assert_eq!(expected.private, cache_control.private(), "{name}");
+  assert_eq!(
+    expected.private_fields,
+    cache_control.private_fields().as_slice(),
+    "{name}"
+  );
+  assert_eq!(expected.public, cache_control.public(), "{name}");
+  assert_eq!(
+    expected.must_revalidate,
+    cache_control.must_revalidate(),
+    "{name}"
+  );
+  assert_eq!(
+    expected.proxy_revalidate,
+    cache_control.proxy_revalidate(),
+    "{name}"
+  );
+  assert_eq!(expected.immutable, cache_control.immutable(), "{name}");
+  assert_eq!(
+    expected.stale_while_revalidate,
+    cache_control.stale_while_revalidate(),
+    "{name}"
+  );
+  assert_eq!(
+    expected.stale_if_error,
+    cache_control.stale_if_error(),
+    "{name}"
+  );
+  assert_eq!(
+    expected.extensions.len(),
+    cache_control.extensions().len(),
+    "{name}"
+  );
+  for ((expected_name, expected_value), observed) in
+    expected.extensions.iter().zip(cache_control.extensions())
+  {
+    assert_eq!(*expected_name, observed.name(), "{name}");
+    assert_eq!(*expected_value, observed.value(), "{name}");
+  }
+}
+
+fn assert_cache_control_helper_rejects_but_preserves_response(name: &str, raw_response: Vec<u8>) {
+  let (addr, handle) = fixtures::spawn_socket2_owned_raw_response_server(raw_response);
+
+  let response = client()
+    .get()
+    .url(format!("http://{}/matrix/cache-control-invalid", addr))
+    .emit()
+    .unwrap_or_else(|err| panic!("{name} response should remain parseable: {err}"));
+
+  assert!(
+    response.cache_control().is_err(),
+    "{name} helper should reject invalid Cache-Control"
+  );
+  assert_eq!("OK", response.body().string().unwrap(), "{name}");
+
+  handle.join().expect("raw response server thread");
+}
+
 enum ConditionalHeader {
   IfNoneMatch(&'static str),
   IfMatch(&'static str),
   IfModifiedSince(&'static str),
   IfUnmodifiedSince(&'static str),
   Manual(&'static str, &'static str),
+}
+
+#[test]
+fn sync_client_parses_shared_cache_control_response_matrix() {
+  for case in fixtures::cache_control::response_cases() {
+    let raw_response = cache_control_response(case.values);
+    let (addr, handle) = fixtures::spawn_socket2_owned_raw_response_server(raw_response);
+
+    let response = client()
+      .get()
+      .url(format!("http://{}/matrix/cache-control", addr))
+      .emit()
+      .unwrap_or_else(|err| panic!("{} response should parse: {err}", case.name));
+
+    assert_response_cache_control(case.name, response, case);
+    handle.join().expect("raw response server thread");
+  }
+}
+
+#[test]
+fn sync_client_cache_control_helper_rejects_shared_invalid_response_matrix() {
+  for case in fixtures::cache_control::invalid_response_cases() {
+    assert_cache_control_helper_rejects_but_preserves_response(
+      case.name,
+      cache_control_response(&[case.value]),
+    );
+  }
+}
+
+#[test]
+fn sync_client_cache_control_helper_enforces_shared_bounds() {
+  assert_cache_control_helper_rejects_but_preserves_response(
+    "too many response Cache-Control directives",
+    cache_control_response(&[&fixtures::cache_control::too_many_directives_value()]),
+  );
+  assert_cache_control_helper_rejects_but_preserves_response(
+    "oversized response Cache-Control value",
+    cache_control_response(&[&fixtures::cache_control::oversized_value()]),
+  );
+}
+
+#[test]
+fn sync_client_cache_control_matrix_keeps_cache_engine_non_goals_explicit() {
+  let raw_response = concat!(
+    "HTTP/1.1 200 OK\r\n",
+    "ETag: \"representation\"\r\n",
+    "Content-Length: 2\r\n",
+    "\r\n",
+    "OK"
+  )
+  .as_bytes();
+  let (addr, handle) = fixtures::spawn_socket2_raw_response_server(raw_response);
+
+  let response = client()
+    .get()
+    .url(format!("http://{}/matrix/cache-control-non-goals", addr))
+    .emit()
+    .expect("response without Cache-Control should parse");
+
+  assert!(response
+    .cache_control()
+    .expect("missing header is valid")
+    .is_none());
+  assert_eq!(
+    Some(&"\"representation\"".to_string()),
+    response.header_value("ETag")
+  );
+  assert_eq!("OK", response.body().string().unwrap());
+
+  handle.join().expect("raw response server thread");
 }
 
 impl ConditionalHeader {

--- a/rttp_http11_test_fixtures/src/lib.rs
+++ b/rttp_http11_test_fixtures/src/lib.rs
@@ -219,6 +219,235 @@ pub mod response {
   .as_bytes();
 }
 
+pub mod cache_control {
+  pub const MAX_VALUE_BYTES: usize = 64 * 1024;
+  pub const MAX_DIRECTIVES: usize = 256;
+
+  pub struct RequestCase {
+    pub name: &'static str,
+    pub values: &'static [&'static str],
+    pub no_cache: bool,
+    pub no_store: bool,
+    pub max_age: Option<u64>,
+    pub max_stale: Option<Option<u64>>,
+    pub min_fresh: Option<u64>,
+    pub no_transform: bool,
+    pub only_if_cached: bool,
+    pub extensions: &'static [(&'static str, Option<&'static str>)],
+  }
+
+  pub struct ResponseCase {
+    pub name: &'static str,
+    pub values: &'static [&'static str],
+    pub no_cache: bool,
+    pub no_cache_fields: &'static [&'static str],
+    pub no_store: bool,
+    pub max_age: Option<u64>,
+    pub s_maxage: Option<u64>,
+    pub private: bool,
+    pub private_fields: &'static [&'static str],
+    pub public: bool,
+    pub must_revalidate: bool,
+    pub proxy_revalidate: bool,
+    pub immutable: bool,
+    pub stale_while_revalidate: Option<u64>,
+    pub stale_if_error: Option<u64>,
+    pub extensions: &'static [(&'static str, Option<&'static str>)],
+  }
+
+  pub struct InvalidCase {
+    pub name: &'static str,
+    pub value: &'static str,
+  }
+
+  pub fn request_cases() -> &'static [RequestCase] {
+    &[
+      RequestCase {
+        name: "request known directives across header fields",
+        values: &[
+          "no-cache, no-store, max-age=60, max-stale=120",
+          "min-fresh=30, no-transform, only-if-cached",
+        ],
+        no_cache: true,
+        no_store: true,
+        max_age: Some(60),
+        max_stale: Some(Some(120)),
+        min_fresh: Some(30),
+        no_transform: true,
+        only_if_cached: true,
+        extensions: &[],
+      },
+      RequestCase {
+        name: "request extension and quoted-string values",
+        values: &[
+          "ext=\"a,b\", token-ext, escaped=\"quoted\\\\value\"",
+          "obs-ext=\"cache policy\"",
+        ],
+        no_cache: false,
+        no_store: false,
+        max_age: None,
+        max_stale: None,
+        min_fresh: None,
+        no_transform: false,
+        only_if_cached: false,
+        extensions: &[
+          ("ext", Some("a,b")),
+          ("token-ext", None),
+          ("escaped", Some("quoted\\value")),
+          ("obs-ext", Some("cache policy")),
+        ],
+      },
+      RequestCase {
+        name: "request duplicate directives keep helper parity",
+        values: &["max-age=10, max-age=20, no-cache, no-cache"],
+        no_cache: true,
+        no_store: false,
+        max_age: Some(20),
+        max_stale: None,
+        min_fresh: None,
+        no_transform: false,
+        only_if_cached: false,
+        extensions: &[],
+      },
+      RequestCase {
+        name: "request max-stale without value remains a bounded helper",
+        values: &["max-stale"],
+        no_cache: false,
+        no_store: false,
+        max_age: None,
+        max_stale: Some(None),
+        min_fresh: None,
+        no_transform: false,
+        only_if_cached: false,
+        extensions: &[],
+      },
+    ]
+  }
+
+  pub fn response_cases() -> &'static [ResponseCase] {
+    &[
+      ResponseCase {
+        name: "response known directives across header fields",
+        values: &[
+          "no-cache=\"Set-Cookie, Authorization\", no-store, max-age=60",
+          "s-maxage=120, private=\"X-User\", public, must-revalidate",
+          "proxy-revalidate, immutable, stale-while-revalidate=30, stale-if-error=90",
+        ],
+        no_cache: true,
+        no_cache_fields: &["Set-Cookie", "Authorization"],
+        no_store: true,
+        max_age: Some(60),
+        s_maxage: Some(120),
+        private: true,
+        private_fields: &["X-User"],
+        public: true,
+        must_revalidate: true,
+        proxy_revalidate: true,
+        immutable: true,
+        stale_while_revalidate: Some(30),
+        stale_if_error: Some(90),
+        extensions: &[],
+      },
+      ResponseCase {
+        name: "response extension and quoted-string values",
+        values: &[
+          "community=\"u=1, tier=gold\", ext-token",
+          "escaped=\"quoted\\\\value\"",
+        ],
+        no_cache: false,
+        no_cache_fields: &[],
+        no_store: false,
+        max_age: None,
+        s_maxage: None,
+        private: false,
+        private_fields: &[],
+        public: false,
+        must_revalidate: false,
+        proxy_revalidate: false,
+        immutable: false,
+        stale_while_revalidate: None,
+        stale_if_error: None,
+        extensions: &[
+          ("community", Some("u=1, tier=gold")),
+          ("ext-token", None),
+          ("escaped", Some("quoted\\value")),
+        ],
+      },
+      ResponseCase {
+        name: "response duplicate directives keep helper parity",
+        values: &["max-age=10, max-age=20, private=\"A\", private=\"B\""],
+        no_cache: false,
+        no_cache_fields: &[],
+        no_store: false,
+        max_age: Some(20),
+        s_maxage: None,
+        private: true,
+        private_fields: &["B"],
+        public: false,
+        must_revalidate: false,
+        proxy_revalidate: false,
+        immutable: false,
+        stale_while_revalidate: None,
+        stale_if_error: None,
+        extensions: &[],
+      },
+    ]
+  }
+
+  pub fn invalid_request_cases() -> &'static [InvalidCase] {
+    &[
+      InvalidCase {
+        name: "request invalid max-age delta-seconds",
+        value: "max-age=-1",
+      },
+      InvalidCase {
+        name: "request invalid max-stale delta-seconds",
+        value: "max-stale=1.5",
+      },
+      InvalidCase {
+        name: "request quoted min-fresh delta-seconds",
+        value: "min-fresh=\"60\"",
+      },
+      InvalidCase {
+        name: "request malformed quoted-string",
+        value: "extension=\"unterminated",
+      },
+    ]
+  }
+
+  pub fn invalid_response_cases() -> &'static [InvalidCase] {
+    &[
+      InvalidCase {
+        name: "response invalid max-age delta-seconds",
+        value: "max-age=-1",
+      },
+      InvalidCase {
+        name: "response invalid s-maxage delta-seconds",
+        value: "s-maxage=abc",
+      },
+      InvalidCase {
+        name: "response quoted stale-if-error delta-seconds",
+        value: "stale-if-error=\"60\"",
+      },
+      InvalidCase {
+        name: "response malformed quoted-string",
+        value: "private=\"unterminated",
+      },
+    ]
+  }
+
+  pub fn too_many_directives_value() -> String {
+    (0..=MAX_DIRECTIVES)
+      .map(|index| format!("ext{index}"))
+      .collect::<Vec<_>>()
+      .join(", ")
+  }
+
+  pub fn oversized_value() -> String {
+    format!("ext=\"{}\"", "a".repeat(MAX_VALUE_BYTES))
+  }
+}
+
 pub fn bind_socket2_tcp_listener(name: &str) -> (TcpListener, SocketAddr) {
   let addr: SocketAddr = "127.0.0.1:0".parse().expect("parse local addr");
   let socket = Socket::new(Domain::IPV4, Type::STREAM, Some(Protocol::TCP))
@@ -283,6 +512,12 @@ pub fn read_http_request<R: Read>(stream: &mut R) -> Vec<u8> {
 pub fn spawn_socket2_raw_response_server(
   response: &'static [u8],
 ) -> (SocketAddr, JoinHandle<Vec<u8>>) {
+  spawn_socket2_owned_raw_response_server(response.to_vec())
+}
+
+pub fn spawn_socket2_owned_raw_response_server(
+  response: Vec<u8>,
+) -> (SocketAddr, JoinHandle<Vec<u8>>) {
   let (listener, addr) = bind_socket2_tcp_listener("raw response server");
   let handle = thread::spawn(move || {
     let Ok((mut stream, _)) = listener.accept() else {
@@ -292,7 +527,7 @@ pub fn spawn_socket2_raw_response_server(
       .set_read_timeout(Some(Duration::from_secs(2)))
       .expect("set read timeout");
     let request = read_http_request(&mut stream);
-    let _ = stream.write_all(response);
+    let _ = stream.write_all(&response);
     request
   });
   (addr, handle)


### PR DESCRIPTION
Added shared HTTP/1.1 Cache-Control compliance fixtures across `rttp` and `rttp_client`, expanded cross-crate parsing/helper coverage, and aligned client response helper bounds with server behavior. Verified with formatting, diff checks, and the full workspace all-features test suite.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1575/
work_kind: code_work
branch: hbx-1575-rttp-add-cross-crate-http
base: main
commit: c2db79648d9472313d19fcd594098edbd8d01456
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1575/
    url: https://plane.kahub.in/endless/browse/HBX-1575/
    close_policy: link_only
```