### PR TITLE
feat: [rttp] Add cross-crate HTTP/1.1 Age and Expires matrix

### DIFF
--- a/rttp/tests/http11_compliance_matrix.rs
+++ b/rttp/tests/http11_compliance_matrix.rs
@@ -2,7 +2,7 @@ use std::io::{Read, Write};
 use std::net::{Shutdown, TcpStream};
 use std::sync::mpsc;
 use std::thread;
-use std::time::Duration;
+use std::time::{Duration, UNIX_EPOCH};
 
 use rttp::server::{
   HttpRequest, HttpRequestCacheControl, HttpResponse, HttpResponseCacheControl, HttpVary,
@@ -61,6 +61,15 @@ fn vary_response(values: &[&str]) -> HttpResponse {
     .fold(HttpResponse::new(200, "OK"), |response, value| {
       response.header("Vary", value)
     })
+}
+
+fn age_expires_response(age: u64, expires: std::time::SystemTime) -> HttpResponse {
+  HttpResponse::ok("OK")
+    .with_age(age)
+    .with_expires(expires)
+    .header("Cache-Control", "public, max-age=60")
+    .with_vary("Accept-Encoding")
+    .expect("test Vary should parse")
 }
 
 fn assert_request_cache_control(
@@ -241,6 +250,97 @@ fn server_response_helper_accepts_shared_vary_response_matrix() {
       .unwrap_or_else(|| panic!("{} should include Vary", case.name));
 
     assert_response_vary(case.name, &vary, case);
+  }
+}
+
+#[test]
+fn server_response_helper_accepts_shared_age_response_matrix() {
+  for case in fixtures::age_expires::age_cases() {
+    let response = HttpResponse::ok("OK").header("Age", case.value);
+
+    assert_eq!(
+      Some(case.delta_seconds),
+      response
+        .age()
+        .unwrap_or_else(|err| panic!("{} Age should parse: {err}", case.name)),
+      "{}",
+      case.name
+    );
+  }
+}
+
+#[test]
+fn server_response_helper_accepts_shared_expires_response_matrix() {
+  for case in fixtures::age_expires::expires_cases() {
+    let response = HttpResponse::ok("OK").header("Expires", case.value);
+
+    assert_eq!(
+      Some(UNIX_EPOCH + Duration::from_secs(case.unix_seconds)),
+      response
+        .expires()
+        .unwrap_or_else(|err| panic!("{} Expires should parse: {err}", case.name)),
+      "{}",
+      case.name
+    );
+  }
+}
+
+#[test]
+fn server_response_with_age_and_expires_declares_shared_metadata_matrix() {
+  for case in fixtures::age_expires::declaration_cases() {
+    let response = age_expires_response(
+      case.age,
+      UNIX_EPOCH + Duration::from_secs(case.expires_unix_seconds),
+    );
+    let serialized = String::from_utf8(response.to_bytes()).expect("response is UTF-8");
+
+    assert_eq!(
+      Some(case.age_value),
+      header_value(&serialized, "Age"),
+      "{}",
+      case.name
+    );
+    assert_eq!(
+      Some(case.expires_value),
+      header_value(&serialized, "Expires"),
+      "{}",
+      case.name
+    );
+    assert_eq!(
+      Some("public, max-age=60"),
+      header_value(&serialized, "Cache-Control"),
+      "{}",
+      case.name
+    );
+    assert_eq!(
+      Some("accept-encoding"),
+      header_value(&serialized, "Vary"),
+      "{}",
+      case.name
+    );
+  }
+}
+
+#[test]
+fn server_response_age_and_expires_helpers_reject_shared_invalid_matrix() {
+  for case in fixtures::age_expires::invalid_age_cases() {
+    let response = HttpResponse::ok("OK").header("Age", case.value);
+
+    assert!(
+      response.age().is_err(),
+      "{} Age helper should reject invalid value",
+      case.name
+    );
+  }
+
+  for case in fixtures::age_expires::invalid_expires_cases() {
+    let response = HttpResponse::ok("OK").header("Expires", case.value);
+
+    assert!(
+      response.expires().is_err(),
+      "{} Expires helper should reject invalid value",
+      case.name
+    );
   }
 }
 

--- a/rttp_client/tests/http11_compliance_matrix.rs
+++ b/rttp_client/tests/http11_compliance_matrix.rs
@@ -39,6 +39,21 @@ fn vary_response(values: &[&str]) -> Vec<u8> {
   response.into_bytes()
 }
 
+fn age_expires_response(age: &str, expires: &str, include_cache_metadata: bool) -> Vec<u8> {
+  let mut response = String::from("HTTP/1.1 200 OK\r\n");
+  response.push_str("Age: ");
+  response.push_str(age);
+  response.push_str("\r\nExpires: ");
+  response.push_str(expires);
+  response.push_str("\r\n");
+  if include_cache_metadata {
+    response.push_str("Cache-Control: public, max-age=60\r\n");
+    response.push_str("Vary: Accept-Encoding\r\n");
+  }
+  response.push_str("Content-Length: 2\r\n\r\nOK");
+  response.into_bytes()
+}
+
 const RANGE_BODY: &[u8] = b"0123456789abcdef";
 const CONDITIONAL_LAST_MODIFIED: &str = "Sun, 06 Nov 1994 08:49:37 GMT";
 const CONDITIONAL_STALE_DATE: &str = "Sun, 06 Nov 1994 08:49:36 GMT";
@@ -396,6 +411,42 @@ fn assert_vary_helper_rejects_but_preserves_response(name: &str, raw_response: V
   handle.join().expect("raw response server thread");
 }
 
+fn assert_age_helper_rejects_but_preserves_response(name: &str, raw_response: Vec<u8>) {
+  let (addr, handle) = fixtures::spawn_socket2_owned_raw_response_server(raw_response);
+
+  let response = client()
+    .get()
+    .url(format!("http://{}/matrix/age-invalid", addr))
+    .emit()
+    .unwrap_or_else(|err| panic!("{name} response should remain parseable: {err}"));
+
+  assert!(
+    response.age().is_err(),
+    "{name} helper should reject invalid Age"
+  );
+  assert_eq!("OK", response.body().string().unwrap(), "{name}");
+
+  handle.join().expect("raw response server thread");
+}
+
+fn assert_expires_helper_rejects_but_preserves_response(name: &str, raw_response: Vec<u8>) {
+  let (addr, handle) = fixtures::spawn_socket2_owned_raw_response_server(raw_response);
+
+  let response = client()
+    .get()
+    .url(format!("http://{}/matrix/expires-invalid", addr))
+    .emit()
+    .unwrap_or_else(|err| panic!("{name} response should remain parseable: {err}"));
+
+  assert!(
+    response.expires().is_err(),
+    "{name} helper should reject invalid Expires"
+  );
+  assert_eq!("OK", response.body().string().unwrap(), "{name}");
+
+  handle.join().expect("raw response server thread");
+}
+
 enum ConditionalHeader {
   IfNoneMatch(&'static str),
   IfMatch(&'static str),
@@ -439,6 +490,124 @@ fn sync_client_parses_shared_vary_response_matrix() {
 }
 
 #[test]
+fn sync_client_parses_shared_age_response_matrix() {
+  for case in fixtures::age_expires::age_cases() {
+    let raw_response = age_expires_response(
+      case.value,
+      fixtures::age_expires::EXPIRES_IMF_FIXDATE,
+      false,
+    );
+    let (addr, handle) = fixtures::spawn_socket2_owned_raw_response_server(raw_response);
+
+    let response = client()
+      .get()
+      .url(format!("http://{}/matrix/age", addr))
+      .emit()
+      .unwrap_or_else(|err| panic!("{} response should parse: {err}", case.name));
+
+    assert_eq!(
+      Some(case.delta_seconds),
+      response
+        .age()
+        .unwrap_or_else(|err| panic!("{} Age should parse: {err}", case.name)),
+      "{}",
+      case.name
+    );
+    assert_eq!(
+      Some(&case.value.to_string()),
+      response.header_value("Age"),
+      "{}",
+      case.name
+    );
+    assert_eq!("OK", response.body().string().unwrap(), "{}", case.name);
+    handle.join().expect("raw response server thread");
+  }
+}
+
+#[test]
+fn sync_client_parses_shared_expires_response_matrix() {
+  for case in fixtures::age_expires::expires_cases() {
+    let raw_response = age_expires_response("0", case.value, false);
+    let (addr, handle) = fixtures::spawn_socket2_owned_raw_response_server(raw_response);
+
+    let response = client()
+      .get()
+      .url(format!("http://{}/matrix/expires", addr))
+      .emit()
+      .unwrap_or_else(|err| panic!("{} response should parse: {err}", case.name));
+
+    assert_eq!(
+      Some(std::time::UNIX_EPOCH + Duration::from_secs(case.unix_seconds)),
+      response
+        .expires()
+        .unwrap_or_else(|err| panic!("{} Expires should parse: {err}", case.name)),
+      "{}",
+      case.name
+    );
+    assert_eq!(
+      Some(&case.value.to_string()),
+      response.header_value("Expires"),
+      "{}",
+      case.name
+    );
+    assert_eq!("OK", response.body().string().unwrap(), "{}", case.name);
+    handle.join().expect("raw response server thread");
+  }
+}
+
+#[test]
+fn sync_client_parses_age_expires_with_existing_cache_metadata_helpers() {
+  for case in fixtures::age_expires::declaration_cases() {
+    let raw_response = age_expires_response(case.age_value, case.expires_value, true);
+    let (addr, handle) = fixtures::spawn_socket2_owned_raw_response_server(raw_response);
+
+    let response = client()
+      .get()
+      .url(format!("http://{}/matrix/cache-metadata", addr))
+      .emit()
+      .unwrap_or_else(|err| panic!("{} response should parse: {err}", case.name));
+
+    assert_eq!(
+      Some(case.age),
+      response
+        .age()
+        .unwrap_or_else(|err| panic!("{} Age should parse: {err}", case.name)),
+      "{}",
+      case.name
+    );
+    assert_eq!(
+      Some(std::time::UNIX_EPOCH + Duration::from_secs(case.expires_unix_seconds)),
+      response
+        .expires()
+        .unwrap_or_else(|err| panic!("{} Expires should parse: {err}", case.name)),
+      "{}",
+      case.name
+    );
+    assert_eq!(
+      Some(60),
+      response
+        .cache_control()
+        .expect("Cache-Control should parse")
+        .expect("Cache-Control should be present")
+        .max_age(),
+      "{}",
+      case.name
+    );
+    assert!(
+      response
+        .vary()
+        .expect("Vary should parse")
+        .expect("Vary should be present")
+        .contains_field_name("accept-encoding"),
+      "{}",
+      case.name
+    );
+    assert_eq!("OK", response.body().string().unwrap(), "{}", case.name);
+    handle.join().expect("raw response server thread");
+  }
+}
+
+#[test]
 fn sync_client_cache_control_helper_rejects_shared_invalid_response_matrix() {
   for case in fixtures::cache_control::invalid_response_cases() {
     assert_cache_control_helper_rejects_but_preserves_response(
@@ -452,6 +621,27 @@ fn sync_client_cache_control_helper_rejects_shared_invalid_response_matrix() {
 fn sync_client_vary_helper_rejects_shared_invalid_response_matrix() {
   for case in fixtures::vary::invalid_cases() {
     assert_vary_helper_rejects_but_preserves_response(case.name, vary_response(&[case.value]));
+  }
+}
+
+#[test]
+fn sync_client_age_and_expires_helpers_reject_shared_invalid_matrix() {
+  for case in fixtures::age_expires::invalid_age_cases() {
+    assert_age_helper_rejects_but_preserves_response(
+      case.name,
+      age_expires_response(
+        case.value,
+        fixtures::age_expires::EXPIRES_IMF_FIXDATE,
+        false,
+      ),
+    );
+  }
+
+  for case in fixtures::age_expires::invalid_expires_cases() {
+    assert_expires_helper_rejects_but_preserves_response(
+      case.name,
+      age_expires_response("0", case.value, false),
+    );
   }
 }
 

--- a/rttp_http11_test_fixtures/src/lib.rs
+++ b/rttp_http11_test_fixtures/src/lib.rs
@@ -448,6 +448,141 @@ pub mod cache_control {
   }
 }
 
+pub mod age_expires {
+  pub const EXPIRES_UNIX_SECONDS: u64 = 784_111_777;
+  pub const EXPIRES_IMF_FIXDATE: &str = "Sun, 06 Nov 1994 08:49:37 GMT";
+
+  pub struct AgeCase {
+    pub name: &'static str,
+    pub value: &'static str,
+    pub delta_seconds: u64,
+  }
+
+  pub struct ExpiresCase {
+    pub name: &'static str,
+    pub value: &'static str,
+    pub unix_seconds: u64,
+  }
+
+  pub struct DeclarationCase {
+    pub name: &'static str,
+    pub age: u64,
+    pub age_value: &'static str,
+    pub expires_unix_seconds: u64,
+    pub expires_value: &'static str,
+  }
+
+  pub struct InvalidCase {
+    pub name: &'static str,
+    pub value: &'static str,
+  }
+
+  const AGE_CASES: &[AgeCase] = &[
+    AgeCase {
+      name: "Age zero delta-seconds",
+      value: "0",
+      delta_seconds: 0,
+    },
+    AgeCase {
+      name: "Age positive delta-seconds",
+      value: "60",
+      delta_seconds: 60,
+    },
+  ];
+
+  const EXPIRES_CASES: &[ExpiresCase] = &[
+    ExpiresCase {
+      name: "Expires IMF-fixdate",
+      value: EXPIRES_IMF_FIXDATE,
+      unix_seconds: EXPIRES_UNIX_SECONDS,
+    },
+    ExpiresCase {
+      name: "Expires obsolete RFC 850 date",
+      value: "Sunday, 06-Nov-94 08:49:37 GMT",
+      unix_seconds: EXPIRES_UNIX_SECONDS,
+    },
+  ];
+
+  const DECLARATION_CASES: &[DeclarationCase] = &[
+    DeclarationCase {
+      name: "declared zero Age with Expires",
+      age: 0,
+      age_value: "0",
+      expires_unix_seconds: EXPIRES_UNIX_SECONDS,
+      expires_value: EXPIRES_IMF_FIXDATE,
+    },
+    DeclarationCase {
+      name: "declared positive Age with Expires",
+      age: 60,
+      age_value: "60",
+      expires_unix_seconds: EXPIRES_UNIX_SECONDS,
+      expires_value: EXPIRES_IMF_FIXDATE,
+    },
+  ];
+
+  const INVALID_AGE_CASES: &[InvalidCase] = &[
+    InvalidCase {
+      name: "Age empty value",
+      value: "",
+    },
+    InvalidCase {
+      name: "Age signed delta-seconds",
+      value: "-1",
+    },
+    InvalidCase {
+      name: "Age fractional delta-seconds",
+      value: "1.5",
+    },
+    InvalidCase {
+      name: "Age non-numeric delta-seconds",
+      value: "abc",
+    },
+    InvalidCase {
+      name: "Age comma-list delta-seconds",
+      value: "0, 60",
+    },
+    InvalidCase {
+      name: "Age overflowing delta-seconds",
+      value: "18446744073709551616",
+    },
+  ];
+
+  const INVALID_EXPIRES_CASES: &[InvalidCase] = &[
+    InvalidCase {
+      name: "Expires empty value",
+      value: "",
+    },
+    InvalidCase {
+      name: "Expires non-date value",
+      value: "not a date",
+    },
+    InvalidCase {
+      name: "Expires unsupported timezone",
+      value: "Sun, 06 Nov 1994 08:49:37 PST",
+    },
+  ];
+
+  pub fn age_cases() -> &'static [AgeCase] {
+    AGE_CASES
+  }
+
+  pub fn expires_cases() -> &'static [ExpiresCase] {
+    EXPIRES_CASES
+  }
+
+  pub fn declaration_cases() -> &'static [DeclarationCase] {
+    DECLARATION_CASES
+  }
+
+  pub fn invalid_age_cases() -> &'static [InvalidCase] {
+    INVALID_AGE_CASES
+  }
+
+  pub fn invalid_expires_cases() -> &'static [InvalidCase] {
+    INVALID_EXPIRES_CASES
+  }
+}
+
 pub mod vary {
   pub const MAX_VALUE_BYTES: usize = 64 * 1024;
   pub const MAX_FIELD_NAMES: usize = 256;


### PR DESCRIPTION
Adds shared HTTP/1.1 Age and Expires compliance fixtures with server/client matrix coverage for bounded metadata parsing and declaration, including Cache-Control/Vary interaction checks.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1585/
work_kind: code_work
branch: hbx-1585-rttp-add-cross-crate-http
base: main
commit: 681a714f042bc63baac208d091276f0ee5ba28d1
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1585/
    url: https://plane.kahub.in/endless/browse/HBX-1585/
    close_policy: link_only
```