### PR TITLE
feat: [rttp] Add bounded HTTP/1.1 Content-Language server helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -608,6 +608,31 @@ These helpers are metadata-only. RTTP does not choose fallback methods, retry
 or replay requests, implement `OPTIONS` policy, generate `405` responses,
 dispatch routes, or provide a status-code policy engine from `Allow`.
 
+### Bounded HTTP/1.1 Content-Language behavior
+
+Server-side `Content-Language` helpers expose response metadata declaration and
+parsing without implementing language negotiation or representation selection.
+`HttpResponse::with_content_language(languages)` validates an explicit language
+tag list and adds one comma-separated `Content-Language` header, while
+`HttpResponse::content_language()` parses any `Content-Language` headers
+already attached to a response into `HttpContentLanguages`.
+`HttpContentLanguages::parse(value)` accepts comma-separated language tags and
+preserves the declared spelling and order.
+
+Parsing is bounded and validation-oriented. Each `Content-Language` field value
+is limited to 64 KiB, the parsed language list is limited to 32 entries, and
+each tag must contain non-empty ASCII alphanumeric subtags separated by hyphens
+with an alphabetic primary subtag. Empty members, malformed tags, duplicates
+across one or more helper-parsed header fields, oversized values, and too many
+tags return `HttpContentLanguageParseError` from the helper. Raw
+`HttpResponse::header("Content-Language", ...)` values remain preserved exactly
+as ordinary response headers; helper parse errors do not remove existing
+headers.
+
+These helpers are metadata-only. RTTP does not perform language negotiation,
+route selection, locale fallback, variant selection, cache policy, retry,
+replay, redirect, or status-policy behavior from `Content-Language`.
+
 ### Bounded HTTP/1.1 Vary behavior
 
 Server-side `Vary` helpers expose response declaration and request-selection
@@ -775,6 +800,7 @@ TLS or async accept loops.
 | Cache-Control | `Request::cache_control`, `HttpRequest::cache_control`, and `HttpResponse::cache_control` parse bounded request/response directives, numeric freshness fields, quoted field-name lists, and extension directives; `HttpResponse::with_age`/`age`, `with_expires`/`expires`, and `with_retry_after_delta`/`with_retry_after_date`/`retry_after` declare and parse response `Age`, `Expires`, and `Retry-After` metadata | No cache storage, automatic revalidation, wall-clock freshness calculation, `Vary` matching, shared-cache policy enforcement, automatic conditional requests, directive-based validator evaluation, automatic sleep, retry, replay, backoff, scheduler integration, or status-code policy engine |
 | Vary | `HttpVary`, `HttpResponse::with_vary`, `HttpResponse::vary`, `Request::vary_selection`, and `HttpRequest::vary_selection` parse, declare, and select bounded `Vary` metadata with case-insensitive field-name handling | No cache storage, stored-response matching engine, cache key persistence, automatic request replay, shared-cache policy enforcement, or automatic conditional requests |
 | Allow | `HttpAllowedMethods`, `HttpResponse::with_allow`, and `HttpResponse::allow` declare and parse bounded `Allow` method-list metadata | No route dispatch, automatic `405` generation, `OPTIONS` policy, fallback method selection, retry/replay, or status-code policy engine |
+| Content-Language | `HttpContentLanguages`, `HttpResponse::with_content_language`, and `HttpResponse::content_language` declare and parse bounded `Content-Language` response metadata | No language negotiation, route selection, locale fallback, variant selection, cache policy, retry/replay, redirect, or status-policy behavior |
 | Upgrade and tunnel targets | `CONNECT` authority-form requests are accepted as HTTP requests; `HttpResponse::upgrade` can hand an upgraded socket to caller code after a matching request | The server does not implement the upgraded protocol after handoff |
 | Trailers | Chunked request trailers are preserved on `Request`; malformed, oversized, forbidden, and pseudo-header trailers are rejected; response trailers can be serialized for chunked responses | Application metadata trailers are allowed; trailer names that affect connection state, routing, authentication/cookies, framing, or payload processing are rejected |
 | Bounded h2c server | The same `socket2` listener detects the HTTP/2 prior-knowledge preface or a valid HTTP/1.1 `Upgrade: h2c` request with `HTTP2-Settings`, validates SETTINGS including legal `SETTINGS_ENABLE_PUSH` and `SETTINGS_ENABLE_CONNECT_PROTOCOL` values of only `0` or `1` and legal `SETTINGS_MAX_FRAME_SIZE` values from 16,384 through 16,777,215 bytes, dispatches RFC 8441 extended CONNECT only after `SETTINGS_ENABLE_CONNECT_PROTOCOL = 1` has been negotiated, exposes negotiated extended CONNECT as a normal `Request` with method `CONNECT`, version `HTTP/2`, target from `:path`, `host` from `:authority`, and `Request::extended_connect_protocol()` from `:protocol`, advertises the default 16,384-byte `SETTINGS_MAX_FRAME_SIZE`, rejects inbound frames above the active local limit, splits outbound HEADERS, DATA, and trailers to the active peer frame-size limit, advertises `SETTINGS_MAX_CONCURRENT_STREAMS` from the bounded active stream allowance, enforces that allowance before dispatching new streams, advertises and enforces a conservative `SETTINGS_MAX_HEADER_LIST_SIZE` for inbound request metadata, bounds HPACK dynamic table use with `SETTINGS_HEADER_TABLE_SIZE`, serves bounded streams including bodyless DELETE, OPTIONS, TRACE, and negotiated extended CONNECT, handles HEAD without response DATA, rejects connection-specific request fields before handler dispatch, strips connection-specific response fields during h2c serialization, treats `RST_STREAM` as a bounded reset/cancellation signal for the affected stream, acknowledges valid PING frames with matching opaque data, accepts padded HEADERS/DATA/trailers without exposing padding, handles HPACK Huffman fields and bounded CONTINUATION header blocks, emits `GOAWAY` with the last completed stream id at bounded shutdown, validates and ignores valid PRIORITY metadata, ignores HTTP/2-allowed unknown/extension frames inside this bounded path, normalizes reserved stream-id high bits, and applies conservative DATA flow control | Ordinary `CONNECT`, missing-negotiation `:protocol`, non-CONNECT `:protocol`, malformed h2c Upgrade, request bodies on h2c Upgrade, and `PUSH_PROMISE` are rejected deterministically before handler dispatch; HTTP/1.1 `CONNECT` and non-h2c `Upgrade` remain separate handoff paths; bounded h2c only, with no public cancellation callback API, no dynamic policy API, no extension callback API, no full extension negotiation, TLS ALPN, external h2 integration, full WebSocket-over-h2, proxy h2, tunnel handoff, connection pooling, persistent multiplex sessions, persistent HTTP/2 session management, automatic retry, server push, full RFC 8441 support, full stream state machine, unbounded multiplexing, unbounded multiplex scheduling, general multiplexing, general tunnel scheduling, priority scheduling, or full HTTP/2 server feature set |

--- a/rttp/README.md
+++ b/rttp/README.md
@@ -244,6 +244,31 @@ These helpers are metadata-only. RTTP does not choose fallback methods, retry
 or replay requests, implement `OPTIONS` policy, generate `405` responses,
 dispatch routes, or provide a status-code policy engine from `Allow`.
 
+## Bounded HTTP/1.1 Content-Language behavior
+
+Server-side `Content-Language` helpers expose response metadata declaration and
+parsing without implementing language negotiation or representation selection.
+`HttpResponse::with_content_language(languages)` validates an explicit language
+tag list and adds one comma-separated `Content-Language` header, while
+`HttpResponse::content_language()` parses any `Content-Language` headers
+already attached to a response into `HttpContentLanguages`.
+`HttpContentLanguages::parse(value)` accepts comma-separated language tags and
+preserves the declared spelling and order.
+
+Parsing is bounded and validation-oriented. Each `Content-Language` field value
+is limited to 64 KiB, the parsed language list is limited to 32 entries, and
+each tag must contain non-empty ASCII alphanumeric subtags separated by hyphens
+with an alphabetic primary subtag. Empty members, malformed tags, duplicates
+across one or more helper-parsed header fields, oversized values, and too many
+tags return `HttpContentLanguageParseError` from the helper. Raw
+`HttpResponse::header("Content-Language", ...)` values remain preserved exactly
+as ordinary response headers; helper parse errors do not remove existing
+headers.
+
+These helpers are metadata-only. RTTP does not perform language negotiation,
+route selection, locale fallback, variant selection, cache policy, retry,
+replay, redirect, or status-policy behavior from `Content-Language`.
+
 ## Bounded trailer behavior
 
 HTTP/1.1 server trailer support remains chunked-scope only. Chunked request
@@ -441,6 +466,7 @@ scheduling, or async accept loops.
 | Cache-Control | `Request::cache_control`, `HttpRequest::cache_control`, and `HttpResponse::cache_control` parse bounded request/response directives, numeric freshness fields, quoted field-name lists, and extension directives; `HttpResponse::with_age`/`age`, `with_expires`/`expires`, and `with_retry_after_delta`/`with_retry_after_date`/`retry_after` declare and parse response `Age`, `Expires`, and `Retry-After` metadata | No cache storage, automatic revalidation, wall-clock freshness calculation, `Vary` matching, shared-cache policy enforcement, automatic conditional requests, directive-based validator evaluation, automatic sleep, retry, replay, backoff, scheduler integration, or status-code policy engine |
 | Vary | `HttpVary`, `HttpResponse::with_vary`, `HttpResponse::vary`, `Request::vary_selection`, and `HttpRequest::vary_selection` parse, declare, and select bounded `Vary` metadata with case-insensitive field-name handling | No cache storage, stored-response matching engine, cache key persistence, automatic request replay, shared-cache policy enforcement, or automatic conditional requests |
 | Allow | `HttpAllowedMethods`, `HttpResponse::with_allow`, and `HttpResponse::allow` declare and parse bounded `Allow` method-list metadata | No route dispatch, automatic `405` generation, `OPTIONS` policy, fallback method selection, retry/replay, or status-code policy engine |
+| Content-Language | `HttpContentLanguages`, `HttpResponse::with_content_language`, and `HttpResponse::content_language` declare and parse bounded `Content-Language` response metadata | No language negotiation, route selection, locale fallback, variant selection, cache policy, retry/replay, redirect, or status-policy behavior |
 | Upgrade and tunnel targets | `CONNECT` authority-form requests are accepted as HTTP requests; `HttpResponse::upgrade` can hand an upgraded socket to caller code after a matching request | The server does not implement the upgraded protocol after handoff |
 | Trailers | Chunked request trailers are preserved on `Request`; malformed, oversized, forbidden, and pseudo-header trailers are rejected; response trailers can be serialized for chunked responses | Application metadata trailers are allowed; trailer names that affect connection state, routing, authentication/cookies, framing, or payload processing are rejected |
 | Bounded h2c server | The same `socket2` listener detects the HTTP/2 prior-knowledge preface or a valid HTTP/1.1 `Upgrade: h2c` request with `HTTP2-Settings`, validates SETTINGS including legal `SETTINGS_ENABLE_PUSH` and `SETTINGS_ENABLE_CONNECT_PROTOCOL` values of only `0` or `1` and legal `SETTINGS_MAX_FRAME_SIZE` values from 16,384 through 16,777,215 bytes, dispatches RFC 8441 extended CONNECT only after `SETTINGS_ENABLE_CONNECT_PROTOCOL = 1` has been negotiated, exposes negotiated extended CONNECT as a normal `Request` with method `CONNECT`, version `HTTP/2`, target from `:path`, `host` from `:authority`, and `Request::extended_connect_protocol()` from `:protocol`, advertises the default 16,384-byte `SETTINGS_MAX_FRAME_SIZE`, rejects inbound frames above the active local limit, splits outbound HEADERS, DATA, and trailers to the active peer frame-size limit, advertises `SETTINGS_MAX_CONCURRENT_STREAMS` from the bounded active stream allowance, enforces that allowance before dispatching new streams, advertises and enforces a conservative `SETTINGS_MAX_HEADER_LIST_SIZE` for inbound request metadata, bounds HPACK dynamic table use with `SETTINGS_HEADER_TABLE_SIZE`, serves bounded streams including bodyless DELETE, OPTIONS, TRACE, and negotiated extended CONNECT, handles HEAD without response DATA, rejects connection-specific request fields before handler dispatch, strips connection-specific response fields during h2c serialization, treats `RST_STREAM` as a bounded reset/cancellation signal for the affected stream, acknowledges valid PING frames with matching opaque data, accepts padded HEADERS/DATA/trailers without exposing padding, handles HPACK Huffman fields and bounded CONTINUATION header blocks, emits `GOAWAY` with the last completed stream id at bounded shutdown, validates and ignores valid PRIORITY metadata, ignores HTTP/2-allowed unknown/extension frames inside this bounded path, normalizes reserved stream-id high bits, and applies conservative DATA flow control | Ordinary `CONNECT`, missing-negotiation `:protocol`, non-CONNECT `:protocol`, malformed h2c Upgrade, request bodies on h2c Upgrade, and `PUSH_PROMISE` are rejected deterministically before handler dispatch; HTTP/1.1 `CONNECT` and non-h2c `Upgrade` remain separate handoff paths; bounded h2c only, with no public cancellation callback API, no dynamic policy API, no extension callback API, no full extension negotiation, TLS ALPN, external h2 integration, full WebSocket-over-h2, proxy h2, tunnel handoff, connection pooling, persistent multiplex sessions, persistent HTTP/2 session management, automatic retry, server push, full RFC 8441 support, full stream state machine, unbounded multiplexing, unbounded multiplex scheduling, general multiplexing, general tunnel scheduling, priority scheduling, or full HTTP/2 server feature set |

--- a/rttp/src/server.rs
+++ b/rttp/src/server.rs
@@ -15,6 +15,8 @@ const MAX_VARY_VALUE_BYTES: usize = 64 * 1024;
 const MAX_VARY_FIELDS: usize = 256;
 const MAX_ALLOW_VALUE_BYTES: usize = 64 * 1024;
 const MAX_ALLOW_METHODS: usize = 32;
+const MAX_CONTENT_LANGUAGE_VALUE_BYTES: usize = 64 * 1024;
+const MAX_CONTENT_LANGUAGES: usize = 32;
 const MAX_RETRY_AFTER_VALUE_BYTES: usize = 64 * 1024;
 const HTTP2_CLIENT_PREFACE: &[u8; 24] = b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n";
 const HTTP2_FRAME_DATA: u8 = 0x0;
@@ -4536,6 +4538,22 @@ impl HttpResponse {
     Ok(self)
   }
 
+  pub fn with_content_language<I, L>(
+    mut self,
+    languages: I,
+  ) -> Result<Self, HttpContentLanguageParseError>
+  where
+    I: IntoIterator<Item = L>,
+    L: AsRef<str>,
+  {
+    let content_languages = HttpContentLanguages::from_languages(languages)?;
+    self.headers.push(HttpHeader::new(
+      "Content-Language",
+      content_languages.header_value(),
+    ));
+    Ok(self)
+  }
+
   pub fn with_age(mut self, delta_seconds: u64) -> Self {
     self
       .headers
@@ -4617,6 +4635,21 @@ impl HttpResponse {
       return Ok(None);
     }
     HttpAllowedMethods::parse_values(values).map(Some)
+  }
+
+  pub fn content_language(
+    &self,
+  ) -> Result<Option<HttpContentLanguages>, HttpContentLanguageParseError> {
+    let values: Vec<&str> = self
+      .headers
+      .iter()
+      .filter(|header| header.name.eq_ignore_ascii_case("Content-Language"))
+      .map(|header| header.value.as_str())
+      .collect();
+    if values.is_empty() {
+      return Ok(None);
+    }
+    HttpContentLanguages::parse_values(values).map(Some)
   }
 
   pub fn age(&self) -> Result<Option<u64>, HttpAgeParseError> {
@@ -5276,6 +5309,134 @@ impl fmt::Display for HttpAllowParseError {
 }
 
 impl Error for HttpAllowParseError {}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct HttpContentLanguages {
+  languages: Vec<String>,
+}
+
+impl HttpContentLanguages {
+  pub fn parse(value: impl AsRef<str>) -> Result<Self, HttpContentLanguageParseError> {
+    Self::parse_values([value.as_ref()])
+  }
+
+  pub fn parse_values<'a, I>(values: I) -> Result<Self, HttpContentLanguageParseError>
+  where
+    I: IntoIterator<Item = &'a str>,
+  {
+    let mut languages = Vec::new();
+
+    for value in values {
+      if value.len() > MAX_CONTENT_LANGUAGE_VALUE_BYTES {
+        return Err(HttpContentLanguageParseError::new(
+          "Content-Language header value is too large",
+        ));
+      }
+
+      for language in value.split(',') {
+        let language = language.trim();
+        if !is_valid_content_language_tag(language) {
+          return Err(HttpContentLanguageParseError::new(
+            "invalid Content-Language tag",
+          ));
+        }
+        if languages
+          .iter()
+          .any(|known: &String| known.eq_ignore_ascii_case(language))
+        {
+          return Err(HttpContentLanguageParseError::new(
+            "duplicate Content-Language tag",
+          ));
+        }
+        if languages.len() >= MAX_CONTENT_LANGUAGES {
+          return Err(HttpContentLanguageParseError::new(
+            "too many Content-Language tags",
+          ));
+        }
+        languages.push(language.to_string());
+      }
+    }
+
+    if languages.is_empty() {
+      return Err(HttpContentLanguageParseError::new(
+        "invalid Content-Language tag",
+      ));
+    }
+
+    Ok(Self { languages })
+  }
+
+  pub fn from_languages<I, L>(languages: I) -> Result<Self, HttpContentLanguageParseError>
+  where
+    I: IntoIterator<Item = L>,
+    L: AsRef<str>,
+  {
+    let mut value = String::new();
+
+    for (index, language) in languages.into_iter().enumerate() {
+      if index > 0 {
+        value.push_str(", ");
+      }
+      value.push_str(language.as_ref());
+      if value.len() > MAX_CONTENT_LANGUAGE_VALUE_BYTES {
+        return Err(HttpContentLanguageParseError::new(
+          "Content-Language header value is too large",
+        ));
+      }
+    }
+
+    Self::parse(value)
+  }
+
+  pub fn languages(&self) -> Vec<&str> {
+    self.languages.iter().map(String::as_str).collect()
+  }
+
+  pub fn header_value(&self) -> String {
+    self.languages.join(", ")
+  }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct HttpContentLanguageParseError {
+  message: String,
+}
+
+impl HttpContentLanguageParseError {
+  fn new<S: AsRef<str>>(message: S) -> Self {
+    Self {
+      message: message.as_ref().to_string(),
+    }
+  }
+}
+
+impl fmt::Display for HttpContentLanguageParseError {
+  fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+    formatter.write_str(&self.message)
+  }
+}
+
+impl Error for HttpContentLanguageParseError {}
+
+fn is_valid_content_language_tag(value: &str) -> bool {
+  let mut subtags = value.split('-');
+  let Some(primary) = subtags.next() else {
+    return false;
+  };
+
+  if primary.is_empty()
+    || primary.len() > 8
+    || !primary.bytes().all(|byte| byte.is_ascii_alphabetic())
+  {
+    return false;
+  }
+
+  subtags.all(|subtag| {
+    !subtag.is_empty()
+      && subtag.len() <= 8
+      && subtag.bytes().all(|byte| byte.is_ascii_alphanumeric())
+  })
+}
 
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct HttpRequestCacheControl {

--- a/rttp/tests/http11_compliance_matrix.rs
+++ b/rttp/tests/http11_compliance_matrix.rs
@@ -5,8 +5,8 @@ use std::thread;
 use std::time::{Duration, UNIX_EPOCH};
 
 use rttp::server::{
-  HttpAllowedMethods, HttpRequest, HttpRequestCacheControl, HttpResponse, HttpResponseCacheControl,
-  HttpRetryAfter, HttpVary,
+  HttpAllowedMethods, HttpContentLanguages, HttpRequest, HttpRequestCacheControl, HttpResponse,
+  HttpResponseCacheControl, HttpRetryAfter, HttpVary,
 };
 use rttp_http11_test_fixtures as fixtures;
 
@@ -69,6 +69,14 @@ fn allow_response(values: &[&str]) -> HttpResponse {
     HttpResponse::new(405, "Method Not Allowed"),
     |response, value| response.header("Allow", value),
   )
+}
+
+fn content_language_response(values: &[&str]) -> HttpResponse {
+  values
+    .iter()
+    .fold(HttpResponse::new(200, "OK"), |response, value| {
+      response.header("Content-Language", value)
+    })
 }
 
 fn age_expires_response(age: u64, expires: std::time::SystemTime) -> HttpResponse {
@@ -660,6 +668,91 @@ fn server_allow_helper_rejects_duplicate_methods_and_enforces_shared_bounds() {
   assert!(
     allow_response(&[&oversized_value]).allow().is_err(),
     "oversized response Allow value should be rejected"
+  );
+}
+
+#[test]
+fn server_response_with_content_language_declares_single_bounded_header() {
+  let response = HttpResponse::ok("OK")
+    .with_content_language(["en", "fr-CA", "es-419"])
+    .expect("Content-Language declaration should parse");
+  let serialized = String::from_utf8(response.to_bytes()).expect("response is UTF-8");
+
+  assert_eq!(
+    Some("en, fr-CA, es-419"),
+    header_value(&serialized, "Content-Language")
+  );
+  assert_eq!(
+    &["en", "fr-CA", "es-419"],
+    response
+      .content_language()
+      .expect("Content-Language should parse")
+      .expect("Content-Language should be present")
+      .languages()
+      .as_slice()
+  );
+}
+
+#[test]
+fn server_content_language_helper_parses_multiple_fields_and_enforces_bounds() {
+  let response = content_language_response(&["en, fr-CA", "es-419"]);
+  let languages = response
+    .content_language()
+    .expect("Content-Language should parse")
+    .expect("Content-Language should be present");
+
+  assert_eq!(vec!["en", "fr-CA", "es-419"], languages.languages());
+
+  for value in ["", "en,", "en_US", "en; q=1", "en, fr, EN"] {
+    assert!(
+      HttpContentLanguages::parse(value).is_err(),
+      "Content-Language helper should reject invalid value {value:?}"
+    );
+    assert!(
+      HttpResponse::ok("OK")
+        .with_content_language([value])
+        .is_err(),
+      "response helper should reject invalid Content-Language value {value:?}"
+    );
+    assert!(
+      content_language_response(&[value])
+        .content_language()
+        .is_err(),
+      "response parser should reject invalid Content-Language value {value:?}"
+    );
+  }
+
+  let too_many_languages = (0..33)
+    .map(|index| format!("x-{index}"))
+    .collect::<Vec<_>>()
+    .join(", ");
+  assert!(
+    HttpContentLanguages::parse(&too_many_languages).is_err(),
+    "too many Content-Language tags should be rejected"
+  );
+
+  let oversized_value = "en".repeat(64 * 1024);
+  assert!(
+    HttpContentLanguages::parse(&oversized_value).is_err(),
+    "oversized Content-Language value should be rejected"
+  );
+}
+
+#[test]
+fn server_content_language_helpers_stay_metadata_only() {
+  let response = HttpResponse::new(302, "Found")
+    .with_content_language(["fr-CA"])
+    .expect("Content-Language declaration should parse")
+    .header("Location", "/fallback")
+    .header("Cache-Control", "no-store");
+  let serialized = String::from_utf8(response.to_bytes()).expect("response is UTF-8");
+
+  assert_eq!(Some("fr-CA"), header_value(&serialized, "Content-Language"));
+  assert_eq!(Some("/fallback"), header_value(&serialized, "Location"));
+  assert_eq!(Some("no-store"), header_value(&serialized, "Cache-Control"));
+  assert!(
+    serialized.starts_with("HTTP/1.1 302 Found\r\n"),
+    "Content-Language should not alter response status policy"
   );
 }
 

--- a/rttp/tests/test_server_models.rs
+++ b/rttp/tests/test_server_models.rs
@@ -1,9 +1,9 @@
 use std::time::{Duration, UNIX_EPOCH};
 
 use rttp::server::{
-  HttpAllowedMethods, HttpByteRange, HttpByteRangeError, HttpConditionalMetadata, HttpEntityTag,
-  HttpIfRangeRequestOutcome, HttpRequest, HttpRequestCacheControl, HttpResponse,
-  HttpResponseCacheControl, HttpRetryAfter, HttpVary,
+  HttpAllowedMethods, HttpByteRange, HttpByteRangeError, HttpConditionalMetadata,
+  HttpContentLanguages, HttpEntityTag, HttpIfRangeRequestOutcome, HttpRequest,
+  HttpRequestCacheControl, HttpResponse, HttpResponseCacheControl, HttpRetryAfter, HttpVary,
 };
 
 fn parse_request(raw: &str) -> HttpRequest {
@@ -244,6 +244,99 @@ fn raw_allow_headers_are_preserved_without_helper_validation() {
   assert!(
     response.allow().is_err(),
     "typed Allow parser should reject malformed raw values"
+  );
+}
+
+#[test]
+fn parses_content_languages_and_serializes_single_header_value() {
+  let languages = HttpContentLanguages::parse("en, fr-CA, x-private")
+    .expect("valid Content-Language header should parse");
+
+  assert_eq!(vec!["en", "fr-CA", "x-private"], languages.languages());
+  assert_eq!("en, fr-CA, x-private", languages.header_value());
+
+  let response = HttpResponse::ok("body")
+    .with_content_language(["en", "fr-CA", "x-private"])
+    .expect("valid Content-Language values should be accepted");
+  let serialized = String::from_utf8(response.to_bytes()).expect("response is UTF-8");
+
+  assert!(serialized.contains("\r\nContent-Language: en, fr-CA, x-private\r\n"));
+  assert_eq!(
+    Some(languages),
+    response
+      .content_language()
+      .expect("Content-Language header should parse")
+  );
+}
+
+#[test]
+fn response_content_language_helper_parses_attached_header_fields() {
+  let response = HttpResponse::ok("body")
+    .header("Content-Language", "en, fr-CA")
+    .header("Content-Language", "es-419");
+
+  let languages = response
+    .content_language()
+    .expect("Content-Language header should parse")
+    .expect("Content-Language header should be present");
+
+  assert_eq!(vec!["en", "fr-CA", "es-419"], languages.languages());
+}
+
+#[test]
+fn content_language_helpers_reject_malformed_duplicate_oversized_and_excessive_values() {
+  for value in [
+    "",
+    " ",
+    "en,",
+    ", en",
+    "en,,fr",
+    "en us",
+    "en_US",
+    "en; q=1",
+    "en, fr, en",
+    "-en",
+    "en-",
+    "en--US",
+  ] {
+    assert!(
+      HttpContentLanguages::parse(value).is_err(),
+      "Content-Language helper should reject {value:?}"
+    );
+  }
+
+  let oversized = "en".repeat(64 * 1024);
+  assert!(
+    HttpContentLanguages::parse(&oversized).is_err(),
+    "Content-Language helper should reject oversized values"
+  );
+
+  let too_many = (0..33)
+    .map(|index| format!("x-{index}"))
+    .collect::<Vec<_>>()
+    .join(", ");
+  assert!(
+    HttpContentLanguages::parse(too_many).is_err(),
+    "Content-Language helper should reject too many language tags"
+  );
+
+  assert!(
+    HttpResponse::ok("body")
+      .with_content_language(["en", "en"])
+      .is_err(),
+    "response Content-Language helper should reject duplicate language tags"
+  );
+}
+
+#[test]
+fn raw_content_language_headers_are_preserved_without_helper_validation() {
+  let response = HttpResponse::ok("body").header("Content-Language", "en,,fr");
+  let serialized = String::from_utf8(response.to_bytes()).expect("response is UTF-8");
+
+  assert!(serialized.contains("\r\nContent-Language: en,,fr\r\n"));
+  assert!(
+    response.content_language().is_err(),
+    "typed Content-Language parser should reject malformed raw values"
   );
 }
 


### PR DESCRIPTION
Bounded HTTP/1.1 `Content-Language` response metadata helpers were added to RTTP with typed parse/serialize APIs, documentation, and passing package/workspace validation.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1599/
work_kind: code_work
branch: hbx-1599-rttp-add-bounded-http-1
base: main
commit: d33bc44760d10c61664b6657294472cb296e5dff
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1599/
    url: https://plane.kahub.in/endless/browse/HBX-1599/
    close_policy: link_only
```