### PR TITLE
feat: [rttp_client] Add bounded HTTP/1.1 Content-Language response helpers

### DIFF
--- a/rttp_client/src/response/response.rs
+++ b/rttp_client/src/response/response.rs
@@ -14,6 +14,8 @@ const MAX_CACHE_CONTROL_DIRECTIVES: usize = 256;
 const MAX_ALLOW_VALUE_BYTES: usize = 64 * 1024;
 const MAX_ALLOW_METHODS: usize = 256;
 const MAX_RETRY_AFTER_VALUE_BYTES: usize = 64 * 1024;
+const MAX_CONTENT_LANGUAGE_VALUE_BYTES: usize = 64 * 1024;
+const MAX_CONTENT_LANGUAGE_TAGS: usize = 256;
 const MAX_VARY_VALUE_BYTES: usize = 64 * 1024;
 const MAX_VARY_FIELD_NAMES: usize = 256;
 
@@ -144,6 +146,14 @@ impl Response {
     self
       .header_value("content-range")
       .and_then(ContentRange::parse)
+  }
+
+  pub fn content_language(&self) -> error::Result<Option<ContentLanguage>> {
+    let values = self.header_values("content-language");
+    if values.is_empty() {
+      return Ok(None);
+    }
+    ContentLanguage::parse_values(values.into_iter().map(String::as_str)).map(Some)
   }
 
   pub fn cache_control(&self) -> error::Result<Option<CacheControl>> {
@@ -420,6 +430,59 @@ fn parse_complete_length(value: &str) -> Option<Option<u64>> {
     return Some(None);
   }
   value.parse::<u64>().ok().map(Some)
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ContentLanguage {
+  tags: Vec<String>,
+}
+
+impl ContentLanguage {
+  pub fn parse(value: impl AsRef<str>) -> error::Result<Self> {
+    Self::parse_values([value.as_ref()])
+  }
+
+  fn parse_values<'a, I>(values: I) -> error::Result<Self>
+  where
+    I: IntoIterator<Item = &'a str>,
+  {
+    let mut tags = Vec::new();
+    let mut seen = HashSet::new();
+
+    for value in values {
+      if value.len() > MAX_CONTENT_LANGUAGE_VALUE_BYTES {
+        return Err(error::bad_response(
+          "Content-Language header value is too large",
+        ));
+      }
+
+      for tag in value.split(',') {
+        let tag = tag.trim();
+        if tag.is_empty() || !is_language_range(tag) {
+          return Err(error::bad_response("Invalid Content-Language tag"));
+        }
+        if tags.len() >= MAX_CONTENT_LANGUAGE_TAGS {
+          return Err(error::bad_response("Too many Content-Language tags"));
+        }
+
+        let normalized = tag.to_ascii_lowercase();
+        if !seen.insert(normalized) {
+          return Err(error::bad_response("Duplicate Content-Language tag"));
+        }
+        tags.push(tag.to_string());
+      }
+    }
+
+    if tags.is_empty() {
+      return Err(error::bad_response("Invalid Content-Language tag"));
+    }
+
+    Ok(Self { tags })
+  }
+
+  pub fn tags(&self) -> Vec<&str> {
+    self.tags.iter().map(String::as_str).collect()
+  }
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -831,6 +894,30 @@ fn split_field_names(value: &str) -> Vec<String> {
     .filter(|field| !field.is_empty())
     .map(ToString::to_string)
     .collect()
+}
+
+fn is_language_range(value: &str) -> bool {
+  if value == "*" {
+    return true;
+  }
+
+  let mut subtags = value.split('-');
+  let Some(primary) = subtags.next() else {
+    return false;
+  };
+  if !is_language_primary_subtag(primary) {
+    return false;
+  }
+
+  subtags.all(is_language_subtag)
+}
+
+fn is_language_primary_subtag(value: &str) -> bool {
+  (1..=8).contains(&value.len()) && value.bytes().all(|byte| byte.is_ascii_alphabetic())
+}
+
+fn is_language_subtag(value: &str) -> bool {
+  (1..=8).contains(&value.len()) && value.bytes().all(|byte| byte.is_ascii_alphanumeric())
 }
 
 fn is_token(value: &str) -> bool {

--- a/rttp_client/tests/test_response.rs
+++ b/rttp_client/tests/test_response.rs
@@ -691,6 +691,132 @@ fn test_parse_vary_rejects_invalid_helper_values_without_rejecting_response() {
 }
 
 #[test]
+fn test_parse_content_language_response_helper_preserves_order_across_header_fields() {
+  let s = concat!(
+    "HTTP/1.1 200 OK\r\n",
+    "Content-Language: en-US, fr\r\n",
+    "content-language: zh-Hant-TW, *\r\n",
+    "Content-Length: 2\r\n",
+    "\r\n",
+    "OK"
+  );
+  let response = Response::new(RoUrl::with("https://example.test"), s.as_bytes().to_vec())
+    .expect("parse response with content-language headers");
+
+  let content_language = response
+    .content_language()
+    .expect("valid content-language should parse")
+    .expect("content-language header should be present");
+
+  assert_eq!(
+    vec!["en-US", "fr", "zh-Hant-TW", "*"],
+    content_language.tags()
+  );
+  assert_eq!(
+    vec![&"en-US, fr".to_string(), &"zh-Hant-TW, *".to_string()],
+    response.header_values("Content-Language")
+  );
+}
+
+#[test]
+fn test_parse_content_language_response_helper_returns_none_when_absent() {
+  let s = concat!("HTTP/1.1 200 OK\r\n", "Content-Length: 2\r\n", "\r\n", "OK");
+  let response = Response::new(RoUrl::with("https://example.test"), s.as_bytes().to_vec())
+    .expect("parse response without content-language");
+
+  assert_eq!(
+    None,
+    response
+      .content_language()
+      .expect("absent content-language should parse")
+  );
+}
+
+#[test]
+fn test_parse_content_language_rejects_invalid_helper_values_without_rejecting_response() {
+  let invalid_values = [
+    "",
+    "en-US,",
+    ",en-US",
+    "en-US,,fr",
+    "en-US, ,fr",
+    "en_US",
+    "en US",
+    "en-",
+    "-en",
+    "englishlong",
+    "en-toolongsubtag",
+    "en-@",
+  ];
+
+  for value in invalid_values {
+    let raw =
+      format!("HTTP/1.1 200 OK\r\nContent-Language: {value}\r\nContent-Length: 2\r\n\r\nOK");
+    let response = Response::new(RoUrl::with("https://example.test"), raw.into_bytes())
+      .expect("raw response remains usable");
+
+    assert!(
+      response.content_language().is_err(),
+      "content-language helper should reject {value:?}"
+    );
+    assert_eq!(
+      Some(&value.to_string()),
+      response.header_value("Content-Language")
+    );
+  }
+}
+
+#[test]
+fn test_parse_content_language_rejects_duplicate_oversized_and_too_many_values() {
+  let raw = concat!(
+    "HTTP/1.1 200 OK\r\n",
+    "Content-Language: en-US, fr\r\n",
+    "content-language: EN-us\r\n",
+    "Content-Length: 2\r\n",
+    "\r\n",
+    "OK"
+  );
+  let response = Response::new(RoUrl::with("https://example.test"), raw.as_bytes().to_vec())
+    .expect("raw response with duplicate content-language remains usable");
+
+  assert!(
+    response.content_language().is_err(),
+    "content-language helper should reject normalized duplicate tags"
+  );
+  assert_eq!(
+    vec![&"en-US, fr".to_string(), &"EN-us".to_string()],
+    response.header_values("Content-Language")
+  );
+
+  let oversized = "en".repeat(32 * 1024 + 1);
+  let raw =
+    format!("HTTP/1.1 200 OK\r\nContent-Language: {oversized}\r\nContent-Length: 2\r\n\r\nOK");
+  let response = Response::new(RoUrl::with("https://example.test"), raw.into_bytes())
+    .expect("raw response with oversized content-language remains usable");
+
+  assert!(
+    response.content_language().is_err(),
+    "content-language helper should reject oversized values"
+  );
+  assert_eq!(Some(&oversized), response.header_value("Content-Language"));
+
+  let too_many = (0..257)
+    .map(|ix| format!("x-{ix}"))
+    .collect::<Vec<_>>()
+    .join(", ");
+  let raw =
+    format!("HTTP/1.1 200 OK\r\nContent-Language: {too_many}\r\nContent-Length: 2\r\n\r\nOK");
+  let response = Response::new(RoUrl::with("https://example.test"), raw.into_bytes())
+    .expect("raw response with too many content-language values remains usable");
+
+  assert!(
+    response.content_language().is_err(),
+    "content-language helper should reject too many values"
+  );
+  assert_eq!(Some(&too_many), response.header_value("Content-Language"));
+}
+
+#[test]
 fn test_parse_response_rejects_header_without_colon() {
   let s = concat!(
     "HTTP/1.1 200 OK\r\n",


### PR DESCRIPTION
Adds bounded `Content-Language` response helper support to `rttp_client`, including ordered multi-field parsing, validation, duplicate detection, and regression coverage. Formatting and full workspace tests pass.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1598/
work_kind: code_work
branch: hbx-1598-rttp-client-add-bounded-http
base: main
commit: 86538dd335971f6f6f28970bc27af197dd623227
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1598/
    url: https://plane.kahub.in/endless/browse/HBX-1598/
    close_policy: link_only
```