### PR TITLE
feat: [rttp_client] Add bounded HTTP/1.1 Allow response helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,25 @@ RTTP does not sleep, retry, replay requests, apply backoff, integrate with a
 scheduler, calculate cache freshness, or decide status-code retry policy from
 `Retry-After`.
 
+### Bounded HTTP/1.1 Allow behavior
+
+`Response::allow()` parses one or more response `Allow` header fields into
+`Allow` metadata. It returns `Ok(None)` when the header is absent. Present
+values are parsed as comma-separated HTTP method tokens across all `Allow`
+fields in wire order, and the resulting method list is exposed by
+`Allow::methods()` and checked with `Allow::contains_method(method)`.
+
+The helper is bounded and validation-oriented. Each header field value is
+limited to 64 KiB, the parsed method list is limited to 256 entries, and each
+method must be a valid HTTP token. Empty list members, malformed method tokens,
+duplicate method names, oversized values, and too many methods make
+`Response::allow()` return an error while leaving the original response headers
+and body available through the ordinary response APIs.
+
+The helper is metadata-only. `rttp_client` does not choose fallback methods,
+retry or replay requests, or attach automatic behavior to `405` or `OPTIONS`
+responses based on `Allow`.
+
 ### Bounded HTTP/1.1 Vary behavior
 
 `Response::vary()` parses one or more response `Vary` header fields into
@@ -243,7 +262,7 @@ gain additional HTTP/2 header-block handling.
 | Redirects | Auto-redirect covers 301, 302, 303, 307, and 308 method/body behavior, relative and absolute `Location` resolution, same- and cross-authority header handling, loop detection, and redirect bounds | Redirects are HTTP client behavior, not a browser policy implementation |
 | Byte ranges | `range`, `range_from`, `range_suffix`, `if_range_etag`, and `if_range_date` emit bounded HTTP/1.1 range request metadata; `Response::content_range`, `is_partial_content`, and `is_range_not_satisfiable` expose `206` and `416` metadata | No client-side `If-Range` evaluation, automatic retry, cache storage, multipart range generation, or automatic cache validation policy |
 | Conditional requests | `if_none_match`, `if_match`, `if_modified_since`, and `if_unmodified_since` emit bounded HTTP/1.1 validators; `Response::is_not_modified`, `is_precondition_failed`, `etag`, and `last_modified` expose `304`/`412` metadata | One ETag validator per helper call, `If-Range` is range-scoped, no cache storage, no automatic revalidation, and no cache-control engine |
-| Cache-Control, Age, Expires, and Retry-After | `Response::cache_control` parses bounded response directives, numeric freshness fields, quoted field-name lists, and extension directives; `Response::age` parses bounded delta-seconds; `Response::expires` parses bounded HTTP-date metadata; `Response::retry_after` parses bounded delta-seconds or HTTP-date metadata | No cache storage, automatic revalidation, wall-clock freshness calculation, `Vary` matching, shared-cache policy enforcement, automatic conditional requests, automatic sleep, retry, replay, backoff, scheduler integration, or status-code policy engine |
+| Cache-Control, Age, Expires, Retry-After, and Allow | `Response::cache_control` parses bounded response directives, numeric freshness fields, quoted field-name lists, and extension directives; `Response::age` parses bounded delta-seconds; `Response::expires` parses bounded HTTP-date metadata; `Response::retry_after` parses bounded delta-seconds or HTTP-date metadata; `Response::allow` parses bounded ordered method metadata | No cache storage, automatic revalidation, wall-clock freshness calculation, `Vary` matching, shared-cache policy enforcement, automatic conditional requests, automatic sleep, retry, replay, backoff, scheduler integration, fallback method selection, or status-code policy engine |
 | Vary | `Response::vary` parses bounded response `Vary` fields into wildcard or normalized case-insensitive field-name metadata | No cache storage, stored-response matching engine, cache key persistence, automatic request replay, shared-cache policy enforcement, or automatic conditional requests |
 | Trailers | Chunked response trailers are exposed for blocking and async APIs; streaming chunked uploads can send declared request trailers | Application metadata trailers such as `X-Trace` are allowed; pseudo-header, connection-specific, routing, authentication/cookie, and framing trailer fields are rejected |
 | Bounded h2c client | With `http2`, direct `socket2` h2c sends GET, HEAD, bodyless DELETE, OPTIONS, or TRACE, buffered POST, PUT, or PATCH requests, and opt-in RFC 8441 extended CONNECT request HEADERS via `http2_extended_connect`, opens at most one request stream, supports prior-knowledge with `emit_http2_prior_knowledge`, supports explicit HTTP/1.1 `Upgrade: h2c` negotiation with `emit_http2_upgrade`, advertises `SETTINGS_ENABLE_PUSH = 0`, advertises `SETTINGS_ENABLE_CONNECT_PROTOCOL = 1` only for the explicit extended CONNECT path, validates received `SETTINGS_ENABLE_PUSH` values as only `0` or `1`, honors initial peer `SETTINGS_MAX_CONCURRENT_STREAMS` by failing before request HEADERS when the peer allows zero streams, honors peer-advertised `SETTINGS_MAX_HEADER_LIST_SIZE` request metadata limits, accepts only legal `SETTINGS_MAX_FRAME_SIZE` values from 16,384 through 16,777,215 bytes, splits outbound HEADERS, DATA, and trailers to the active peer frame-size limit, rejects oversized inbound frames when a configured local frame-size limit is exceeded, bounds HPACK dynamic table use with `SETTINGS_HEADER_TABLE_SIZE`, strips HTTP/1.x connection-specific request fields before emission, rejects connection-specific peer response fields, suppresses HEAD response bodies, treats `RST_STREAM` on the active stream as a bounded reset/cancellation signal, acknowledges valid PING frames with matching opaque data, DATA bodies, trailers, HPACK static Huffman strings, bounded large header blocks, padded incoming frames, `GOAWAY` shutdown boundaries, PRIORITY metadata validation without scheduling, HTTP/2-allowed unknown/extension frame ignoring inside this bounded path, reserved stream-id high-bit normalization, and conservative DATA flow control | Ordinary `CONNECT`, header-configured `:protocol` metadata, non-h2c HTTP/1.1 `Upgrade` handoff requests, and proxies are rejected deterministically, and `PUSH_PROMISE`/server push is rejected instead of managed; bounded direct h2c only, with no public cancellation callback API, no dynamic policy API, no extension callback API, no full extension negotiation, TLS ALPN, external h2 integration, proxy tunneling to h2, proxy h2, tunnel handoff, connection pooling, persistent HTTP/2 session management, automatic retry, server push, full stream state machine, unbounded multiplex scheduling, general multiplexing, priority scheduling, request bodies or trailers for extended CONNECT, or request bodies for GET, HEAD, DELETE, OPTIONS, or TRACE |

--- a/rttp/README.md
+++ b/rttp/README.md
@@ -438,9 +438,11 @@ client helpers do not evaluate `If-Range`, retry requests, store cache entries,
 generate multipart range requests, or apply automatic cache validation. The
 client response API also includes `Response::cache_control()` from
 `rttp_client`, which parses bounded response `Cache-Control` directives and
-extensions as metadata only; the wrapper does not add cache storage,
-automatic revalidation, wall-clock freshness calculation, `Vary` matching,
-shared-cache policy enforcement, or automatic conditional requests. The
+extensions as metadata only, and `Response::allow()`, which parses bounded
+ordered HTTP method metadata from `Allow`; the wrapper does not add cache
+storage, automatic revalidation, wall-clock freshness calculation, `Vary`
+matching, shared-cache policy enforcement, automatic conditional requests,
+fallback method selection, retry/replay, or status-code policy behavior. The
 `http2` feature exposes the bounded
 prior-knowledge h2c client path for GET, HEAD, bodyless DELETE, OPTIONS, or
 TRACE, and buffered POST, PUT, or PATCH requests. It opens at most one request

--- a/rttp_client/README.md
+++ b/rttp_client/README.md
@@ -164,6 +164,25 @@ RTTP does not sleep, retry, replay requests, apply backoff, integrate with a
 scheduler, calculate cache freshness, or decide status-code retry policy from
 `Retry-After`.
 
+## Bounded HTTP/1.1 Allow behavior
+
+`Response::allow()` parses one or more response `Allow` header fields into
+`Allow` metadata. It returns `Ok(None)` when the header is absent. Present
+values are parsed as comma-separated HTTP method tokens across all `Allow`
+fields in wire order, and the resulting method list is exposed by
+`Allow::methods()` and checked with `Allow::contains_method(method)`.
+
+The helper is bounded and validation-oriented. Each header field value is
+limited to 64 KiB, the parsed method list is limited to 256 entries, and each
+method must be a valid HTTP token. Empty list members, malformed method tokens,
+duplicate method names, oversized values, and too many methods make
+`Response::allow()` return an error while leaving the original response headers
+and body available through the ordinary response APIs.
+
+The helper is metadata-only. `rttp_client` does not choose fallback methods,
+retry or replay requests, or attach automatic behavior to `405` or `OPTIONS`
+responses based on `Allow`.
+
 ## Bounded HTTP/1.1 Vary behavior
 
 `Response::vary()` parses one or more response `Vary` header fields into
@@ -257,6 +276,7 @@ header-block model.
 | Byte ranges | `range`, `range_from`, `range_suffix`, `if_range_etag`, and `if_range_date` emit bounded HTTP/1.1 range request metadata; `Response::content_range`, `is_partial_content`, and `is_range_not_satisfiable` expose `206` and `416` metadata | No client-side `If-Range` evaluation, automatic retry, cache storage, multipart range generation, or automatic cache validation policy |
 | Conditional requests | `if_none_match`, `if_match`, `if_modified_since`, and `if_unmodified_since` emit bounded HTTP/1.1 validators; `Response::is_not_modified`, `is_precondition_failed`, `etag`, and `last_modified` expose `304`/`412` metadata | One ETag validator per helper call, `If-Range` is range-scoped, no cache storage, no automatic revalidation, and no cache-control engine |
 | Cache-Control, Age, and Expires | `Response::cache_control` parses bounded response directives, numeric freshness fields, quoted field-name lists, and extension directives; `Response::age` parses bounded delta-seconds; `Response::expires` parses bounded HTTP-date metadata | No cache storage, automatic revalidation, wall-clock freshness calculation, `Vary` matching, shared-cache policy enforcement, or automatic conditional requests |
+| Allow | `Response::allow` parses bounded response `Allow` fields into an ordered HTTP method-token list | No fallback method selection, automatic retry/replay, or status-code policy behavior for `405` or `OPTIONS` |
 | Vary | `Response::vary` parses bounded response `Vary` fields into wildcard or normalized case-insensitive field-name metadata | No cache storage, stored-response matching engine, cache key persistence, automatic request replay, shared-cache policy enforcement, or automatic conditional requests |
 | Trailers | Chunked response trailers are exposed for blocking and async APIs; streaming chunked uploads can send declared request trailers | Application metadata trailers such as `X-Trace` are allowed; pseudo-header, connection-specific, routing, authentication/cookie, and framing trailer fields are rejected |
 | Bounded h2c client | With `http2`, direct `socket2` h2c sends GET, HEAD, bodyless DELETE, OPTIONS, or TRACE, buffered POST, PUT, or PATCH requests, and opt-in RFC 8441 extended CONNECT request HEADERS via `http2_extended_connect`, opens at most one request stream, supports prior-knowledge with `emit_http2_prior_knowledge`, supports explicit HTTP/1.1 `Upgrade: h2c` negotiation with `emit_http2_upgrade`, advertises `SETTINGS_ENABLE_PUSH = 0`, advertises `SETTINGS_ENABLE_CONNECT_PROTOCOL = 1` only for the explicit extended CONNECT path, validates received `SETTINGS_ENABLE_PUSH` values as only `0` or `1`, honors initial peer `SETTINGS_MAX_CONCURRENT_STREAMS` by failing before request HEADERS when the peer allows zero streams, honors peer-advertised `SETTINGS_MAX_HEADER_LIST_SIZE` request metadata limits, accepts only legal `SETTINGS_MAX_FRAME_SIZE` values from 16,384 through 16,777,215 bytes, splits outbound HEADERS, DATA, and trailers to the active peer frame-size limit, rejects oversized inbound frames when a configured local frame-size limit is exceeded, bounds HPACK dynamic table use with `SETTINGS_HEADER_TABLE_SIZE`, strips HTTP/1.x connection-specific request fields before emission, rejects connection-specific peer response fields, suppresses HEAD response bodies, treats `RST_STREAM` on the active stream as a bounded reset/cancellation signal, acknowledges valid PING frames with matching opaque data, DATA bodies, trailers, HPACK static Huffman strings, bounded large header blocks, padded incoming frames, `GOAWAY` shutdown boundaries, PRIORITY metadata validation without scheduling, HTTP/2-allowed unknown/extension frame ignoring inside this bounded path, reserved stream-id high-bit normalization, and conservative DATA flow control | Ordinary `CONNECT`, header-configured `:protocol` metadata, non-h2c HTTP/1.1 `Upgrade` handoff requests, and proxies are rejected deterministically, and `PUSH_PROMISE`/server push is rejected instead of managed; bounded direct h2c only, with no public cancellation callback API, no dynamic policy API, no extension callback API, no full extension negotiation, TLS ALPN, external h2 integration, proxy tunneling to h2, proxy h2, tunnel handoff, connection pooling, persistent HTTP/2 session management, automatic retry, server push, full stream state machine, unbounded multiplex scheduling, general multiplexing, priority scheduling, request bodies or trailers for extended CONNECT, or request bodies for GET, HEAD, DELETE, OPTIONS, or TRACE |

--- a/rttp_client/src/response/response.rs
+++ b/rttp_client/src/response/response.rs
@@ -11,6 +11,8 @@ use crate::types::{Cookie, Header, RoUrl};
 
 const MAX_CACHE_CONTROL_VALUE_BYTES: usize = 64 * 1024;
 const MAX_CACHE_CONTROL_DIRECTIVES: usize = 256;
+const MAX_ALLOW_VALUE_BYTES: usize = 64 * 1024;
+const MAX_ALLOW_METHODS: usize = 256;
 const MAX_RETRY_AFTER_VALUE_BYTES: usize = 64 * 1024;
 const MAX_VARY_VALUE_BYTES: usize = 64 * 1024;
 const MAX_VARY_FIELD_NAMES: usize = 256;
@@ -130,6 +132,14 @@ impl Response {
     }
   }
 
+  pub fn allow(&self) -> error::Result<Option<Allow>> {
+    let values = self.header_values("allow");
+    if values.is_empty() {
+      return Ok(None);
+    }
+    Allow::parse_values(values.into_iter().map(String::as_str)).map(Some)
+  }
+
   pub fn content_range(&self) -> Option<ContentRange> {
     self
       .header_value("content-range")
@@ -239,6 +249,65 @@ impl fmt::Display for Response {
   #[inline]
   fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
     fmt::Display::fmt(&self.raw, formatter)
+  }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Allow {
+  methods: Vec<String>,
+}
+
+impl Allow {
+  pub fn parse(value: impl AsRef<str>) -> error::Result<Self> {
+    Self::parse_values([value.as_ref()])
+  }
+
+  fn parse_values<'a, I>(values: I) -> error::Result<Self>
+  where
+    I: IntoIterator<Item = &'a str>,
+  {
+    let mut methods = Vec::new();
+    let mut seen = HashSet::new();
+
+    for value in values {
+      if value.len() > MAX_ALLOW_VALUE_BYTES {
+        return Err(error::bad_response("Allow header value is too large"));
+      }
+
+      for method in value.split(',') {
+        let method = method.trim();
+        if method.is_empty() {
+          return Err(error::bad_response("Invalid Allow method"));
+        }
+        if !is_token(method) {
+          return Err(error::bad_response("Invalid Allow method"));
+        }
+        if methods.len() >= MAX_ALLOW_METHODS {
+          return Err(error::bad_response("Too many Allow methods"));
+        }
+        if !seen.insert(method.to_string()) {
+          return Err(error::bad_response("Duplicate Allow method"));
+        }
+        methods.push(method.to_string());
+      }
+    }
+
+    if methods.is_empty() {
+      return Err(error::bad_response("Invalid Allow method"));
+    }
+
+    Ok(Self { methods })
+  }
+
+  pub fn methods(&self) -> Vec<&str> {
+    self.methods.iter().map(String::as_str).collect()
+  }
+
+  pub fn contains_method(&self, method: impl AsRef<str>) -> bool {
+    self
+      .methods
+      .iter()
+      .any(|candidate| candidate == method.as_ref())
   }
 }
 

--- a/rttp_client/tests/http11_compliance_matrix.rs
+++ b/rttp_client/tests/http11_compliance_matrix.rs
@@ -39,6 +39,17 @@ fn vary_response(values: &[&str]) -> Vec<u8> {
   response.into_bytes()
 }
 
+fn allow_response(values: &[&str]) -> Vec<u8> {
+  let mut response = String::from("HTTP/1.1 405 Method Not Allowed\r\n");
+  for value in values {
+    response.push_str("Allow: ");
+    response.push_str(value);
+    response.push_str("\r\n");
+  }
+  response.push_str("Content-Length: 0\r\n\r\n");
+  response.into_bytes()
+}
+
 fn age_expires_response(age: &str, expires: &str, include_cache_metadata: bool) -> Vec<u8> {
   let mut response = String::from("HTTP/1.1 200 OK\r\n");
   response.push_str("Age: ");
@@ -392,6 +403,29 @@ fn assert_response_vary(
   }
 }
 
+fn assert_response_allow(
+  name: &str,
+  response: rttp_client::response::Response,
+  expected: &fixtures::allow::ResponseCase,
+) {
+  let raw_values: Vec<&str> = response
+    .header_values("allow")
+    .into_iter()
+    .map(String::as_str)
+    .collect();
+  assert_eq!(expected.values, raw_values.as_slice(), "{name}");
+
+  let allow = response
+    .allow()
+    .unwrap_or_else(|err| panic!("{name} Allow should parse: {err}"))
+    .unwrap_or_else(|| panic!("{name} should include Allow"));
+
+  assert_eq!(expected.methods, allow.methods().as_slice(), "{name}");
+  for method in expected.methods {
+    assert!(allow.contains_method(method), "{name} {method}");
+  }
+}
+
 fn assert_cache_control_helper_rejects_but_preserves_response(name: &str, raw_response: Vec<u8>) {
   let (addr, handle) = fixtures::spawn_socket2_owned_raw_response_server(raw_response);
 
@@ -482,12 +516,47 @@ fn assert_retry_after_helper_rejects_but_preserves_response(name: &str, raw_resp
   handle.join().expect("raw response server thread");
 }
 
+fn assert_allow_helper_rejects_but_preserves_response(name: &str, raw_response: Vec<u8>) {
+  let (addr, handle) = fixtures::spawn_socket2_owned_raw_response_server(raw_response);
+
+  let response = client()
+    .get()
+    .url(format!("http://{}/matrix/allow-invalid", addr))
+    .emit()
+    .unwrap_or_else(|err| panic!("{name} response should remain parseable: {err}"));
+
+  assert!(
+    response.allow().is_err(),
+    "{name} helper should reject invalid Allow"
+  );
+  assert_eq!("", response.body().string().unwrap(), "{name}");
+
+  handle.join().expect("raw response server thread");
+}
+
 enum ConditionalHeader {
   IfNoneMatch(&'static str),
   IfMatch(&'static str),
   IfModifiedSince(&'static str),
   IfUnmodifiedSince(&'static str),
   Manual(&'static str, &'static str),
+}
+
+#[test]
+fn sync_client_parses_shared_allow_response_matrix() {
+  for case in fixtures::allow::response_cases() {
+    let raw_response = allow_response(case.values);
+    let (addr, handle) = fixtures::spawn_socket2_owned_raw_response_server(raw_response);
+
+    let response = client()
+      .get()
+      .url(format!("http://{}/matrix/allow", addr))
+      .emit()
+      .unwrap_or_else(|err| panic!("{} response should parse: {err}", case.name));
+
+    assert_response_allow(case.name, response, case);
+    handle.join().expect("raw response server thread");
+  }
 }
 
 #[test]
@@ -760,6 +829,13 @@ fn sync_client_cache_control_helper_rejects_shared_invalid_response_matrix() {
 }
 
 #[test]
+fn sync_client_allow_helper_rejects_shared_invalid_response_matrix() {
+  for case in fixtures::allow::invalid_cases() {
+    assert_allow_helper_rejects_but_preserves_response(case.name, allow_response(&[case.value]));
+  }
+}
+
+#[test]
 fn sync_client_vary_helper_rejects_shared_invalid_response_matrix() {
   for case in fixtures::vary::invalid_cases() {
     assert_vary_helper_rejects_but_preserves_response(case.name, vary_response(&[case.value]));
@@ -818,6 +894,22 @@ fn sync_client_retry_after_helper_rejects_duplicate_singleton_and_oversized_valu
   assert_retry_after_helper_rejects_but_preserves_response(
     "oversized Retry-After value",
     retry_after_response(&[&fixtures::retry_after::oversized_value()], false),
+  );
+}
+
+#[test]
+fn sync_client_allow_helper_rejects_duplicate_methods_and_enforces_shared_bounds() {
+  assert_allow_helper_rejects_but_preserves_response(
+    "duplicate Allow methods across header fields",
+    allow_response(&["GET, HEAD", "POST, GET"]),
+  );
+  assert_allow_helper_rejects_but_preserves_response(
+    "too many Allow methods",
+    allow_response(&[&fixtures::allow::too_many_methods_value()]),
+  );
+  assert_allow_helper_rejects_but_preserves_response(
+    "oversized Allow value",
+    allow_response(&[&fixtures::allow::oversized_value()]),
   );
 }
 

--- a/rttp_client/tests/test_response.rs
+++ b/rttp_client/tests/test_response.rs
@@ -450,6 +450,116 @@ fn test_parse_retry_after_rejects_duplicate_and_oversized_helper_values() {
 }
 
 #[test]
+fn test_parse_allow_response_helper_preserves_method_order_across_header_fields() {
+  let s = concat!(
+    "HTTP/1.1 405 Method Not Allowed\r\n",
+    "Allow: GET, HEAD\r\n",
+    "allow: POST, OPTIONS\r\n",
+    "Content-Length: 0\r\n",
+    "\r\n"
+  );
+  let response = Response::new(RoUrl::with("https://example.test"), s.as_bytes().to_vec())
+    .expect("parse response with allow headers");
+  let allow = response
+    .allow()
+    .expect("valid allow should parse")
+    .expect("allow header should be present");
+
+  assert_eq!(vec!["GET", "HEAD", "POST", "OPTIONS"], allow.methods());
+  assert!(allow.contains_method("POST"));
+  assert!(!allow.contains_method("PATCH"));
+  assert_eq!(
+    vec![&"GET, HEAD".to_string(), &"POST, OPTIONS".to_string()],
+    response.header_values("Allow")
+  );
+}
+
+#[test]
+fn test_parse_allow_response_helper_returns_none_when_absent() {
+  let s = concat!("HTTP/1.1 200 OK\r\n", "Content-Length: 2\r\n", "\r\n", "OK");
+  let response = Response::new(RoUrl::with("https://example.test"), s.as_bytes().to_vec())
+    .expect("parse response without allow");
+
+  assert_eq!(None, response.allow().expect("absent allow should parse"));
+}
+
+#[test]
+fn test_parse_allow_rejects_invalid_helper_values_without_rejecting_response() {
+  let invalid_values = [
+    "",
+    "GET,",
+    ",GET",
+    "GET,,POST",
+    "GET, ,POST",
+    "GET POST",
+    "GET@POST",
+    "GE\tT",
+  ];
+
+  for value in invalid_values {
+    let raw =
+      format!("HTTP/1.1 405 Method Not Allowed\r\nAllow: {value}\r\nContent-Length: 0\r\n\r\n");
+    let response = Response::new(RoUrl::with("https://example.test"), raw.into_bytes())
+      .expect("raw response remains usable");
+
+    assert!(
+      response.allow().is_err(),
+      "allow helper should reject {value:?}"
+    );
+    assert_eq!(Some(&value.to_string()), response.header_value("Allow"));
+  }
+}
+
+#[test]
+fn test_parse_allow_rejects_duplicate_oversized_and_too_many_methods() {
+  let raw = concat!(
+    "HTTP/1.1 405 Method Not Allowed\r\n",
+    "Allow: GET, HEAD\r\n",
+    "allow: POST, GET\r\n",
+    "Content-Length: 0\r\n",
+    "\r\n"
+  );
+  let response = Response::new(RoUrl::with("https://example.test"), raw.as_bytes().to_vec())
+    .expect("raw response with duplicate allow remains usable");
+
+  assert!(
+    response.allow().is_err(),
+    "allow helper should reject duplicate method names"
+  );
+  assert_eq!(
+    vec![&"GET, HEAD".to_string(), &"POST, GET".to_string()],
+    response.header_values("Allow")
+  );
+
+  let oversized = "GET".repeat(64 * 1024);
+  let raw =
+    format!("HTTP/1.1 405 Method Not Allowed\r\nAllow: {oversized}\r\nContent-Length: 0\r\n\r\n");
+  let response = Response::new(RoUrl::with("https://example.test"), raw.into_bytes())
+    .expect("raw response with oversized allow remains usable");
+
+  assert!(
+    response.allow().is_err(),
+    "allow helper should reject oversized values"
+  );
+  assert_eq!(Some(&oversized), response.header_value("Allow"));
+
+  let too_many = (0..257)
+    .map(|ix| format!("M{ix}"))
+    .collect::<Vec<_>>()
+    .join(", ");
+  let raw =
+    format!("HTTP/1.1 405 Method Not Allowed\r\nAllow: {too_many}\r\nContent-Length: 0\r\n\r\n");
+  let response = Response::new(RoUrl::with("https://example.test"), raw.into_bytes())
+    .expect("raw response with too many allow methods remains usable");
+
+  assert!(
+    response.allow().is_err(),
+    "allow helper should reject too many methods"
+  );
+  assert_eq!(Some(&too_many), response.header_value("Allow"));
+}
+
+#[test]
 fn test_parse_age_rejects_invalid_helper_values_without_rejecting_response() {
   let invalid_values = [
     "",

--- a/rttp_http11_test_fixtures/src/lib.rs
+++ b/rttp_http11_test_fixtures/src/lib.rs
@@ -699,6 +699,81 @@ pub mod retry_after {
   }
 }
 
+pub mod allow {
+  pub const MAX_VALUE_BYTES: usize = 64 * 1024;
+  pub const MAX_METHODS: usize = 256;
+
+  pub struct ResponseCase {
+    pub name: &'static str,
+    pub values: &'static [&'static str],
+    pub methods: &'static [&'static str],
+  }
+
+  pub struct InvalidCase {
+    pub name: &'static str,
+    pub value: &'static str,
+  }
+
+  const RESPONSE_CASES: &[ResponseCase] = &[
+    ResponseCase {
+      name: "methods across header fields",
+      values: &["GET, HEAD", "POST, OPTIONS"],
+      methods: &["GET", "HEAD", "POST", "OPTIONS"],
+    },
+    ResponseCase {
+      name: "extension methods preserve token order",
+      values: &["PATCH, MKCOL, REPORT"],
+      methods: &["PATCH", "MKCOL", "REPORT"],
+    },
+  ];
+
+  const INVALID_CASES: &[InvalidCase] = &[
+    InvalidCase {
+      name: "empty value",
+      value: "",
+    },
+    InvalidCase {
+      name: "trailing comma",
+      value: "GET,",
+    },
+    InvalidCase {
+      name: "leading comma",
+      value: ", GET",
+    },
+    InvalidCase {
+      name: "empty member",
+      value: "GET,,POST",
+    },
+    InvalidCase {
+      name: "method with whitespace",
+      value: "GET POST",
+    },
+    InvalidCase {
+      name: "method with separator",
+      value: "GET@POST",
+    },
+  ];
+
+  pub fn response_cases() -> &'static [ResponseCase] {
+    RESPONSE_CASES
+  }
+
+  pub fn invalid_cases() -> &'static [InvalidCase] {
+    INVALID_CASES
+  }
+
+  pub fn too_many_methods_value() -> String {
+    (0..=MAX_METHODS)
+      .map(|index| format!("M{index}"))
+      .collect::<Vec<_>>()
+      .join(", ")
+  }
+
+  pub fn oversized_value() -> String {
+    format!("M{}", "A".repeat(MAX_VALUE_BYTES))
+  }
+}
+
 pub mod vary {
   pub const MAX_VALUE_BYTES: usize = 64 * 1024;
   pub const MAX_FIELD_NAMES: usize = 256;


### PR DESCRIPTION
rttp_client now exposes bounded Allow response metadata parsing through Response::allow(), with validation, shared matrix coverage, focused tests, and documentation updates. Workspace verification passed.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1593/
work_kind: code_work
branch: hbx-1593-rttp-client-add-bounded-http
base: main
commit: 85b1087ca2c9e2b7adbee13daf5312b60620b86c
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1593/
    url: https://plane.kahub.in/endless/browse/HBX-1593/
    close_policy: link_only
```