### PR TITLE
feat: [rttp] Add bounded HTTP/1.1 Retry-After server helpers

### DIFF
--- a/rttp/README.md
+++ b/rttp/README.md
@@ -174,12 +174,23 @@ overflowing values return `HttpAgeParseError`.
 header as an HTTP-date. Valid HTTP-date values parse to `SystemTime`; malformed,
 duplicated, or non-date values return `HttpExpiresParseError`.
 
+`HttpResponse::with_retry_after_delta(delta_seconds)` serializes a
+delta-seconds `Retry-After` header from a non-negative `u64`, while
+`HttpResponse::with_retry_after_date(time)` serializes an HTTP-date
+`Retry-After` header from `SystemTime`. `HttpResponse::retry_after()` parses an
+attached single `Retry-After` header into `HttpRetryAfter::DeltaSeconds` or
+`HttpRetryAfter::HttpDate`. Empty, signed, fractional, non-numeric non-date,
+comma-list, duplicated, overflowing, oversized, or malformed HTTP-date values
+return `HttpRetryAfterParseError`.
+
 Malformed typed helper reads return validation errors, while raw
-`HttpResponse::header("Age", ...)` and `HttpResponse::header("Expires", ...)`
-values remain preserved exactly as response headers. These helpers do not
-calculate freshness, validate cache state against wall-clock time, store
-responses, match stored responses, revalidate responses, enforce shared-cache
-policy, or issue automatic conditional requests.
+`HttpResponse::header("Age", ...)`, `HttpResponse::header("Expires", ...)`,
+and `HttpResponse::header("Retry-After", ...)` values remain preserved exactly
+as response headers. These helpers do not calculate freshness, validate cache
+state against wall-clock time, store responses, match stored responses,
+revalidate responses, enforce shared-cache policy, attach behavior to status
+codes, throttle requests, sleep, schedule work, retry, or issue automatic
+conditional requests.
 
 ## Bounded HTTP/1.1 Vary behavior
 
@@ -405,7 +416,7 @@ scheduling, or async accept loops.
 | HTTP/1.1 response framing | Automatic `Content-Length`, explicit chunked responses, bodyless `HEAD`, `101`, `204`, and `304`, response trailers after the terminating chunk | No server TLS |
 | Byte ranges | `HttpByteRange` parses one `bytes` range, `Request::evaluate_if_range` and `HttpRequest::evaluate_if_range` gate it with caller-provided strong ETag or exact HTTP-date metadata, and `HttpResponse::partial_content`/`range_not_satisfiable` serialize `206`/`416` with `Content-Range` | No multipart range serialization, automatic retry, cache storage, filesystem serving, automatic cache validation, or static-file policy |
 | Conditional requests | `Request::evaluate_conditional`, `evaluate_conditional_request`, `HttpConditionalMetadata`, and `HttpEntityTag` evaluate bounded HTTP/1.1 validators; `HttpResponse::not_modified` and `precondition_failed` serialize `304` and `412` outcomes | No cache storage, static-file serving policy, automatic revalidation, or cache-control engine |
-| Cache-Control | `Request::cache_control`, `HttpRequest::cache_control`, and `HttpResponse::cache_control` parse bounded request/response directives, numeric freshness fields, quoted field-name lists, and extension directives; `HttpResponse::with_age`/`age` and `with_expires`/`expires` declare and parse response `Age` and `Expires` metadata | No cache storage, automatic revalidation, wall-clock freshness calculation, `Vary` matching, shared-cache policy enforcement, automatic conditional requests, or directive-based validator evaluation |
+| Cache-Control | `Request::cache_control`, `HttpRequest::cache_control`, and `HttpResponse::cache_control` parse bounded request/response directives, numeric freshness fields, quoted field-name lists, and extension directives; `HttpResponse::with_age`/`age`, `with_expires`/`expires`, and `with_retry_after_delta`/`with_retry_after_date`/`retry_after` declare and parse response `Age`, `Expires`, and `Retry-After` metadata | No cache storage, automatic revalidation, wall-clock freshness calculation, `Vary` matching, shared-cache policy enforcement, automatic conditional requests, directive-based validator evaluation, automatic retry, throttling, sleeping, or scheduling |
 | Vary | `HttpVary`, `HttpResponse::with_vary`, `HttpResponse::vary`, `Request::vary_selection`, and `HttpRequest::vary_selection` parse, declare, and select bounded `Vary` metadata with case-insensitive field-name handling | No cache storage, stored-response matching engine, cache key persistence, automatic request replay, shared-cache policy enforcement, or automatic conditional requests |
 | Upgrade and tunnel targets | `CONNECT` authority-form requests are accepted as HTTP requests; `HttpResponse::upgrade` can hand an upgraded socket to caller code after a matching request | The server does not implement the upgraded protocol after handoff |
 | Trailers | Chunked request trailers are preserved on `Request`; malformed, oversized, forbidden, and pseudo-header trailers are rejected; response trailers can be serialized for chunked responses | Application metadata trailers are allowed; trailer names that affect connection state, routing, authentication/cookies, framing, or payload processing are rejected |

--- a/rttp/src/server.rs
+++ b/rttp/src/server.rs
@@ -13,6 +13,7 @@ const MAX_CACHE_CONTROL_VALUE_BYTES: usize = 64 * 1024;
 const MAX_CACHE_CONTROL_DIRECTIVES: usize = 256;
 const MAX_VARY_VALUE_BYTES: usize = 64 * 1024;
 const MAX_VARY_FIELDS: usize = 256;
+const MAX_RETRY_AFTER_VALUE_BYTES: usize = 64 * 1024;
 const HTTP2_CLIENT_PREFACE: &[u8; 24] = b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n";
 const HTTP2_FRAME_DATA: u8 = 0x0;
 const HTTP2_FRAME_HEADERS: u8 = 0x1;
@@ -4536,6 +4537,21 @@ impl HttpResponse {
     self
   }
 
+  pub fn with_retry_after_delta(mut self, delta_seconds: u64) -> Self {
+    self
+      .headers
+      .push(HttpHeader::new("Retry-After", delta_seconds.to_string()));
+    self
+  }
+
+  pub fn with_retry_after_date(mut self, http_date: SystemTime) -> Self {
+    self.headers.push(HttpHeader::new(
+      "Retry-After",
+      httpdate::fmt_http_date(http_date),
+    ));
+    self
+  }
+
   pub fn trailers(&self) -> &[HttpHeader] {
     &self.trailers
   }
@@ -4596,6 +4612,17 @@ impl HttpResponse {
     httpdate::parse_http_date(value)
       .map(Some)
       .map_err(|_| HttpExpiresParseError::new("invalid Expires HTTP-date"))
+  }
+
+  pub fn retry_after(&self) -> Result<Option<HttpRetryAfter>, HttpRetryAfterParseError> {
+    let Some(value) = self.single_header_value(
+      "Retry-After",
+      HttpRetryAfterParseError::new("multiple Retry-After headers"),
+    )?
+    else {
+      return Ok(None);
+    };
+    parse_http_retry_after(value).map(Some)
   }
 
   pub fn body<B: AsRef<[u8]>>(mut self, body: B) -> Self {
@@ -4867,6 +4894,33 @@ impl fmt::Display for HttpExpiresParseError {
 
 impl Error for HttpExpiresParseError {}
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum HttpRetryAfter {
+  DeltaSeconds(u64),
+  HttpDate(SystemTime),
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct HttpRetryAfterParseError {
+  message: String,
+}
+
+impl HttpRetryAfterParseError {
+  fn new<S: AsRef<str>>(message: S) -> Self {
+    Self {
+      message: message.as_ref().to_string(),
+    }
+  }
+}
+
+impl fmt::Display for HttpRetryAfterParseError {
+  fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+    formatter.write_str(&self.message)
+  }
+}
+
+impl Error for HttpRetryAfterParseError {}
+
 fn parse_http_age(value: &str) -> Result<u64, HttpAgeParseError> {
   let value = value.trim();
   if value.is_empty() || !value.bytes().all(|byte| byte.is_ascii_digit()) {
@@ -4875,6 +4929,30 @@ fn parse_http_age(value: &str) -> Result<u64, HttpAgeParseError> {
   value
     .parse::<u64>()
     .map_err(|_| HttpAgeParseError::new("invalid Age delta-seconds"))
+}
+
+fn parse_http_retry_after(value: &str) -> Result<HttpRetryAfter, HttpRetryAfterParseError> {
+  if value.len() > MAX_RETRY_AFTER_VALUE_BYTES {
+    return Err(HttpRetryAfterParseError::new(
+      "Retry-After value is too large",
+    ));
+  }
+
+  let value = value.trim();
+  if value.is_empty() {
+    return Err(HttpRetryAfterParseError::new("invalid Retry-After value"));
+  }
+
+  if value.bytes().all(|byte| byte.is_ascii_digit()) {
+    return value
+      .parse::<u64>()
+      .map(HttpRetryAfter::DeltaSeconds)
+      .map_err(|_| HttpRetryAfterParseError::new("invalid Retry-After delta-seconds"));
+  }
+
+  httpdate::parse_http_date(value)
+    .map(HttpRetryAfter::HttpDate)
+    .map_err(|_| HttpRetryAfterParseError::new("invalid Retry-After HTTP-date"))
 }
 
 fn parse_suffix_byte_range(

--- a/rttp/tests/http11_compliance_matrix.rs
+++ b/rttp/tests/http11_compliance_matrix.rs
@@ -5,7 +5,8 @@ use std::thread;
 use std::time::{Duration, UNIX_EPOCH};
 
 use rttp::server::{
-  HttpRequest, HttpRequestCacheControl, HttpResponse, HttpResponseCacheControl, HttpVary,
+  HttpRequest, HttpRequestCacheControl, HttpResponse, HttpResponseCacheControl, HttpRetryAfter,
+  HttpVary,
 };
 use rttp_http11_test_fixtures as fixtures;
 
@@ -70,6 +71,17 @@ fn age_expires_response(age: u64, expires: std::time::SystemTime) -> HttpRespons
     .header("Cache-Control", "public, max-age=60")
     .with_vary("Accept-Encoding")
     .expect("test Vary should parse")
+}
+
+fn expected_retry_after(kind: &fixtures::retry_after::RetryAfterKind) -> HttpRetryAfter {
+  match kind {
+    fixtures::retry_after::RetryAfterKind::DeltaSeconds(delta_seconds) => {
+      HttpRetryAfter::DeltaSeconds(*delta_seconds)
+    }
+    fixtures::retry_after::RetryAfterKind::HttpDate(unix_seconds) => {
+      HttpRetryAfter::HttpDate(UNIX_EPOCH + Duration::from_secs(*unix_seconds))
+    }
+  }
 }
 
 fn assert_request_cache_control(
@@ -339,6 +351,60 @@ fn server_response_age_and_expires_helpers_reject_shared_invalid_matrix() {
     assert!(
       response.expires().is_err(),
       "{} Expires helper should reject invalid value",
+      case.name
+    );
+  }
+}
+
+#[test]
+fn server_response_helper_accepts_shared_retry_after_response_matrix() {
+  for case in fixtures::retry_after::retry_after_cases() {
+    let response = HttpResponse::ok("OK").header("Retry-After", case.value);
+
+    assert_eq!(
+      Some(expected_retry_after(&case.kind)),
+      response
+        .retry_after()
+        .unwrap_or_else(|err| panic!("{} Retry-After should parse: {err}", case.name)),
+      "{}",
+      case.name
+    );
+  }
+}
+
+#[test]
+fn server_response_with_retry_after_declares_shared_metadata_matrix() {
+  for case in fixtures::retry_after::declaration_cases() {
+    let delta_response =
+      HttpResponse::new(503, "Service Unavailable").with_retry_after_delta(case.delta_seconds);
+    let date_response = HttpResponse::new(503, "Service Unavailable")
+      .with_retry_after_date(UNIX_EPOCH + Duration::from_secs(case.date_unix_seconds));
+    let delta_serialized = String::from_utf8(delta_response.to_bytes()).expect("response is UTF-8");
+    let date_serialized = String::from_utf8(date_response.to_bytes()).expect("response is UTF-8");
+
+    assert_eq!(
+      Some(case.delta_value),
+      header_value(&delta_serialized, "Retry-After"),
+      "{}",
+      case.name
+    );
+    assert_eq!(
+      Some(case.date_value),
+      header_value(&date_serialized, "Retry-After"),
+      "{}",
+      case.name
+    );
+  }
+}
+
+#[test]
+fn server_response_retry_after_helper_rejects_shared_invalid_matrix() {
+  for case in fixtures::retry_after::invalid_cases() {
+    let response = HttpResponse::ok("OK").header("Retry-After", case.value);
+
+    assert!(
+      response.retry_after().is_err(),
+      "{} Retry-After helper should reject invalid value",
       case.name
     );
   }

--- a/rttp/tests/test_server_models.rs
+++ b/rttp/tests/test_server_models.rs
@@ -3,7 +3,7 @@ use std::time::{Duration, UNIX_EPOCH};
 use rttp::server::{
   HttpByteRange, HttpByteRangeError, HttpConditionalMetadata, HttpEntityTag,
   HttpIfRangeRequestOutcome, HttpRequest, HttpRequestCacheControl, HttpResponse,
-  HttpResponseCacheControl, HttpVary,
+  HttpResponseCacheControl, HttpRetryAfter, HttpVary,
 };
 
 fn parse_request(raw: &str) -> HttpRequest {
@@ -192,6 +192,94 @@ fn response_age_and_expires_helpers_parse_raw_metadata_headers() {
 }
 
 #[test]
+fn response_retry_after_helpers_declare_delta_seconds_and_http_date() {
+  let retry_at = UNIX_EPOCH + Duration::from_secs(784_111_777);
+
+  let delta_response = HttpResponse::new(503, "Service Unavailable").with_retry_after_delta(120);
+  let date_response = HttpResponse::new(503, "Service Unavailable").with_retry_after_date(retry_at);
+
+  let delta_serialized = String::from_utf8(delta_response.to_bytes()).expect("response is UTF-8");
+  let date_serialized = String::from_utf8(date_response.to_bytes()).expect("response is UTF-8");
+
+  assert!(delta_serialized.contains("\r\nRetry-After: 120\r\n"));
+  assert!(date_serialized.contains("\r\nRetry-After: Sun, 06 Nov 1994 08:49:37 GMT\r\n"));
+  assert_eq!(
+    Some(HttpRetryAfter::DeltaSeconds(120)),
+    delta_response
+      .retry_after()
+      .expect("Retry-After delta should parse")
+  );
+  assert_eq!(
+    Some(HttpRetryAfter::HttpDate(retry_at)),
+    date_response
+      .retry_after()
+      .expect("Retry-After date should parse")
+  );
+}
+
+#[test]
+fn response_retry_after_helper_parses_raw_delta_seconds_and_http_date() {
+  let delta_response = HttpResponse::ok("body").header("Retry-After", "0");
+  let date_response =
+    HttpResponse::ok("body").header("Retry-After", "Sunday, 06-Nov-94 08:49:37 GMT");
+
+  assert_eq!(
+    Some(HttpRetryAfter::DeltaSeconds(0)),
+    delta_response
+      .retry_after()
+      .expect("Retry-After delta should parse")
+  );
+  assert_eq!(
+    Some(HttpRetryAfter::HttpDate(
+      UNIX_EPOCH + Duration::from_secs(784_111_777)
+    )),
+    date_response
+      .retry_after()
+      .expect("Retry-After date should parse")
+  );
+}
+
+#[test]
+fn response_retry_after_helper_rejects_malformed_overflowing_or_oversized_values() {
+  for value in [
+    "",
+    " ",
+    "-1",
+    "+1",
+    "1.5",
+    "abc",
+    "0, 60",
+    "18446744073709551616",
+    "Sun, 06 Nov 1994 08:49:37 PST",
+  ] {
+    let response = HttpResponse::ok("body").header("Retry-After", value);
+
+    assert!(
+      response.retry_after().is_err(),
+      "Retry-After helper should reject {value:?}"
+    );
+  }
+
+  let response = HttpResponse::ok("body").header("Retry-After", "1".repeat(64 * 1024 + 1));
+  assert!(
+    response.retry_after().is_err(),
+    "Retry-After helper should reject oversized values"
+  );
+}
+
+#[test]
+fn response_retry_after_helper_rejects_duplicate_values() {
+  let response = HttpResponse::ok("body")
+    .header("Retry-After", "60")
+    .header("Retry-After", "120");
+
+  assert!(
+    response.retry_after().is_err(),
+    "Retry-After helper should reject duplicate header fields"
+  );
+}
+
+#[test]
 fn response_age_helper_rejects_malformed_or_overflowing_values() {
   for value in ["", " ", "-1", "+1", "1.5", "abc", "18446744073709551616"] {
     let response = HttpResponse::ok("body").header("Age", value);
@@ -219,12 +307,14 @@ fn response_expires_helper_rejects_malformed_values() {
 fn raw_age_and_expires_headers_are_preserved_without_helper_validation() {
   let response = HttpResponse::ok("body")
     .header("Age", "not-a-delta")
-    .header("Expires", "not-a-date");
+    .header("Expires", "not-a-date")
+    .header("Retry-After", "not-a-delta-or-date");
 
   let serialized = String::from_utf8(response.to_bytes()).expect("response is UTF-8");
 
   assert!(serialized.contains("\r\nAge: not-a-delta\r\n"));
   assert!(serialized.contains("\r\nExpires: not-a-date\r\n"));
+  assert!(serialized.contains("\r\nRetry-After: not-a-delta-or-date\r\n"));
 }
 
 #[test]

--- a/rttp_http11_test_fixtures/src/lib.rs
+++ b/rttp_http11_test_fixtures/src/lib.rs
@@ -583,6 +583,118 @@ pub mod age_expires {
   }
 }
 
+pub mod retry_after {
+  pub const RETRY_AFTER_UNIX_SECONDS: u64 = 784_111_777;
+  pub const RETRY_AFTER_IMF_FIXDATE: &str = "Sun, 06 Nov 1994 08:49:37 GMT";
+
+  pub struct RetryAfterCase {
+    pub name: &'static str,
+    pub value: &'static str,
+    pub kind: RetryAfterKind,
+  }
+
+  pub enum RetryAfterKind {
+    DeltaSeconds(u64),
+    HttpDate(u64),
+  }
+
+  pub struct DeclarationCase {
+    pub name: &'static str,
+    pub delta_seconds: u64,
+    pub delta_value: &'static str,
+    pub date_unix_seconds: u64,
+    pub date_value: &'static str,
+  }
+
+  pub struct InvalidCase {
+    pub name: &'static str,
+    pub value: &'static str,
+  }
+
+  const RETRY_AFTER_CASES: &[RetryAfterCase] = &[
+    RetryAfterCase {
+      name: "Retry-After zero delta-seconds",
+      value: "0",
+      kind: RetryAfterKind::DeltaSeconds(0),
+    },
+    RetryAfterCase {
+      name: "Retry-After positive delta-seconds",
+      value: "120",
+      kind: RetryAfterKind::DeltaSeconds(120),
+    },
+    RetryAfterCase {
+      name: "Retry-After IMF-fixdate",
+      value: RETRY_AFTER_IMF_FIXDATE,
+      kind: RetryAfterKind::HttpDate(RETRY_AFTER_UNIX_SECONDS),
+    },
+    RetryAfterCase {
+      name: "Retry-After obsolete RFC 850 date",
+      value: "Sunday, 06-Nov-94 08:49:37 GMT",
+      kind: RetryAfterKind::HttpDate(RETRY_AFTER_UNIX_SECONDS),
+    },
+  ];
+
+  const DECLARATION_CASES: &[DeclarationCase] = &[
+    DeclarationCase {
+      name: "declared zero Retry-After delta with HTTP-date",
+      delta_seconds: 0,
+      delta_value: "0",
+      date_unix_seconds: RETRY_AFTER_UNIX_SECONDS,
+      date_value: RETRY_AFTER_IMF_FIXDATE,
+    },
+    DeclarationCase {
+      name: "declared positive Retry-After delta with HTTP-date",
+      delta_seconds: 120,
+      delta_value: "120",
+      date_unix_seconds: RETRY_AFTER_UNIX_SECONDS,
+      date_value: RETRY_AFTER_IMF_FIXDATE,
+    },
+  ];
+
+  const INVALID_CASES: &[InvalidCase] = &[
+    InvalidCase {
+      name: "Retry-After empty value",
+      value: "",
+    },
+    InvalidCase {
+      name: "Retry-After signed delta-seconds",
+      value: "-1",
+    },
+    InvalidCase {
+      name: "Retry-After fractional delta-seconds",
+      value: "1.5",
+    },
+    InvalidCase {
+      name: "Retry-After non-numeric non-date value",
+      value: "abc",
+    },
+    InvalidCase {
+      name: "Retry-After comma-list delta-seconds",
+      value: "0, 60",
+    },
+    InvalidCase {
+      name: "Retry-After overflowing delta-seconds",
+      value: "18446744073709551616",
+    },
+    InvalidCase {
+      name: "Retry-After unsupported timezone",
+      value: "Sun, 06 Nov 1994 08:49:37 PST",
+    },
+  ];
+
+  pub fn retry_after_cases() -> &'static [RetryAfterCase] {
+    RETRY_AFTER_CASES
+  }
+
+  pub fn declaration_cases() -> &'static [DeclarationCase] {
+    DECLARATION_CASES
+  }
+
+  pub fn invalid_cases() -> &'static [InvalidCase] {
+    INVALID_CASES
+  }
+}
+
 pub mod vary {
   pub const MAX_VALUE_BYTES: usize = 64 * 1024;
   pub const MAX_FIELD_NAMES: usize = 256;


### PR DESCRIPTION
Adds bounded HTTP/1.1 `Retry-After` response helpers to the rttp server crate, including delta-seconds and HTTP-date declaration, typed parsing, validation coverage, fixtures, and documentation.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1589/
work_kind: code_work
branch: hbx-1589-rttp-add-bounded-http-1
base: main
commit: 2b36cb5ba0eeff1779a9ea35eb5a1ee99d53ec8b
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1589/
    url: https://plane.kahub.in/endless/browse/HBX-1589/
    close_policy: link_only
```