### PR TITLE
feat: [rttp_client] Add bounded HTTP/1.1 Retry-After response helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,23 @@ not calculate freshness, validate cache state against wall-clock time, store
 responses, match stored responses, revalidate responses, apply shared-cache
 policy, or issue automatic conditional requests.
 
+### Bounded HTTP/1.1 Retry-After behavior
+
+`Response::retry_after()` parses a single response `Retry-After` header as
+either HTTP-date metadata or non-negative delta-seconds. It returns `Ok(None)`
+when the header is absent. Present values are exposed as `RetryAfter`, with
+`delta_seconds()` returning `u64` for the delta form and `http_date()`
+returning `SystemTime` for the date form.
+
+The helper is bounded and validation-oriented. The header value is limited to
+64 KiB, duplicate `Retry-After` header fields are rejected, delta-seconds must
+be unsigned decimal digits that fit in `u64`, and malformed dates or other
+invalid values return an error. The original response headers remain available
+through `Response::header_value()` and `Response::header_values()`.
+
+RTTP does not sleep, schedule retries, replay requests, apply backoff, calculate
+cache freshness, or decide status-code retry policy from `Retry-After`.
+
 ### Bounded HTTP/1.1 Vary behavior
 
 `Response::vary()` parses one or more response `Vary` header fields into

--- a/rttp_client/README.md
+++ b/rttp_client/README.md
@@ -146,6 +146,23 @@ the other raw header accessors. These helpers expose metadata only;
 wall-clock time, store responses, match stored responses, revalidate responses,
 apply shared-cache policy, or issue automatic conditional requests.
 
+## Bounded HTTP/1.1 Retry-After behavior
+
+`Response::retry_after()` parses a single response `Retry-After` header as
+either HTTP-date metadata or non-negative delta-seconds. It returns `Ok(None)`
+when the header is absent. Present values are exposed as `RetryAfter`, with
+`delta_seconds()` returning `u64` for the delta form and `http_date()`
+returning `SystemTime` for the date form.
+
+The helper is bounded and validation-oriented. The header value is limited to
+64 KiB, duplicate `Retry-After` header fields are rejected, delta-seconds must
+be unsigned decimal digits that fit in `u64`, and malformed dates or other
+invalid values return an error. The original response headers remain available
+through `Response::header_value()` and `Response::header_values()`.
+
+RTTP does not sleep, schedule retries, replay requests, apply backoff, calculate
+cache freshness, or decide status-code retry policy from `Retry-After`.
+
 ## Bounded HTTP/1.1 Vary behavior
 
 `Response::vary()` parses one or more response `Vary` header fields into

--- a/rttp_client/src/response/response.rs
+++ b/rttp_client/src/response/response.rs
@@ -11,6 +11,7 @@ use crate::types::{Cookie, Header, RoUrl};
 
 const MAX_CACHE_CONTROL_VALUE_BYTES: usize = 64 * 1024;
 const MAX_CACHE_CONTROL_DIRECTIVES: usize = 256;
+const MAX_RETRY_AFTER_VALUE_BYTES: usize = 64 * 1024;
 const MAX_VARY_VALUE_BYTES: usize = 64 * 1024;
 const MAX_VARY_FIELD_NAMES: usize = 256;
 
@@ -118,6 +119,15 @@ impl Response {
           .map_err(|_| error::bad_response("Invalid Expires HTTP-date"))
       })
       .unwrap_or(Ok(None))
+  }
+
+  pub fn retry_after(&self) -> error::Result<Option<RetryAfter>> {
+    let values = self.header_values("retry-after");
+    match values.as_slice() {
+      [] => Ok(None),
+      [value] => RetryAfter::parse(value).map(Some),
+      _ => Err(error::bad_response("Duplicate Retry-After header values")),
+    }
   }
 
   pub fn content_range(&self) -> Option<ContentRange> {
@@ -229,6 +239,47 @@ impl fmt::Display for Response {
   #[inline]
   fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
     fmt::Display::fmt(&self.raw, formatter)
+  }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum RetryAfter {
+  DeltaSeconds(u64),
+  HttpDate(SystemTime),
+}
+
+impl RetryAfter {
+  pub fn parse(value: impl AsRef<str>) -> error::Result<Self> {
+    let value = value.as_ref();
+    if value.len() > MAX_RETRY_AFTER_VALUE_BYTES {
+      return Err(error::bad_response("Retry-After header value is too large"));
+    }
+    if value.is_empty() {
+      return Err(error::bad_response("Invalid Retry-After value"));
+    }
+    if value.chars().all(|ch| ch.is_ascii_digit()) {
+      return value
+        .parse::<u64>()
+        .map(Self::DeltaSeconds)
+        .map_err(|_| error::bad_response("Invalid Retry-After delta-seconds"));
+    }
+    parse_http_date(value)
+      .map(Self::HttpDate)
+      .map_err(|_| error::bad_response("Invalid Retry-After value"))
+  }
+
+  pub fn delta_seconds(&self) -> Option<u64> {
+    match self {
+      Self::DeltaSeconds(delta_seconds) => Some(*delta_seconds),
+      Self::HttpDate(_) => None,
+    }
+  }
+
+  pub fn http_date(&self) -> Option<SystemTime> {
+    match self {
+      Self::DeltaSeconds(_) => None,
+      Self::HttpDate(http_date) => Some(*http_date),
+    }
   }
 }
 

--- a/rttp_client/tests/test_response.rs
+++ b/rttp_client/tests/test_response.rs
@@ -324,6 +324,132 @@ fn test_parse_age_and_expires_response_metadata() {
 }
 
 #[test]
+fn test_parse_retry_after_response_metadata() {
+  let s = concat!(
+    "HTTP/1.1 503 Service Unavailable\r\n",
+    "Retry-After: 120\r\n",
+    "Content-Length: 4\r\n",
+    "\r\n",
+    "busy"
+  );
+  let response = Response::new(RoUrl::with("https://example.test"), s.as_bytes().to_vec())
+    .expect("parse response with retry-after delta metadata");
+  let retry_after = response
+    .retry_after()
+    .expect("valid retry-after should parse")
+    .expect("retry-after should be present");
+
+  assert_eq!(Some(120), retry_after.delta_seconds());
+  assert_eq!(None, retry_after.http_date());
+  assert_eq!(
+    Some(&"120".to_string()),
+    response.header_value("Retry-After")
+  );
+
+  let s = concat!(
+    "HTTP/1.1 503 Service Unavailable\r\n",
+    "Retry-After: Sun, 06 Nov 1994 08:49:37 GMT\r\n",
+    "Content-Length: 4\r\n",
+    "\r\n",
+    "busy"
+  );
+  let response = Response::new(RoUrl::with("https://example.test"), s.as_bytes().to_vec())
+    .expect("parse response with retry-after date metadata");
+  let retry_after = response
+    .retry_after()
+    .expect("valid retry-after date should parse")
+    .expect("retry-after should be present");
+
+  assert_eq!(None, retry_after.delta_seconds());
+  assert_eq!(
+    Some(UNIX_EPOCH + Duration::from_secs(784111777)),
+    retry_after.http_date()
+  );
+  assert_eq!(
+    Some(&"Sun, 06 Nov 1994 08:49:37 GMT".to_string()),
+    response.header_value("Retry-After")
+  );
+
+  let s = concat!("HTTP/1.1 200 OK\r\n", "Content-Length: 2\r\n", "\r\n", "OK");
+  let response = Response::new(RoUrl::with("https://example.test"), s.as_bytes().to_vec())
+    .expect("parse response without retry-after");
+  assert_eq!(
+    None,
+    response
+      .retry_after()
+      .expect("absent retry-after should parse")
+  );
+}
+
+#[test]
+fn test_parse_retry_after_rejects_invalid_helper_values_without_rejecting_response() {
+  let invalid_values = [
+    "",
+    "-1",
+    "+1",
+    "1.5",
+    "6 0",
+    "60,61",
+    "abc",
+    "18446744073709551616",
+    "Sun, 06 Nov 1994 08:49:37 PST",
+  ];
+
+  for value in invalid_values {
+    let raw = format!(
+      "HTTP/1.1 503 Service Unavailable\r\nRetry-After: {value}\r\nContent-Length: 4\r\n\r\nbusy"
+    );
+    let response = Response::new(RoUrl::with("https://example.test"), raw.into_bytes())
+      .expect("raw response remains usable");
+
+    assert!(
+      response.retry_after().is_err(),
+      "retry-after helper should reject {value:?}"
+    );
+    assert_eq!(
+      Some(&value.to_string()),
+      response.header_value("Retry-After")
+    );
+  }
+}
+
+#[test]
+fn test_parse_retry_after_rejects_duplicate_and_oversized_helper_values() {
+  let raw = concat!(
+    "HTTP/1.1 503 Service Unavailable\r\n",
+    "Retry-After: 60\r\n",
+    "retry-after: 120\r\n",
+    "Content-Length: 4\r\n",
+    "\r\n",
+    "busy"
+  );
+  let response = Response::new(RoUrl::with("https://example.test"), raw.as_bytes().to_vec())
+    .expect("raw response with duplicate retry-after remains usable");
+
+  assert!(
+    response.retry_after().is_err(),
+    "retry-after helper should reject duplicates"
+  );
+  assert_eq!(
+    vec![&"60".to_string(), &"120".to_string()],
+    response.header_values("Retry-After")
+  );
+
+  let oversized = "1".repeat(64 * 1024 + 1);
+  let raw = format!(
+    "HTTP/1.1 503 Service Unavailable\r\nRetry-After: {oversized}\r\nContent-Length: 4\r\n\r\nbusy"
+  );
+  let response = Response::new(RoUrl::with("https://example.test"), raw.into_bytes())
+    .expect("raw response with oversized retry-after remains usable");
+
+  assert!(
+    response.retry_after().is_err(),
+    "retry-after helper should reject oversized values"
+  );
+  assert_eq!(Some(&oversized), response.header_value("Retry-After"));
+}
+
+#[test]
 fn test_parse_age_rejects_invalid_helper_values_without_rejecting_response() {
   let invalid_values = [
     "",


### PR DESCRIPTION
Added bounded `Response::retry_after()` support with `RetryAfter` metadata, validation coverage, and README documentation. Verification passed for the `rttp_client` crate.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1588/
work_kind: code_work
branch: hbx-1588-rttp-client-add-bounded-http
base: main
commit: 78774da4f7d7e0d00a0e461a5b75cdb1ffc124aa
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1588/
    url: https://plane.kahub.in/endless/browse/HBX-1588/
    close_policy: link_only
```