### PR TITLE
feat: [rttp] Add cross-crate HTTP/1.1 Content-Language matrix

### DIFF
--- a/rttp/tests/http11_compliance_matrix.rs
+++ b/rttp/tests/http11_compliance_matrix.rs
@@ -226,6 +226,18 @@ fn assert_response_allow(
   assert_eq!(expected.methods, allow.methods().as_slice(), "{name}");
 }
 
+fn assert_response_content_language(
+  name: &str,
+  content_language: &HttpContentLanguages,
+  expected: &fixtures::content_language::ResponseCase,
+) {
+  assert_eq!(
+    expected.languages,
+    content_language.languages().as_slice(),
+    "{name}"
+  );
+}
+
 #[test]
 fn model_parser_accepts_shared_fixed_length_request_fixture() {
   let fixture = fixtures::request::fixed_length_post();
@@ -320,6 +332,19 @@ fn server_response_helper_accepts_shared_vary_response_matrix() {
       .unwrap_or_else(|| panic!("{} should include Vary", case.name));
 
     assert_response_vary(case.name, &vary, case);
+  }
+}
+
+#[test]
+fn server_response_helper_accepts_shared_content_language_response_matrix() {
+  for case in fixtures::content_language::response_cases() {
+    let response = content_language_response(case.values);
+    let content_language = response
+      .content_language()
+      .unwrap_or_else(|err| panic!("{} Content-Language should parse: {err}", case.name))
+      .unwrap_or_else(|| panic!("{} should include Content-Language", case.name));
+
+    assert_response_content_language(case.name, &content_language, case);
   }
 }
 
@@ -673,68 +698,78 @@ fn server_allow_helper_rejects_duplicate_methods_and_enforces_shared_bounds() {
 
 #[test]
 fn server_response_with_content_language_declares_single_bounded_header() {
-  let response = HttpResponse::ok("OK")
-    .with_content_language(["en", "fr-CA", "es-419"])
-    .expect("Content-Language declaration should parse");
-  let serialized = String::from_utf8(response.to_bytes()).expect("response is UTF-8");
+  for case in fixtures::content_language::response_cases() {
+    let response = HttpResponse::ok("OK")
+      .with_content_language(case.languages.iter().copied())
+      .unwrap_or_else(|err| {
+        panic!(
+          "{} Content-Language declaration should parse: {err}",
+          case.name
+        )
+      });
+    let serialized = String::from_utf8(response.to_bytes()).expect("response is UTF-8");
 
-  assert_eq!(
-    Some("en, fr-CA, es-419"),
-    header_value(&serialized, "Content-Language")
-  );
-  assert_eq!(
-    &["en", "fr-CA", "es-419"],
-    response
-      .content_language()
-      .expect("Content-Language should parse")
-      .expect("Content-Language should be present")
-      .languages()
-      .as_slice()
-  );
+    assert_eq!(
+      Some(case.languages.join(", ").as_str()),
+      header_value(&serialized, "Content-Language"),
+      "{}",
+      case.name
+    );
+    assert_response_content_language(
+      case.name,
+      &response
+        .content_language()
+        .expect("Content-Language should parse")
+        .expect("Content-Language should be present"),
+      case,
+    );
+  }
 }
 
 #[test]
 fn server_content_language_helper_parses_multiple_fields_and_enforces_bounds() {
-  let response = content_language_response(&["en, fr-CA", "es-419"]);
-  let languages = response
-    .content_language()
-    .expect("Content-Language should parse")
-    .expect("Content-Language should be present");
-
-  assert_eq!(vec!["en", "fr-CA", "es-419"], languages.languages());
-
-  for value in ["", "en,", "en_US", "en; q=1", "en, fr, EN"] {
+  for case in fixtures::content_language::invalid_cases() {
     assert!(
-      HttpContentLanguages::parse(value).is_err(),
-      "Content-Language helper should reject invalid value {value:?}"
+      HttpContentLanguages::parse(case.value).is_err(),
+      "{} Content-Language helper should reject invalid value",
+      case.name
     );
     assert!(
       HttpResponse::ok("OK")
-        .with_content_language([value])
+        .with_content_language([case.value])
         .is_err(),
-      "response helper should reject invalid Content-Language value {value:?}"
+      "{} response helper should reject invalid Content-Language value",
+      case.name
     );
     assert!(
-      content_language_response(&[value])
+      content_language_response(&[case.value])
         .content_language()
         .is_err(),
-      "response parser should reject invalid Content-Language value {value:?}"
+      "{} response parser should reject invalid Content-Language value",
+      case.name
     );
   }
 
-  let too_many_languages = (0..33)
-    .map(|index| format!("x-{index}"))
-    .collect::<Vec<_>>()
-    .join(", ");
+  let too_many_languages = fixtures::content_language::too_many_server_languages_value();
   assert!(
     HttpContentLanguages::parse(&too_many_languages).is_err(),
     "too many Content-Language tags should be rejected"
   );
 
-  let oversized_value = "en".repeat(64 * 1024);
+  let oversized_value = fixtures::content_language::oversized_value();
   assert!(
     HttpContentLanguages::parse(&oversized_value).is_err(),
     "oversized Content-Language value should be rejected"
+  );
+}
+
+#[test]
+fn server_content_language_helper_rejects_duplicate_tags_across_fields() {
+  let response = content_language_response(&["en-US, fr", "EN-us"]);
+
+  assert!(
+    response.content_language().is_err(),
+    "duplicate Content-Language tags across header fields should be rejected"
   );
 }
 
@@ -753,6 +788,77 @@ fn server_content_language_helpers_stay_metadata_only() {
   assert!(
     serialized.starts_with("HTTP/1.1 302 Found\r\n"),
     "Content-Language should not alter response status policy"
+  );
+}
+
+#[test]
+fn server_content_language_helpers_coexist_with_adjacent_metadata_helpers() {
+  let response = HttpResponse::new(405, "Method Not Allowed")
+    .with_content_language(["fr-CA", "es-419"])
+    .expect("Content-Language declaration should parse")
+    .with_allow(["GET", "HEAD"])
+    .expect("Allow declaration should parse")
+    .with_retry_after_delta(30)
+    .with_age(5)
+    .with_expires(UNIX_EPOCH + Duration::from_secs(fixtures::age_expires::EXPIRES_UNIX_SECONDS))
+    .header("Cache-Control", "public, max-age=60")
+    .with_vary("Accept-Encoding")
+    .expect("Vary declaration should parse");
+  let serialized = String::from_utf8(response.to_bytes()).expect("response is UTF-8");
+
+  assert_eq!(
+    Some("fr-CA, es-419"),
+    header_value(&serialized, "Content-Language")
+  );
+  assert_eq!(Some("GET, HEAD"), header_value(&serialized, "Allow"));
+  assert_eq!(
+    Some("public, max-age=60"),
+    header_value(&serialized, "Cache-Control")
+  );
+  assert_eq!(Some("5"), header_value(&serialized, "Age"));
+  assert_eq!(
+    Some(fixtures::age_expires::EXPIRES_IMF_FIXDATE),
+    header_value(&serialized, "Expires")
+  );
+  assert_eq!(Some("accept-encoding"), header_value(&serialized, "Vary"));
+  assert_eq!(Some("30"), header_value(&serialized, "Retry-After"));
+  assert_eq!(
+    &["fr-CA", "es-419"],
+    response
+      .content_language()
+      .expect("Content-Language should parse")
+      .expect("Content-Language should be present")
+      .languages()
+      .as_slice()
+  );
+  assert!(response
+    .allow()
+    .expect("Allow should parse")
+    .expect("Allow should be present")
+    .methods()
+    .contains(&"GET"));
+  assert_eq!(
+    Some(60),
+    response
+      .cache_control()
+      .expect("Cache-Control should parse")
+      .expect("Cache-Control should be present")
+      .max_age()
+  );
+  assert_eq!(Some(5), response.age().expect("Age should parse"));
+  assert_eq!(
+    Some(UNIX_EPOCH + Duration::from_secs(fixtures::age_expires::EXPIRES_UNIX_SECONDS)),
+    response.expires().expect("Expires should parse")
+  );
+  assert!(response
+    .vary()
+    .expect("Vary should parse")
+    .expect("Vary should be present")
+    .field_names()
+    .contains(&"accept-encoding"));
+  assert_eq!(
+    Some(HttpRetryAfter::DeltaSeconds(30)),
+    response.retry_after().expect("Retry-After should parse")
   );
 }
 

--- a/rttp_client/tests/http11_compliance_matrix.rs
+++ b/rttp_client/tests/http11_compliance_matrix.rs
@@ -50,6 +50,25 @@ fn allow_response(values: &[&str]) -> Vec<u8> {
   response.into_bytes()
 }
 
+fn content_language_response(values: &[&str], include_adjacent_metadata: bool) -> Vec<u8> {
+  let mut response = String::from("HTTP/1.1 200 OK\r\n");
+  for value in values {
+    response.push_str("Content-Language: ");
+    response.push_str(value);
+    response.push_str("\r\n");
+  }
+  if include_adjacent_metadata {
+    response.push_str("Cache-Control: public, max-age=60\r\n");
+    response.push_str("Age: 5\r\n");
+    response.push_str("Expires: Sun, 06 Nov 1994 08:49:37 GMT\r\n");
+    response.push_str("Vary: Accept-Encoding\r\n");
+    response.push_str("Retry-After: 30\r\n");
+    response.push_str("Allow: GET, HEAD\r\n");
+  }
+  response.push_str("Content-Length: 2\r\n\r\nOK");
+  response.into_bytes()
+}
+
 fn allow_response_with_cache_metadata(values: &[&str]) -> Vec<u8> {
   let mut response = String::from("HTTP/1.1 405 Method Not Allowed\r\n");
   for value in values {
@@ -442,6 +461,30 @@ fn assert_response_allow(
   }
 }
 
+fn assert_response_content_language(
+  name: &str,
+  response: &rttp_client::response::Response,
+  expected: &fixtures::content_language::ResponseCase,
+) {
+  let raw_values: Vec<&str> = response
+    .header_values("content-language")
+    .into_iter()
+    .map(String::as_str)
+    .collect();
+  assert_eq!(expected.values, raw_values.as_slice(), "{name}");
+
+  let content_language = response
+    .content_language()
+    .unwrap_or_else(|err| panic!("{name} Content-Language should parse: {err}"))
+    .unwrap_or_else(|| panic!("{name} should include Content-Language"));
+
+  assert_eq!(
+    expected.languages,
+    content_language.tags().as_slice(),
+    "{name}"
+  );
+}
+
 fn assert_cache_control_helper_rejects_but_preserves_response(name: &str, raw_response: Vec<u8>) {
   let (addr, handle) = fixtures::spawn_socket2_owned_raw_response_server(raw_response);
 
@@ -550,6 +593,28 @@ fn assert_allow_helper_rejects_but_preserves_response(name: &str, raw_response: 
   handle.join().expect("raw response server thread");
 }
 
+fn assert_content_language_helper_rejects_but_preserves_response(
+  name: &str,
+  raw_response: Vec<u8>,
+  expected_body: &str,
+) {
+  let (addr, handle) = fixtures::spawn_socket2_owned_raw_response_server(raw_response);
+
+  let response = client()
+    .get()
+    .url(format!("http://{}/matrix/content-language-invalid", addr))
+    .emit()
+    .unwrap_or_else(|err| panic!("{name} response should remain parseable: {err}"));
+
+  assert!(
+    response.content_language().is_err(),
+    "{name} helper should reject invalid Content-Language"
+  );
+  assert_eq!(expected_body, response.body().string().unwrap(), "{name}");
+
+  handle.join().expect("raw response server thread");
+}
+
 enum ConditionalHeader {
   IfNoneMatch(&'static str),
   IfMatch(&'static str),
@@ -571,6 +636,24 @@ fn sync_client_parses_shared_allow_response_matrix() {
       .unwrap_or_else(|err| panic!("{} response should parse: {err}", case.name));
 
     assert_response_allow(case.name, response, case);
+    handle.join().expect("raw response server thread");
+  }
+}
+
+#[test]
+fn sync_client_parses_shared_content_language_response_matrix() {
+  for case in fixtures::content_language::response_cases() {
+    let raw_response = content_language_response(case.values, false);
+    let (addr, handle) = fixtures::spawn_socket2_owned_raw_response_server(raw_response);
+
+    let response = client()
+      .get()
+      .url(format!("http://{}/matrix/content-language", addr))
+      .emit()
+      .unwrap_or_else(|err| panic!("{} response should parse: {err}", case.name));
+
+    assert_response_content_language(case.name, &response, case);
+    assert_eq!("OK", response.body().string().unwrap(), "{}", case.name);
     handle.join().expect("raw response server thread");
   }
 }
@@ -886,6 +969,69 @@ fn sync_client_parses_retry_after_with_existing_cache_metadata_helpers() {
 }
 
 #[test]
+fn sync_client_parses_content_language_with_existing_metadata_helpers() {
+  for case in fixtures::content_language::response_cases() {
+    let raw_response = content_language_response(case.values, true);
+    let (addr, handle) = fixtures::spawn_socket2_owned_raw_response_server(raw_response);
+
+    let response = client()
+      .get()
+      .url(format!("http://{}/matrix/content-language-adjacent", addr))
+      .emit()
+      .unwrap_or_else(|err| panic!("{} response should parse: {err}", case.name));
+
+    assert_response_content_language(case.name, &response, case);
+    assert_eq!(
+      Some(60),
+      response
+        .cache_control()
+        .expect("Cache-Control should parse")
+        .expect("Cache-Control should be present")
+        .max_age(),
+      "{}",
+      case.name
+    );
+    assert_eq!(Some(5), response.age().expect("Age should parse"));
+    assert_eq!(
+      Some(UNIX_EPOCH + Duration::from_secs(fixtures::age_expires::EXPIRES_UNIX_SECONDS)),
+      response.expires().expect("Expires should parse"),
+      "{}",
+      case.name
+    );
+    assert!(
+      response
+        .vary()
+        .expect("Vary should parse")
+        .expect("Vary should be present")
+        .contains_field_name("accept-encoding"),
+      "{}",
+      case.name
+    );
+    assert_eq!(
+      Some(30),
+      response
+        .retry_after()
+        .expect("Retry-After should parse")
+        .expect("Retry-After should be present")
+        .delta_seconds(),
+      "{}",
+      case.name
+    );
+    assert!(
+      response
+        .allow()
+        .expect("Allow should parse")
+        .expect("Allow should be present")
+        .contains_method("GET"),
+      "{}",
+      case.name
+    );
+    assert_eq!("OK", response.body().string().unwrap(), "{}", case.name);
+    handle.join().expect("raw response server thread");
+  }
+}
+
+#[test]
 fn sync_client_cache_control_helper_rejects_shared_invalid_response_matrix() {
   for case in fixtures::cache_control::invalid_response_cases() {
     assert_cache_control_helper_rejects_but_preserves_response(
@@ -926,6 +1072,17 @@ fn sync_client_age_and_expires_helpers_reject_shared_invalid_matrix() {
     assert_expires_helper_rejects_but_preserves_response(
       case.name,
       age_expires_response("0", case.value, false),
+    );
+  }
+}
+
+#[test]
+fn sync_client_content_language_helper_rejects_shared_invalid_response_matrix() {
+  for case in fixtures::content_language::invalid_cases() {
+    assert_content_language_helper_rejects_but_preserves_response(
+      case.name,
+      content_language_response(&[case.value], false),
+      "OK",
     );
   }
 }
@@ -977,6 +1134,28 @@ fn sync_client_allow_helper_rejects_duplicate_methods_and_enforces_shared_bounds
   assert_allow_helper_rejects_but_preserves_response(
     "oversized Allow value",
     allow_response(&[&fixtures::allow::oversized_value()]),
+  );
+}
+
+#[test]
+fn sync_client_content_language_helper_rejects_duplicates_and_enforces_client_bounds() {
+  assert_content_language_helper_rejects_but_preserves_response(
+    "duplicate Content-Language tags across header fields",
+    content_language_response(&["en-US, fr", "EN-us"], false),
+    "OK",
+  );
+  assert_content_language_helper_rejects_but_preserves_response(
+    "too many client Content-Language tags",
+    content_language_response(
+      &[&fixtures::content_language::too_many_client_languages_value()],
+      false,
+    ),
+    "OK",
+  );
+  assert_content_language_helper_rejects_but_preserves_response(
+    "oversized Content-Language value",
+    content_language_response(&[&fixtures::content_language::oversized_value()], false),
+    "OK",
   );
 }
 

--- a/rttp_http11_test_fixtures/src/lib.rs
+++ b/rttp_http11_test_fixtures/src/lib.rs
@@ -937,6 +937,132 @@ pub mod vary {
   }
 }
 
+pub mod content_language {
+  pub const MAX_VALUE_BYTES: usize = 64 * 1024;
+  pub const SERVER_MAX_LANGUAGES: usize = 32;
+  pub const CLIENT_MAX_LANGUAGES: usize = 256;
+
+  pub struct ResponseCase {
+    pub name: &'static str,
+    pub values: &'static [&'static str],
+    pub languages: &'static [&'static str],
+  }
+
+  pub struct InvalidCase {
+    pub name: &'static str,
+    pub value: &'static str,
+  }
+
+  const RESPONSE_CASES: &[ResponseCase] = &[
+    ResponseCase {
+      name: "single language tag",
+      values: &["en"],
+      languages: &["en"],
+    },
+    ResponseCase {
+      name: "language tags across header fields preserve order",
+      values: &["en-US, fr", "zh-Hant-TW, es-419"],
+      languages: &["en-US", "fr", "zh-Hant-TW", "es-419"],
+    },
+    ResponseCase {
+      name: "optional whitespace around commas",
+      values: &["en-US,\tfr-CA , es-419"],
+      languages: &["en-US", "fr-CA", "es-419"],
+    },
+    ResponseCase {
+      name: "private-use style tag preserves spelling",
+      values: &["x-private, i-klingon"],
+      languages: &["x-private", "i-klingon"],
+    },
+  ];
+
+  const INVALID_CASES: &[InvalidCase] = &[
+    InvalidCase {
+      name: "empty value",
+      value: "",
+    },
+    InvalidCase {
+      name: "blank value",
+      value: " ",
+    },
+    InvalidCase {
+      name: "trailing comma",
+      value: "en,",
+    },
+    InvalidCase {
+      name: "leading comma",
+      value: ", en",
+    },
+    InvalidCase {
+      name: "empty member",
+      value: "en,,fr",
+    },
+    InvalidCase {
+      name: "language with whitespace",
+      value: "en US",
+    },
+    InvalidCase {
+      name: "language with underscore",
+      value: "en_US",
+    },
+    InvalidCase {
+      name: "language with parameter",
+      value: "en; q=1",
+    },
+    InvalidCase {
+      name: "leading hyphen",
+      value: "-en",
+    },
+    InvalidCase {
+      name: "trailing hyphen",
+      value: "en-",
+    },
+    InvalidCase {
+      name: "empty subtag",
+      value: "en--US",
+    },
+    InvalidCase {
+      name: "primary subtag too long",
+      value: "englishlong",
+    },
+    InvalidCase {
+      name: "secondary subtag too long",
+      value: "en-toolongsubtag",
+    },
+    InvalidCase {
+      name: "invalid subtag character",
+      value: "en-@",
+    },
+  ];
+
+  pub fn response_cases() -> &'static [ResponseCase] {
+    RESPONSE_CASES
+  }
+
+  pub fn invalid_cases() -> &'static [InvalidCase] {
+    INVALID_CASES
+  }
+
+  pub fn too_many_server_languages_value() -> String {
+    too_many_languages_value(SERVER_MAX_LANGUAGES)
+  }
+
+  pub fn too_many_client_languages_value() -> String {
+    too_many_languages_value(CLIENT_MAX_LANGUAGES)
+  }
+
+  pub fn oversized_value() -> String {
+    format!("x-{}", "a".repeat(MAX_VALUE_BYTES))
+  }
+
+  fn too_many_languages_value(max_languages: usize) -> String {
+    (0..=max_languages)
+      .map(|index| format!("x-{index}"))
+      .collect::<Vec<_>>()
+      .join(", ")
+  }
+}
+
 pub fn bind_socket2_tcp_listener(name: &str) -> (TcpListener, SocketAddr) {
   let addr: SocketAddr = "127.0.0.1:0".parse().expect("parse local addr");
   let socket = Socket::new(Domain::IPV4, Type::STREAM, Some(Protocol::TCP))


### PR DESCRIPTION
Added shared HTTP/1.1 Content-Language fixtures and cross-crate client/server matrix coverage while preserving existing production behavior.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1600/
work_kind: code_work
branch: hbx-1600-rttp-add-cross-crate-http
base: main
commit: 88b3757387c93e9eb0a76f330e7d18d49ee1d6ad
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1600/
    url: https://plane.kahub.in/endless/browse/HBX-1600/
    close_policy: link_only
```