### PR TITLE
feat: [rttp] Add bounded HTTP/1.1 Content-Location server helpers

### DIFF
--- a/rttp/src/server.rs
+++ b/rttp/src/server.rs
@@ -17,6 +17,7 @@ const MAX_ALLOW_VALUE_BYTES: usize = 64 * 1024;
 const MAX_ALLOW_METHODS: usize = 32;
 const MAX_CONTENT_LANGUAGE_VALUE_BYTES: usize = 64 * 1024;
 const MAX_CONTENT_LANGUAGES: usize = 32;
+const MAX_CONTENT_LOCATION_VALUE_BYTES: usize = 64 * 1024;
 const MAX_ACCEPT_RANGES_VALUE_BYTES: usize = 64 * 1024;
 const MAX_ACCEPT_RANGES_UNITS: usize = 32;
 const MAX_RETRY_AFTER_VALUE_BYTES: usize = 64 * 1024;
@@ -4556,6 +4557,20 @@ impl HttpResponse {
     Ok(self)
   }
 
+  pub fn with_content_location<V: AsRef<str>>(
+    mut self,
+    value: V,
+  ) -> Result<Self, HttpContentLocationParseError> {
+    let value = parse_http_content_location(value.as_ref())?;
+    self
+      .headers
+      .retain(|header| !header.name.eq_ignore_ascii_case("Content-Location"));
+    self
+      .headers
+      .push(HttpHeader::new("Content-Location", value));
+    Ok(self)
+  }
+
   pub fn with_accept_ranges<I, U>(mut self, units: I) -> Result<Self, HttpAcceptRangesParseError>
   where
     I: IntoIterator<Item = U>,
@@ -4679,6 +4694,17 @@ impl HttpResponse {
       return Ok(None);
     }
     HttpContentLanguages::parse_values(values).map(Some)
+  }
+
+  pub fn content_location(&self) -> Result<Option<&str>, HttpContentLocationParseError> {
+    let Some(value) = self.single_header_value(
+      "Content-Location",
+      HttpContentLocationParseError::new("multiple Content-Location headers"),
+    )?
+    else {
+      return Ok(None);
+    };
+    parse_http_content_location(value).map(Some)
   }
 
   pub fn accept_ranges(&self) -> Result<Option<HttpAcceptRanges>, HttpAcceptRangesParseError> {
@@ -5459,6 +5485,49 @@ impl fmt::Display for HttpContentLanguageParseError {
 }
 
 impl Error for HttpContentLanguageParseError {}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct HttpContentLocationParseError {
+  message: String,
+}
+
+impl HttpContentLocationParseError {
+  fn new<S: AsRef<str>>(message: S) -> Self {
+    Self {
+      message: message.as_ref().to_string(),
+    }
+  }
+}
+
+impl fmt::Display for HttpContentLocationParseError {
+  fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+    formatter.write_str(&self.message)
+  }
+}
+
+impl Error for HttpContentLocationParseError {}
+
+fn parse_http_content_location(value: &str) -> Result<&str, HttpContentLocationParseError> {
+  if value.len() > MAX_CONTENT_LOCATION_VALUE_BYTES {
+    return Err(HttpContentLocationParseError::new(
+      "Content-Location header value is too large",
+    ));
+  }
+
+  let value = value.trim();
+  if value.is_empty() {
+    return Err(HttpContentLocationParseError::new(
+      "invalid Content-Location value",
+    ));
+  }
+  if value.bytes().any(|byte| byte.is_ascii_control()) {
+    return Err(HttpContentLocationParseError::new(
+      "invalid Content-Location value",
+    ));
+  }
+
+  Ok(value)
+}
 
 fn is_valid_content_language_tag(value: &str) -> bool {
   let mut subtags = value.split('-');

--- a/rttp/tests/http11_compliance_matrix.rs
+++ b/rttp/tests/http11_compliance_matrix.rs
@@ -1013,6 +1013,97 @@ fn server_content_language_helpers_stay_metadata_only() {
 }
 
 #[test]
+fn server_response_with_content_location_declares_single_bounded_header() {
+  let response = HttpResponse::new(201, "Created")
+    .header("Content-Location", "/old")
+    .with_content_location(" /representations/current ")
+    .expect("Content-Location declaration should parse");
+  let serialized = String::from_utf8(response.to_bytes()).expect("response is UTF-8");
+
+  assert_eq!(
+    Some("/representations/current"),
+    header_value(&serialized, "Content-Location")
+  );
+  assert_eq!(1, serialized.matches("\r\nContent-Location: ").count());
+  assert_eq!(
+    Some("/representations/current"),
+    response
+      .content_location()
+      .expect("Content-Location should parse")
+  );
+}
+
+#[test]
+fn server_content_location_helper_rejects_duplicate_unsafe_and_oversized_values() {
+  for value in [
+    "",
+    " ",
+    "/safe\u{7f}",
+    "/safe\u{1f}",
+    "/safe\r\nInjected: true",
+  ] {
+    assert!(
+      HttpResponse::ok("OK").with_content_location(value).is_err(),
+      "Content-Location declaration should reject {value:?}"
+    );
+  }
+
+  for value in ["", " ", "/safe\u{7f}", "/safe\u{1f}"] {
+    assert!(
+      HttpResponse::ok("OK")
+        .header("Content-Location", value)
+        .content_location()
+        .is_err(),
+      "Content-Location parser should reject {value:?}"
+    );
+  }
+
+  let duplicate = HttpResponse::ok("OK")
+    .header("Content-Location", "/one")
+    .header("Content-Location", "/two");
+  assert!(
+    duplicate.content_location().is_err(),
+    "duplicate Content-Location header fields should be rejected"
+  );
+
+  let oversized = format!("/{}", "a".repeat(64 * 1024 + 1));
+  assert!(
+    HttpResponse::ok("OK")
+      .with_content_location(&oversized)
+      .is_err(),
+    "oversized Content-Location declaration should be rejected"
+  );
+  assert!(
+    HttpResponse::ok("OK")
+      .header("Content-Location", oversized)
+      .content_location()
+      .is_err(),
+    "oversized Content-Location raw value should be rejected"
+  );
+}
+
+#[test]
+fn server_content_location_helpers_stay_metadata_only() {
+  let response = HttpResponse::new(302, "Found")
+    .with_content_location("/representation")
+    .expect("Content-Location declaration should parse")
+    .header("Location", "/fallback")
+    .header("Cache-Control", "no-store");
+  let serialized = String::from_utf8(response.to_bytes()).expect("response is UTF-8");
+
+  assert_eq!(
+    Some("/representation"),
+    header_value(&serialized, "Content-Location")
+  );
+  assert_eq!(Some("/fallback"), header_value(&serialized, "Location"));
+  assert_eq!(Some("no-store"), header_value(&serialized, "Cache-Control"));
+  assert!(
+    serialized.starts_with("HTTP/1.1 302 Found\r\n"),
+    "Content-Location should not alter response status policy"
+  );
+}
+
+#[test]
 fn server_content_language_helpers_coexist_with_adjacent_metadata_helpers() {
   let response = HttpResponse::new(405, "Method Not Allowed")
     .with_content_language(["fr-CA", "es-419"])

--- a/rttp/tests/test_server_models.rs
+++ b/rttp/tests/test_server_models.rs
@@ -459,6 +459,84 @@ fn raw_accept_ranges_headers_are_preserved_without_helper_validation() {
 }
 
 #[test]
+fn response_content_location_helper_declares_single_header_value() {
+  let response = HttpResponse::ok("body")
+    .header("Content-Location", "/old")
+    .with_content_location(" /representations/current ")
+    .expect("valid Content-Location should be accepted");
+  let serialized = String::from_utf8(response.to_bytes()).expect("response is UTF-8");
+
+  assert!(serialized.contains("\r\nContent-Location: /representations/current\r\n"));
+  assert_eq!(1, serialized.matches("\r\nContent-Location: ").count());
+  assert_eq!(
+    Some("/representations/current"),
+    response
+      .content_location()
+      .expect("Content-Location should parse")
+  );
+}
+
+#[test]
+fn response_content_location_helper_parses_attached_singleton_header() {
+  let response = HttpResponse::ok("body").header("Content-Location", "../variant.en");
+
+  assert_eq!(
+    Some("../variant.en"),
+    response
+      .content_location()
+      .expect("Content-Location should parse")
+  );
+}
+
+#[test]
+fn content_location_helper_rejects_empty_control_duplicate_and_oversized_values() {
+  for value in [
+    "",
+    " ",
+    "/safe\u{7f}",
+    "/safe\u{1f}",
+    "/safe\r\nX-Evil: true",
+  ] {
+    assert!(
+      HttpResponse::ok("body")
+        .with_content_location(value)
+        .is_err(),
+      "Content-Location helper should reject {value:?}"
+    );
+  }
+
+  for value in ["", " ", "/safe\u{7f}", "/safe\u{1f}"] {
+    let response = HttpResponse::ok("body").header("Content-Location", value);
+    assert!(
+      response.content_location().is_err(),
+      "Content-Location parser should reject {value:?}"
+    );
+  }
+
+  let response = HttpResponse::ok("body")
+    .header("Content-Location", "/one")
+    .header("Content-Location", "/two");
+  assert!(
+    response.content_location().is_err(),
+    "Content-Location parser should reject duplicate header fields"
+  );
+
+  let oversized = format!("/{}", "a".repeat(64 * 1024 + 1));
+  assert!(
+    HttpResponse::ok("body")
+      .with_content_location(&oversized)
+      .is_err(),
+    "Content-Location helper should reject oversized values"
+  );
+
+  let response = HttpResponse::ok("body").header("Content-Location", oversized);
+  assert!(
+    response.content_location().is_err(),
+    "Content-Location parser should reject oversized raw values"
+  );
+}
+
+#[test]
 fn response_age_and_expires_helpers_declare_metadata_headers() {
   let expires = UNIX_EPOCH + Duration::from_secs(784_111_777);
   let response = HttpResponse::ok("body").with_age(60).with_expires(expires);


### PR DESCRIPTION
Added bounded HTTP/1.1 `Content-Location` helpers for rttp server responses with singleton serialization and validation coverage.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1609/
work_kind: code_work
branch: hbx-1609-rttp-add-bounded-http-1
base: main
commit: 23cf3ba052ded0487761b398c8ffef07a973cdb5
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1609/
    url: https://plane.kahub.in/endless/browse/HBX-1609/
    close_policy: link_only
```