### PR TITLE
feat: [rttp] Document bounded HTTP/1.1 Cache-Control behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,38 @@ cache-control engine. `If-Range` is range-scoped and uses the dedicated
 request headers and exposes response metadata; cache persistence and validation
 policy remain application-owned.
 
+### Bounded HTTP/1.1 Cache-Control behavior
+
+`Response::cache_control()` parses one or more response `Cache-Control` header
+fields into `CacheControl`. It exposes the common response directives
+`no-cache`, `no-store`, `max-age`, `s-maxage`, `private`, `public`,
+`must-revalidate`, `proxy-revalidate`, `immutable`,
+`stale-while-revalidate`, and `stale-if-error`. Quoted field-name lists on
+`no-cache` and `private` are split into field names, and unknown extension
+directives are preserved as `CacheControlExtension` values with their token name
+and optional parsed value.
+
+The parser is bounded and validation-oriented. Each header field value is
+limited to 64 KiB, the parsed header set is limited to 256 directives, directive
+names and unquoted values must be valid HTTP tokens, quoted strings must be
+well formed, and delta-seconds values must be unquoted non-negative decimal
+integers that fit in `u64`. A malformed `Cache-Control` value makes
+`Response::cache_control()` return an error; the original response headers and
+body remain available through the ordinary response APIs.
+
+`Cache-Control` parsing is intentionally separate from conditional validator
+helpers. `Response::etag()` and `Response::last_modified()` expose validators,
+and request helpers such as `if_none_match()` and `if_modified_since()` can
+emit conditional requests when the application chooses to do so. RTTP does not
+combine `Cache-Control` directives with validators to decide freshness, build a
+cache entry, or issue a follow-up request.
+
+The client has no cache store and does not perform automatic revalidation,
+freshness calculation against wall-clock time, `Vary` matching, shared-cache
+policy enforcement, or automatic conditional requests. Directives such as
+`max-age`, `s-maxage`, `no-cache`, `must-revalidate`, and extension directives
+are exposed as parsed metadata only.
+
 ### Bounded trailer behavior
 
 Trailer support is explicit and bounded by protocol path. On the client,
@@ -149,6 +181,7 @@ gain additional HTTP/2 header-block handling.
 | Redirects | Auto-redirect covers 301, 302, 303, 307, and 308 method/body behavior, relative and absolute `Location` resolution, same- and cross-authority header handling, loop detection, and redirect bounds | Redirects are HTTP client behavior, not a browser policy implementation |
 | Byte ranges | `range`, `range_from`, `range_suffix`, `if_range_etag`, and `if_range_date` emit bounded HTTP/1.1 range request metadata; `Response::content_range`, `is_partial_content`, and `is_range_not_satisfiable` expose `206` and `416` metadata | No client-side `If-Range` evaluation, automatic retry, cache storage, multipart range generation, or automatic cache validation policy |
 | Conditional requests | `if_none_match`, `if_match`, `if_modified_since`, and `if_unmodified_since` emit bounded HTTP/1.1 validators; `Response::is_not_modified`, `is_precondition_failed`, `etag`, and `last_modified` expose `304`/`412` metadata | One ETag validator per helper call, `If-Range` is range-scoped, no cache storage, no automatic revalidation, and no cache-control engine |
+| Cache-Control | `Response::cache_control` parses bounded response directives, numeric freshness fields, quoted field-name lists, and extension directives into metadata helpers | No cache storage, automatic revalidation, wall-clock freshness calculation, `Vary` matching, shared-cache policy enforcement, or automatic conditional requests |
 | Trailers | Chunked response trailers are exposed for blocking and async APIs; streaming chunked uploads can send declared request trailers | Application metadata trailers such as `X-Trace` are allowed; pseudo-header, connection-specific, routing, authentication/cookie, and framing trailer fields are rejected |
 | Bounded h2c client | With `http2`, direct `socket2` h2c sends GET, HEAD, bodyless DELETE, OPTIONS, or TRACE, buffered POST, PUT, or PATCH requests, and opt-in RFC 8441 extended CONNECT request HEADERS via `http2_extended_connect`, opens at most one request stream, supports prior-knowledge with `emit_http2_prior_knowledge`, supports explicit HTTP/1.1 `Upgrade: h2c` negotiation with `emit_http2_upgrade`, advertises `SETTINGS_ENABLE_PUSH = 0`, advertises `SETTINGS_ENABLE_CONNECT_PROTOCOL = 1` only for the explicit extended CONNECT path, validates received `SETTINGS_ENABLE_PUSH` values as only `0` or `1`, honors initial peer `SETTINGS_MAX_CONCURRENT_STREAMS` by failing before request HEADERS when the peer allows zero streams, honors peer-advertised `SETTINGS_MAX_HEADER_LIST_SIZE` request metadata limits, accepts only legal `SETTINGS_MAX_FRAME_SIZE` values from 16,384 through 16,777,215 bytes, splits outbound HEADERS, DATA, and trailers to the active peer frame-size limit, rejects oversized inbound frames when a configured local frame-size limit is exceeded, bounds HPACK dynamic table use with `SETTINGS_HEADER_TABLE_SIZE`, strips HTTP/1.x connection-specific request fields before emission, rejects connection-specific peer response fields, suppresses HEAD response bodies, treats `RST_STREAM` on the active stream as a bounded reset/cancellation signal, acknowledges valid PING frames with matching opaque data, DATA bodies, trailers, HPACK static Huffman strings, bounded large header blocks, padded incoming frames, `GOAWAY` shutdown boundaries, PRIORITY metadata validation without scheduling, HTTP/2-allowed unknown/extension frame ignoring inside this bounded path, reserved stream-id high-bit normalization, and conservative DATA flow control | Ordinary `CONNECT`, header-configured `:protocol` metadata, non-h2c HTTP/1.1 `Upgrade` handoff requests, and proxies are rejected deterministically, and `PUSH_PROMISE`/server push is rejected instead of managed; bounded direct h2c only, with no public cancellation callback API, no dynamic policy API, no extension callback API, no full extension negotiation, TLS ALPN, external h2 integration, proxy tunneling to h2, proxy h2, tunnel handoff, connection pooling, persistent HTTP/2 session management, automatic retry, server push, full stream state machine, unbounded multiplex scheduling, general multiplexing, priority scheduling, request bodies or trailers for extended CONNECT, or request bodies for GET, HEAD, DELETE, OPTIONS, or TRACE |
 
@@ -398,6 +431,48 @@ serve files, implement static-file serving policy, store cached responses,
 automatically revalidate stale entries, or provide a full cache-control engine.
 Those remain application policy around the validator helpers.
 
+### Bounded HTTP/1.1 Cache-Control behavior
+
+Server `Cache-Control` helpers parse directive metadata for application policy;
+they do not enforce cache behavior. `Request::cache_control()` and
+`HttpRequest::cache_control()` parse request directives into
+`HttpRequestCacheControl`, including `no-cache`, `no-store`, `max-age`,
+`max-stale` with or without a value, `min-fresh`, `no-transform`,
+`only-if-cached`, and extension directives. `HttpResponse::cache_control()`
+parses response headers already attached to an `HttpResponse` into
+`HttpResponseCacheControl`, including `no-cache`, `no-store`, `max-age`,
+`s-maxage`, `private`, `public`, `must-revalidate`, `proxy-revalidate`,
+`immutable`, `stale-while-revalidate`, `stale-if-error`, quoted field-name
+lists, and extension directives.
+
+Unknown extension directives are preserved rather than discarded. Each
+`HttpCacheControlExtension` exposes the directive token name and optional
+parsed value, with quoted-string escaping removed when a quoted value is used.
+The helpers do not interpret extension semantics or negotiate extension
+behavior.
+
+Parsing is bounded and validation-oriented. Each `Cache-Control` field value is
+limited to 64 KiB, the parsed set is limited to 256 directives across all
+values passed to the helper, directive names and unquoted values must be valid
+HTTP tokens, quoted strings must be well formed, and delta-seconds values must
+be unquoted non-negative decimal integers that fit in `u64`. Invalid
+`Cache-Control` syntax returns `HttpCacheControlParseError` from the helper;
+it does not by itself reject the request before handler code or remove the
+original header from the response model.
+
+These helpers are separate from conditional validator evaluation.
+`Request::evaluate_conditional()` and `Request::evaluate_if_range()` use only
+caller-supplied `HttpConditionalMetadata` and the conditional request headers.
+They do not consult `Cache-Control` directives to decide whether a response is
+fresh, whether it must be revalidated, or whether validators should be emitted
+on a later request.
+
+RTTP does not provide cache storage, automatic revalidation, freshness
+calculation against wall-clock time, `Vary` matching, shared-cache policy
+enforcement, or automatic conditional requests. Directives such as `max-age`,
+`s-maxage`, `no-cache`, `only-if-cached`, `must-revalidate`, and extension
+directives are exposed as parsed metadata for application-owned policy.
+
 The server is intentionally small: it handles blocking HTTP/1.x request parsing
 for local tests and simple embedded use. It accepts fixed `Content-Length` and
 chunked request bodies, exposes chunked request trailers, applies bounded
@@ -532,6 +607,7 @@ TLS or async accept loops.
 | HTTP/1.1 response framing | Automatic `Content-Length`, explicit chunked responses, bodyless `HEAD`, `101`, `204`, and `304`, response trailers after the terminating chunk | No server TLS |
 | Byte ranges | `HttpByteRange` parses one `bytes` range, `Request::evaluate_if_range` gates it with caller-provided strong ETag or exact HTTP-date metadata, and `HttpResponse::partial_content`/`range_not_satisfiable` serialize `206`/`416` with `Content-Range` | No multipart range serialization, automatic retry, cache storage, filesystem serving, MIME detection, automatic cache validation, or automatic static-file policy |
 | Conditional requests | `Request::evaluate_conditional`, `evaluate_conditional_request`, `HttpConditionalMetadata`, and `HttpEntityTag` evaluate bounded HTTP/1.1 validators; `HttpResponse::not_modified` and `precondition_failed` serialize `304` and `412` outcomes | No cache storage, static-file serving policy, automatic revalidation, or cache-control engine |
+| Cache-Control | `Request::cache_control`, `HttpRequest::cache_control`, and `HttpResponse::cache_control` parse bounded request/response directives, numeric freshness fields, quoted field-name lists, and extension directives | No cache storage, automatic revalidation, wall-clock freshness calculation, `Vary` matching, shared-cache policy enforcement, automatic conditional requests, or directive-based validator evaluation |
 | Upgrade and tunnel targets | `CONNECT` authority-form requests are accepted as HTTP requests; `HttpResponse::upgrade` can hand an upgraded socket to caller code after a matching request | The server does not implement the upgraded protocol after handoff |
 | Trailers | Chunked request trailers are preserved on `Request`; malformed, oversized, forbidden, and pseudo-header trailers are rejected; response trailers can be serialized for chunked responses | Application metadata trailers are allowed; trailer names that affect connection state, routing, authentication/cookies, framing, or payload processing are rejected |
 | Bounded h2c server | The same `socket2` listener detects the HTTP/2 prior-knowledge preface or a valid HTTP/1.1 `Upgrade: h2c` request with `HTTP2-Settings`, validates SETTINGS including legal `SETTINGS_ENABLE_PUSH` and `SETTINGS_ENABLE_CONNECT_PROTOCOL` values of only `0` or `1` and legal `SETTINGS_MAX_FRAME_SIZE` values from 16,384 through 16,777,215 bytes, dispatches RFC 8441 extended CONNECT only after `SETTINGS_ENABLE_CONNECT_PROTOCOL = 1` has been negotiated, exposes negotiated extended CONNECT as a normal `Request` with method `CONNECT`, version `HTTP/2`, target from `:path`, `host` from `:authority`, and `Request::extended_connect_protocol()` from `:protocol`, advertises the default 16,384-byte `SETTINGS_MAX_FRAME_SIZE`, rejects inbound frames above the active local limit, splits outbound HEADERS, DATA, and trailers to the active peer frame-size limit, advertises `SETTINGS_MAX_CONCURRENT_STREAMS` from the bounded active stream allowance, enforces that allowance before dispatching new streams, advertises and enforces a conservative `SETTINGS_MAX_HEADER_LIST_SIZE` for inbound request metadata, bounds HPACK dynamic table use with `SETTINGS_HEADER_TABLE_SIZE`, serves bounded streams including bodyless DELETE, OPTIONS, TRACE, and negotiated extended CONNECT, handles HEAD without response DATA, rejects connection-specific request fields before handler dispatch, strips connection-specific response fields during h2c serialization, treats `RST_STREAM` as a bounded reset/cancellation signal for the affected stream, acknowledges valid PING frames with matching opaque data, accepts padded HEADERS/DATA/trailers without exposing padding, handles HPACK Huffman fields and bounded CONTINUATION header blocks, emits `GOAWAY` with the last completed stream id at bounded shutdown, validates and ignores valid PRIORITY metadata, ignores HTTP/2-allowed unknown/extension frames inside this bounded path, normalizes reserved stream-id high bits, and applies conservative DATA flow control | Ordinary `CONNECT`, missing-negotiation `:protocol`, non-CONNECT `:protocol`, malformed h2c Upgrade, request bodies on h2c Upgrade, and `PUSH_PROMISE` are rejected deterministically before handler dispatch; HTTP/1.1 `CONNECT` and non-h2c `Upgrade` remain separate handoff paths; bounded h2c only, with no public cancellation callback API, no dynamic policy API, no extension callback API, no full extension negotiation, TLS ALPN, external h2 integration, full WebSocket-over-h2, proxy h2, tunnel handoff, connection pooling, persistent multiplex sessions, persistent HTTP/2 session management, automatic retry, server push, full RFC 8441 support, full stream state machine, unbounded multiplexing, unbounded multiplex scheduling, general multiplexing, general tunnel scheduling, priority scheduling, or full HTTP/2 server feature set |

--- a/rttp/README.md
+++ b/rttp/README.md
@@ -119,6 +119,48 @@ implement a full cache-control engine. Invalid conditional headers that cannot
 be parsed as the bounded helper syntax are ignored by the evaluation helper
 rather than rejected before handler code.
 
+## Bounded HTTP/1.1 Cache-Control behavior
+
+Server `Cache-Control` helpers parse directive metadata for application policy;
+they do not enforce cache behavior. `Request::cache_control()` and
+`HttpRequest::cache_control()` parse request directives into
+`HttpRequestCacheControl`, including `no-cache`, `no-store`, `max-age`,
+`max-stale` with or without a value, `min-fresh`, `no-transform`,
+`only-if-cached`, and extension directives. `HttpResponse::cache_control()`
+parses response headers already attached to an `HttpResponse` into
+`HttpResponseCacheControl`, including `no-cache`, `no-store`, `max-age`,
+`s-maxage`, `private`, `public`, `must-revalidate`, `proxy-revalidate`,
+`immutable`, `stale-while-revalidate`, `stale-if-error`, quoted field-name
+lists, and extension directives.
+
+Unknown extension directives are preserved rather than discarded. Each
+`HttpCacheControlExtension` exposes the directive token name and optional
+parsed value, with quoted-string escaping removed when a quoted value is used.
+The helpers do not interpret extension semantics or negotiate extension
+behavior.
+
+Parsing is bounded and validation-oriented. Each `Cache-Control` field value is
+limited to 64 KiB, the parsed set is limited to 256 directives across all
+values passed to the helper, directive names and unquoted values must be valid
+HTTP tokens, quoted strings must be well formed, and delta-seconds values must
+be unquoted non-negative decimal integers that fit in `u64`. Invalid
+`Cache-Control` syntax returns `HttpCacheControlParseError` from the helper;
+it does not by itself reject the request before handler code or remove the
+original header from the response model.
+
+These helpers are separate from conditional validator evaluation.
+`Request::evaluate_conditional()` and `Request::evaluate_if_range()` use only
+caller-supplied `HttpConditionalMetadata` and the conditional request headers.
+They do not consult `Cache-Control` directives to decide whether a response is
+fresh, whether it must be revalidated, or whether validators should be emitted
+on a later request.
+
+RTTP does not provide cache storage, automatic revalidation, freshness
+calculation against wall-clock time, `Vary` matching, shared-cache policy
+enforcement, or automatic conditional requests. Directives such as `max-age`,
+`s-maxage`, `no-cache`, `only-if-cached`, `must-revalidate`, and extension
+directives are exposed as parsed metadata for application-owned policy.
+
 ## Bounded trailer behavior
 
 HTTP/1.1 server trailer support remains chunked-scope only. Chunked request
@@ -313,6 +355,7 @@ scheduling, or async accept loops.
 | HTTP/1.1 response framing | Automatic `Content-Length`, explicit chunked responses, bodyless `HEAD`, `101`, `204`, and `304`, response trailers after the terminating chunk | No server TLS |
 | Byte ranges | `HttpByteRange` parses one `bytes` range, `Request::evaluate_if_range` and `HttpRequest::evaluate_if_range` gate it with caller-provided strong ETag or exact HTTP-date metadata, and `HttpResponse::partial_content`/`range_not_satisfiable` serialize `206`/`416` with `Content-Range` | No multipart range serialization, automatic retry, cache storage, filesystem serving, automatic cache validation, or static-file policy |
 | Conditional requests | `Request::evaluate_conditional`, `evaluate_conditional_request`, `HttpConditionalMetadata`, and `HttpEntityTag` evaluate bounded HTTP/1.1 validators; `HttpResponse::not_modified` and `precondition_failed` serialize `304` and `412` outcomes | No cache storage, static-file serving policy, automatic revalidation, or cache-control engine |
+| Cache-Control | `Request::cache_control`, `HttpRequest::cache_control`, and `HttpResponse::cache_control` parse bounded request/response directives, numeric freshness fields, quoted field-name lists, and extension directives | No cache storage, automatic revalidation, wall-clock freshness calculation, `Vary` matching, shared-cache policy enforcement, automatic conditional requests, or directive-based validator evaluation |
 | Upgrade and tunnel targets | `CONNECT` authority-form requests are accepted as HTTP requests; `HttpResponse::upgrade` can hand an upgraded socket to caller code after a matching request | The server does not implement the upgraded protocol after handoff |
 | Trailers | Chunked request trailers are preserved on `Request`; malformed, oversized, forbidden, and pseudo-header trailers are rejected; response trailers can be serialized for chunked responses | Application metadata trailers are allowed; trailer names that affect connection state, routing, authentication/cookies, framing, or payload processing are rejected |
 | Bounded h2c server | The same `socket2` listener detects the HTTP/2 prior-knowledge preface or a valid HTTP/1.1 `Upgrade: h2c` request with `HTTP2-Settings`, validates SETTINGS including legal `SETTINGS_ENABLE_PUSH` and `SETTINGS_ENABLE_CONNECT_PROTOCOL` values of only `0` or `1` and legal `SETTINGS_MAX_FRAME_SIZE` values from 16,384 through 16,777,215 bytes, dispatches RFC 8441 extended CONNECT only after `SETTINGS_ENABLE_CONNECT_PROTOCOL = 1` has been negotiated, exposes negotiated extended CONNECT as a normal `Request` with method `CONNECT`, version `HTTP/2`, target from `:path`, `host` from `:authority`, and `Request::extended_connect_protocol()` from `:protocol`, advertises the default 16,384-byte `SETTINGS_MAX_FRAME_SIZE`, rejects inbound frames above the active local limit, splits outbound HEADERS, DATA, and trailers to the active peer frame-size limit, advertises `SETTINGS_MAX_CONCURRENT_STREAMS` from the bounded active stream allowance, enforces that allowance before dispatching new streams, advertises and enforces a conservative `SETTINGS_MAX_HEADER_LIST_SIZE` for inbound request metadata, bounds HPACK dynamic table use with `SETTINGS_HEADER_TABLE_SIZE`, serves bounded streams including bodyless DELETE, OPTIONS, TRACE, and negotiated extended CONNECT, handles HEAD without response DATA, rejects connection-specific request fields before handler dispatch, strips connection-specific response fields during h2c serialization, treats `RST_STREAM` as a bounded reset/cancellation signal for the affected stream, acknowledges valid PING frames with matching opaque data, accepts padded HEADERS/DATA/trailers without exposing padding, handles HPACK Huffman fields and bounded CONTINUATION header blocks, emits `GOAWAY` with the last completed stream id at bounded shutdown, validates and ignores valid PRIORITY metadata, ignores HTTP/2-allowed unknown/extension frames inside this bounded path, normalizes reserved stream-id high bits, and applies conservative DATA flow control | Ordinary `CONNECT`, missing-negotiation `:protocol`, non-CONNECT `:protocol`, malformed h2c Upgrade, request bodies on h2c Upgrade, and `PUSH_PROMISE` are rejected deterministically before handler dispatch; HTTP/1.1 `CONNECT` and non-h2c `Upgrade` remain separate handoff paths; bounded h2c only, with no public cancellation callback API, no dynamic policy API, no extension callback API, no full extension negotiation, TLS ALPN, external h2 integration, full WebSocket-over-h2, proxy h2, tunnel handoff, connection pooling, persistent multiplex sessions, persistent HTTP/2 session management, automatic retry, server push, full RFC 8441 support, full stream state machine, unbounded multiplexing, unbounded multiplex scheduling, general multiplexing, general tunnel scheduling, priority scheduling, or full HTTP/2 server feature set |
@@ -331,6 +374,11 @@ exposes `is_partial_content()`, `is_range_not_satisfiable()`, and
 `If-Range` headers remain available through the generic header API. These
 client helpers do not evaluate `If-Range`, retry requests, store cache entries,
 generate multipart range requests, or apply automatic cache validation. The
+client response API also includes `Response::cache_control()` from
+`rttp_client`, which parses bounded response `Cache-Control` directives and
+extensions as metadata only; the wrapper does not add cache storage,
+automatic revalidation, wall-clock freshness calculation, `Vary` matching,
+shared-cache policy enforcement, or automatic conditional requests. The
 `http2` feature exposes the bounded
 prior-knowledge h2c client path for GET, HEAD, bodyless DELETE, OPTIONS, or
 TRACE, and buffered POST, PUT, or PATCH requests. It opens at most one request

--- a/rttp_client/README.md
+++ b/rttp_client/README.md
@@ -92,6 +92,38 @@ cache-control engine. Client conditional helpers only set request headers and
 expose response metadata; applications decide when to persist validators, when
 to revalidate, and how to interpret cache directives.
 
+## Bounded HTTP/1.1 Cache-Control behavior
+
+`Response::cache_control()` parses one or more response `Cache-Control` header
+fields into `CacheControl`. It exposes the common response directives
+`no-cache`, `no-store`, `max-age`, `s-maxage`, `private`, `public`,
+`must-revalidate`, `proxy-revalidate`, `immutable`,
+`stale-while-revalidate`, and `stale-if-error`. Quoted field-name lists on
+`no-cache` and `private` are split into field names, and unknown extension
+directives are preserved as `CacheControlExtension` values with their token name
+and optional parsed value.
+
+The parser is bounded and validation-oriented. Each header field value is
+limited to 64 KiB, the parsed header set is limited to 256 directives, directive
+names and unquoted values must be valid HTTP tokens, quoted strings must be
+well formed, and delta-seconds values must be unquoted non-negative decimal
+integers that fit in `u64`. A malformed `Cache-Control` value makes
+`Response::cache_control()` return an error; the original response headers and
+body remain available through the ordinary response APIs.
+
+`Cache-Control` parsing is intentionally separate from conditional validator
+helpers. `Response::etag()` and `Response::last_modified()` expose validators,
+and request helpers such as `if_none_match()` and `if_modified_since()` can
+emit conditional requests when the application chooses to do so. RTTP does not
+combine `Cache-Control` directives with validators to decide freshness, build a
+cache entry, or issue a follow-up request.
+
+The client has no cache store and does not perform automatic revalidation,
+freshness calculation against wall-clock time, `Vary` matching, shared-cache
+policy enforcement, or automatic conditional requests. Directives such as
+`max-age`, `s-maxage`, `no-cache`, `must-revalidate`, and extension directives
+are exposed as parsed metadata only.
+
 ## Bounded trailer behavior
 
 Trailer support is explicit and bounded by protocol path. Use
@@ -162,6 +194,7 @@ header-block model.
 | Redirects | Auto-redirect covers 301, 302, 303, 307, and 308 method/body behavior, relative and absolute `Location` resolution, same- and cross-authority header handling, loop detection, and redirect bounds | Redirects are HTTP client behavior, not a browser policy implementation |
 | Byte ranges | `range`, `range_from`, `range_suffix`, `if_range_etag`, and `if_range_date` emit bounded HTTP/1.1 range request metadata; `Response::content_range`, `is_partial_content`, and `is_range_not_satisfiable` expose `206` and `416` metadata | No client-side `If-Range` evaluation, automatic retry, cache storage, multipart range generation, or automatic cache validation policy |
 | Conditional requests | `if_none_match`, `if_match`, `if_modified_since`, and `if_unmodified_since` emit bounded HTTP/1.1 validators; `Response::is_not_modified`, `is_precondition_failed`, `etag`, and `last_modified` expose `304`/`412` metadata | One ETag validator per helper call, `If-Range` is range-scoped, no cache storage, no automatic revalidation, and no cache-control engine |
+| Cache-Control | `Response::cache_control` parses bounded response directives, numeric freshness fields, quoted field-name lists, and extension directives into metadata helpers | No cache storage, automatic revalidation, wall-clock freshness calculation, `Vary` matching, shared-cache policy enforcement, or automatic conditional requests |
 | Trailers | Chunked response trailers are exposed for blocking and async APIs; streaming chunked uploads can send declared request trailers | Application metadata trailers such as `X-Trace` are allowed; pseudo-header, connection-specific, routing, authentication/cookie, and framing trailer fields are rejected |
 | Bounded h2c client | With `http2`, direct `socket2` h2c sends GET, HEAD, bodyless DELETE, OPTIONS, or TRACE, buffered POST, PUT, or PATCH requests, and opt-in RFC 8441 extended CONNECT request HEADERS via `http2_extended_connect`, opens at most one request stream, supports prior-knowledge with `emit_http2_prior_knowledge`, supports explicit HTTP/1.1 `Upgrade: h2c` negotiation with `emit_http2_upgrade`, advertises `SETTINGS_ENABLE_PUSH = 0`, advertises `SETTINGS_ENABLE_CONNECT_PROTOCOL = 1` only for the explicit extended CONNECT path, validates received `SETTINGS_ENABLE_PUSH` values as only `0` or `1`, honors initial peer `SETTINGS_MAX_CONCURRENT_STREAMS` by failing before request HEADERS when the peer allows zero streams, honors peer-advertised `SETTINGS_MAX_HEADER_LIST_SIZE` request metadata limits, accepts only legal `SETTINGS_MAX_FRAME_SIZE` values from 16,384 through 16,777,215 bytes, splits outbound HEADERS, DATA, and trailers to the active peer frame-size limit, rejects oversized inbound frames when a configured local frame-size limit is exceeded, bounds HPACK dynamic table use with `SETTINGS_HEADER_TABLE_SIZE`, strips HTTP/1.x connection-specific request fields before emission, rejects connection-specific peer response fields, suppresses HEAD response bodies, treats `RST_STREAM` on the active stream as a bounded reset/cancellation signal, acknowledges valid PING frames with matching opaque data, DATA bodies, trailers, HPACK static Huffman strings, bounded large header blocks, padded incoming frames, `GOAWAY` shutdown boundaries, PRIORITY metadata validation without scheduling, HTTP/2-allowed unknown/extension frame ignoring inside this bounded path, reserved stream-id high-bit normalization, and conservative DATA flow control | Ordinary `CONNECT`, header-configured `:protocol` metadata, non-h2c HTTP/1.1 `Upgrade` handoff requests, and proxies are rejected deterministically, and `PUSH_PROMISE`/server push is rejected instead of managed; bounded direct h2c only, with no public cancellation callback API, no dynamic policy API, no extension callback API, no full extension negotiation, TLS ALPN, external h2 integration, proxy tunneling to h2, proxy h2, tunnel handoff, connection pooling, persistent HTTP/2 session management, automatic retry, server push, full stream state machine, unbounded multiplex scheduling, general multiplexing, priority scheduling, request bodies or trailers for extended CONNECT, or request bodies for GET, HEAD, DELETE, OPTIONS, or TRACE |
 


### PR DESCRIPTION
README documentation now covers bounded HTTP/1.1 Cache-Control behavior for client and server helpers, including parser limits, extension directives, validator interaction, and cache-policy limitations. Fresh workspace verification passes.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1576/
work_kind: code_work
branch: hbx-1576-rttp-document-bounded-http-1
base: main
commit: 784f6a29eaf46e3d62411b105771ade77224ce0a
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1576/
    url: https://plane.kahub.in/endless/browse/HBX-1576/
    close_policy: link_only
```