### PR TITLE
feat: [rttp_client] Add bounded HTTP/1.1 Content-Location response helpers

### DIFF
--- a/rttp_client/src/response/response.rs
+++ b/rttp_client/src/response/response.rs
@@ -16,6 +16,7 @@ const MAX_ALLOW_METHODS: usize = 256;
 const MAX_ACCEPT_RANGES_VALUE_BYTES: usize = 64 * 1024;
 const MAX_ACCEPT_RANGE_UNITS: usize = 256;
 const MAX_RETRY_AFTER_VALUE_BYTES: usize = 64 * 1024;
+const MAX_CONTENT_LOCATION_VALUE_BYTES: usize = 64 * 1024;
 const MAX_CONTENT_LANGUAGE_VALUE_BYTES: usize = 64 * 1024;
 const MAX_CONTENT_LANGUAGE_TAGS: usize = 256;
 const MAX_VARY_VALUE_BYTES: usize = 64 * 1024;
@@ -156,6 +157,17 @@ impl Response {
     self
       .header_value("content-range")
       .and_then(ContentRange::parse)
+  }
+
+  pub fn content_location(&self) -> error::Result<Option<ContentLocation>> {
+    let values = self.header_values("content-location");
+    match values.as_slice() {
+      [] => Ok(None),
+      [value] => ContentLocation::parse(value).map(Some),
+      _ => Err(error::bad_response(
+        "Duplicate Content-Location header values",
+      )),
+    }
   }
 
   pub fn content_language(&self) -> error::Result<Option<ContentLanguage>> {
@@ -506,6 +518,53 @@ fn parse_complete_length(value: &str) -> Option<Option<u64>> {
     return Some(None);
   }
   value.parse::<u64>().ok().map(Some)
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ContentLocation {
+  value: String,
+}
+
+impl ContentLocation {
+  pub fn parse(value: impl AsRef<str>) -> error::Result<Self> {
+    let value = value.as_ref();
+    if value.len() > MAX_CONTENT_LOCATION_VALUE_BYTES {
+      return Err(error::bad_response(
+        "Content-Location header value is too large",
+      ));
+    }
+
+    let value = trim_http_optional_whitespace(value);
+    if value.is_empty() {
+      return Err(error::bad_response("Invalid Content-Location value"));
+    }
+    if !is_content_location_field_value(value) {
+      return Err(error::bad_response("Invalid Content-Location value"));
+    }
+
+    if Url::parse(value).is_ok() {
+      return Ok(Self {
+        value: value.to_string(),
+      });
+    }
+
+    let base = Url::parse("http://example.invalid/").expect("valid internal base URL");
+    if !is_relative_uri_reference_field_value(value) {
+      return Err(error::bad_response("Invalid Content-Location value"));
+    }
+    Url::options()
+      .base_url(Some(&base))
+      .parse(value)
+      .map_err(|_| error::bad_response("Invalid Content-Location value"))?;
+
+    Ok(Self {
+      value: value.to_string(),
+    })
+  }
+
+  pub fn as_str(&self) -> &str {
+    &self.value
+  }
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -970,6 +1029,100 @@ fn split_field_names(value: &str) -> Vec<String> {
     .filter(|field| !field.is_empty())
     .map(ToString::to_string)
     .collect()
+}
+
+fn trim_http_optional_whitespace(value: &str) -> &str {
+  value.trim_matches(|ch| matches!(ch, ' ' | '\t'))
+}
+
+fn is_content_location_field_value(value: &str) -> bool {
+  value.bytes().all(|byte| {
+    byte.is_ascii_graphic() && byte != b'"' && byte != b'<' && byte != b'>' && byte != b'\\'
+  })
+}
+
+fn is_relative_uri_reference_field_value(value: &str) -> bool {
+  let mut fragment_seen = false;
+  let mut query_seen = false;
+  let mut bytes = value.bytes().peekable();
+
+  while let Some(byte) = bytes.next() {
+    match byte {
+      b'%' => {
+        let Some(first) = bytes.next() else {
+          return false;
+        };
+        let Some(second) = bytes.next() else {
+          return false;
+        };
+        if !first.is_ascii_hexdigit() || !second.is_ascii_hexdigit() {
+          return false;
+        }
+      }
+      b'#' => {
+        if fragment_seen {
+          return false;
+        }
+        fragment_seen = true;
+      }
+      b'?' => {
+        if !fragment_seen {
+          query_seen = true;
+        }
+      }
+      _ => {
+        if fragment_seen {
+          if !is_fragment_char(byte) {
+            return false;
+          }
+        } else if query_seen {
+          if !is_query_char(byte) {
+            return false;
+          }
+        } else if !is_uri_path_char(byte) {
+          return false;
+        }
+      }
+    }
+  }
+
+  true
+}
+
+fn is_uri_path_char(byte: u8) -> bool {
+  is_uri_pchar(byte) || byte == b'/'
+}
+
+fn is_query_char(byte: u8) -> bool {
+  is_uri_pchar(byte) || matches!(byte, b'/' | b'?')
+}
+
+fn is_fragment_char(byte: u8) -> bool {
+  is_query_char(byte)
+}
+
+fn is_uri_pchar(byte: u8) -> bool {
+  byte.is_ascii_alphanumeric()
+    || matches!(
+      byte,
+      b'-'
+        | b'.'
+        | b'_'
+        | b'~'
+        | b'!'
+        | b'$'
+        | b'&'
+        | b'\''
+        | b'('
+        | b')'
+        | b'*'
+        | b'+'
+        | b','
+        | b';'
+        | b'='
+        | b':'
+        | b'@'
+    )
 }
 
 fn is_language_range(value: &str) -> bool {

--- a/rttp_client/tests/test_response.rs
+++ b/rttp_client/tests/test_response.rs
@@ -1,4 +1,4 @@
-use rttp_client::response::Response;
+use rttp_client::response::{ContentLocation, Response};
 use rttp_client::types::{Cookie, RoUrl};
 use std::time::{Duration, UNIX_EPOCH};
 
@@ -208,6 +208,160 @@ fn test_parse_conditional_response_metadata() {
   assert!(response.is_precondition_failed());
   assert_eq!(Some(&"W/\"stale\"".to_string()), response.etag());
   assert_eq!(None, response.last_modified());
+}
+
+#[test]
+fn test_parse_content_location_response_helper_accepts_uri_references() {
+  let cases = [
+    (
+      "https://cdn.example.test/images/logo.png?size=small#v1",
+      "absolute URI",
+    ),
+    (
+      "http://[::1]/images/logo.png",
+      "absolute URI with IPv6 authority",
+    ),
+    ("/images/logo.png?size=small#v1", "absolute path"),
+    ("images/logo.png?size=small#v1", "relative path reference"),
+    ("../images/logo.png", "relative dot segment reference"),
+    ("?variant=small", "query-only relative reference"),
+  ];
+
+  for (value, name) in cases {
+    let raw =
+      format!("HTTP/1.1 200 OK\r\nContent-Location: {value}\r\nContent-Length: 2\r\n\r\nOK");
+    let response = Response::new(
+      RoUrl::with("https://example.test/base/page"),
+      raw.into_bytes(),
+    )
+    .unwrap_or_else(|err| panic!("{name} response should parse: {err}"));
+    let content_location = response
+      .content_location()
+      .unwrap_or_else(|err| panic!("{name} content-location should parse: {err}"))
+      .unwrap_or_else(|| panic!("{name} content-location should be present"));
+
+    assert_eq!(value, content_location.as_str());
+    assert_eq!(
+      Some(&value.to_string()),
+      response.header_value("Content-Location")
+    );
+  }
+}
+
+#[test]
+fn test_parse_content_location_response_helper_trims_outer_whitespace_and_allows_absent() {
+  let raw = concat!(
+    "HTTP/1.1 200 OK\r\n",
+    "Content-Location:   /representations/current.json   \r\n",
+    "Content-Length: 2\r\n",
+    "\r\n",
+    "OK"
+  );
+  let response = Response::new(
+    RoUrl::with("https://example.test/base/page"),
+    raw.as_bytes().to_vec(),
+  )
+  .expect("parse response with content-location");
+  let content_location = response
+    .content_location()
+    .expect("valid content-location should parse")
+    .expect("content-location header should be present");
+
+  assert_eq!("/representations/current.json", content_location.as_str());
+  assert_eq!(
+    Some(&"/representations/current.json".to_string()),
+    response.header_value("Content-Location")
+  );
+
+  let raw = concat!("HTTP/1.1 200 OK\r\n", "Content-Length: 2\r\n", "\r\n", "OK");
+  let response = Response::new(
+    RoUrl::with("https://example.test/base/page"),
+    raw.as_bytes().to_vec(),
+  )
+  .expect("parse response without content-location");
+  assert_eq!(
+    None,
+    response
+      .content_location()
+      .expect("absent content-location should parse")
+  );
+}
+
+#[test]
+fn test_parse_content_location_rejects_invalid_helper_values_without_rejecting_response() {
+  let invalid_values = ["", "http://[::1", "not valid", "/bad path", "ok\u{7f}"];
+
+  for value in invalid_values {
+    let raw =
+      format!("HTTP/1.1 200 OK\r\nContent-Location: {value}\r\nContent-Length: 2\r\n\r\nOK");
+    let response = Response::new(
+      RoUrl::with("https://example.test/base/page"),
+      raw.into_bytes(),
+    )
+    .expect("raw response remains usable");
+
+    assert!(
+      response.content_location().is_err(),
+      "content-location helper should reject {value:?}"
+    );
+    assert_eq!(
+      Some(&value.trim().to_string()),
+      response.header_value("Content-Location")
+    );
+  }
+}
+
+#[test]
+fn test_parse_content_location_rejects_duplicate_and_oversized_values() {
+  let raw = concat!(
+    "HTTP/1.1 200 OK\r\n",
+    "Content-Location: /one\r\n",
+    "content-location: /two\r\n",
+    "Content-Length: 2\r\n",
+    "\r\n",
+    "OK"
+  );
+  let response = Response::new(
+    RoUrl::with("https://example.test/base/page"),
+    raw.as_bytes().to_vec(),
+  )
+  .expect("raw response with duplicate content-location remains usable");
+
+  assert!(
+    response.content_location().is_err(),
+    "content-location helper should reject duplicate singleton headers"
+  );
+  assert_eq!(
+    vec![&"/one".to_string(), &"/two".to_string()],
+    response.header_values("Content-Location")
+  );
+
+  let oversized = format!("/{}", "a".repeat(64 * 1024));
+  let raw =
+    format!("HTTP/1.1 200 OK\r\nContent-Location: {oversized}\r\nContent-Length: 2\r\n\r\nOK");
+  let response = Response::new(
+    RoUrl::with("https://example.test/base/page"),
+    raw.into_bytes(),
+  )
+  .expect("raw response with oversized content-location remains usable");
+
+  assert!(
+    response.content_location().is_err(),
+    "content-location helper should reject oversized values"
+  );
+  assert_eq!(Some(&oversized), response.header_value("Content-Location"));
+}
+
+#[test]
+fn test_parse_content_location_rejects_control_characters_and_crlf_injection() {
+  let invalid_values = ["\r\nLocation: /evil", "/ok\r", "/ok\n", "/ok\tinner"];
+
+  for value in invalid_values {
+    assert!(
+      ContentLocation::parse(value).is_err(),
+      "content-location parser should reject {value:?}"
+    );
+  }
 }
 
 #[test]


### PR DESCRIPTION
`rttp_client` now has bounded `Content-Location` response metadata parsing with coverage for valid URI references, singleton enforcement, invalid values, injection controls, and size limits.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1608/
work_kind: code_work
branch: hbx-1608-rttp-client-add-bounded-http
base: main
commit: 41ebd5a714b0c6e7dbf22015e66d6eb455597558
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1608/
    url: https://plane.kahub.in/endless/browse/HBX-1608/
    close_policy: link_only
```