### PR TITLE
feat: [rttp_client] Add bounded HTTP/1.1 Accept-Ranges response helpers

### DIFF
--- a/rttp_client/src/response/response.rs
+++ b/rttp_client/src/response/response.rs
@@ -13,6 +13,8 @@ const MAX_CACHE_CONTROL_VALUE_BYTES: usize = 64 * 1024;
 const MAX_CACHE_CONTROL_DIRECTIVES: usize = 256;
 const MAX_ALLOW_VALUE_BYTES: usize = 64 * 1024;
 const MAX_ALLOW_METHODS: usize = 256;
+const MAX_ACCEPT_RANGES_VALUE_BYTES: usize = 64 * 1024;
+const MAX_ACCEPT_RANGE_UNITS: usize = 256;
 const MAX_RETRY_AFTER_VALUE_BYTES: usize = 64 * 1024;
 const MAX_CONTENT_LANGUAGE_VALUE_BYTES: usize = 64 * 1024;
 const MAX_CONTENT_LANGUAGE_TAGS: usize = 256;
@@ -140,6 +142,14 @@ impl Response {
       return Ok(None);
     }
     Allow::parse_values(values.into_iter().map(String::as_str)).map(Some)
+  }
+
+  pub fn accept_ranges(&self) -> error::Result<Option<AcceptRanges>> {
+    let values = self.header_values("accept-ranges");
+    if values.is_empty() {
+      return Ok(None);
+    }
+    AcceptRanges::parse_values(values.into_iter().map(String::as_str)).map(Some)
   }
 
   pub fn content_range(&self) -> Option<ContentRange> {
@@ -318,6 +328,72 @@ impl Allow {
       .methods
       .iter()
       .any(|candidate| candidate == method.as_ref())
+  }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AcceptRanges {
+  units: Vec<String>,
+}
+
+impl AcceptRanges {
+  pub fn parse(value: impl AsRef<str>) -> error::Result<Self> {
+    Self::parse_values([value.as_ref()])
+  }
+
+  fn parse_values<'a, I>(values: I) -> error::Result<Self>
+  where
+    I: IntoIterator<Item = &'a str>,
+  {
+    let mut units = Vec::new();
+    let mut seen = HashSet::new();
+
+    for value in values {
+      if value.len() > MAX_ACCEPT_RANGES_VALUE_BYTES {
+        return Err(error::bad_response(
+          "Accept-Ranges header value is too large",
+        ));
+      }
+
+      for unit in value.split(',') {
+        let unit = unit.trim();
+        if unit.is_empty() || !is_token(unit) {
+          return Err(error::bad_response("Invalid Accept-Ranges range-unit"));
+        }
+        if units.len() >= MAX_ACCEPT_RANGE_UNITS {
+          return Err(error::bad_response("Too many Accept-Ranges range-units"));
+        }
+
+        let normalized = unit.to_ascii_lowercase();
+        if !seen.insert(normalized.clone()) {
+          return Err(error::bad_response("Duplicate Accept-Ranges range-unit"));
+        }
+        units.push(normalized);
+      }
+    }
+
+    if units.is_empty() {
+      return Err(error::bad_response("Invalid Accept-Ranges range-unit"));
+    }
+    if units.iter().any(|unit| unit == "none") && units.len() != 1 {
+      return Err(error::bad_response(
+        "Accept-Ranges none cannot be combined with range-units",
+      ));
+    }
+
+    Ok(Self { units })
+  }
+
+  pub fn units(&self) -> Vec<&str> {
+    self.units.iter().map(String::as_str).collect()
+  }
+
+  pub fn is_none(&self) -> bool {
+    self.units.as_slice() == ["none"]
+  }
+
+  pub fn accepts_bytes(&self) -> bool {
+    self.units.iter().any(|unit| unit == "bytes")
   }
 }
 

--- a/rttp_client/tests/test_response.rs
+++ b/rttp_client/tests/test_response.rs
@@ -560,6 +560,141 @@ fn test_parse_allow_rejects_duplicate_oversized_and_too_many_methods() {
 }
 
 #[test]
+fn test_parse_accept_ranges_response_helper_preserves_order_across_header_fields() {
+  let s = concat!(
+    "HTTP/1.1 200 OK\r\n",
+    "Accept-Ranges: bytes, pages\r\n",
+    "accept-ranges: records\r\n",
+    "Content-Length: 2\r\n",
+    "\r\n",
+    "OK"
+  );
+  let response = Response::new(RoUrl::with("https://example.test"), s.as_bytes().to_vec())
+    .expect("parse response with accept-ranges headers");
+  let accept_ranges = response
+    .accept_ranges()
+    .expect("valid accept-ranges should parse")
+    .expect("accept-ranges header should be present");
+
+  assert!(!accept_ranges.is_none());
+  assert!(accept_ranges.accepts_bytes());
+  assert_eq!(vec!["bytes", "pages", "records"], accept_ranges.units());
+  assert_eq!(
+    vec![&"bytes, pages".to_string(), &"records".to_string()],
+    response.header_values("Accept-Ranges")
+  );
+}
+
+#[test]
+fn test_parse_accept_ranges_response_helper_supports_none_and_absent_header() {
+  let s = concat!(
+    "HTTP/1.1 200 OK\r\n",
+    "Accept-Ranges: none\r\n",
+    "Content-Length: 2\r\n",
+    "\r\n",
+    "OK"
+  );
+  let response = Response::new(RoUrl::with("https://example.test"), s.as_bytes().to_vec())
+    .expect("parse response with none accept-ranges");
+  let accept_ranges = response
+    .accept_ranges()
+    .expect("valid none accept-ranges should parse")
+    .expect("accept-ranges header should be present");
+
+  assert!(accept_ranges.is_none());
+  assert!(!accept_ranges.accepts_bytes());
+  assert_eq!(vec!["none"], accept_ranges.units());
+
+  let s = concat!("HTTP/1.1 200 OK\r\n", "Content-Length: 2\r\n", "\r\n", "OK");
+  let response = Response::new(RoUrl::with("https://example.test"), s.as_bytes().to_vec())
+    .expect("parse response without accept-ranges");
+  assert_eq!(
+    None,
+    response
+      .accept_ranges()
+      .expect("absent accept-ranges should parse")
+  );
+}
+
+#[test]
+fn test_parse_accept_ranges_rejects_invalid_helper_values_without_rejecting_response() {
+  let invalid_values = [
+    "",
+    "bytes,",
+    ",bytes",
+    "bytes,,pages",
+    "bytes, ,pages",
+    "byte ranges",
+    "bytes@pages",
+    "bytes, none",
+    "none, bytes",
+  ];
+
+  for value in invalid_values {
+    let raw = format!("HTTP/1.1 200 OK\r\nAccept-Ranges: {value}\r\nContent-Length: 2\r\n\r\nOK");
+    let response = Response::new(RoUrl::with("https://example.test"), raw.into_bytes())
+      .expect("raw response remains usable");
+
+    assert!(
+      response.accept_ranges().is_err(),
+      "accept-ranges helper should reject {value:?}"
+    );
+    assert_eq!(
+      Some(&value.to_string()),
+      response.header_value("Accept-Ranges")
+    );
+  }
+}
+
+#[test]
+fn test_parse_accept_ranges_rejects_duplicate_oversized_and_too_many_values() {
+  let raw = concat!(
+    "HTTP/1.1 200 OK\r\n",
+    "Accept-Ranges: bytes, pages\r\n",
+    "accept-ranges: BYTES\r\n",
+    "Content-Length: 2\r\n",
+    "\r\n",
+    "OK"
+  );
+  let response = Response::new(RoUrl::with("https://example.test"), raw.as_bytes().to_vec())
+    .expect("raw response with duplicate accept-ranges remains usable");
+
+  assert!(
+    response.accept_ranges().is_err(),
+    "accept-ranges helper should reject normalized duplicate units"
+  );
+  assert_eq!(
+    vec![&"bytes, pages".to_string(), &"BYTES".to_string()],
+    response.header_values("Accept-Ranges")
+  );
+
+  let oversized = "bytes".repeat(16 * 1024);
+  let raw = format!("HTTP/1.1 200 OK\r\nAccept-Ranges: {oversized}\r\nContent-Length: 2\r\n\r\nOK");
+  let response = Response::new(RoUrl::with("https://example.test"), raw.into_bytes())
+    .expect("raw response with oversized accept-ranges remains usable");
+
+  assert!(
+    response.accept_ranges().is_err(),
+    "accept-ranges helper should reject oversized values"
+  );
+  assert_eq!(Some(&oversized), response.header_value("Accept-Ranges"));
+
+  let too_many = (0..257)
+    .map(|ix| format!("unit{ix}"))
+    .collect::<Vec<_>>()
+    .join(", ");
+  let raw = format!("HTTP/1.1 200 OK\r\nAccept-Ranges: {too_many}\r\nContent-Length: 2\r\n\r\nOK");
+  let response = Response::new(RoUrl::with("https://example.test"), raw.into_bytes())
+    .expect("raw response with too many accept-ranges values remains usable");
+
+  assert!(
+    response.accept_ranges().is_err(),
+    "accept-ranges helper should reject too many values"
+  );
+  assert_eq!(Some(&too_many), response.header_value("Accept-Ranges"));
+}
+
+#[test]
 fn test_parse_age_rejects_invalid_helper_values_without_rejecting_response() {
   let invalid_values = [
     "",


### PR DESCRIPTION
Adds bounded `Accept-Ranges` response metadata parsing to `rttp_client`, including validation and regression coverage, with workspace formatting and tests passing.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1603/
work_kind: code_work
branch: hbx-1603-rttp-client-add-bounded-http
base: main
commit: ff946271c5a4dd3511e5b9f0f0001201662cbec7
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1603/
    url: https://plane.kahub.in/endless/browse/HBX-1603/
    close_policy: link_only
```