### PR TITLE
feat: [rttp_client] Preserve bounded HTTP/1.1 informational response metadata

### DIFF
--- a/rttp_client/src/connection/async_connection.rs
+++ b/rttp_client/src/connection/async_connection.rs
@@ -10,13 +10,13 @@ use url::Url;
 use std::sync::Arc;
 
 use crate::connection::connection::{
-  connect_tcp_stream, read_proxy_connect_response, request_expects_continue, Connection,
-  ExpectContinueResult,
+  connect_tcp_stream, prepend_informational_responses, read_proxy_connect_response,
+  request_expects_continue, Connection, ExpectContinueResult,
 };
 use crate::connection::connection_reader::{
-  is_skippable_informational_status, response_body_kind, response_connection_reusable,
-  response_connection_should_close, response_headers, response_status_code,
-  validate_response_trailer_header, ResponseBodyKind, ResponseParts,
+  is_skippable_informational_status, parse_informational_response, response_body_kind,
+  response_connection_reusable, response_connection_should_close, response_headers,
+  response_status_code, validate_response_trailer_header, ResponseBodyKind, ResponseParts,
   MAX_CHUNKED_RESPONSE_LINE_BYTES,
 };
 use crate::error;
@@ -70,6 +70,7 @@ impl<'a, S: AsyncRead + Unpin + ?Sized> AsyncStreamingResponse<'a, S> {
     Ok(ResponseParts {
       binary,
       trailers: self.body.trailers().clone(),
+      informational_responses: Vec::new(),
       connection_reusable,
       close_connection,
     })
@@ -253,8 +254,12 @@ impl<'a> AsyncConnection<'a> {
       };
 
       let close_connection = parts.close_connection;
-      let response =
-        Response::with_trailers(self.conn.rourl().clone(), parts.binary, parts.trailers)?;
+      let response = Response::with_trailers_and_informational(
+        self.conn.rourl().clone(),
+        parts.binary,
+        parts.trailers,
+        parts.informational_responses,
+      )?;
       let config = self.conn.config().clone();
 
       if response.is_redirect() {
@@ -311,8 +316,12 @@ impl<'a> AsyncConnection<'a> {
     let url = self.conn.url().map_err(error::builder)?;
     let parts = self.async_send_streaming_parts(&url, body).await?;
     let close_connection = parts.close_connection;
-    let response =
-      Response::with_trailers(self.conn.rourl().clone(), parts.binary, parts.trailers)?;
+    let response = Response::with_trailers_and_informational(
+      self.conn.rourl().clone(),
+      parts.binary,
+      parts.trailers,
+      parts.informational_responses,
+    )?;
     self.conn.closed_set(close_connection);
     Ok(response)
   }
@@ -411,24 +420,33 @@ impl<'a> AsyncConnection<'a> {
   where
     S: AsyncRead + Unpin,
   {
-    let binary = async_read_response_head(stream).await?;
+    let (binary, informational_responses) =
+      async_read_response_head_with_informational(stream).await?;
     self
-      .async_read_stream_parts_after_header(stream, binary)
+      .async_read_stream_parts_after_header_with_informational(
+        stream,
+        binary,
+        informational_responses,
+      )
       .await
   }
 
-  async fn async_read_stream_parts_after_header<S>(
+  async fn async_read_stream_parts_after_header_with_informational<S>(
     &self,
     stream: &mut S,
     binary: Vec<u8>,
+    informational_responses: Vec<crate::response::InformationalResponse>,
   ) -> error::Result<ResponseParts>
   where
     S: AsyncRead + Unpin,
   {
-    async_streaming_response_after_header(stream, self.conn.expect_no_response_body(), binary)
-      .await?
-      .read_to_parts()
-      .await
+    let mut parts =
+      async_streaming_response_after_header(stream, self.conn.expect_no_response_body(), binary)
+        .await?
+        .read_to_parts()
+        .await?;
+    parts.informational_responses = informational_responses;
+    Ok(parts)
   }
 
   async fn async_send_expect_continue_parts<S>(
@@ -456,24 +474,32 @@ impl<'a> AsyncConnection<'a> {
     }
 
     self.async_write_request_header_with(stream, header).await?;
+    let mut informational_responses = Vec::new();
     loop {
       let header = async_read_response_header(stream).await?;
       let status_code = response_status_code(&header)?;
       if status_code == 100 {
+        informational_responses.push(parse_informational_response(&header)?);
         self.async_write_request_body(stream).await?;
-        return Ok(ExpectContinueResult::BodySent);
+        return Ok(ExpectContinueResult::BodySent(informational_responses));
       }
       if is_skippable_informational_status(status_code) {
+        informational_responses.push(parse_informational_response(&header)?);
         continue;
       }
       return self
-        .async_read_stream_parts_after_header(stream, header)
+        .async_read_stream_parts_after_header_with_informational(
+          stream,
+          header,
+          informational_responses,
+        )
         .await
         .map(ExpectContinueResult::Final);
     }
   }
 }
 
+#[cfg(test)]
 async fn async_read_response_head<S>(stream: &mut S) -> error::Result<Vec<u8>>
 where
   S: AsyncRead + Unpin + ?Sized,
@@ -485,6 +511,24 @@ where
       continue;
     }
     return Ok(header);
+  }
+}
+
+async fn async_read_response_head_with_informational<S>(
+  stream: &mut S,
+) -> error::Result<(Vec<u8>, Vec<crate::response::InformationalResponse>)>
+where
+  S: AsyncRead + Unpin + ?Sized,
+{
+  let mut informational_responses = Vec::new();
+  loop {
+    let header = async_read_response_header(stream).await?;
+    let status_code = response_status_code(&header)?;
+    if is_skippable_informational_status(status_code) {
+      informational_responses.push(parse_informational_response(&header)?);
+      continue;
+    }
+    return Ok((header, informational_responses));
   }
 }
 
@@ -784,7 +828,12 @@ impl<'a> AsyncConnection<'a> {
   {
     match self.async_send_expect_continue_parts(stream).await? {
       ExpectContinueResult::NotUsed => self.async_write_stream(stream).await?,
-      ExpectContinueResult::BodySent => {}
+      ExpectContinueResult::BodySent(informational_responses) => {
+        return self
+          .async_read_stream_parts(url, stream)
+          .await
+          .map(|parts| prepend_informational_responses(parts, informational_responses));
+      }
       ExpectContinueResult::Final(parts) => return Ok(parts),
     }
     self.async_read_stream_parts(url, stream).await
@@ -908,7 +957,12 @@ impl<'a> AsyncConnection<'a> {
       .await?
     {
       ExpectContinueResult::NotUsed => self.async_write_stream(&mut tls_stream).await?,
-      ExpectContinueResult::BodySent => {}
+      ExpectContinueResult::BodySent(informational_responses) => {
+        return self
+          .async_read_stream_parts(url, &mut tls_stream)
+          .await
+          .map(|parts| prepend_informational_responses(parts, informational_responses));
+      }
       ExpectContinueResult::Final(parts) => return Ok(parts),
     }
     self.async_read_stream_parts(url, &mut tls_stream).await
@@ -1075,7 +1129,12 @@ impl<'a> AsyncConnection<'a> {
       .await?
     {
       ExpectContinueResult::NotUsed => self.async_write_request(&mut stream, &header).await?,
-      ExpectContinueResult::BodySent => {}
+      ExpectContinueResult::BodySent(informational_responses) => {
+        return self
+          .async_read_stream_parts(url, &mut stream)
+          .await
+          .map(|parts| prepend_informational_responses(parts, informational_responses));
+      }
       ExpectContinueResult::Final(parts) => return Ok(parts),
     }
     self.async_read_stream_parts(url, &mut stream).await

--- a/rttp_client/src/connection/block_connection.rs
+++ b/rttp_client/src/connection/block_connection.rs
@@ -6,7 +6,8 @@ use socks::{Socks4Stream, Socks5Stream};
 use url::Url;
 
 use crate::connection::connection::{
-  Connection, ExpectContinueResult, HandoffConnection, HandoffKind, StreamingRequestBody,
+  prepend_informational_responses, Connection, ExpectContinueResult, HandoffConnection,
+  HandoffKind, StreamingRequestBody,
 };
 use crate::connection::connection_reader::ResponseParts;
 use crate::error;
@@ -58,8 +59,12 @@ impl<'a> BlockConnection<'a> {
       };
 
       let close_connection = parts.close_connection;
-      let response =
-        Response::with_trailers(self.conn.rourl().clone(), parts.binary, parts.trailers)?;
+      let response = Response::with_trailers_and_informational(
+        self.conn.rourl().clone(),
+        parts.binary,
+        parts.trailers,
+        parts.informational_responses,
+      )?;
       let config = self.conn.config().clone();
 
       if response.is_redirect() {
@@ -115,8 +120,12 @@ impl<'a> BlockConnection<'a> {
     let url = self.conn.url().map_err(error::builder)?;
     let parts = self.conn.block_send_streaming_parts(&url, body)?;
     let close_connection = parts.close_connection;
-    let response =
-      Response::with_trailers(self.conn.rourl().clone(), parts.binary, parts.trailers)?;
+    let response = Response::with_trailers_and_informational(
+      self.conn.rourl().clone(),
+      parts.binary,
+      parts.trailers,
+      parts.informational_responses,
+    )?;
     self.conn.closed_set(close_connection);
     Ok(response)
   }
@@ -181,7 +190,12 @@ impl<'a> BlockConnection<'a> {
         }
         stream.flush().map_err(error::request)?;
       }
-      ExpectContinueResult::BodySent => {}
+      ExpectContinueResult::BodySent(informational_responses) => {
+        return self
+          .conn
+          .block_read_stream_parts(url, &mut stream)
+          .map(|parts| prepend_informational_responses(parts, informational_responses));
+      }
       ExpectContinueResult::Final(parts) => return Ok(parts),
     }
 

--- a/rttp_client/src/connection/connection.rs
+++ b/rttp_client/src/connection/connection.rs
@@ -10,11 +10,13 @@ use std::sync::Arc;
 use url::Url;
 
 use crate::connection::connection_reader::{
-  is_skippable_informational_status, read_response_head, read_response_header,
-  read_response_parts_after_header, response_status_code, ConnectionReader, ResponseParts,
+  is_skippable_informational_status, parse_informational_response, read_response_head,
+  read_response_header, read_response_parts_after_header,
+  read_response_parts_after_header_with_informational, response_status_code, ConnectionReader,
+  ResponseParts,
 };
 use crate::request::{RawRequest, RequestBody};
-use crate::response::Response;
+use crate::response::{InformationalResponse, Response};
 use crate::types::{Header, Proxy, RoUrl, ToUrl};
 use crate::{error, Config};
 
@@ -532,8 +534,20 @@ fn response_header_has_upgrade(header: &[u8]) -> error::Result<bool> {
 
 pub(crate) enum ExpectContinueResult {
   NotUsed,
-  BodySent,
+  BodySent(Vec<InformationalResponse>),
   Final(ResponseParts),
+}
+
+pub(crate) fn prepend_informational_responses(
+  mut parts: ResponseParts,
+  mut informational_responses: Vec<InformationalResponse>,
+) -> ResponseParts {
+  if informational_responses.is_empty() {
+    return parts;
+  }
+  informational_responses.extend(parts.informational_responses);
+  parts.informational_responses = informational_responses;
+  parts
 }
 
 pub(crate) enum HandoffKind {
@@ -761,18 +775,26 @@ impl<'a> Connection<'a> {
     }
 
     self.block_write_request_header_with(stream, header)?;
+    let mut informational_responses = Vec::new();
     loop {
       let header = read_response_header(stream)?;
       let status_code = response_status_code(&header)?;
       if status_code == 100 {
+        informational_responses.push(parse_informational_response(&header)?);
         self.block_write_request_body(stream)?;
-        return Ok(ExpectContinueResult::BodySent);
+        return Ok(ExpectContinueResult::BodySent(informational_responses));
       }
       if is_skippable_informational_status(status_code) {
+        informational_responses.push(parse_informational_response(&header)?);
         continue;
       }
-      return read_response_parts_after_header(stream, self.expect_no_response_body(), header)
-        .map(ExpectContinueResult::Final);
+      return read_response_parts_after_header_with_informational(
+        stream,
+        self.expect_no_response_body(),
+        header,
+        informational_responses,
+      )
+      .map(ExpectContinueResult::Final);
     }
   }
 
@@ -879,7 +901,11 @@ impl<'a> Connection<'a> {
   {
     match self.block_send_expect_continue_parts(stream)? {
       ExpectContinueResult::NotUsed => self.block_write_stream(stream)?,
-      ExpectContinueResult::BodySent => {}
+      ExpectContinueResult::BodySent(informational_responses) => {
+        return self
+          .block_read_stream_parts(url, stream)
+          .map(|parts| prepend_informational_responses(parts, informational_responses));
+      }
       ExpectContinueResult::Final(parts) => return Ok(parts),
     }
     self.block_read_stream_parts(url, stream)
@@ -982,7 +1008,11 @@ impl<'a> Connection<'a> {
 
     match self.block_send_expect_continue_parts(&mut ssl_stream)? {
       ExpectContinueResult::NotUsed => self.block_write_stream(&mut ssl_stream)?,
-      ExpectContinueResult::BodySent => {}
+      ExpectContinueResult::BodySent(informational_responses) => {
+        return self
+          .block_read_stream_parts(url, &mut ssl_stream)
+          .map(|parts| prepend_informational_responses(parts, informational_responses));
+      }
       ExpectContinueResult::Final(parts) => return Ok(parts),
     }
     self.block_read_stream_parts(url, &mut ssl_stream)
@@ -1060,7 +1090,11 @@ impl<'a> Connection<'a> {
 
     match self.block_send_expect_continue_parts(&mut tls)? {
       ExpectContinueResult::NotUsed => self.block_write_stream(&mut tls)?,
-      ExpectContinueResult::BodySent => {}
+      ExpectContinueResult::BodySent(informational_responses) => {
+        return self
+          .block_read_stream_parts(url, &mut tls)
+          .map(|parts| prepend_informational_responses(parts, informational_responses));
+      }
       ExpectContinueResult::Final(parts) => return Ok(parts),
     }
     self.block_read_stream_parts(url, &mut tls)

--- a/rttp_client/src/connection/connection_reader.rs
+++ b/rttp_client/src/connection/connection_reader.rs
@@ -593,11 +593,10 @@ fn has_only_crlf_line_breaks(bytes: &[u8]) -> bool {
           return false;
         }
       }
-      b'\n' => {
-        if index == 0 || bytes.get(index - 1) != Some(&b'\r') {
-          return false;
-        }
+      b'\n' if index == 0 || bytes.get(index - 1) != Some(&b'\r') => {
+        return false;
       }
+      b'\n' => {}
       _ => {}
     }
   }

--- a/rttp_client/src/connection/connection_reader.rs
+++ b/rttp_client/src/connection/connection_reader.rs
@@ -4,12 +4,13 @@ use std::io::Read;
 use url::Url;
 
 use crate::error;
-use crate::response::Response;
+use crate::response::{InformationalResponse, Response};
 use crate::types::{Header, IntoHeader, RoUrl};
 
 const HEADER_END: &[u8] = b"\r\n\r\n";
 const CRLF: &[u8] = b"\r\n";
 pub(crate) const MAX_CHUNKED_RESPONSE_LINE_BYTES: usize = 8 * 1024;
+pub(crate) const MAX_RESPONSE_HEAD_BYTES: usize = 64 * 1024;
 
 #[derive(Debug, Eq, PartialEq)]
 pub(crate) enum ResponseBodyKind {
@@ -22,6 +23,7 @@ pub(crate) enum ResponseBodyKind {
 pub(crate) struct ResponseParts {
   pub(crate) binary: Vec<u8>,
   pub(crate) trailers: Vec<Header>,
+  pub(crate) informational_responses: Vec<InformationalResponse>,
   pub(crate) connection_reusable: bool,
   pub(crate) close_connection: bool,
 }
@@ -220,7 +222,13 @@ impl<'a> ConnectionReader<'a> {
 
   #[allow(dead_code)]
   pub fn response(&mut self) -> error::Result<Response> {
-    self.streaming_response()?.read_to_response()
+    let parts = self.response_parts()?;
+    Response::with_trailers_and_informational(
+      RoUrl::from(self.url.clone()),
+      parts.binary,
+      parts.trailers,
+      parts.informational_responses,
+    )
   }
 
   // todo Connection reader will read more type from io::Reader, like Chunk data, and Stream data.
@@ -233,8 +241,23 @@ pub(crate) fn read_response_parts<R>(
 where
   R: Read + ?Sized,
 {
-  let binary = read_response_head(reader)?;
-  read_response_parts_after_header(reader, expect_no_body, binary)
+  read_response_parts_with_informational(reader, expect_no_body)
+}
+
+pub(crate) fn read_response_parts_with_informational<R>(
+  reader: &mut R,
+  expect_no_body: bool,
+) -> error::Result<ResponseParts>
+where
+  R: Read + ?Sized,
+{
+  let (binary, informational_responses) = read_response_head_with_informational(reader)?;
+  read_response_parts_after_header_with_informational(
+    reader,
+    expect_no_body,
+    binary,
+    informational_responses,
+  )
 }
 
 pub(crate) fn read_response_head<R>(reader: &mut R) -> error::Result<Vec<u8>>
@@ -251,10 +274,40 @@ where
   }
 }
 
+pub(crate) fn read_response_head_with_informational<R>(
+  reader: &mut R,
+) -> error::Result<(Vec<u8>, Vec<InformationalResponse>)>
+where
+  R: Read + ?Sized,
+{
+  let mut informational_responses = Vec::new();
+  loop {
+    let header = read_response_header(reader)?;
+    let status_code = response_status_code(&header)?;
+    if is_skippable_informational_status(status_code) {
+      informational_responses.push(parse_informational_response(&header)?);
+      continue;
+    }
+    return Ok((header, informational_responses));
+  }
+}
+
 pub(crate) fn read_response_parts_after_header<R>(
   reader: &mut R,
   expect_no_body: bool,
+  binary: Vec<u8>,
+) -> error::Result<ResponseParts>
+where
+  R: Read + ?Sized,
+{
+  read_response_parts_after_header_with_informational(reader, expect_no_body, binary, Vec::new())
+}
+
+pub(crate) fn read_response_parts_after_header_with_informational<R>(
+  reader: &mut R,
+  expect_no_body: bool,
   mut binary: Vec<u8>,
+  informational_responses: Vec<InformationalResponse>,
 ) -> error::Result<ResponseParts>
 where
   R: Read + ?Sized,
@@ -286,6 +339,7 @@ where
   Ok(ResponseParts {
     binary,
     trailers,
+    informational_responses,
     connection_reusable,
     close_connection,
   })
@@ -466,6 +520,113 @@ pub(crate) fn response_body_kind(
 
 fn is_supported_chunked_transfer_coding_path(transfer_codings: &[&str]) -> bool {
   transfer_codings.len() == 1 && transfer_codings[0].eq_ignore_ascii_case("chunked")
+}
+
+pub(crate) fn parse_informational_response(header: &[u8]) -> error::Result<InformationalResponse> {
+  if header.len() > MAX_RESPONSE_HEAD_BYTES {
+    return Err(error::bad_response(
+      "HTTP informational response head is too large",
+    ));
+  }
+  let (status_line, header_lines) = split_response_head_lines(header)?;
+  let (version, status_code, reason) = parse_response_status_line(status_line)?;
+  if !version.eq_ignore_ascii_case("HTTP/1.1") || !(100..200).contains(&status_code) {
+    return Err(error::bad_response("Invalid informational response"));
+  }
+
+  let mut headers = Vec::new();
+  for line in header_lines {
+    if line.is_empty() {
+      continue;
+    }
+    let line = std::str::from_utf8(line).map_err(error::response)?;
+    let (name, value) = line
+      .split_once(':')
+      .ok_or_else(|| error::bad_response("Invalid informational response header"))?;
+    if !is_http_token(name) || !value.bytes().all(is_header_value_byte) {
+      return Err(error::bad_response("Invalid informational response header"));
+    }
+    if name.eq_ignore_ascii_case("Content-Length") || name.eq_ignore_ascii_case("Transfer-Encoding")
+    {
+      return Err(error::bad_response(
+        "Informational response must not declare body framing",
+      ));
+    }
+    headers.push(Header::new(name, value));
+  }
+
+  Ok(InformationalResponse::new(
+    status_code,
+    reason.to_string(),
+    headers,
+  ))
+}
+
+fn split_response_head_lines(header: &[u8]) -> error::Result<(&[u8], Vec<&[u8]>)> {
+  let header = header
+    .strip_suffix(HEADER_END)
+    .ok_or_else(|| error::bad_response("Invalid informational response"))?;
+  if header.is_empty() {
+    return Err(error::bad_response("Invalid informational response"));
+  }
+  if !has_only_crlf_line_breaks(header) {
+    return Err(error::bad_response("Invalid informational response"));
+  }
+  let mut lines = header
+    .split(|byte| *byte == b'\n')
+    .map(|line| line.strip_suffix(b"\r").unwrap_or(line));
+  let Some(status_line) = lines.next() else {
+    return Err(error::bad_response("Invalid informational response"));
+  };
+  let mut header_lines = Vec::new();
+  for line in lines {
+    header_lines.push(line);
+  }
+  Ok((status_line, header_lines))
+}
+
+fn has_only_crlf_line_breaks(bytes: &[u8]) -> bool {
+  for (index, byte) in bytes.iter().enumerate() {
+    match *byte {
+      b'\r' => {
+        if bytes.get(index + 1) != Some(&b'\n') {
+          return false;
+        }
+      }
+      b'\n' => {
+        if index == 0 || bytes.get(index - 1) != Some(&b'\r') {
+          return false;
+        }
+      }
+      _ => {}
+    }
+  }
+  true
+}
+
+fn parse_response_status_line(status_line: &[u8]) -> error::Result<(&str, u16, &str)> {
+  if status_line.contains(&b'\r') || status_line.contains(&b'\n') {
+    return Err(error::bad_response("Invalid informational response"));
+  }
+  let status_line = std::str::from_utf8(status_line).map_err(error::response)?;
+  let mut parts = status_line.splitn(3, ' ');
+  let version = parts
+    .next()
+    .ok_or_else(|| error::bad_response("Invalid informational response"))?;
+  let code = parts
+    .next()
+    .ok_or_else(|| error::bad_response("Invalid informational response"))?;
+  if code.len() != 3 || !code.bytes().all(|byte| byte.is_ascii_digit()) {
+    return Err(error::bad_response("Invalid informational response"));
+  }
+  let reason = parts.next().unwrap_or_default();
+  if !reason.bytes().all(is_reason_phrase_byte) {
+    return Err(error::bad_response("Invalid informational response"));
+  }
+  let status_code = code
+    .parse::<u16>()
+    .map_err(|_| error::bad_response("Invalid informational response"))?;
+  Ok((version, status_code, reason))
 }
 
 fn validate_response_header_lines(header: &[u8]) -> error::Result<()> {
@@ -754,12 +915,16 @@ fn is_header_value_byte(byte: u8) -> bool {
   byte == b'\t' || byte == b' ' || (0x21..=0x7e).contains(&byte) || byte >= 0x80
 }
 
+fn is_reason_phrase_byte(byte: u8) -> bool {
+  byte == b'\t' || byte == b' ' || (0x21..=0x7e).contains(&byte) || byte >= 0x80
+}
+
 #[cfg(test)]
 mod tests {
   use std::error::Error as StdError;
   use std::io::{self, Cursor, Read};
 
-  use super::{ConnectionReader, ResponseBodyKind};
+  use super::{ConnectionReader, ResponseBodyKind, MAX_RESPONSE_HEAD_BYTES};
 
   #[test]
   fn test_chunked_binary_is_decoded() {
@@ -991,6 +1156,151 @@ mod tests {
       (raw.len() - "OK".len()) as u64,
       cursor.position(),
       "malformed response headers must be rejected before body bytes are consumed"
+    );
+  }
+
+  #[test]
+  fn response_parts_preserve_skipped_informational_heads() {
+    let raw = concat!(
+      "HTTP/1.1 100 Continue\r\n",
+      "X-Continue: yes\r\n",
+      "\r\n",
+      "HTTP/1.1 103 Early Hints\r\n",
+      "Link: </style.css>; rel=preload\r\n",
+      "X-Trace: hint\r\n",
+      "\r\n",
+      "HTTP/1.1 200 OK\r\n",
+      "Content-Length: 2\r\n",
+      "\r\n",
+      "OK"
+    );
+    let url = url::Url::parse("http://localhost").unwrap();
+    let mut cursor = Cursor::new(raw.as_bytes());
+    let mut reader = ConnectionReader::new(&url, &mut cursor, false);
+
+    let response = reader.response().unwrap();
+    let informational = response.informational_responses();
+
+    assert_eq!(200, response.code());
+    assert_eq!("OK", response.body().string().unwrap());
+    assert_eq!(2, informational.len());
+    assert_eq!(100, informational[0].code());
+    assert_eq!("Continue", informational[0].reason());
+    assert_eq!(
+      Some("yes"),
+      informational[0]
+        .header_value("X-Continue")
+        .map(String::as_str)
+    );
+    assert_eq!(103, informational[1].code());
+    assert_eq!("Early Hints", informational[1].reason());
+    assert_eq!(
+      Some("</style.css>; rel=preload"),
+      informational[1].header_value("Link").map(String::as_str)
+    );
+    assert_eq!(
+      Some("hint"),
+      informational[1].header_value("X-Trace").map(String::as_str)
+    );
+  }
+
+  #[test]
+  fn malformed_informational_response_header_is_rejected() {
+    let raw = concat!(
+      "HTTP/1.1 103 Early Hints\r\n",
+      "BrokenHeader\r\n",
+      "\r\n",
+      "HTTP/1.1 200 OK\r\n",
+      "Content-Length: 2\r\n",
+      "\r\n",
+      "OK"
+    );
+    let url = url::Url::parse("http://localhost").unwrap();
+    let mut cursor = Cursor::new(raw.as_bytes());
+    let mut reader = ConnectionReader::new(&url, &mut cursor, false);
+
+    let error = reader
+      .response()
+      .expect_err("malformed informational header should be rejected");
+
+    assert!(
+      error.to_string().contains("Invalid informational response"),
+      "unexpected error: {error}"
+    );
+    assert_eq!(
+      "HTTP/1.1 103 Early Hints\r\nBrokenHeader\r\n\r\n".len() as u64,
+      cursor.position(),
+      "malformed informational heads are rejected before final response bytes are consumed"
+    );
+  }
+
+  #[test]
+  fn ambiguous_informational_response_framing_is_rejected() {
+    for framing in ["Content-Length: 2", "Transfer-Encoding: chunked"] {
+      let raw = format!(
+        "HTTP/1.1 103 Early Hints\r\n{framing}\r\n\r\nHTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nOK"
+      );
+      let url = url::Url::parse("http://localhost").unwrap();
+      let mut cursor = Cursor::new(raw.as_bytes());
+      let mut reader = ConnectionReader::new(&url, &mut cursor, false);
+
+      let error = reader
+        .response()
+        .expect_err("informational body framing should be rejected");
+
+      assert!(
+        error
+          .to_string()
+          .contains("Informational response must not declare body framing"),
+        "unexpected error for {framing}: {error}"
+      );
+    }
+  }
+
+  #[test]
+  fn malformed_informational_status_line_is_rejected() {
+    for status_line in [
+      "HTTP/1.1 103 Early\x7fHints",
+      "HTTP/1.0 103 Early Hints",
+      "HTTP/9.9 103 Early Hints",
+    ] {
+      let raw = format!(
+        "{status_line}\r\nX-Interim: ignored\r\n\r\nHTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nOK"
+      );
+      let url = url::Url::parse("http://localhost").unwrap();
+      let mut cursor = Cursor::new(raw.as_bytes());
+      let mut reader = ConnectionReader::new(&url, &mut cursor, false);
+
+      let error = reader
+        .response()
+        .expect_err("malformed informational status line should be rejected");
+
+      assert!(
+        error.to_string().contains("Invalid informational response"),
+        "unexpected error for {status_line:?}: {error}"
+      );
+    }
+  }
+
+  #[test]
+  fn oversized_informational_response_head_is_rejected() {
+    let oversized = "a".repeat(MAX_RESPONSE_HEAD_BYTES);
+    let raw = format!(
+      "HTTP/1.1 103 Early Hints\r\nX-Large: {oversized}\r\n\r\nHTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nOK"
+    );
+    let url = url::Url::parse("http://localhost").unwrap();
+    let mut cursor = Cursor::new(raw.as_bytes());
+    let mut reader = ConnectionReader::new(&url, &mut cursor, false);
+
+    let error = reader
+      .response()
+      .expect_err("oversized informational head should be rejected");
+
+    assert!(
+      error
+        .to_string()
+        .contains("HTTP informational response head is too large"),
+      "unexpected error: {error}"
     );
   }
 

--- a/rttp_client/src/response/response.rs
+++ b/rttp_client/src/response/response.rs
@@ -25,12 +25,14 @@ const MAX_VARY_FIELD_NAMES: usize = 256;
 #[derive(Clone)]
 pub struct Response {
   raw: RawResponse,
+  informational_responses: Vec<InformationalResponse>,
 }
 
 impl Response {
   pub fn new(url: RoUrl, binary: Vec<u8>) -> error::Result<Self> {
     Ok(Self {
       raw: RawResponse::new(url, binary)?,
+      informational_responses: Vec::new(),
     })
   }
 
@@ -39,9 +41,76 @@ impl Response {
     binary: Vec<u8>,
     trailers: Vec<Header>,
   ) -> error::Result<Self> {
+    Self::with_trailers_and_informational(url, binary, trailers, Vec::new())
+  }
+
+  pub(crate) fn with_trailers_and_informational(
+    url: RoUrl,
+    binary: Vec<u8>,
+    trailers: Vec<Header>,
+    informational_responses: Vec<InformationalResponse>,
+  ) -> error::Result<Self> {
     Ok(Self {
       raw: RawResponse::with_trailers(url, binary, trailers)?,
+      informational_responses,
     })
+  }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct InformationalResponse {
+  code: u16,
+  reason: String,
+  headers: Vec<Header>,
+}
+
+impl InformationalResponse {
+  pub(crate) fn new(code: u16, reason: String, headers: Vec<Header>) -> Self {
+    Self {
+      code,
+      reason,
+      headers,
+    }
+  }
+
+  pub fn code(&self) -> u16 {
+    self.code
+  }
+
+  pub fn reason(&self) -> &String {
+    &self.reason
+  }
+
+  pub fn headers(&self) -> &Vec<Header> {
+    &self.headers
+  }
+
+  pub fn headers_of_name<S: AsRef<str>>(&self, name: S) -> Vec<&Header> {
+    self
+      .headers()
+      .iter()
+      .filter(|header| header.name().eq_ignore_ascii_case(name.as_ref()))
+      .collect()
+  }
+
+  pub fn header<S: AsRef<str>>(&self, name: S) -> Option<&Header> {
+    self
+      .headers()
+      .iter()
+      .find(|header| header.name().eq_ignore_ascii_case(name.as_ref()))
+  }
+
+  pub fn header_values<S: AsRef<str>>(&self, name: S) -> Vec<&String> {
+    self
+      .headers()
+      .iter()
+      .filter(|header| header.name().eq_ignore_ascii_case(name.as_ref()))
+      .map(|header| header.value())
+      .collect()
+  }
+
+  pub fn header_value<S: AsRef<str>>(&self, name: S) -> Option<&String> {
+    self.header(name).map(|header| header.value())
   }
 }
 
@@ -200,6 +269,10 @@ impl Response {
 
   pub fn trailers(&self) -> &Vec<Header> {
     self.raw.trailers_get()
+  }
+
+  pub fn informational_responses(&self) -> &[InformationalResponse] {
+    &self.informational_responses
   }
 
   pub fn headers_of_name<S: AsRef<str>>(&self, name: S) -> Vec<&Header> {

--- a/rttp_client/src/types/header.rs
+++ b/rttp_client/src/types/header.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Header {
   name: String,
   value: String,

--- a/rttp_client/tests/test_http_async.rs
+++ b/rttp_client/tests/test_http_async.rs
@@ -145,6 +145,39 @@ fn test_async_head_response_is_bodyless_and_preserves_headers() {
 
 #[test]
 #[cfg(feature = "async")]
+fn test_async_client_preserves_informational_response_metadata() {
+  let (addr, _handle) = support::spawn_informational_then_ok_server("103 Early Hints");
+  block_on(async {
+    let response = client()
+      .get()
+      .url(format!("http://{}/early-hints", addr))
+      .rasync()
+      .await
+      .expect("async informational response");
+
+    assert_eq!(200, response.code());
+    assert_eq!("final body", response.body().string().unwrap());
+    assert_eq!(
+      Some("yes"),
+      response.header_value("X-Final").map(String::as_str)
+    );
+    assert!(response.header_value("X-Interim").is_none());
+
+    let informational = response.informational_responses();
+    assert_eq!(1, informational.len());
+    assert_eq!(103, informational[0].code());
+    assert_eq!("Early Hints", informational[0].reason());
+    assert_eq!(
+      Some("ignored"),
+      informational[0]
+        .header_value("X-Interim")
+        .map(String::as_str)
+    );
+  });
+}
+
+#[test]
+#[cfg(feature = "async")]
 fn test_async_chunked() {
   let (addr, _handle) = support::spawn_chunked_server();
   block_on(async {

--- a/rttp_client/tests/test_http_basic.rs
+++ b/rttp_client/tests/test_http_basic.rs
@@ -1000,6 +1000,10 @@ fn test_sync_client_waits_for_100_continue_before_sending_body() {
 
   assert_eq!(200, response.code());
   assert_eq!("accepted", response.body().string().unwrap());
+  let informational = response.informational_responses();
+  assert_eq!(1, informational.len());
+  assert_eq!(100, informational[0].code());
+  assert_eq!("Continue", informational[0].reason());
 
   let request = handle.join().expect("expect continue gate thread");
   assert!(!request.is_empty(), "body was sent before 100 Continue");
@@ -1047,6 +1051,16 @@ fn test_sync_client_skips_103_early_hints_before_final_response() {
   );
   assert_eq!(Some(&"yes".to_string()), response.header_value("X-Final"));
   assert!(response.header_value("X-Interim").is_none());
+  let informational = response.informational_responses();
+  assert_eq!(1, informational.len());
+  assert_eq!(103, informational[0].code());
+  assert_eq!("Early Hints", informational[0].reason());
+  assert_eq!(
+    Some("ignored"),
+    informational[0]
+      .header_value("X-Interim")
+      .map(String::as_str)
+  );
   assert_eq!("final body", response.body().string().unwrap());
 }
 
@@ -1073,6 +1087,7 @@ fn test_sync_client_returns_101_switching_protocols_as_terminal_response() {
     Some(&"test-accept".to_string()),
     response.header_value("Sec-WebSocket-Accept")
   );
+  assert!(response.informational_responses().is_empty());
   assert_eq!("", response.body().string().unwrap());
 }
 


### PR DESCRIPTION
Adds `Response::informational_responses()` for preserved bounded HTTP/1.1 informational response metadata while keeping final-response and upgrade behavior unchanged.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1613/
work_kind: code_work
branch: hbx-1613-rttp-client-preserve-bounded-http
base: main
commit: e8214abf3d78daeac93f4ac762cb37e0c3219153
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1613/
    url: https://plane.kahub.in/endless/browse/HBX-1613/
    close_policy: link_only
```