### PR TITLE
feat: [rttp] Add cross-crate HTTP/1.1 Vary matrix

### DIFF
--- a/rttp/tests/http11_compliance_matrix.rs
+++ b/rttp/tests/http11_compliance_matrix.rs
@@ -4,7 +4,9 @@ use std::sync::mpsc;
 use std::thread;
 use std::time::Duration;
 
-use rttp::server::{HttpRequest, HttpRequestCacheControl, HttpResponse, HttpResponseCacheControl};
+use rttp::server::{
+  HttpRequest, HttpRequestCacheControl, HttpResponse, HttpResponseCacheControl, HttpVary,
+};
 use rttp_http11_test_fixtures as fixtures;
 
 #[derive(Debug)]
@@ -50,6 +52,14 @@ fn cache_control_response(values: &[&str]) -> HttpResponse {
     .iter()
     .fold(HttpResponse::new(200, "OK"), |response, value| {
       response.header("Cache-Control", value)
+    })
+}
+
+fn vary_response(values: &[&str]) -> HttpResponse {
+  values
+    .iter()
+    .fold(HttpResponse::new(200, "OK"), |response, value| {
+      response.header("Vary", value)
     })
 }
 
@@ -141,6 +151,15 @@ fn assert_response_cache_control(
   }
 }
 
+fn assert_response_vary(name: &str, vary: &HttpVary, expected: &fixtures::vary::ResponseCase) {
+  assert_eq!(expected.wildcard, vary.is_wildcard(), "{name}");
+  assert_eq!(
+    expected.field_names,
+    vary.field_names().as_slice(),
+    "{name}"
+  );
+}
+
 #[test]
 fn model_parser_accepts_shared_fixed_length_request_fixture() {
   let fixture = fixtures::request::fixed_length_post();
@@ -209,6 +228,100 @@ fn model_parser_cache_control_helper_enforces_shared_bounds() {
   assert!(
     HttpRequestCacheControl::parse(&oversized_value).is_err(),
     "oversized request Cache-Control value helper should reject invalid Cache-Control"
+  );
+}
+
+#[test]
+fn server_response_helper_accepts_shared_vary_response_matrix() {
+  for case in fixtures::vary::response_cases() {
+    let response = vary_response(case.values);
+    let vary = response
+      .vary()
+      .unwrap_or_else(|err| panic!("{} Vary should parse: {err}", case.name))
+      .unwrap_or_else(|| panic!("{} should include Vary", case.name));
+
+    assert_response_vary(case.name, &vary, case);
+  }
+}
+
+#[test]
+fn server_response_with_vary_declares_normalized_shared_vary_matrix() {
+  for case in fixtures::vary::response_cases() {
+    let Some(value) = case.values.first() else {
+      continue;
+    };
+    let response = HttpResponse::ok("accepted")
+      .with_vary(value)
+      .unwrap_or_else(|err| panic!("{} Vary declaration should parse: {err}", case.name));
+    let serialized = String::from_utf8(response.to_bytes()).expect("response is UTF-8");
+    let expected = HttpVary::parse(value)
+      .expect("already parsed by with_vary")
+      .header_value();
+
+    assert_eq!(
+      Some(expected.as_str()),
+      header_value(&serialized, "Vary"),
+      "{}",
+      case.name
+    );
+  }
+}
+
+#[test]
+fn server_request_selection_accepts_shared_vary_matrix() {
+  for case in fixtures::vary::selection_cases() {
+    let request = HttpRequest::parse(case.request).expect("request should parse");
+    let vary = HttpVary::parse(case.value)
+      .unwrap_or_else(|err| panic!("{} Vary should parse: {err}", case.name));
+
+    let selection = request.vary_selection(&vary);
+
+    assert_eq!(case.wildcard, selection.is_wildcard(), "{}", case.name);
+    assert_eq!(
+      case.field_names,
+      selection.field_names().as_slice(),
+      "{}",
+      case.name
+    );
+    for (field_name, expected_values) in case.selected_values {
+      assert_eq!(
+        *expected_values,
+        selection.values(field_name).as_slice(),
+        "{} {field_name}",
+        case.name
+      );
+    }
+  }
+}
+
+#[test]
+fn server_vary_helpers_reject_shared_invalid_matrix() {
+  for case in fixtures::vary::invalid_cases() {
+    assert!(
+      HttpVary::parse(case.value).is_err(),
+      "{} Vary helper should reject invalid value",
+      case.name
+    );
+    assert!(
+      HttpResponse::ok("body").with_vary(case.value).is_err(),
+      "{} response helper should reject invalid Vary value",
+      case.name
+    );
+  }
+}
+
+#[test]
+fn server_vary_helper_enforces_shared_bounds() {
+  let too_many_fields = fixtures::vary::too_many_field_names_value();
+  assert!(
+    HttpVary::parse(&too_many_fields).is_err(),
+    "too many Vary field names should be rejected"
+  );
+
+  let oversized_value = fixtures::vary::oversized_value();
+  assert!(
+    HttpVary::parse(&oversized_value).is_err(),
+    "oversized Vary value should be rejected"
   );
 }
 

--- a/rttp_client/tests/http11_compliance_matrix.rs
+++ b/rttp_client/tests/http11_compliance_matrix.rs
@@ -28,6 +28,17 @@ fn cache_control_response(values: &[&str]) -> Vec<u8> {
   response.into_bytes()
 }
 
+fn vary_response(values: &[&str]) -> Vec<u8> {
+  let mut response = String::from("HTTP/1.1 200 OK\r\n");
+  for value in values {
+    response.push_str("Vary: ");
+    response.push_str(value);
+    response.push_str("\r\n");
+  }
+  response.push_str("Content-Length: 2\r\n\r\nOK");
+  response.into_bytes()
+}
+
 const RANGE_BODY: &[u8] = b"0123456789abcdef";
 const CONDITIONAL_LAST_MODIFIED: &str = "Sun, 06 Nov 1994 08:49:37 GMT";
 const CONDITIONAL_STALE_DATE: &str = "Sun, 06 Nov 1994 08:49:36 GMT";
@@ -317,6 +328,38 @@ fn assert_response_cache_control(
   }
 }
 
+fn assert_response_vary(
+  name: &str,
+  response: rttp_client::response::Response,
+  expected: &fixtures::vary::ResponseCase,
+) {
+  let raw_values: Vec<&str> = response
+    .header_values("vary")
+    .into_iter()
+    .map(String::as_str)
+    .collect();
+  assert_eq!(expected.values, raw_values.as_slice(), "{name}");
+
+  let vary = response
+    .vary()
+    .unwrap_or_else(|err| panic!("{name} Vary should parse: {err}"))
+    .unwrap_or_else(|| panic!("{name} should include Vary"));
+
+  assert_eq!(expected.wildcard, vary.is_any(), "{name}");
+  assert_eq!(
+    expected.field_names,
+    vary.field_names().as_slice(),
+    "{name}"
+  );
+  for field_name in expected.field_names {
+    assert!(vary.contains_field_name(field_name), "{name} {field_name}");
+    assert!(
+      vary.contains_field_name(field_name.to_ascii_uppercase()),
+      "{name} uppercase {field_name}"
+    );
+  }
+}
+
 fn assert_cache_control_helper_rejects_but_preserves_response(name: &str, raw_response: Vec<u8>) {
   let (addr, handle) = fixtures::spawn_socket2_owned_raw_response_server(raw_response);
 
@@ -329,6 +372,24 @@ fn assert_cache_control_helper_rejects_but_preserves_response(name: &str, raw_re
   assert!(
     response.cache_control().is_err(),
     "{name} helper should reject invalid Cache-Control"
+  );
+  assert_eq!("OK", response.body().string().unwrap(), "{name}");
+
+  handle.join().expect("raw response server thread");
+}
+
+fn assert_vary_helper_rejects_but_preserves_response(name: &str, raw_response: Vec<u8>) {
+  let (addr, handle) = fixtures::spawn_socket2_owned_raw_response_server(raw_response);
+
+  let response = client()
+    .get()
+    .url(format!("http://{}/matrix/vary-invalid", addr))
+    .emit()
+    .unwrap_or_else(|err| panic!("{name} response should remain parseable: {err}"));
+
+  assert!(
+    response.vary().is_err(),
+    "{name} helper should reject invalid Vary"
   );
   assert_eq!("OK", response.body().string().unwrap(), "{name}");
 
@@ -361,12 +422,36 @@ fn sync_client_parses_shared_cache_control_response_matrix() {
 }
 
 #[test]
+fn sync_client_parses_shared_vary_response_matrix() {
+  for case in fixtures::vary::response_cases() {
+    let raw_response = vary_response(case.values);
+    let (addr, handle) = fixtures::spawn_socket2_owned_raw_response_server(raw_response);
+
+    let response = client()
+      .get()
+      .url(format!("http://{}/matrix/vary", addr))
+      .emit()
+      .unwrap_or_else(|err| panic!("{} response should parse: {err}", case.name));
+
+    assert_response_vary(case.name, response, case);
+    handle.join().expect("raw response server thread");
+  }
+}
+
+#[test]
 fn sync_client_cache_control_helper_rejects_shared_invalid_response_matrix() {
   for case in fixtures::cache_control::invalid_response_cases() {
     assert_cache_control_helper_rejects_but_preserves_response(
       case.name,
       cache_control_response(&[case.value]),
     );
+  }
+}
+
+#[test]
+fn sync_client_vary_helper_rejects_shared_invalid_response_matrix() {
+  for case in fixtures::vary::invalid_cases() {
+    assert_vary_helper_rejects_but_preserves_response(case.name, vary_response(&[case.value]));
   }
 }
 
@@ -379,6 +464,18 @@ fn sync_client_cache_control_helper_enforces_shared_bounds() {
   assert_cache_control_helper_rejects_but_preserves_response(
     "oversized response Cache-Control value",
     cache_control_response(&[&fixtures::cache_control::oversized_value()]),
+  );
+}
+
+#[test]
+fn sync_client_vary_helper_enforces_shared_bounds() {
+  assert_vary_helper_rejects_but_preserves_response(
+    "too many Vary field names",
+    vary_response(&[&fixtures::vary::too_many_field_names_value()]),
+  );
+  assert_vary_helper_rejects_but_preserves_response(
+    "oversized Vary value",
+    vary_response(&[&fixtures::vary::oversized_value()]),
   );
 }
 

--- a/rttp_http11_test_fixtures/src/lib.rs
+++ b/rttp_http11_test_fixtures/src/lib.rs
@@ -448,6 +448,159 @@ pub mod cache_control {
   }
 }
 
+pub mod vary {
+  pub const MAX_VALUE_BYTES: usize = 64 * 1024;
+  pub const MAX_FIELD_NAMES: usize = 256;
+
+  pub struct ResponseCase {
+    pub name: &'static str,
+    pub values: &'static [&'static str],
+    pub wildcard: bool,
+    pub field_names: &'static [&'static str],
+  }
+
+  pub struct SelectionCase {
+    pub name: &'static str,
+    pub request: &'static [u8],
+    pub value: &'static str,
+    pub wildcard: bool,
+    pub field_names: &'static [&'static str],
+    pub selected_values: &'static [(&'static str, &'static [&'static str])],
+  }
+
+  pub struct InvalidCase {
+    pub name: &'static str,
+    pub value: &'static str,
+  }
+
+  const RESPONSE_CASES: &[ResponseCase] = &[
+    ResponseCase {
+      name: "field names across header fields",
+      values: &["Accept-Encoding, User-Agent", "accept-language, X-Feature"],
+      wildcard: false,
+      field_names: &[
+        "accept-encoding",
+        "user-agent",
+        "accept-language",
+        "x-feature",
+      ],
+    },
+    ResponseCase {
+      name: "case-insensitive duplicate field names are deduplicated",
+      values: &["Accept-Encoding, accept-encoding, ACCEPT-LANGUAGE"],
+      wildcard: false,
+      field_names: &["accept-encoding", "accept-language"],
+    },
+    ResponseCase {
+      name: "wildcard response",
+      values: &["*"],
+      wildcard: true,
+      field_names: &[],
+    },
+  ];
+
+  const ACCEPT_ENCODING_VALUES: &[&str] = &["gzip", "br"];
+  const X_USER_VALUES: &[&str] = &["123"];
+  const EMPTY_VALUES: &[&str] = &[];
+  const SELECTION_VALUES: &[(&str, &[&str])] = &[
+    ("accept-encoding", ACCEPT_ENCODING_VALUES),
+    ("x-user", X_USER_VALUES),
+    ("accept-language", EMPTY_VALUES),
+  ];
+  const EMPTY_SELECTION_VALUES: &[(&str, &[&str])] = &[];
+
+  const SELECTION_CASES: &[SelectionCase] = &[
+    SelectionCase {
+      name: "case-insensitive field selection preserves duplicate request values",
+      request: concat!(
+        "GET /matrix/vary HTTP/1.1\r\n",
+        "Host: example.test\r\n",
+        "Accept-Encoding: gzip\r\n",
+        "accept-encoding: br\r\n",
+        "X-User: 123\r\n",
+        "\r\n"
+      )
+      .as_bytes(),
+      value: "ACCEPT-ENCODING, x-user, accept-language",
+      wildcard: false,
+      field_names: &["accept-encoding", "x-user", "accept-language"],
+      selected_values: SELECTION_VALUES,
+    },
+    SelectionCase {
+      name: "wildcard selection does not bind request fields",
+      request: concat!(
+        "GET /matrix/vary HTTP/1.1\r\n",
+        "Host: example.test\r\n",
+        "Accept-Encoding: gzip\r\n",
+        "\r\n"
+      )
+      .as_bytes(),
+      value: "*",
+      wildcard: true,
+      field_names: &[],
+      selected_values: EMPTY_SELECTION_VALUES,
+    },
+  ];
+
+  const INVALID_CASES: &[InvalidCase] = &[
+    InvalidCase {
+      name: "empty value",
+      value: "",
+    },
+    InvalidCase {
+      name: "trailing comma",
+      value: "Accept-Encoding,",
+    },
+    InvalidCase {
+      name: "leading comma",
+      value: ", Accept-Encoding",
+    },
+    InvalidCase {
+      name: "empty member",
+      value: "Accept-Encoding,,User-Agent",
+    },
+    InvalidCase {
+      name: "field name with whitespace",
+      value: "Accept Encoding",
+    },
+    InvalidCase {
+      name: "field name with separator",
+      value: "Accept@Encoding",
+    },
+    InvalidCase {
+      name: "wildcard followed by field name",
+      value: "*, Accept-Encoding",
+    },
+    InvalidCase {
+      name: "field name followed by wildcard",
+      value: "Accept-Encoding, *",
+    },
+  ];
+
+  pub fn response_cases() -> &'static [ResponseCase] {
+    RESPONSE_CASES
+  }
+
+  pub fn selection_cases() -> &'static [SelectionCase] {
+    SELECTION_CASES
+  }
+
+  pub fn invalid_cases() -> &'static [InvalidCase] {
+    INVALID_CASES
+  }
+
+  pub fn too_many_field_names_value() -> String {
+    (0..=MAX_FIELD_NAMES)
+      .map(|index| format!("x-vary-{index}"))
+      .collect::<Vec<_>>()
+      .join(", ")
+  }
+
+  pub fn oversized_value() -> String {
+    format!("x-{}", "a".repeat(MAX_VALUE_BYTES))
+  }
+}
+
 pub fn bind_socket2_tcp_listener(name: &str) -> (TcpListener, SocketAddr) {
   let addr: SocketAddr = "127.0.0.1:0".parse().expect("parse local addr");
   let socket = Socket::new(Domain::IPV4, Type::STREAM, Some(Protocol::TCP))


### PR DESCRIPTION
Added shared cross-crate HTTP/1.1 Vary compliance coverage for rttp and rttp_client, with formatting and matrix tests passing.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1580/
work_kind: code_work
branch: hbx-1580-rttp-add-cross-crate-http
base: main
commit: 126954dc3c40533ad791ec2fe5c5e28783a7857f
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1580/
    url: https://plane.kahub.in/endless/browse/HBX-1580/
    close_policy: link_only
```