### PR TITLE
feat: [rttp] Add bounded HTTP/1.1 Age and Expires server helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -496,6 +496,17 @@ enforcement, or automatic conditional requests. Directives such as `max-age`,
 `s-maxage`, `no-cache`, `only-if-cached`, `must-revalidate`, and extension
 directives are exposed as parsed metadata for application-owned policy.
 
+Server `Age` and `Expires` helpers expose adjacent response metadata without
+adding cache policy. `HttpResponse::with_age(delta_seconds)` adds an `Age`
+header from a non-negative `u64` delta-seconds value, and
+`HttpResponse::age()` parses an attached `Age` header back into `u64`,
+rejecting malformed or overflowing values. `HttpResponse::with_expires(time)`
+serializes an HTTP-date `Expires` header from `SystemTime`, and
+`HttpResponse::expires()` parses an attached `Expires` header as an HTTP-date.
+Malformed typed helper reads return validation errors, while raw
+`HttpResponse::header("Age", ...)` and `HttpResponse::header("Expires", ...)`
+values remain preserved exactly as response headers.
+
 ### Bounded HTTP/1.1 Vary behavior
 
 Server-side `Vary` helpers expose response declaration and request-selection
@@ -660,7 +671,7 @@ TLS or async accept loops.
 | HTTP/1.1 response framing | Automatic `Content-Length`, explicit chunked responses, bodyless `HEAD`, `101`, `204`, and `304`, response trailers after the terminating chunk | No server TLS |
 | Byte ranges | `HttpByteRange` parses one `bytes` range, `Request::evaluate_if_range` gates it with caller-provided strong ETag or exact HTTP-date metadata, and `HttpResponse::partial_content`/`range_not_satisfiable` serialize `206`/`416` with `Content-Range` | No multipart range serialization, automatic retry, cache storage, filesystem serving, MIME detection, automatic cache validation, or automatic static-file policy |
 | Conditional requests | `Request::evaluate_conditional`, `evaluate_conditional_request`, `HttpConditionalMetadata`, and `HttpEntityTag` evaluate bounded HTTP/1.1 validators; `HttpResponse::not_modified` and `precondition_failed` serialize `304` and `412` outcomes | No cache storage, static-file serving policy, automatic revalidation, or cache-control engine |
-| Cache-Control | `Request::cache_control`, `HttpRequest::cache_control`, and `HttpResponse::cache_control` parse bounded request/response directives, numeric freshness fields, quoted field-name lists, and extension directives | No cache storage, automatic revalidation, wall-clock freshness calculation, `Vary` matching, shared-cache policy enforcement, automatic conditional requests, or directive-based validator evaluation |
+| Cache-Control | `Request::cache_control`, `HttpRequest::cache_control`, and `HttpResponse::cache_control` parse bounded request/response directives, numeric freshness fields, quoted field-name lists, and extension directives; `HttpResponse::with_age`/`age` and `with_expires`/`expires` declare and parse response `Age` and `Expires` metadata | No cache storage, automatic revalidation, wall-clock freshness calculation, `Vary` matching, shared-cache policy enforcement, automatic conditional requests, or directive-based validator evaluation |
 | Vary | `HttpVary`, `HttpResponse::with_vary`, `HttpResponse::vary`, `Request::vary_selection`, and `HttpRequest::vary_selection` parse, declare, and select bounded `Vary` metadata with case-insensitive field-name handling | No cache storage, stored-response matching engine, cache key persistence, automatic request replay, shared-cache policy enforcement, or automatic conditional requests |
 | Upgrade and tunnel targets | `CONNECT` authority-form requests are accepted as HTTP requests; `HttpResponse::upgrade` can hand an upgraded socket to caller code after a matching request | The server does not implement the upgraded protocol after handoff |
 | Trailers | Chunked request trailers are preserved on `Request`; malformed, oversized, forbidden, and pseudo-header trailers are rejected; response trailers can be serialized for chunked responses | Application metadata trailers are allowed; trailer names that affect connection state, routing, authentication/cookies, framing, or payload processing are rejected |

--- a/rttp/README.md
+++ b/rttp/README.md
@@ -161,6 +161,17 @@ enforcement, or automatic conditional requests. Directives such as `max-age`,
 `s-maxage`, `no-cache`, `only-if-cached`, `must-revalidate`, and extension
 directives are exposed as parsed metadata for application-owned policy.
 
+Server `Age` and `Expires` helpers expose adjacent response metadata without
+adding cache policy. `HttpResponse::with_age(delta_seconds)` adds an `Age`
+header from a non-negative `u64` delta-seconds value, and
+`HttpResponse::age()` parses an attached `Age` header back into `u64`,
+rejecting malformed or overflowing values. `HttpResponse::with_expires(time)`
+serializes an HTTP-date `Expires` header from `SystemTime`, and
+`HttpResponse::expires()` parses an attached `Expires` header as an HTTP-date.
+Malformed typed helper reads return validation errors, while raw
+`HttpResponse::header("Age", ...)` and `HttpResponse::header("Expires", ...)`
+values remain preserved exactly as response headers.
+
 ## Bounded HTTP/1.1 Vary behavior
 
 Server-side `Vary` helpers expose response declaration and request-selection
@@ -385,7 +396,7 @@ scheduling, or async accept loops.
 | HTTP/1.1 response framing | Automatic `Content-Length`, explicit chunked responses, bodyless `HEAD`, `101`, `204`, and `304`, response trailers after the terminating chunk | No server TLS |
 | Byte ranges | `HttpByteRange` parses one `bytes` range, `Request::evaluate_if_range` and `HttpRequest::evaluate_if_range` gate it with caller-provided strong ETag or exact HTTP-date metadata, and `HttpResponse::partial_content`/`range_not_satisfiable` serialize `206`/`416` with `Content-Range` | No multipart range serialization, automatic retry, cache storage, filesystem serving, automatic cache validation, or static-file policy |
 | Conditional requests | `Request::evaluate_conditional`, `evaluate_conditional_request`, `HttpConditionalMetadata`, and `HttpEntityTag` evaluate bounded HTTP/1.1 validators; `HttpResponse::not_modified` and `precondition_failed` serialize `304` and `412` outcomes | No cache storage, static-file serving policy, automatic revalidation, or cache-control engine |
-| Cache-Control | `Request::cache_control`, `HttpRequest::cache_control`, and `HttpResponse::cache_control` parse bounded request/response directives, numeric freshness fields, quoted field-name lists, and extension directives | No cache storage, automatic revalidation, wall-clock freshness calculation, `Vary` matching, shared-cache policy enforcement, automatic conditional requests, or directive-based validator evaluation |
+| Cache-Control | `Request::cache_control`, `HttpRequest::cache_control`, and `HttpResponse::cache_control` parse bounded request/response directives, numeric freshness fields, quoted field-name lists, and extension directives; `HttpResponse::with_age`/`age` and `with_expires`/`expires` declare and parse response `Age` and `Expires` metadata | No cache storage, automatic revalidation, wall-clock freshness calculation, `Vary` matching, shared-cache policy enforcement, automatic conditional requests, or directive-based validator evaluation |
 | Vary | `HttpVary`, `HttpResponse::with_vary`, `HttpResponse::vary`, `Request::vary_selection`, and `HttpRequest::vary_selection` parse, declare, and select bounded `Vary` metadata with case-insensitive field-name handling | No cache storage, stored-response matching engine, cache key persistence, automatic request replay, shared-cache policy enforcement, or automatic conditional requests |
 | Upgrade and tunnel targets | `CONNECT` authority-form requests are accepted as HTTP requests; `HttpResponse::upgrade` can hand an upgraded socket to caller code after a matching request | The server does not implement the upgraded protocol after handoff |
 | Trailers | Chunked request trailers are preserved on `Request`; malformed, oversized, forbidden, and pseudo-header trailers are rejected; response trailers can be serialized for chunked responses | Application metadata trailers are allowed; trailer names that affect connection state, routing, authentication/cookies, framing, or payload processing are rejected |

--- a/rttp/src/server.rs
+++ b/rttp/src/server.rs
@@ -4521,6 +4521,21 @@ impl HttpResponse {
     Ok(self)
   }
 
+  pub fn with_age(mut self, delta_seconds: u64) -> Self {
+    self
+      .headers
+      .push(HttpHeader::new("Age", delta_seconds.to_string()));
+    self
+  }
+
+  pub fn with_expires(mut self, http_date: SystemTime) -> Self {
+    self.headers.push(HttpHeader::new(
+      "Expires",
+      httpdate::fmt_http_date(http_date),
+    ));
+    self
+  }
+
   pub fn trailers(&self) -> &[HttpHeader] {
     &self.trailers
   }
@@ -4559,6 +4574,28 @@ impl HttpResponse {
       return Ok(None);
     }
     HttpVary::parse_values(values).map(Some)
+  }
+
+  pub fn age(&self) -> Result<Option<u64>, HttpAgeParseError> {
+    let Some(value) =
+      self.single_header_value("Age", HttpAgeParseError::new("multiple Age headers"))?
+    else {
+      return Ok(None);
+    };
+    parse_http_age(value).map(Some)
+  }
+
+  pub fn expires(&self) -> Result<Option<SystemTime>, HttpExpiresParseError> {
+    let Some(value) = self.single_header_value(
+      "Expires",
+      HttpExpiresParseError::new("multiple Expires headers"),
+    )?
+    else {
+      return Ok(None);
+    };
+    httpdate::parse_http_date(value)
+      .map(Some)
+      .map_err(|_| HttpExpiresParseError::new("invalid Expires HTTP-date"))
   }
 
   pub fn body<B: AsRef<[u8]>>(mut self, body: B) -> Self {
@@ -4764,6 +4801,21 @@ impl HttpResponse {
       .rposition(|header| header.name.eq_ignore_ascii_case("Connection"))
   }
 
+  fn single_header_value<E>(&self, name: &str, multiple_error: E) -> Result<Option<&str>, E> {
+    let mut values = self
+      .headers
+      .iter()
+      .filter(|header| header.name.eq_ignore_ascii_case(name))
+      .map(|header| header.value.as_str());
+    let Some(value) = values.next() else {
+      return Ok(None);
+    };
+    if values.next().is_some() {
+      return Err(multiple_error);
+    }
+    Ok(Some(value))
+  }
+
   fn closes_connection(&self) -> bool {
     self
       .headers
@@ -4771,6 +4823,58 @@ impl HttpResponse {
       .filter(|header| header.name.eq_ignore_ascii_case("Connection"))
       .any(|header| connection_header_has_token(Some(header.value.as_str()), "close"))
   }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct HttpAgeParseError {
+  message: String,
+}
+
+impl HttpAgeParseError {
+  fn new<S: AsRef<str>>(message: S) -> Self {
+    Self {
+      message: message.as_ref().to_string(),
+    }
+  }
+}
+
+impl fmt::Display for HttpAgeParseError {
+  fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+    formatter.write_str(&self.message)
+  }
+}
+
+impl Error for HttpAgeParseError {}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct HttpExpiresParseError {
+  message: String,
+}
+
+impl HttpExpiresParseError {
+  fn new<S: AsRef<str>>(message: S) -> Self {
+    Self {
+      message: message.as_ref().to_string(),
+    }
+  }
+}
+
+impl fmt::Display for HttpExpiresParseError {
+  fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+    formatter.write_str(&self.message)
+  }
+}
+
+impl Error for HttpExpiresParseError {}
+
+fn parse_http_age(value: &str) -> Result<u64, HttpAgeParseError> {
+  let value = value.trim();
+  if value.is_empty() || !value.bytes().all(|byte| byte.is_ascii_digit()) {
+    return Err(HttpAgeParseError::new("invalid Age delta-seconds"));
+  }
+  value
+    .parse::<u64>()
+    .map_err(|_| HttpAgeParseError::new("invalid Age delta-seconds"))
 }
 
 fn parse_suffix_byte_range(

--- a/rttp/tests/test_server_models.rs
+++ b/rttp/tests/test_server_models.rs
@@ -1,3 +1,5 @@
+use std::time::{Duration, UNIX_EPOCH};
+
 use rttp::server::{
   HttpByteRange, HttpByteRangeError, HttpConditionalMetadata, HttpEntityTag,
   HttpIfRangeRequestOutcome, HttpRequest, HttpRequestCacheControl, HttpResponse,
@@ -158,6 +160,71 @@ fn response_vary_helper_declares_normalized_vary_header() {
   let serialized = String::from_utf8(response.to_bytes()).expect("response is UTF-8");
 
   assert!(serialized.contains("\r\nVary: accept-encoding, x-user\r\n"));
+}
+
+#[test]
+fn response_age_and_expires_helpers_declare_metadata_headers() {
+  let expires = UNIX_EPOCH + Duration::from_secs(784_111_777);
+  let response = HttpResponse::ok("body").with_age(60).with_expires(expires);
+
+  let serialized = String::from_utf8(response.to_bytes()).expect("response is UTF-8");
+
+  assert!(serialized.contains("\r\nAge: 60\r\n"));
+  assert!(serialized.contains("\r\nExpires: Sun, 06 Nov 1994 08:49:37 GMT\r\n"));
+  assert_eq!(Some(60), response.age().expect("Age should parse"));
+  assert_eq!(
+    Some(expires),
+    response.expires().expect("Expires should parse")
+  );
+}
+
+#[test]
+fn response_age_and_expires_helpers_parse_raw_metadata_headers() {
+  let response = HttpResponse::ok("body")
+    .header("Age", "0")
+    .header("Expires", "Sunday, 06-Nov-94 08:49:37 GMT");
+
+  assert_eq!(Some(0), response.age().expect("Age should parse"));
+  assert_eq!(
+    Some(UNIX_EPOCH + Duration::from_secs(784_111_777)),
+    response.expires().expect("Expires should parse")
+  );
+}
+
+#[test]
+fn response_age_helper_rejects_malformed_or_overflowing_values() {
+  for value in ["", " ", "-1", "+1", "1.5", "abc", "18446744073709551616"] {
+    let response = HttpResponse::ok("body").header("Age", value);
+
+    assert!(
+      response.age().is_err(),
+      "Age helper should reject {value:?}"
+    );
+  }
+}
+
+#[test]
+fn response_expires_helper_rejects_malformed_values() {
+  for value in ["", "not a date", "Sun, 06 Nov 1994 08:49:37 PST"] {
+    let response = HttpResponse::ok("body").header("Expires", value);
+
+    assert!(
+      response.expires().is_err(),
+      "Expires helper should reject {value:?}"
+    );
+  }
+}
+
+#[test]
+fn raw_age_and_expires_headers_are_preserved_without_helper_validation() {
+  let response = HttpResponse::ok("body")
+    .header("Age", "not-a-delta")
+    .header("Expires", "not-a-date");
+
+  let serialized = String::from_utf8(response.to_bytes()).expect("response is UTF-8");
+
+  assert!(serialized.contains("\r\nAge: not-a-delta\r\n"));
+  assert!(serialized.contains("\r\nExpires: not-a-date\r\n"));
 }
 
 #[test]


### PR DESCRIPTION
Adds bounded `HttpResponse` helpers for declaring and parsing HTTP/1.1 `Age` and `Expires` metadata, with validation, raw-header preservation, tests, and documentation.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1584/
work_kind: code_work
branch: hbx-1584-rttp-add-bounded-http-1
base: main
commit: fa469b3613994e5254b6f9030dd3df1c95167631
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1584/
    url: https://plane.kahub.in/endless/browse/HBX-1584/
    close_policy: link_only
```