### PR TITLE
feat: [rttp_client] Add bounded HTTP/1.1 Age and Expires response helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,23 @@ policy enforcement, or automatic conditional requests. Directives such as
 `max-age`, `s-maxage`, `no-cache`, `must-revalidate`, and extension directives
 are exposed as parsed metadata only.
 
+### Bounded HTTP/1.1 Age and Expires behavior
+
+`Response::age()` parses the response `Age` header as HTTP/1.1 delta-seconds
+metadata. It returns `Ok(None)` when the header is absent, returns the
+non-negative decimal value as `u64` when the header is present and valid, and
+returns an error for empty, signed, fractional, non-numeric, comma-list, or
+overflowing values. `Response::expires()` parses the response `Expires` header
+as an HTTP-date using the same HTTP-date parser used by the client date
+helpers.
+
+Malformed helper values do not reject the raw response. The original `Age` and
+`Expires` fields remain available through `header_value`, `header_values`, and
+the other raw header accessors. These helpers expose metadata only; RTTP does
+not calculate freshness against wall-clock time, store cache entries,
+revalidate responses, match stored responses, or issue automatic conditional
+requests.
+
 ### Bounded HTTP/1.1 Vary behavior
 
 `Response::vary()` parses one or more response `Vary` header fields into
@@ -203,7 +220,7 @@ gain additional HTTP/2 header-block handling.
 | Redirects | Auto-redirect covers 301, 302, 303, 307, and 308 method/body behavior, relative and absolute `Location` resolution, same- and cross-authority header handling, loop detection, and redirect bounds | Redirects are HTTP client behavior, not a browser policy implementation |
 | Byte ranges | `range`, `range_from`, `range_suffix`, `if_range_etag`, and `if_range_date` emit bounded HTTP/1.1 range request metadata; `Response::content_range`, `is_partial_content`, and `is_range_not_satisfiable` expose `206` and `416` metadata | No client-side `If-Range` evaluation, automatic retry, cache storage, multipart range generation, or automatic cache validation policy |
 | Conditional requests | `if_none_match`, `if_match`, `if_modified_since`, and `if_unmodified_since` emit bounded HTTP/1.1 validators; `Response::is_not_modified`, `is_precondition_failed`, `etag`, and `last_modified` expose `304`/`412` metadata | One ETag validator per helper call, `If-Range` is range-scoped, no cache storage, no automatic revalidation, and no cache-control engine |
-| Cache-Control | `Response::cache_control` parses bounded response directives, numeric freshness fields, quoted field-name lists, and extension directives into metadata helpers | No cache storage, automatic revalidation, wall-clock freshness calculation, `Vary` matching, shared-cache policy enforcement, or automatic conditional requests |
+| Cache-Control, Age, and Expires | `Response::cache_control` parses bounded response directives, numeric freshness fields, quoted field-name lists, and extension directives; `Response::age` parses bounded delta-seconds; `Response::expires` parses bounded HTTP-date metadata | No cache storage, automatic revalidation, wall-clock freshness calculation, `Vary` matching, shared-cache policy enforcement, or automatic conditional requests |
 | Vary | `Response::vary` parses bounded response `Vary` fields into wildcard or normalized case-insensitive field-name metadata | No cache storage, stored-response matching engine, cache key persistence, automatic request replay, shared-cache policy enforcement, or automatic conditional requests |
 | Trailers | Chunked response trailers are exposed for blocking and async APIs; streaming chunked uploads can send declared request trailers | Application metadata trailers such as `X-Trace` are allowed; pseudo-header, connection-specific, routing, authentication/cookie, and framing trailer fields are rejected |
 | Bounded h2c client | With `http2`, direct `socket2` h2c sends GET, HEAD, bodyless DELETE, OPTIONS, or TRACE, buffered POST, PUT, or PATCH requests, and opt-in RFC 8441 extended CONNECT request HEADERS via `http2_extended_connect`, opens at most one request stream, supports prior-knowledge with `emit_http2_prior_knowledge`, supports explicit HTTP/1.1 `Upgrade: h2c` negotiation with `emit_http2_upgrade`, advertises `SETTINGS_ENABLE_PUSH = 0`, advertises `SETTINGS_ENABLE_CONNECT_PROTOCOL = 1` only for the explicit extended CONNECT path, validates received `SETTINGS_ENABLE_PUSH` values as only `0` or `1`, honors initial peer `SETTINGS_MAX_CONCURRENT_STREAMS` by failing before request HEADERS when the peer allows zero streams, honors peer-advertised `SETTINGS_MAX_HEADER_LIST_SIZE` request metadata limits, accepts only legal `SETTINGS_MAX_FRAME_SIZE` values from 16,384 through 16,777,215 bytes, splits outbound HEADERS, DATA, and trailers to the active peer frame-size limit, rejects oversized inbound frames when a configured local frame-size limit is exceeded, bounds HPACK dynamic table use with `SETTINGS_HEADER_TABLE_SIZE`, strips HTTP/1.x connection-specific request fields before emission, rejects connection-specific peer response fields, suppresses HEAD response bodies, treats `RST_STREAM` on the active stream as a bounded reset/cancellation signal, acknowledges valid PING frames with matching opaque data, DATA bodies, trailers, HPACK static Huffman strings, bounded large header blocks, padded incoming frames, `GOAWAY` shutdown boundaries, PRIORITY metadata validation without scheduling, HTTP/2-allowed unknown/extension frame ignoring inside this bounded path, reserved stream-id high-bit normalization, and conservative DATA flow control | Ordinary `CONNECT`, header-configured `:protocol` metadata, non-h2c HTTP/1.1 `Upgrade` handoff requests, and proxies are rejected deterministically, and `PUSH_PROMISE`/server push is rejected instead of managed; bounded direct h2c only, with no public cancellation callback API, no dynamic policy API, no extension callback API, no full extension negotiation, TLS ALPN, external h2 integration, proxy tunneling to h2, proxy h2, tunnel handoff, connection pooling, persistent HTTP/2 session management, automatic retry, server push, full stream state machine, unbounded multiplex scheduling, general multiplexing, priority scheduling, request bodies or trailers for extended CONNECT, or request bodies for GET, HEAD, DELETE, OPTIONS, or TRACE |

--- a/rttp_client/README.md
+++ b/rttp_client/README.md
@@ -124,6 +124,22 @@ policy enforcement, or automatic conditional requests. Directives such as
 `max-age`, `s-maxage`, `no-cache`, `must-revalidate`, and extension directives
 are exposed as parsed metadata only.
 
+## Bounded HTTP/1.1 Age and Expires behavior
+
+`Response::age()` parses the response `Age` header as HTTP/1.1 delta-seconds
+metadata. The helper returns `Ok(None)` when the header is absent, returns the
+non-negative decimal value as `u64` when it is present and valid, and returns an
+error for empty, signed, fractional, non-numeric, comma-list, or overflowing
+values. `Response::expires()` parses the response `Expires` header as an
+HTTP-date using the same HTTP-date parser used by the client date helpers.
+
+Malformed helper values do not reject the raw response. The original `Age` and
+`Expires` fields remain available through `header_value`, `header_values`, and
+the other raw header accessors. These helpers expose metadata only;
+`rttp_client` does not calculate freshness against wall-clock time, store cache
+entries, revalidate responses, match stored responses, or issue automatic
+conditional requests.
+
 ## Bounded HTTP/1.1 Vary behavior
 
 `Response::vary()` parses one or more response `Vary` header fields into
@@ -216,7 +232,7 @@ header-block model.
 | Redirects | Auto-redirect covers 301, 302, 303, 307, and 308 method/body behavior, relative and absolute `Location` resolution, same- and cross-authority header handling, loop detection, and redirect bounds | Redirects are HTTP client behavior, not a browser policy implementation |
 | Byte ranges | `range`, `range_from`, `range_suffix`, `if_range_etag`, and `if_range_date` emit bounded HTTP/1.1 range request metadata; `Response::content_range`, `is_partial_content`, and `is_range_not_satisfiable` expose `206` and `416` metadata | No client-side `If-Range` evaluation, automatic retry, cache storage, multipart range generation, or automatic cache validation policy |
 | Conditional requests | `if_none_match`, `if_match`, `if_modified_since`, and `if_unmodified_since` emit bounded HTTP/1.1 validators; `Response::is_not_modified`, `is_precondition_failed`, `etag`, and `last_modified` expose `304`/`412` metadata | One ETag validator per helper call, `If-Range` is range-scoped, no cache storage, no automatic revalidation, and no cache-control engine |
-| Cache-Control | `Response::cache_control` parses bounded response directives, numeric freshness fields, quoted field-name lists, and extension directives into metadata helpers | No cache storage, automatic revalidation, wall-clock freshness calculation, `Vary` matching, shared-cache policy enforcement, or automatic conditional requests |
+| Cache-Control, Age, and Expires | `Response::cache_control` parses bounded response directives, numeric freshness fields, quoted field-name lists, and extension directives; `Response::age` parses bounded delta-seconds; `Response::expires` parses bounded HTTP-date metadata | No cache storage, automatic revalidation, wall-clock freshness calculation, `Vary` matching, shared-cache policy enforcement, or automatic conditional requests |
 | Vary | `Response::vary` parses bounded response `Vary` fields into wildcard or normalized case-insensitive field-name metadata | No cache storage, stored-response matching engine, cache key persistence, automatic request replay, shared-cache policy enforcement, or automatic conditional requests |
 | Trailers | Chunked response trailers are exposed for blocking and async APIs; streaming chunked uploads can send declared request trailers | Application metadata trailers such as `X-Trace` are allowed; pseudo-header, connection-specific, routing, authentication/cookie, and framing trailer fields are rejected |
 | Bounded h2c client | With `http2`, direct `socket2` h2c sends GET, HEAD, bodyless DELETE, OPTIONS, or TRACE, buffered POST, PUT, or PATCH requests, and opt-in RFC 8441 extended CONNECT request HEADERS via `http2_extended_connect`, opens at most one request stream, supports prior-knowledge with `emit_http2_prior_knowledge`, supports explicit HTTP/1.1 `Upgrade: h2c` negotiation with `emit_http2_upgrade`, advertises `SETTINGS_ENABLE_PUSH = 0`, advertises `SETTINGS_ENABLE_CONNECT_PROTOCOL = 1` only for the explicit extended CONNECT path, validates received `SETTINGS_ENABLE_PUSH` values as only `0` or `1`, honors initial peer `SETTINGS_MAX_CONCURRENT_STREAMS` by failing before request HEADERS when the peer allows zero streams, honors peer-advertised `SETTINGS_MAX_HEADER_LIST_SIZE` request metadata limits, accepts only legal `SETTINGS_MAX_FRAME_SIZE` values from 16,384 through 16,777,215 bytes, splits outbound HEADERS, DATA, and trailers to the active peer frame-size limit, rejects oversized inbound frames when a configured local frame-size limit is exceeded, bounds HPACK dynamic table use with `SETTINGS_HEADER_TABLE_SIZE`, strips HTTP/1.x connection-specific request fields before emission, rejects connection-specific peer response fields, suppresses HEAD response bodies, treats `RST_STREAM` on the active stream as a bounded reset/cancellation signal, acknowledges valid PING frames with matching opaque data, DATA bodies, trailers, HPACK static Huffman strings, bounded large header blocks, padded incoming frames, `GOAWAY` shutdown boundaries, PRIORITY metadata validation without scheduling, HTTP/2-allowed unknown/extension frame ignoring inside this bounded path, reserved stream-id high-bit normalization, and conservative DATA flow control | Ordinary `CONNECT`, header-configured `:protocol` metadata, non-h2c HTTP/1.1 `Upgrade` handoff requests, and proxies are rejected deterministically, and `PUSH_PROMISE`/server push is rejected instead of managed; bounded direct h2c only, with no public cancellation callback API, no dynamic policy API, no extension callback API, no full extension negotiation, TLS ALPN, external h2 integration, proxy tunneling to h2, proxy h2, tunnel handoff, connection pooling, persistent HTTP/2 session management, automatic retry, server push, full stream state machine, unbounded multiplex scheduling, general multiplexing, priority scheduling, request bodies or trailers for extended CONNECT, or request bodies for GET, HEAD, DELETE, OPTIONS, or TRACE |

--- a/rttp_client/src/response/response.rs
+++ b/rttp_client/src/response/response.rs
@@ -1,6 +1,8 @@
 use std::collections::HashSet;
 use std::fmt;
+use std::time::SystemTime;
 
+use httpdate::parse_http_date;
 use url::Url;
 
 use crate::error;
@@ -98,6 +100,24 @@ impl Response {
 
   pub fn last_modified(&self) -> Option<&String> {
     self.header_value("last-modified")
+  }
+
+  pub fn age(&self) -> error::Result<Option<u64>> {
+    self
+      .header_value("age")
+      .map(|value| parse_age_delta_seconds(value).map(Some))
+      .unwrap_or(Ok(None))
+  }
+
+  pub fn expires(&self) -> error::Result<Option<SystemTime>> {
+    self
+      .header_value("expires")
+      .map(|value| {
+        parse_http_date(value)
+          .map(Some)
+          .map_err(|_| error::bad_response("Invalid Expires HTTP-date"))
+      })
+      .unwrap_or(Ok(None))
   }
 
   pub fn content_range(&self) -> Option<ContentRange> {
@@ -673,6 +693,15 @@ fn parse_delta_seconds(
   value
     .parse::<u64>()
     .map_err(|_| error::bad_response(format!("Invalid Cache-Control {name} delta-seconds")))
+}
+
+fn parse_age_delta_seconds(value: &str) -> error::Result<u64> {
+  if value.is_empty() || !value.chars().all(|ch| ch.is_ascii_digit()) {
+    return Err(error::bad_response("Invalid Age delta-seconds"));
+  }
+  value
+    .parse::<u64>()
+    .map_err(|_| error::bad_response("Invalid Age delta-seconds"))
 }
 
 fn split_field_names(value: &str) -> Vec<String> {

--- a/rttp_client/tests/test_response.rs
+++ b/rttp_client/tests/test_response.rs
@@ -1,5 +1,6 @@
 use rttp_client::response::Response;
 use rttp_client::types::{Cookie, RoUrl};
+use std::time::{Duration, UNIX_EPOCH};
 
 #[test]
 fn test_parse_cookie_name_can_match_attribute_name() {
@@ -279,6 +280,89 @@ fn test_parse_cache_control_rejects_invalid_helper_values_without_rejecting_resp
       Some(&value.to_string()),
       response.header_value("Cache-Control")
     );
+  }
+}
+
+#[test]
+fn test_parse_age_and_expires_response_metadata() {
+  let s = concat!(
+    "HTTP/1.1 200 OK\r\n",
+    "Age: 2147483648\r\n",
+    "Expires: Sun, 06 Nov 1994 08:49:37 GMT\r\n",
+    "Content-Length: 2\r\n",
+    "\r\n",
+    "OK"
+  );
+  let response = Response::new(RoUrl::with("https://example.test"), s.as_bytes().to_vec())
+    .expect("parse response with age and expires metadata");
+
+  assert_eq!(
+    Some(2_147_483_648),
+    response.age().expect("valid age should parse")
+  );
+  assert_eq!(
+    Some(UNIX_EPOCH + Duration::from_secs(784111777)),
+    response.expires().expect("valid expires should parse")
+  );
+  assert_eq!(
+    Some(&"2147483648".to_string()),
+    response.header_value("Age")
+  );
+  assert_eq!(
+    Some(&"Sun, 06 Nov 1994 08:49:37 GMT".to_string()),
+    response.header_value("Expires")
+  );
+
+  let s = concat!("HTTP/1.1 200 OK\r\n", "Content-Length: 2\r\n", "\r\n", "OK");
+  let response = Response::new(RoUrl::with("https://example.test"), s.as_bytes().to_vec())
+    .expect("parse response without age or expires");
+  assert_eq!(None, response.age().expect("absent age should parse"));
+  assert_eq!(
+    None,
+    response.expires().expect("absent expires should parse")
+  );
+}
+
+#[test]
+fn test_parse_age_rejects_invalid_helper_values_without_rejecting_response() {
+  let invalid_values = [
+    "",
+    "-1",
+    "+1",
+    "1.5",
+    "6 0",
+    "60,61",
+    "abc",
+    "18446744073709551616",
+  ];
+
+  for value in invalid_values {
+    let raw = format!("HTTP/1.1 200 OK\r\nAge: {value}\r\nContent-Length: 2\r\n\r\nOK");
+    let response = Response::new(RoUrl::with("https://example.test"), raw.into_bytes())
+      .expect("raw response remains usable");
+
+    assert!(
+      response.age().is_err(),
+      "age helper should reject {value:?}"
+    );
+    assert_eq!(Some(&value.to_string()), response.header_value("Age"));
+  }
+}
+
+#[test]
+fn test_parse_expires_rejects_invalid_helper_values_without_rejecting_response() {
+  let invalid_values = ["", "not a date", "Sun, 06 Nov 1994 08:49:37 PST"];
+
+  for value in invalid_values {
+    let raw = format!("HTTP/1.1 200 OK\r\nExpires: {value}\r\nContent-Length: 2\r\n\r\nOK");
+    let response = Response::new(RoUrl::with("https://example.test"), raw.into_bytes())
+      .expect("raw response remains usable");
+
+    assert!(
+      response.expires().is_err(),
+      "expires helper should reject {value:?}"
+    );
+    assert_eq!(Some(&value.to_string()), response.header_value("Expires"));
   }
 }
 


### PR DESCRIPTION
Added bounded `Response::age()` and `Response::expires()` helpers for HTTP/1.1 response cache metadata, with tests and documentation covering valid parsing, malformed rejection, raw header preservation, and cache non-goals.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1583/
work_kind: code_work
branch: hbx-1583-rttp-client-add-bounded-http
base: main
commit: e30e28bfa3c49d92636f452217daa99943abfb4b
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1583/
    url: https://plane.kahub.in/endless/browse/HBX-1583/
    close_policy: link_only
```