### PR TITLE
feat: [rttp_client] Add bounded HTTP/1.1 Vary response helpers

### DIFF
--- a/rttp_client/src/response/response.rs
+++ b/rttp_client/src/response/response.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::fmt;
 
 use url::Url;
@@ -8,6 +9,8 @@ use crate::types::{Cookie, Header, RoUrl};
 
 const MAX_CACHE_CONTROL_VALUE_BYTES: usize = 64 * 1024;
 const MAX_CACHE_CONTROL_DIRECTIVES: usize = 256;
+const MAX_VARY_VALUE_BYTES: usize = 64 * 1024;
+const MAX_VARY_FIELD_NAMES: usize = 256;
 
 #[derive(Clone)]
 pub struct Response {
@@ -109,6 +112,14 @@ impl Response {
       return Ok(None);
     }
     CacheControl::parse_values(values.into_iter().map(String::as_str)).map(Some)
+  }
+
+  pub fn vary(&self) -> error::Result<Option<Vary>> {
+    let values = self.header_values("vary");
+    if values.is_empty() {
+      return Ok(None);
+    }
+    Vary::parse_values(values.into_iter().map(String::as_str)).map(Some)
   }
 
   pub fn headers(&self) -> &Vec<Header> {
@@ -269,6 +280,93 @@ fn parse_complete_length(value: &str) -> Option<Option<u64>> {
     return Some(None);
   }
   value.parse::<u64>().ok().map(Some)
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Vary {
+  any: bool,
+  field_names: Vec<String>,
+}
+
+impl Vary {
+  pub fn parse(value: impl AsRef<str>) -> error::Result<Self> {
+    Self::parse_values([value.as_ref()])
+  }
+
+  fn parse_values<'a, I>(values: I) -> error::Result<Self>
+  where
+    I: IntoIterator<Item = &'a str>,
+  {
+    let mut any = false;
+    let mut field_names = Vec::new();
+    let mut seen = HashSet::new();
+    let mut field_name_count = 0usize;
+
+    for value in values {
+      if value.len() > MAX_VARY_VALUE_BYTES {
+        return Err(error::bad_response("Vary header value is too large"));
+      }
+
+      for member in value.split(',') {
+        let member = member.trim();
+        if member.is_empty() {
+          return Err(error::bad_response("Invalid Vary field name"));
+        }
+
+        if member == "*" {
+          if any || field_names.is_empty() {
+            any = true;
+            continue;
+          }
+          return Err(error::bad_response(
+            "Vary wildcard cannot be combined with field names",
+          ));
+        }
+
+        if any {
+          return Err(error::bad_response(
+            "Vary wildcard cannot be combined with field names",
+          ));
+        }
+        if !is_token(member) {
+          return Err(error::bad_response("Invalid Vary field name"));
+        }
+
+        field_name_count += 1;
+        if field_name_count > MAX_VARY_FIELD_NAMES {
+          return Err(error::bad_response("Too many Vary field names"));
+        }
+
+        let normalized = member.to_ascii_lowercase();
+        if seen.insert(normalized.clone()) {
+          field_names.push(normalized);
+        }
+      }
+    }
+
+    if !any && field_names.is_empty() {
+      return Err(error::bad_response("Invalid Vary field name"));
+    }
+
+    Ok(Self { any, field_names })
+  }
+
+  pub fn is_any(&self) -> bool {
+    self.any
+  }
+
+  pub fn field_names(&self) -> Vec<&str> {
+    self.field_names.iter().map(String::as_str).collect()
+  }
+
+  pub fn contains_field_name(&self, field_name: impl AsRef<str>) -> bool {
+    let field_name = field_name.as_ref();
+    if !is_token(field_name) {
+      return false;
+    }
+    let field_name = field_name.to_ascii_lowercase();
+    self.field_names.iter().any(|name| name == &field_name)
+  }
 }
 
 #[derive(Clone, Debug, Default, Eq, PartialEq)]

--- a/rttp_client/tests/test_response.rs
+++ b/rttp_client/tests/test_response.rs
@@ -283,6 +283,94 @@ fn test_parse_cache_control_rejects_invalid_helper_values_without_rejecting_resp
 }
 
 #[test]
+fn test_parse_vary_response_helper_normalizes_and_deduplicates_field_names() {
+  let s = concat!(
+    "HTTP/1.1 200 OK\r\n",
+    "Vary: Accept-Encoding, User-Agent\r\n",
+    "VARY: accept-encoding, X-Feature\r\n",
+    "Content-Length: 2\r\n",
+    "\r\n",
+    "OK"
+  );
+  let response = Response::new(RoUrl::with("https://example.test"), s.as_bytes().to_vec())
+    .expect("parse response with vary headers");
+
+  let vary = response
+    .vary()
+    .expect("valid vary should parse")
+    .expect("vary header should be present");
+
+  assert!(!vary.is_any());
+  assert_eq!(
+    vec!["accept-encoding", "user-agent", "x-feature"],
+    vary.field_names()
+  );
+  assert!(vary.contains_field_name("ACCEPT-ENCODING"));
+  assert!(vary.contains_field_name("user-agent"));
+  assert!(!vary.contains_field_name("authorization"));
+  assert_eq!(
+    vec![
+      &"Accept-Encoding, User-Agent".to_string(),
+      &"accept-encoding, X-Feature".to_string()
+    ],
+    response.header_values("vary")
+  );
+}
+
+#[test]
+fn test_parse_vary_response_helper_supports_wildcard_and_absent_header() {
+  let s = concat!(
+    "HTTP/1.1 200 OK\r\n",
+    "Vary: *\r\n",
+    "Content-Length: 2\r\n",
+    "\r\n",
+    "OK"
+  );
+  let response = Response::new(RoUrl::with("https://example.test"), s.as_bytes().to_vec())
+    .expect("parse response with wildcard vary");
+  let vary = response
+    .vary()
+    .expect("valid wildcard vary should parse")
+    .expect("vary header should be present");
+
+  assert!(vary.is_any());
+  assert!(vary.field_names().is_empty());
+  assert!(!vary.contains_field_name("accept"));
+
+  let s = concat!("HTTP/1.1 200 OK\r\n", "Content-Length: 2\r\n", "\r\n", "OK");
+  let response = Response::new(RoUrl::with("https://example.test"), s.as_bytes().to_vec())
+    .expect("parse response without vary");
+  assert_eq!(None, response.vary().expect("absent vary should parse"));
+}
+
+#[test]
+fn test_parse_vary_rejects_invalid_helper_values_without_rejecting_response() {
+  let invalid_values = [
+    "",
+    "Accept,",
+    ",Accept",
+    "Accept,,User-Agent",
+    "Accept, ,User-Agent",
+    "Accept Encoding",
+    "Accept@Encoding",
+    "*, Accept",
+    "Accept, *",
+  ];
+
+  for value in invalid_values {
+    let raw = format!("HTTP/1.1 200 OK\r\nVary: {value}\r\nContent-Length: 2\r\n\r\nOK");
+    let response = Response::new(RoUrl::with("https://example.test"), raw.into_bytes())
+      .expect("raw response remains usable");
+
+    assert!(
+      response.vary().is_err(),
+      "vary helper should reject {value:?}"
+    );
+    assert_eq!(Some(&value.to_string()), response.header_value("Vary"));
+  }
+}
+
+#[test]
 fn test_parse_response_rejects_header_without_colon() {
   let s = concat!(
     "HTTP/1.1 200 OK\r\n",


### PR DESCRIPTION
Added bounded `Vary` response helper support to `rttp_client`, including wildcard handling, normalized field-name helpers, deterministic duplicate handling, malformed-value rejection, and regression coverage.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1578/
work_kind: code_work
branch: hbx-1578-rttp-client-add-bounded-http
base: main
commit: 94e75bd1fa38238866397f04e73d56c2b4ae4ffd
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1578/
    url: https://plane.kahub.in/endless/browse/HBX-1578/
    close_policy: link_only
```