### PR TITLE
feat: [rttp] Add bounded HTTP/1.1 103 Early Hints server model helpers

### DIFF
--- a/rttp/src/server.rs
+++ b/rttp/src/server.rs
@@ -21,6 +21,7 @@ const MAX_CONTENT_LOCATION_VALUE_BYTES: usize = 64 * 1024;
 const MAX_ACCEPT_RANGES_VALUE_BYTES: usize = 64 * 1024;
 const MAX_ACCEPT_RANGES_UNITS: usize = 32;
 const MAX_RETRY_AFTER_VALUE_BYTES: usize = 64 * 1024;
+const MAX_EARLY_HINTS_VALUE_BYTES: usize = 64 * 1024;
 const HTTP2_CLIENT_PREFACE: &[u8; 24] = b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n";
 const HTTP2_FRAME_DATA: u8 = 0x0;
 const HTTP2_FRAME_HEADERS: u8 = 0x1;
@@ -4444,6 +4445,27 @@ impl fmt::Display for HttpByteRangeError {
 
 impl Error for HttpByteRangeError {}
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct HttpEarlyHintsError {
+  message: String,
+}
+
+impl HttpEarlyHintsError {
+  fn new<S: AsRef<str>>(message: S) -> Self {
+    Self {
+      message: message.as_ref().to_string(),
+    }
+  }
+}
+
+impl fmt::Display for HttpEarlyHintsError {
+  fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+    formatter.write_str(&self.message)
+  }
+}
+
+impl Error for HttpEarlyHintsError {}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum DefaultConnectionHeader {
   Close,
@@ -4500,6 +4522,47 @@ impl HttpResponse {
 
   pub fn precondition_failed() -> Self {
     Self::new(412, "Precondition Failed")
+  }
+
+  pub fn early_hints<I, L>(links: I) -> Result<Self, HttpEarlyHintsError>
+  where
+    I: IntoIterator<Item = L>,
+    L: AsRef<str>,
+  {
+    Self::early_hints_with_headers(links, std::iter::empty::<(&str, &str)>())
+  }
+
+  pub fn early_hints_with_headers<I, L, H, N, V>(
+    links: I,
+    metadata: H,
+  ) -> Result<Self, HttpEarlyHintsError>
+  where
+    I: IntoIterator<Item = L>,
+    L: AsRef<str>,
+    H: IntoIterator<Item = (N, V)>,
+    N: AsRef<str>,
+    V: AsRef<str>,
+  {
+    let mut response = Self::new(103, "Early Hints");
+    let mut link_count = 0usize;
+    for link in links {
+      let link = validate_early_hints_link_value(link.as_ref())?;
+      response.headers.push(HttpHeader::new("Link", link));
+      link_count += 1;
+    }
+    if link_count == 0 {
+      return Err(HttpEarlyHintsError::new(
+        "Early Hints requires at least one Link header",
+      ));
+    }
+
+    for (name, value) in metadata {
+      let name = validate_early_hints_metadata_name(name.as_ref())?;
+      let value = validate_early_hints_header_value(value.as_ref())?;
+      response.headers.push(HttpHeader::new(name, value));
+    }
+
+    Ok(response)
   }
 
   pub fn header<N: AsRef<str>, V: AsRef<str>>(mut self, name: N, value: V) -> Self {
@@ -7003,6 +7066,63 @@ fn assert_valid_header_component(component: &str) {
     !component.contains('\r') && !component.contains('\n'),
     "response headers must not contain CR or LF"
   );
+}
+
+fn validate_early_hints_link_value(value: &str) -> Result<&str, HttpEarlyHintsError> {
+  let value = validate_early_hints_header_value(value)?;
+  if value.trim().is_empty() {
+    return Err(HttpEarlyHintsError::new(
+      "Early Hints Link header must not be empty",
+    ));
+  }
+  Ok(value)
+}
+
+fn validate_early_hints_metadata_name(name: &str) -> Result<&str, HttpEarlyHintsError> {
+  if !is_http_token(name) {
+    return Err(HttpEarlyHintsError::new(
+      "Early Hints metadata header name is invalid",
+    ));
+  }
+  if name.eq_ignore_ascii_case("Link") {
+    return Err(HttpEarlyHintsError::new(
+      "Early Hints Link headers must be provided through the links argument",
+    ));
+  }
+  if is_forbidden_early_hints_metadata_name(name) {
+    return Err(HttpEarlyHintsError::new(
+      "Early Hints metadata must not contain framing or connection fields",
+    ));
+  }
+  Ok(name)
+}
+
+fn validate_early_hints_header_value(value: &str) -> Result<&str, HttpEarlyHintsError> {
+  if value.len() > MAX_EARLY_HINTS_VALUE_BYTES {
+    return Err(HttpEarlyHintsError::new(
+      "Early Hints header value is too large",
+    ));
+  }
+  if !value.bytes().all(is_header_value_byte) {
+    return Err(HttpEarlyHintsError::new(
+      "Early Hints header value contains invalid bytes",
+    ));
+  }
+  Ok(value)
+}
+
+fn is_forbidden_early_hints_metadata_name(name: &str) -> bool {
+  matches!(
+    name.to_ascii_lowercase().as_str(),
+    "connection"
+      | "content-length"
+      | "keep-alive"
+      | "proxy-connection"
+      | "te"
+      | "trailer"
+      | "transfer-encoding"
+      | "upgrade"
+  )
 }
 
 fn assert_allowed_trailer_name(name: &str) {

--- a/rttp/tests/test_server_models.rs
+++ b/rttp/tests/test_server_models.rs
@@ -1475,3 +1475,85 @@ fn serializes_empty_http_response_without_content_length_for_1xx() {
     serialized.as_slice()
   );
 }
+
+#[test]
+fn early_hints_serializes_link_metadata_without_body_or_content_length() {
+  let response = HttpResponse::early_hints([
+    r#"</style.css>; rel=preload; as=style"#,
+    r#"</app.js>; rel=preload; as=script"#,
+  ])
+  .expect("early hints should build");
+
+  assert_eq!(
+    concat!(
+      "HTTP/1.1 103 Early Hints\r\n",
+      "Link: </style.css>; rel=preload; as=style\r\n",
+      "Link: </app.js>; rel=preload; as=script\r\n",
+      "\r\n"
+    )
+    .as_bytes(),
+    response.body("ignored").to_bytes().as_slice()
+  );
+}
+
+#[test]
+fn early_hints_accepts_safe_metadata_headers() {
+  let response = HttpResponse::early_hints_with_headers(
+    [r#"</style.css>; rel=preload; as=style"#],
+    [("Server", "rttp"), ("Cache-Control", "public, max-age=60")],
+  )
+  .expect("safe metadata should build");
+
+  assert_eq!(
+    concat!(
+      "HTTP/1.1 103 Early Hints\r\n",
+      "Link: </style.css>; rel=preload; as=style\r\n",
+      "Server: rttp\r\n",
+      "Cache-Control: public, max-age=60\r\n",
+      "\r\n"
+    )
+    .as_bytes(),
+    response.to_bytes().as_slice()
+  );
+}
+
+#[test]
+fn early_hints_rejects_invalid_injected_forbidden_and_oversized_headers() {
+  assert!(HttpResponse::early_hints([r#"</style.css>; rel=preload; as=style"#]).is_ok());
+  assert!(HttpResponse::early_hints([""]).is_err());
+  assert!(HttpResponse::early_hints(["/safe\r\nX-Evil: true"]).is_err());
+  assert!(HttpResponse::early_hints(["x".repeat(64 * 1024 + 1)]).is_err());
+
+  for name in [
+    "",
+    "Bad Name",
+    "Content-Length",
+    "Transfer-Encoding",
+    "Connection",
+    "TE",
+    "Trailer",
+    "Upgrade",
+    "Keep-Alive",
+    "Proxy-Connection",
+  ] {
+    assert!(
+      HttpResponse::early_hints_with_headers(
+        [r#"</style.css>; rel=preload; as=style"#],
+        [(name, "safe")]
+      )
+      .is_err(),
+      "{name:?} metadata header should reject"
+    );
+  }
+
+  assert!(HttpResponse::early_hints_with_headers(
+    [r#"</style.css>; rel=preload; as=style"#],
+    [("X-Trace", "safe\r\nX-Evil: true")]
+  )
+  .is_err());
+  assert!(HttpResponse::early_hints_with_headers(
+    [r#"</style.css>; rel=preload; as=style"#],
+    [("X-Trace", "x".repeat(64 * 1024 + 1))]
+  )
+  .is_err());
+}


### PR DESCRIPTION
Adds bounded `HttpResponse` helpers for HTTP/1.1 `103 Early Hints`, including validated `Link` and safe metadata headers, bodyless serialization, and regression coverage for invalid, injected, forbidden, and oversized inputs.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1614/
work_kind: code_work
branch: hbx-1614-rttp-add-bounded-http-1
base: main
commit: 649a3c2698a7170e37b80fab5ef7e7755abc71a5
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1614/
    url: https://plane.kahub.in/endless/browse/HBX-1614/
    close_policy: link_only
```