### PR TITLE
feat: [rttp] Add cross-crate HTTP/1.1 Content-Location matrix

### DIFF
--- a/rttp/tests/http11_compliance_matrix.rs
+++ b/rttp/tests/http11_compliance_matrix.rs
@@ -87,6 +87,14 @@ fn content_language_response(values: &[&str]) -> HttpResponse {
     })
 }
 
+fn content_location_response(values: &[&str]) -> HttpResponse {
+  values
+    .iter()
+    .fold(HttpResponse::new(200, "OK"), |response, value| {
+      response.header("Content-Location", value)
+    })
+}
+
 fn age_expires_response(age: u64, expires: std::time::SystemTime) -> HttpResponse {
   HttpResponse::ok("OK")
     .with_age(age)
@@ -293,6 +301,20 @@ fn model_parser_accepts_shared_cache_control_request_matrix() {
   }
 }
 
+fn assert_response_content_location(
+  name: &str,
+  response: &HttpResponse,
+  expected: &fixtures::content_location::ResponseCase,
+) {
+  assert_eq!(
+    Some(expected.normalized_value),
+    response
+      .content_location()
+      .unwrap_or_else(|err| panic!("{name} Content-Location should parse: {err}")),
+    "{name}"
+  );
+}
+
 #[test]
 fn model_parser_cache_control_helper_rejects_shared_invalid_request_matrix() {
   for case in fixtures::cache_control::invalid_request_cases() {
@@ -385,6 +407,15 @@ fn server_response_helper_accepts_shared_content_language_response_matrix() {
       .unwrap_or_else(|| panic!("{} should include Content-Language", case.name));
 
     assert_response_content_language(case.name, &content_language, case);
+  }
+}
+
+#[test]
+fn server_response_helper_accepts_shared_content_location_response_matrix() {
+  for case in fixtures::content_location::response_cases() {
+    let response = content_location_response(case.values);
+
+    assert_response_content_location(case.name, &response, case);
   }
 }
 
@@ -1014,47 +1045,41 @@ fn server_content_language_helpers_stay_metadata_only() {
 
 #[test]
 fn server_response_with_content_location_declares_single_bounded_header() {
-  let response = HttpResponse::new(201, "Created")
-    .header("Content-Location", "/old")
-    .with_content_location(" /representations/current ")
-    .expect("Content-Location declaration should parse");
-  let serialized = String::from_utf8(response.to_bytes()).expect("response is UTF-8");
+  for case in fixtures::content_location::response_cases() {
+    let response = HttpResponse::new(201, "Created")
+      .header("Content-Location", "/old")
+      .with_content_location(case.declaration_value)
+      .expect("Content-Location declaration should parse");
+    let serialized = String::from_utf8(response.to_bytes()).expect("response is UTF-8");
 
-  assert_eq!(
-    Some("/representations/current"),
-    header_value(&serialized, "Content-Location")
-  );
-  assert_eq!(1, serialized.matches("\r\nContent-Location: ").count());
-  assert_eq!(
-    Some("/representations/current"),
-    response
-      .content_location()
-      .expect("Content-Location should parse")
-  );
+    assert_eq!(
+      Some(case.normalized_value),
+      header_value(&serialized, "Content-Location"),
+      "{}",
+      case.name
+    );
+    assert_eq!(1, serialized.matches("\r\nContent-Location: ").count());
+    assert_response_content_location(case.name, &response, case);
+  }
 }
 
 #[test]
 fn server_content_location_helper_rejects_duplicate_unsafe_and_oversized_values() {
-  for value in [
-    "",
-    " ",
-    "/safe\u{7f}",
-    "/safe\u{1f}",
-    "/safe\r\nInjected: true",
-  ] {
-    assert!(
-      HttpResponse::ok("OK").with_content_location(value).is_err(),
-      "Content-Location declaration should reject {value:?}"
-    );
-  }
-
-  for value in ["", " ", "/safe\u{7f}", "/safe\u{1f}"] {
+  for case in fixtures::content_location::invalid_cases() {
     assert!(
       HttpResponse::ok("OK")
-        .header("Content-Location", value)
+        .with_content_location(case.value)
+        .is_err(),
+      "{} Content-Location declaration should reject invalid value",
+      case.name
+    );
+    assert!(
+      HttpResponse::ok("OK")
+        .header("Content-Location", case.value)
         .content_location()
         .is_err(),
-      "Content-Location parser should reject {value:?}"
+      "{} Content-Location parser should reject invalid value",
+      case.name
     );
   }
 
@@ -1083,6 +1108,26 @@ fn server_content_location_helper_rejects_duplicate_unsafe_and_oversized_values(
 }
 
 #[test]
+fn server_content_location_parser_preserves_invalid_raw_header_values() {
+  for case in fixtures::content_location::invalid_cases() {
+    let response = content_location_response(&[case.value]);
+    let serialized = String::from_utf8(response.to_bytes()).expect("response is UTF-8");
+
+    assert!(
+      response.content_location().is_err(),
+      "{} Content-Location parser should reject invalid value",
+      case.name
+    );
+    assert_eq!(
+      Some(case.value.trim()),
+      header_value(&serialized, "Content-Location"),
+      "{}",
+      case.name
+    );
+  }
+}
+
+#[test]
 fn server_content_location_helpers_stay_metadata_only() {
   let response = HttpResponse::new(302, "Found")
     .with_content_location("/representation")
@@ -1100,6 +1145,57 @@ fn server_content_location_helpers_stay_metadata_only() {
   assert!(
     serialized.starts_with("HTTP/1.1 302 Found\r\n"),
     "Content-Location should not alter response status policy"
+  );
+}
+
+#[test]
+fn server_content_location_helpers_coexist_with_adjacent_metadata_helpers() {
+  let response = HttpResponse::new(405, "Method Not Allowed")
+    .with_content_location(" /representations/current ")
+    .expect("Content-Location declaration should parse")
+    .with_allow(["GET", "HEAD"])
+    .expect("Allow declaration should parse")
+    .with_retry_after_delta(30)
+    .with_age(5)
+    .with_expires(UNIX_EPOCH + Duration::from_secs(fixtures::age_expires::EXPIRES_UNIX_SECONDS))
+    .header("Cache-Control", "public, max-age=60")
+    .with_vary("Accept-Encoding")
+    .expect("Vary declaration should parse")
+    .with_content_language(["fr-CA", "es-419"])
+    .expect("Content-Language declaration should parse")
+    .with_accept_ranges(["bytes", "pages"])
+    .expect("Accept-Ranges declaration should parse");
+  let serialized = String::from_utf8(response.to_bytes()).expect("response is UTF-8");
+
+  assert_eq!(
+    Some("/representations/current"),
+    header_value(&serialized, "Content-Location")
+  );
+  assert_eq!(Some("GET, HEAD"), header_value(&serialized, "Allow"));
+  assert_eq!(
+    Some("public, max-age=60"),
+    header_value(&serialized, "Cache-Control")
+  );
+  assert_eq!(Some("5"), header_value(&serialized, "Age"));
+  assert_eq!(
+    Some(fixtures::age_expires::EXPIRES_IMF_FIXDATE),
+    header_value(&serialized, "Expires")
+  );
+  assert_eq!(Some("accept-encoding"), header_value(&serialized, "Vary"));
+  assert_eq!(Some("30"), header_value(&serialized, "Retry-After"));
+  assert_eq!(
+    Some("fr-CA, es-419"),
+    header_value(&serialized, "Content-Language")
+  );
+  assert_eq!(
+    Some("bytes, pages"),
+    header_value(&serialized, "Accept-Ranges")
+  );
+  assert_eq!(
+    Some("/representations/current"),
+    response
+      .content_location()
+      .expect("Content-Location should parse")
   );
 }
 

--- a/rttp_client/tests/http11_compliance_matrix.rs
+++ b/rttp_client/tests/http11_compliance_matrix.rs
@@ -89,6 +89,27 @@ fn content_language_response(values: &[&str], include_adjacent_metadata: bool) -
   response.into_bytes()
 }
 
+fn content_location_response(values: &[&str], include_adjacent_metadata: bool) -> Vec<u8> {
+  let mut response = String::from("HTTP/1.1 200 OK\r\n");
+  for value in values {
+    response.push_str("Content-Location: ");
+    response.push_str(value);
+    response.push_str("\r\n");
+  }
+  if include_adjacent_metadata {
+    response.push_str("Cache-Control: public, max-age=60\r\n");
+    response.push_str("Age: 5\r\n");
+    response.push_str("Expires: Sun, 06 Nov 1994 08:49:37 GMT\r\n");
+    response.push_str("Vary: Accept-Encoding\r\n");
+    response.push_str("Retry-After: 30\r\n");
+    response.push_str("Allow: GET, HEAD\r\n");
+    response.push_str("Content-Language: fr-CA, es-419\r\n");
+    response.push_str("Accept-Ranges: bytes, pages\r\n");
+  }
+  response.push_str("Content-Length: 2\r\n\r\nOK");
+  response.into_bytes()
+}
+
 fn allow_response_with_cache_metadata(values: &[&str]) -> Vec<u8> {
   let mut response = String::from("HTTP/1.1 405 Method Not Allowed\r\n");
   for value in values {
@@ -531,6 +552,28 @@ fn assert_response_content_language(
   );
 }
 
+fn assert_response_content_location(
+  name: &str,
+  response: &rttp_client::response::Response,
+  expected: &fixtures::content_location::ResponseCase,
+) {
+  let content_location = response
+    .content_location()
+    .unwrap_or_else(|err| panic!("{name} Content-Location should parse: {err}"))
+    .unwrap_or_else(|| panic!("{name} should include Content-Location"));
+
+  assert_eq!(
+    expected.normalized_value,
+    content_location.as_str(),
+    "{name}"
+  );
+  assert_eq!(
+    Some(&expected.raw_value.to_string()),
+    response.header_value("Content-Location"),
+    "{name}"
+  );
+}
+
 fn assert_cache_control_helper_rejects_but_preserves_response(name: &str, raw_response: Vec<u8>) {
   let (addr, handle) = fixtures::spawn_socket2_owned_raw_response_server(raw_response);
 
@@ -679,6 +722,33 @@ fn assert_content_language_helper_rejects_but_preserves_response(
   handle.join().expect("raw response server thread");
 }
 
+fn assert_content_location_helper_rejects_but_preserves_response(
+  name: &str,
+  raw_response: Vec<u8>,
+  expected_value: &str,
+) {
+  let (addr, handle) = fixtures::spawn_socket2_owned_raw_response_server(raw_response);
+
+  let response = client()
+    .get()
+    .url(format!("http://{}/matrix/content-location-invalid", addr))
+    .emit()
+    .unwrap_or_else(|err| panic!("{name} response should remain parseable: {err}"));
+
+  assert!(
+    response.content_location().is_err(),
+    "{name} helper should reject invalid Content-Location"
+  );
+  assert_eq!(
+    Some(&expected_value.to_string()),
+    response.header_value("Content-Location"),
+    "{name}"
+  );
+  assert_eq!("OK", response.body().string().unwrap(), "{name}");
+
+  handle.join().expect("raw response server thread");
+}
+
 enum ConditionalHeader {
   IfNoneMatch(&'static str),
   IfMatch(&'static str),
@@ -735,6 +805,24 @@ fn sync_client_parses_shared_content_language_response_matrix() {
       .unwrap_or_else(|err| panic!("{} response should parse: {err}", case.name));
 
     assert_response_content_language(case.name, &response, case);
+    assert_eq!("OK", response.body().string().unwrap(), "{}", case.name);
+    handle.join().expect("raw response server thread");
+  }
+}
+
+#[test]
+fn sync_client_parses_shared_content_location_response_matrix() {
+  for case in fixtures::content_location::response_cases() {
+    let raw_response = content_location_response(case.values, false);
+    let (addr, handle) = fixtures::spawn_socket2_owned_raw_response_server(raw_response);
+
+    let response = client()
+      .get()
+      .url(format!("http://{}/matrix/content-location", addr))
+      .emit()
+      .unwrap_or_else(|err| panic!("{} response should parse: {err}", case.name));
+
+    assert_response_content_location(case.name, &response, case);
     assert_eq!("OK", response.body().string().unwrap(), "{}", case.name);
     handle.join().expect("raw response server thread");
   }
@@ -1179,6 +1267,91 @@ fn sync_client_parses_content_language_with_existing_metadata_helpers() {
 }
 
 #[test]
+fn sync_client_parses_content_location_with_existing_metadata_helpers() {
+  for case in fixtures::content_location::response_cases() {
+    let raw_response = content_location_response(case.values, true);
+    let (addr, handle) = fixtures::spawn_socket2_owned_raw_response_server(raw_response);
+
+    let response = client()
+      .get()
+      .url(format!("http://{}/matrix/content-location-adjacent", addr))
+      .emit()
+      .unwrap_or_else(|err| panic!("{} response should parse: {err}", case.name));
+
+    assert_response_content_location(case.name, &response, case);
+    assert_eq!(
+      Some(60),
+      response
+        .cache_control()
+        .expect("Cache-Control should parse")
+        .expect("Cache-Control should be present")
+        .max_age(),
+      "{}",
+      case.name
+    );
+    assert_eq!(Some(5), response.age().expect("Age should parse"));
+    assert_eq!(
+      Some(UNIX_EPOCH + Duration::from_secs(fixtures::age_expires::EXPIRES_UNIX_SECONDS)),
+      response.expires().expect("Expires should parse"),
+      "{}",
+      case.name
+    );
+    assert!(
+      response
+        .vary()
+        .expect("Vary should parse")
+        .expect("Vary should be present")
+        .contains_field_name("accept-encoding"),
+      "{}",
+      case.name
+    );
+    assert_eq!(
+      Some(30),
+      response
+        .retry_after()
+        .expect("Retry-After should parse")
+        .expect("Retry-After should be present")
+        .delta_seconds(),
+      "{}",
+      case.name
+    );
+    assert!(
+      response
+        .allow()
+        .expect("Allow should parse")
+        .expect("Allow should be present")
+        .contains_method("GET"),
+      "{}",
+      case.name
+    );
+    assert_eq!(
+      &["fr-CA", "es-419"],
+      response
+        .content_language()
+        .expect("Content-Language should parse")
+        .expect("Content-Language should be present")
+        .tags()
+        .as_slice(),
+      "{}",
+      case.name
+    );
+    assert_eq!(
+      &["bytes", "pages"],
+      response
+        .accept_ranges()
+        .expect("Accept-Ranges should parse")
+        .expect("Accept-Ranges should be present")
+        .units()
+        .as_slice(),
+      "{}",
+      case.name
+    );
+    assert_eq!("OK", response.body().string().unwrap(), "{}", case.name);
+    handle.join().expect("raw response server thread");
+  }
+}
+
+#[test]
 fn sync_client_cache_control_helper_rejects_shared_invalid_response_matrix() {
   for case in fixtures::cache_control::invalid_response_cases() {
     assert_cache_control_helper_rejects_but_preserves_response(
@@ -1245,6 +1418,17 @@ fn sync_client_content_language_helper_rejects_shared_invalid_response_matrix() 
 }
 
 #[test]
+fn sync_client_content_location_helper_rejects_shared_invalid_response_matrix() {
+  for case in fixtures::content_location::invalid_cases() {
+    assert_content_location_helper_rejects_but_preserves_response(
+      case.name,
+      content_location_response(&[case.value], false),
+      case.value.trim(),
+    );
+  }
+}
+
+#[test]
 fn sync_client_retry_after_helper_rejects_shared_invalid_response_matrix() {
   for case in fixtures::retry_after::invalid_cases() {
     assert_retry_after_helper_rejects_but_preserves_response(
@@ -1275,6 +1459,21 @@ fn sync_client_retry_after_helper_rejects_duplicate_singleton_and_oversized_valu
   assert_retry_after_helper_rejects_but_preserves_response(
     "oversized Retry-After value",
     retry_after_response(&[&fixtures::retry_after::oversized_value()], false),
+  );
+}
+
+#[test]
+fn sync_client_content_location_helper_rejects_duplicate_singleton_and_oversized_values() {
+  assert_content_location_helper_rejects_but_preserves_response(
+    "duplicate Content-Location header fields",
+    content_location_response(&["/one", "/two"], false),
+    "/one",
+  );
+  let oversized = fixtures::content_location::oversized_value();
+  assert_content_location_helper_rejects_but_preserves_response(
+    "oversized Content-Location value",
+    content_location_response(&[&oversized], false),
+    &oversized,
   );
 }
 

--- a/rttp_http11_test_fixtures/src/lib.rs
+++ b/rttp_http11_test_fixtures/src/lib.rs
@@ -1058,6 +1058,78 @@ pub mod vary {
   }
 }
 
+pub mod content_location {
+  pub const MAX_VALUE_BYTES: usize = 64 * 1024;
+
+  pub struct ResponseCase {
+    pub name: &'static str,
+    pub values: &'static [&'static str],
+    pub raw_value: &'static str,
+    pub normalized_value: &'static str,
+    pub declaration_value: &'static str,
+  }
+
+  pub struct InvalidCase {
+    pub name: &'static str,
+    pub value: &'static str,
+  }
+
+  const RESPONSE_CASES: &[ResponseCase] = &[
+    ResponseCase {
+      name: "absolute URI",
+      values: &["https://example.test/representations/current.json"],
+      raw_value: "https://example.test/representations/current.json",
+      normalized_value: "https://example.test/representations/current.json",
+      declaration_value: "https://example.test/representations/current.json",
+    },
+    ResponseCase {
+      name: "absolute path reference with optional whitespace",
+      values: &[" /representations/current.json "],
+      raw_value: "/representations/current.json",
+      normalized_value: "/representations/current.json",
+      declaration_value: " /representations/current.json ",
+    },
+    ResponseCase {
+      name: "relative path reference with query and fragment",
+      values: &["../current?variant=full#metadata"],
+      raw_value: "../current?variant=full#metadata",
+      normalized_value: "../current?variant=full#metadata",
+      declaration_value: "../current?variant=full#metadata",
+    },
+  ];
+
+  const INVALID_CASES: &[InvalidCase] = &[
+    InvalidCase {
+      name: "empty value",
+      value: "",
+    },
+    InvalidCase {
+      name: "blank value",
+      value: " ",
+    },
+    InvalidCase {
+      name: "delete control character",
+      value: "/safe\u{7f}",
+    },
+    InvalidCase {
+      name: "unit separator control character",
+      value: "/safe\u{1f}",
+    },
+  ];
+
+  pub fn response_cases() -> &'static [ResponseCase] {
+    RESPONSE_CASES
+  }
+
+  pub fn invalid_cases() -> &'static [InvalidCase] {
+    INVALID_CASES
+  }
+
+  pub fn oversized_value() -> String {
+    format!("/{}", "a".repeat(MAX_VALUE_BYTES + 1))
+  }
+}
+
 pub mod content_language {
   pub const MAX_VALUE_BYTES: usize = 64 * 1024;
   pub const SERVER_MAX_LANGUAGES: usize = 32;


### PR DESCRIPTION
Shared Content-Location fixtures and cross-crate HTTP/1.1 matrix coverage were added for server and client parity, serialization, rejection, preservation, bounds, and adjacent metadata coexistence. Validation passed.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1610/
work_kind: code_work
branch: hbx-1610-rttp-add-cross-crate-http
base: main
commit: 4c6d8f4152d5b192b13318195af3ab7dc78dcaed
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1610/
    url: https://plane.kahub.in/endless/browse/HBX-1610/
    close_policy: link_only
```