### PR TITLE
feat: [rttp] Add cross-crate HTTP/1.1 Accept-Ranges matrix

### DIFF
--- a/rttp/tests/http11_compliance_matrix.rs
+++ b/rttp/tests/http11_compliance_matrix.rs
@@ -5,8 +5,8 @@ use std::thread;
 use std::time::{Duration, UNIX_EPOCH};
 
 use rttp::server::{
-  HttpAllowedMethods, HttpContentLanguages, HttpRequest, HttpRequestCacheControl, HttpResponse,
-  HttpResponseCacheControl, HttpRetryAfter, HttpVary,
+  HttpAcceptRanges, HttpAllowedMethods, HttpContentLanguages, HttpRequest, HttpRequestCacheControl,
+  HttpResponse, HttpResponseCacheControl, HttpRetryAfter, HttpVary,
 };
 use rttp_http11_test_fixtures as fixtures;
 
@@ -69,6 +69,14 @@ fn allow_response(values: &[&str]) -> HttpResponse {
     HttpResponse::new(405, "Method Not Allowed"),
     |response, value| response.header("Allow", value),
   )
+}
+
+fn accept_ranges_response(values: &[&str]) -> HttpResponse {
+  values
+    .iter()
+    .fold(HttpResponse::new(200, "OK"), |response, value| {
+      response.header("Accept-Ranges", value)
+    })
 }
 
 fn content_language_response(values: &[&str]) -> HttpResponse {
@@ -226,6 +234,25 @@ fn assert_response_allow(
   assert_eq!(expected.methods, allow.methods().as_slice(), "{name}");
 }
 
+fn assert_response_accept_ranges(
+  name: &str,
+  accept_ranges: &HttpAcceptRanges,
+  expected: &fixtures::accept_ranges::ResponseCase,
+) {
+  assert_eq!(expected.none, accept_ranges.is_none(), "{name}");
+  if expected.none {
+    assert!(accept_ranges.units().is_empty(), "{name}");
+    assert_eq!("none", accept_ranges.header_value(), "{name}");
+  } else {
+    assert_eq!(expected.units, accept_ranges.units().as_slice(), "{name}");
+    assert_eq!(
+      expected.units.join(", "),
+      accept_ranges.header_value(),
+      "{name}"
+    );
+  }
+}
+
 fn assert_response_content_language(
   name: &str,
   content_language: &HttpContentLanguages,
@@ -319,6 +346,19 @@ fn server_response_helper_accepts_shared_allow_response_matrix() {
       .unwrap_or_else(|| panic!("{} should include Allow", case.name));
 
     assert_response_allow(case.name, &allow, case);
+  }
+}
+
+#[test]
+fn server_response_helper_accepts_shared_accept_ranges_response_matrix() {
+  for case in fixtures::accept_ranges::response_cases() {
+    let response = accept_ranges_response(case.values);
+    let accept_ranges = response
+      .accept_ranges()
+      .unwrap_or_else(|err| panic!("{} Accept-Ranges should parse: {err}", case.name))
+      .unwrap_or_else(|| panic!("{} should include Accept-Ranges", case.name));
+
+    assert_response_accept_ranges(case.name, &accept_ranges, case);
   }
 }
 
@@ -693,6 +733,187 @@ fn server_allow_helper_rejects_duplicate_methods_and_enforces_shared_bounds() {
   assert!(
     allow_response(&[&oversized_value]).allow().is_err(),
     "oversized response Allow value should be rejected"
+  );
+}
+
+#[test]
+fn server_response_with_accept_ranges_declares_shared_matrix() {
+  for case in fixtures::accept_ranges::response_cases() {
+    let response = if case.none {
+      HttpResponse::ok("OK").with_accept_ranges_none()
+    } else {
+      HttpResponse::ok("OK")
+        .with_accept_ranges(case.units.iter().copied())
+        .unwrap_or_else(|err| {
+          panic!(
+            "{} Accept-Ranges declaration should parse: {err}",
+            case.name
+          )
+        })
+    };
+    let serialized = String::from_utf8(response.to_bytes()).expect("response is UTF-8");
+
+    assert_eq!(
+      Some(case.header_value),
+      header_value(&serialized, "Accept-Ranges"),
+      "{}",
+      case.name
+    );
+    assert_response_accept_ranges(
+      case.name,
+      &response
+        .accept_ranges()
+        .expect("Accept-Ranges should parse")
+        .expect("Accept-Ranges should be present"),
+      case,
+    );
+  }
+}
+
+#[test]
+fn server_accept_ranges_helpers_reject_shared_invalid_matrix() {
+  for case in fixtures::accept_ranges::invalid_cases() {
+    assert!(
+      HttpAcceptRanges::parse(case.value).is_err(),
+      "{} Accept-Ranges helper should reject invalid value",
+      case.name
+    );
+    assert!(
+      accept_ranges_response(&[case.value])
+        .accept_ranges()
+        .is_err(),
+      "{} response parser should reject invalid Accept-Ranges value",
+      case.name
+    );
+  }
+}
+
+#[test]
+fn server_accept_ranges_helper_rejects_duplicates_and_enforces_shared_bounds() {
+  let duplicate = accept_ranges_response(&["bytes, pages", "BYTES"]);
+  assert!(
+    duplicate.accept_ranges().is_err(),
+    "duplicate Accept-Ranges units across header fields should be rejected"
+  );
+  assert!(
+    HttpResponse::ok("OK")
+      .with_accept_ranges(["bytes", "BYTES"])
+      .is_err(),
+    "duplicate Accept-Ranges units from declaration helper should be rejected"
+  );
+  assert!(
+    HttpResponse::ok("OK").with_accept_ranges(["none"]).is_err(),
+    "Accept-Ranges none sentinel should use the none helper"
+  );
+
+  let too_many_units = fixtures::accept_ranges::too_many_server_units_value();
+  assert!(
+    HttpAcceptRanges::parse(&too_many_units).is_err(),
+    "too many Accept-Ranges units should be rejected"
+  );
+
+  let oversized_value = fixtures::accept_ranges::oversized_value();
+  assert!(
+    HttpAcceptRanges::parse(&oversized_value).is_err(),
+    "oversized Accept-Ranges value should be rejected"
+  );
+}
+
+#[test]
+fn server_accept_ranges_raw_headers_are_preserved_without_helper_validation() {
+  let response = HttpResponse::ok("OK").header("Accept-Ranges", "bytes,,custom");
+  let serialized = String::from_utf8(response.to_bytes()).expect("response is UTF-8");
+
+  assert!(serialized.contains("\r\nAccept-Ranges: bytes,,custom\r\n"));
+  assert!(
+    response.accept_ranges().is_err(),
+    "typed Accept-Ranges parser should reject malformed raw values"
+  );
+}
+
+#[test]
+fn server_accept_ranges_helpers_coexist_with_adjacent_metadata_helpers() {
+  let response = HttpResponse::new(405, "Method Not Allowed")
+    .with_accept_ranges(["bytes", "pages"])
+    .expect("Accept-Ranges declaration should parse")
+    .with_content_language(["fr-CA", "es-419"])
+    .expect("Content-Language declaration should parse")
+    .with_allow(["GET", "HEAD"])
+    .expect("Allow declaration should parse")
+    .with_retry_after_delta(30)
+    .with_age(5)
+    .with_expires(UNIX_EPOCH + Duration::from_secs(fixtures::age_expires::EXPIRES_UNIX_SECONDS))
+    .header("Cache-Control", "public, max-age=60")
+    .with_vary("Accept-Encoding")
+    .expect("Vary declaration should parse");
+  let serialized = String::from_utf8(response.to_bytes()).expect("response is UTF-8");
+
+  assert_eq!(
+    Some("bytes, pages"),
+    header_value(&serialized, "Accept-Ranges")
+  );
+  assert_eq!(
+    Some("fr-CA, es-419"),
+    header_value(&serialized, "Content-Language")
+  );
+  assert_eq!(Some("GET, HEAD"), header_value(&serialized, "Allow"));
+  assert_eq!(
+    Some("public, max-age=60"),
+    header_value(&serialized, "Cache-Control")
+  );
+  assert_eq!(Some("5"), header_value(&serialized, "Age"));
+  assert_eq!(
+    Some(fixtures::age_expires::EXPIRES_IMF_FIXDATE),
+    header_value(&serialized, "Expires")
+  );
+  assert_eq!(Some("accept-encoding"), header_value(&serialized, "Vary"));
+  assert_eq!(Some("30"), header_value(&serialized, "Retry-After"));
+  assert_eq!(
+    &["bytes", "pages"],
+    response
+      .accept_ranges()
+      .expect("Accept-Ranges should parse")
+      .expect("Accept-Ranges should be present")
+      .units()
+      .as_slice()
+  );
+  assert_eq!(
+    &["fr-CA", "es-419"],
+    response
+      .content_language()
+      .expect("Content-Language should parse")
+      .expect("Content-Language should be present")
+      .languages()
+      .as_slice()
+  );
+  assert!(response
+    .allow()
+    .expect("Allow should parse")
+    .expect("Allow should be present")
+    .methods()
+    .contains(&"GET"));
+  assert_eq!(
+    Some(60),
+    response
+      .cache_control()
+      .expect("Cache-Control should parse")
+      .expect("Cache-Control should be present")
+      .max_age()
+  );
+  assert_eq!(Some(5), response.age().expect("Age should parse"));
+  assert_eq!(
+    Some(UNIX_EPOCH + Duration::from_secs(fixtures::age_expires::EXPIRES_UNIX_SECONDS)),
+    response.expires().expect("Expires should parse")
+  );
+  assert!(response
+    .vary()
+    .expect("Vary should parse")
+    .expect("Vary should be present")
+    .field_names()
+    .contains(&"accept-encoding"));
+  assert_eq!(
+    Some(HttpRetryAfter::DeltaSeconds(30)),
+    response.retry_after().expect("Retry-After should parse")
   );
 }
 

--- a/rttp_client/tests/http11_compliance_matrix.rs
+++ b/rttp_client/tests/http11_compliance_matrix.rs
@@ -50,6 +50,26 @@ fn allow_response(values: &[&str]) -> Vec<u8> {
   response.into_bytes()
 }
 
+fn accept_ranges_response(values: &[&str], include_adjacent_metadata: bool) -> Vec<u8> {
+  let mut response = String::from("HTTP/1.1 200 OK\r\n");
+  for value in values {
+    response.push_str("Accept-Ranges: ");
+    response.push_str(value);
+    response.push_str("\r\n");
+  }
+  if include_adjacent_metadata {
+    response.push_str("Cache-Control: public, max-age=60\r\n");
+    response.push_str("Age: 5\r\n");
+    response.push_str("Expires: Sun, 06 Nov 1994 08:49:37 GMT\r\n");
+    response.push_str("Vary: Accept-Encoding\r\n");
+    response.push_str("Retry-After: 30\r\n");
+    response.push_str("Allow: GET, HEAD\r\n");
+    response.push_str("Content-Language: fr-CA, es-419\r\n");
+  }
+  response.push_str("Content-Length: 2\r\n\r\nOK");
+  response.into_bytes()
+}
+
 fn content_language_response(values: &[&str], include_adjacent_metadata: bool) -> Vec<u8> {
   let mut response = String::from("HTTP/1.1 200 OK\r\n");
   for value in values {
@@ -461,6 +481,32 @@ fn assert_response_allow(
   }
 }
 
+fn assert_response_accept_ranges(
+  name: &str,
+  response: &rttp_client::response::Response,
+  expected: &fixtures::accept_ranges::ResponseCase,
+) {
+  let raw_values: Vec<&str> = response
+    .header_values("accept-ranges")
+    .into_iter()
+    .map(String::as_str)
+    .collect();
+  assert_eq!(expected.values, raw_values.as_slice(), "{name}");
+
+  let accept_ranges = response
+    .accept_ranges()
+    .unwrap_or_else(|err| panic!("{name} Accept-Ranges should parse: {err}"))
+    .unwrap_or_else(|| panic!("{name} should include Accept-Ranges"));
+
+  assert_eq!(expected.none, accept_ranges.is_none(), "{name}");
+  assert_eq!(
+    expected.accepts_bytes,
+    accept_ranges.accepts_bytes(),
+    "{name}"
+  );
+  assert_eq!(expected.units, accept_ranges.units().as_slice(), "{name}");
+}
+
 fn assert_response_content_language(
   name: &str,
   response: &rttp_client::response::Response,
@@ -593,6 +639,24 @@ fn assert_allow_helper_rejects_but_preserves_response(name: &str, raw_response: 
   handle.join().expect("raw response server thread");
 }
 
+fn assert_accept_ranges_helper_rejects_but_preserves_response(name: &str, raw_response: Vec<u8>) {
+  let (addr, handle) = fixtures::spawn_socket2_owned_raw_response_server(raw_response);
+
+  let response = client()
+    .get()
+    .url(format!("http://{}/matrix/accept-ranges-invalid", addr))
+    .emit()
+    .unwrap_or_else(|err| panic!("{name} response should remain parseable: {err}"));
+
+  assert!(
+    response.accept_ranges().is_err(),
+    "{name} helper should reject invalid Accept-Ranges"
+  );
+  assert_eq!("OK", response.body().string().unwrap(), "{name}");
+
+  handle.join().expect("raw response server thread");
+}
+
 fn assert_content_language_helper_rejects_but_preserves_response(
   name: &str,
   raw_response: Vec<u8>,
@@ -636,6 +700,24 @@ fn sync_client_parses_shared_allow_response_matrix() {
       .unwrap_or_else(|err| panic!("{} response should parse: {err}", case.name));
 
     assert_response_allow(case.name, response, case);
+    handle.join().expect("raw response server thread");
+  }
+}
+
+#[test]
+fn sync_client_parses_shared_accept_ranges_response_matrix() {
+  for case in fixtures::accept_ranges::response_cases() {
+    let raw_response = accept_ranges_response(case.values, false);
+    let (addr, handle) = fixtures::spawn_socket2_owned_raw_response_server(raw_response);
+
+    let response = client()
+      .get()
+      .url(format!("http://{}/matrix/accept-ranges", addr))
+      .emit()
+      .unwrap_or_else(|err| panic!("{} response should parse: {err}", case.name));
+
+    assert_response_accept_ranges(case.name, &response, case);
+    assert_eq!("OK", response.body().string().unwrap(), "{}", case.name);
     handle.join().expect("raw response server thread");
   }
 }
@@ -857,6 +939,71 @@ fn sync_client_parses_allow_with_existing_cache_and_retry_metadata_helpers() {
 }
 
 #[test]
+fn sync_client_parses_accept_ranges_with_existing_metadata_helpers() {
+  let raw_response = accept_ranges_response(&["bytes, pages"], true);
+  let (addr, handle) = fixtures::spawn_socket2_owned_raw_response_server(raw_response);
+
+  let response = client()
+    .get()
+    .url(format!("http://{}/matrix/accept-ranges-metadata", addr))
+    .emit()
+    .expect("Accept-Ranges response with adjacent metadata should parse");
+
+  assert_eq!(
+    &["bytes", "pages"],
+    response
+      .accept_ranges()
+      .expect("Accept-Ranges should parse")
+      .expect("Accept-Ranges should be present")
+      .units()
+      .as_slice()
+  );
+  assert_eq!(
+    Some(60),
+    response
+      .cache_control()
+      .expect("Cache-Control should parse")
+      .expect("Cache-Control should be present")
+      .max_age()
+  );
+  assert_eq!(Some(5), response.age().expect("Age should parse"));
+  assert_eq!(
+    Some(UNIX_EPOCH + Duration::from_secs(fixtures::age_expires::EXPIRES_UNIX_SECONDS)),
+    response.expires().expect("Expires should parse")
+  );
+  assert!(response
+    .vary()
+    .expect("Vary should parse")
+    .expect("Vary should be present")
+    .contains_field_name("accept-encoding"));
+  assert_eq!(
+    Some(30),
+    response
+      .retry_after()
+      .expect("Retry-After should parse")
+      .expect("Retry-After should be present")
+      .delta_seconds()
+  );
+  assert!(response
+    .allow()
+    .expect("Allow should parse")
+    .expect("Allow should be present")
+    .contains_method("GET"));
+  assert_eq!(
+    &["fr-CA", "es-419"],
+    response
+      .content_language()
+      .expect("Content-Language should parse")
+      .expect("Content-Language should be present")
+      .tags()
+      .as_slice()
+  );
+  assert_eq!("OK", response.body().string().unwrap());
+
+  handle.join().expect("raw response server thread");
+}
+
+#[test]
 fn sync_client_parses_age_expires_with_existing_cache_metadata_helpers() {
   for case in fixtures::age_expires::declaration_cases() {
     let raw_response = age_expires_response(case.age_value, case.expires_value, true);
@@ -1049,6 +1196,16 @@ fn sync_client_allow_helper_rejects_shared_invalid_response_matrix() {
 }
 
 #[test]
+fn sync_client_accept_ranges_helper_rejects_shared_invalid_response_matrix() {
+  for case in fixtures::accept_ranges::invalid_cases() {
+    assert_accept_ranges_helper_rejects_but_preserves_response(
+      case.name,
+      accept_ranges_response(&[case.value], false),
+    );
+  }
+}
+
+#[test]
 fn sync_client_vary_helper_rejects_shared_invalid_response_matrix() {
   for case in fixtures::vary::invalid_cases() {
     assert_vary_helper_rejects_but_preserves_response(case.name, vary_response(&[case.value]));
@@ -1134,6 +1291,25 @@ fn sync_client_allow_helper_rejects_duplicate_methods_and_enforces_shared_bounds
   assert_allow_helper_rejects_but_preserves_response(
     "oversized Allow value",
     allow_response(&[&fixtures::allow::oversized_value()]),
+  );
+}
+
+#[test]
+fn sync_client_accept_ranges_helper_rejects_duplicates_and_enforces_shared_bounds() {
+  assert_accept_ranges_helper_rejects_but_preserves_response(
+    "duplicate Accept-Ranges units across header fields",
+    accept_ranges_response(&["bytes, pages", "BYTES"], false),
+  );
+  assert_accept_ranges_helper_rejects_but_preserves_response(
+    "too many client Accept-Ranges units",
+    accept_ranges_response(
+      &[&fixtures::accept_ranges::too_many_client_units_value()],
+      false,
+    ),
+  );
+  assert_accept_ranges_helper_rejects_but_preserves_response(
+    "oversized Accept-Ranges value",
+    accept_ranges_response(&[&fixtures::accept_ranges::oversized_value()], false),
   );
 }
 

--- a/rttp_http11_test_fixtures/src/lib.rs
+++ b/rttp_http11_test_fixtures/src/lib.rs
@@ -784,6 +784,127 @@ pub mod allow {
   }
 }
 
+pub mod accept_ranges {
+  pub const MAX_VALUE_BYTES: usize = 64 * 1024;
+  pub const SERVER_MAX_UNITS: usize = 32;
+  pub const CLIENT_MAX_UNITS: usize = 256;
+
+  pub struct ResponseCase {
+    pub name: &'static str,
+    pub values: &'static [&'static str],
+    pub units: &'static [&'static str],
+    pub header_value: &'static str,
+    pub none: bool,
+    pub accepts_bytes: bool,
+  }
+
+  pub struct InvalidCase {
+    pub name: &'static str,
+    pub value: &'static str,
+  }
+
+  const RESPONSE_CASES: &[ResponseCase] = &[
+    ResponseCase {
+      name: "single bytes unit",
+      values: &["bytes"],
+      units: &["bytes"],
+      header_value: "bytes",
+      none: false,
+      accepts_bytes: true,
+    },
+    ResponseCase {
+      name: "range units across header fields preserve order",
+      values: &["bytes, pages", "records"],
+      units: &["bytes", "pages", "records"],
+      header_value: "bytes, pages, records",
+      none: false,
+      accepts_bytes: true,
+    },
+    ResponseCase {
+      name: "optional whitespace around range units",
+      values: &["bytes,\tcustom-unit , pages"],
+      units: &["bytes", "custom-unit", "pages"],
+      header_value: "bytes, custom-unit, pages",
+      none: false,
+      accepts_bytes: true,
+    },
+    ResponseCase {
+      name: "none sentinel",
+      values: &["none"],
+      units: &["none"],
+      header_value: "none",
+      none: true,
+      accepts_bytes: false,
+    },
+  ];
+
+  const INVALID_CASES: &[InvalidCase] = &[
+    InvalidCase {
+      name: "empty value",
+      value: "",
+    },
+    InvalidCase {
+      name: "blank value",
+      value: " ",
+    },
+    InvalidCase {
+      name: "trailing comma",
+      value: "bytes,",
+    },
+    InvalidCase {
+      name: "leading comma",
+      value: ", bytes",
+    },
+    InvalidCase {
+      name: "empty member",
+      value: "bytes,,pages",
+    },
+    InvalidCase {
+      name: "unit with whitespace",
+      value: "byte ranges",
+    },
+    InvalidCase {
+      name: "unit with separator",
+      value: "bytes:pages",
+    },
+    InvalidCase {
+      name: "none followed by unit",
+      value: "none, bytes",
+    },
+    InvalidCase {
+      name: "unit followed by none",
+      value: "bytes, none",
+    },
+  ];
+
+  pub fn response_cases() -> &'static [ResponseCase] {
+    RESPONSE_CASES
+  }
+
+  pub fn invalid_cases() -> &'static [InvalidCase] {
+    INVALID_CASES
+  }
+
+  pub fn too_many_server_units_value() -> String {
+    too_many_units_value(SERVER_MAX_UNITS)
+  }
+
+  pub fn too_many_client_units_value() -> String {
+    too_many_units_value(CLIENT_MAX_UNITS)
+  }
+
+  pub fn oversized_value() -> String {
+    format!("unit-{}", "a".repeat(MAX_VALUE_BYTES))
+  }
+
+  fn too_many_units_value(max_units: usize) -> String {
+    (0..=max_units)
+      .map(|index| format!("unit{index}"))
+      .collect::<Vec<_>>()
+      .join(", ")
+  }
+}
+
 pub mod vary {
   pub const MAX_VALUE_BYTES: usize = 64 * 1024;
   pub const MAX_FIELD_NAMES: usize = 256;


### PR DESCRIPTION
Added cross-crate HTTP/1.1 Accept-Ranges fixture and matrix coverage without changing production behavior.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1605/
work_kind: code_work
branch: hbx-1605-rttp-add-cross-crate-http
base: main
commit: 8b716874f5009abb37dd8f132e11d3239f054efa
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1605/
    url: https://plane.kahub.in/endless/browse/HBX-1605/
    close_policy: link_only
```