### PR TITLE
feat: [rttp] Add cross-crate HTTP/1.1 Early Hints matrix

### DIFF
--- a/rttp/tests/http11_compliance_matrix.rs
+++ b/rttp/tests/http11_compliance_matrix.rs
@@ -1481,6 +1481,65 @@ fn model_parser_rejects_shared_obsolete_line_folding_fixtures() {
 }
 
 #[test]
+fn server_serializes_shared_early_hints_link_metadata_fixture() {
+  let early_hints = HttpResponse::early_hints_with_headers(
+    fixtures::response::EARLY_HINTS_LINKS.iter().copied(),
+    fixtures::response::EARLY_HINTS_METADATA.iter().copied(),
+  )
+  .expect("shared Early Hints fixture should serialize");
+
+  assert_eq!(
+    fixtures::response::VALID_EARLY_HINTS_HEAD,
+    early_hints.to_bytes().as_slice()
+  );
+}
+
+#[test]
+fn server_serialization_preserves_shared_final_response_after_early_hints() {
+  let early_hints = HttpResponse::early_hints_with_headers(
+    fixtures::response::EARLY_HINTS_LINKS.iter().copied(),
+    fixtures::response::EARLY_HINTS_METADATA.iter().copied(),
+  )
+  .expect("shared Early Hints fixture should serialize");
+  let final_response = HttpResponse::new(200, "OK")
+    .header("X-Final", "early-hints")
+    .body("OK");
+  let mut serialized = early_hints.to_bytes();
+  serialized.extend(final_response.to_bytes());
+
+  assert_eq!(
+    fixtures::response::VALID_EARLY_HINTS_WITH_FINAL,
+    serialized.as_slice()
+  );
+}
+
+#[test]
+fn server_serializes_shared_101_handoff_without_body_framing() {
+  let response = HttpResponse::new(101, "Switching Protocols")
+    .header("Connection", "Upgrade")
+    .header("Upgrade", "websocket")
+    .header("Sec-WebSocket-Accept", "shared-accept");
+
+  assert_eq!(
+    fixtures::response::SWITCHING_PROTOCOLS_HEAD,
+    response.to_bytes().as_slice()
+  );
+}
+
+#[test]
+fn server_early_hints_helper_rejects_shared_invalid_metadata() {
+  for case in fixtures::response::invalid_early_hints_metadata_cases() {
+    let error = HttpResponse::early_hints_with_headers(
+      fixtures::response::EARLY_HINTS_LINKS.iter().copied(),
+      [(case.header_name, case.value)],
+    )
+    .expect_err(case.name);
+
+    assert_eq!(case.error, error.to_string(), "{}", case.name);
+  }
+}
+
+#[test]
 fn live_socket2_server_accepts_shared_chunk_extensions_and_trailers_fixture() {
   let fixture = fixtures::request::chunked_with_extensions_and_trailers();
   let server = rttp::Http::server("127.0.0.1:0").expect("bind server");

--- a/rttp_client/tests/http11_compliance_matrix.rs
+++ b/rttp_client/tests/http11_compliance_matrix.rs
@@ -574,6 +574,26 @@ fn assert_response_content_location(
   );
 }
 
+fn assert_informational_response(
+  name: &str,
+  observed: &rttp_client::response::InformationalResponse,
+  expected: &fixtures::response::InformationalExpectation,
+) {
+  assert_eq!(expected.code, observed.code(), "{name}");
+  assert_eq!(expected.reason, observed.reason(), "{name}");
+  assert_eq!(expected.headers.len(), observed.headers().len(), "{name}");
+  for ((header_name, header_value), observed_header) in
+    expected.headers.iter().zip(observed.headers())
+  {
+    assert_eq!(*header_name, observed_header.name(), "{name}");
+    assert_eq!(
+      *header_value,
+      observed_header.value(),
+      "{name} {header_name}"
+    );
+  }
+}
+
 fn assert_cache_control_helper_rejects_but_preserves_response(name: &str, raw_response: Vec<u8>) {
   let (addr, handle) = fixtures::spawn_socket2_owned_raw_response_server(raw_response);
 
@@ -755,6 +775,115 @@ enum ConditionalHeader {
   IfModifiedSince(&'static str),
   IfUnmodifiedSince(&'static str),
   Manual(&'static str, &'static str),
+}
+
+#[test]
+fn sync_client_preserves_shared_informational_response_matrix() {
+  for case in fixtures::response::informational_response_cases() {
+    let (addr, handle) = fixtures::spawn_socket2_raw_response_server(case.raw);
+
+    let response = client()
+      .get()
+      .url(format!("http://{}/matrix/informational", addr))
+      .emit()
+      .unwrap_or_else(|err| panic!("{} response should parse: {err}", case.name));
+
+    assert_eq!(case.final_status, response.code(), "{}", case.name);
+    assert_eq!(case.final_reason, response.reason(), "{}", case.name);
+    assert_eq!(
+      Some(&case.final_marker.to_string()),
+      response.header_value("X-Final"),
+      "{}",
+      case.name
+    );
+    assert_eq!(
+      case.final_body,
+      response.body().string().unwrap(),
+      "{}",
+      case.name
+    );
+    assert_eq!(
+      case.informational.len(),
+      response.informational_responses().len(),
+      "{}",
+      case.name
+    );
+    for (observed, expected) in response
+      .informational_responses()
+      .iter()
+      .zip(case.informational)
+    {
+      assert_informational_response(case.name, observed, expected);
+    }
+
+    handle.join().expect("raw response server thread");
+  }
+}
+
+#[test]
+fn sync_client_rejects_shared_malformed_informational_heads() {
+  for case in fixtures::response::malformed_informational_response_cases() {
+    let (addr, handle) = fixtures::spawn_socket2_raw_response_server(case.raw);
+
+    let error = client()
+      .get()
+      .url(format!("http://{}/matrix/informational-invalid", addr))
+      .emit()
+      .expect_err(case.name);
+
+    assert!(
+      error.to_string().contains(case.error_contains),
+      "{} unexpected error: {error}",
+      case.name
+    );
+
+    handle.join().expect("raw response server thread");
+  }
+}
+
+#[test]
+fn sync_client_rejects_shared_oversized_informational_head() {
+  let (addr, handle) = fixtures::spawn_socket2_owned_raw_response_server(
+    fixtures::response::oversized_informational_response(),
+  );
+
+  let error = client()
+    .get()
+    .url(format!("http://{}/matrix/informational-oversized", addr))
+    .emit()
+    .expect_err("oversized informational response should be rejected");
+
+  assert!(
+    error
+      .to_string()
+      .contains("HTTP informational response head is too large"),
+    "unexpected error: {error}"
+  );
+
+  handle.join().expect("raw response server thread");
+}
+
+#[test]
+fn sync_client_keeps_shared_101_handoff_separate_from_informational_history() {
+  let (addr, handle) =
+    fixtures::spawn_socket2_raw_response_server(fixtures::response::SWITCHING_PROTOCOLS_HANDOFF);
+
+  let response = client()
+    .get()
+    .url(format!("http://{}/matrix/upgrade", addr))
+    .emit()
+    .expect("101 response should parse as the final response");
+
+  assert_eq!(101, response.code());
+  assert_eq!("Switching Protocols", response.reason());
+  assert!(response.informational_responses().is_empty());
+  assert_eq!(
+    Some(&"websocket".to_string()),
+    response.header_value("Upgrade")
+  );
+  assert_eq!("", response.body().string().unwrap());
+
+  handle.join().expect("raw response server thread");
 }
 
 #[test]
@@ -2195,6 +2324,131 @@ fn sync_client_manual_range_header_interoperates_with_server_partial_content_hel
 
   assert_partial_response("manual range", response, "bytes 5-9/16", "56789");
   assert_observed_range(handle, "bytes=5-9", "manual range");
+}
+
+#[test]
+#[cfg(feature = "async")]
+fn async_client_preserves_shared_informational_response_matrix() {
+  for case in fixtures::response::informational_response_cases() {
+    let (addr, handle) = fixtures::spawn_socket2_raw_response_server(case.raw);
+
+    block_on(async {
+      let response = client()
+        .get()
+        .url(format!("http://{}/matrix/informational", addr))
+        .rasync()
+        .await
+        .unwrap_or_else(|err| panic!("{} response should parse: {err}", case.name));
+
+      assert_eq!(case.final_status, response.code(), "{}", case.name);
+      assert_eq!(case.final_reason, response.reason(), "{}", case.name);
+      assert_eq!(
+        Some(&case.final_marker.to_string()),
+        response.header_value("X-Final"),
+        "{}",
+        case.name
+      );
+      assert_eq!(
+        case.final_body,
+        response.body().string().unwrap(),
+        "{}",
+        case.name
+      );
+      assert_eq!(
+        case.informational.len(),
+        response.informational_responses().len(),
+        "{}",
+        case.name
+      );
+      for (observed, expected) in response
+        .informational_responses()
+        .iter()
+        .zip(case.informational)
+      {
+        assert_informational_response(case.name, observed, expected);
+      }
+    });
+
+    handle.join().expect("raw response server thread");
+  }
+}
+
+#[test]
+#[cfg(feature = "async")]
+fn async_client_rejects_shared_malformed_informational_heads() {
+  for case in fixtures::response::malformed_informational_response_cases() {
+    let (addr, handle) = fixtures::spawn_socket2_raw_response_server(case.raw);
+
+    block_on(async {
+      let error = client()
+        .get()
+        .url(format!("http://{}/matrix/informational-invalid", addr))
+        .rasync()
+        .await
+        .expect_err(case.name);
+
+      assert!(
+        error.to_string().contains(case.error_contains),
+        "{} unexpected error: {error}",
+        case.name
+      );
+    });
+
+    handle.join().expect("raw response server thread");
+  }
+}
+
+#[test]
+#[cfg(feature = "async")]
+fn async_client_rejects_shared_oversized_informational_head() {
+  let (addr, handle) = fixtures::spawn_socket2_owned_raw_response_server(
+    fixtures::response::oversized_informational_response(),
+  );
+
+  block_on(async {
+    let error = client()
+      .get()
+      .url(format!("http://{}/matrix/informational-oversized", addr))
+      .rasync()
+      .await
+      .expect_err("oversized informational response should be rejected");
+
+    assert!(
+      error
+        .to_string()
+        .contains("HTTP informational response head is too large"),
+      "unexpected error: {error}"
+    );
+  });
+
+  handle.join().expect("raw response server thread");
+}
+
+#[test]
+#[cfg(feature = "async")]
+fn async_client_keeps_shared_101_handoff_separate_from_informational_history() {
+  let (addr, handle) =
+    fixtures::spawn_socket2_raw_response_server(fixtures::response::SWITCHING_PROTOCOLS_HANDOFF);
+
+  block_on(async {
+    let response = client()
+      .get()
+      .url(format!("http://{}/matrix/upgrade", addr))
+      .rasync()
+      .await
+      .expect("101 response should parse as the final response");
+
+    assert_eq!(101, response.code());
+    assert_eq!("Switching Protocols", response.reason());
+    assert!(response.informational_responses().is_empty());
+    assert_eq!(
+      Some(&"websocket".to_string()),
+      response.header_value("Upgrade")
+    );
+    assert_eq!("", response.body().string().unwrap());
+  });
+
+  handle.join().expect("raw response server thread");
 }
 
 #[test]

--- a/rttp_http11_test_fixtures/src/lib.rs
+++ b/rttp_http11_test_fixtures/src/lib.rs
@@ -192,6 +192,285 @@ pub mod request {
 
 pub mod response {
   pub const CONTINUE: &[u8] = b"HTTP/1.1 100 Continue\r\n\r\n";
+  pub const MAX_HEAD_BYTES: usize = 64 * 1024;
+
+  pub struct InformationalExpectation {
+    pub code: u16,
+    pub reason: &'static str,
+    pub headers: &'static [(&'static str, &'static str)],
+  }
+
+  pub struct InformationalResponseCase {
+    pub name: &'static str,
+    pub raw: &'static [u8],
+    pub informational: &'static [InformationalExpectation],
+    pub final_status: u32,
+    pub final_reason: &'static str,
+    pub final_marker: &'static str,
+    pub final_body: &'static str,
+  }
+
+  pub struct InvalidInformationalResponseCase {
+    pub name: &'static str,
+    pub raw: &'static [u8],
+    pub error_contains: &'static str,
+  }
+
+  pub struct InvalidEarlyHintsMetadataCase {
+    pub name: &'static str,
+    pub header_name: &'static str,
+    pub value: &'static str,
+    pub error: &'static str,
+  }
+
+  pub const EARLY_HINTS_LINKS: &[&str] = &[
+    "</style.css>; rel=preload; as=style",
+    "</script.js>; rel=preload; as=script",
+  ];
+  pub const EARLY_HINTS_METADATA: &[(&str, &str)] = &[("X-Trace", "early")];
+
+  pub const VALID_EARLY_HINTS_HEAD: &[u8] = concat!(
+    "HTTP/1.1 103 Early Hints\r\n",
+    "Link: </style.css>; rel=preload; as=style\r\n",
+    "Link: </script.js>; rel=preload; as=script\r\n",
+    "X-Trace: early\r\n",
+    "\r\n"
+  )
+  .as_bytes();
+
+  pub const VALID_EARLY_HINTS_WITH_FINAL: &[u8] = concat!(
+    "HTTP/1.1 103 Early Hints\r\n",
+    "Link: </style.css>; rel=preload; as=style\r\n",
+    "Link: </script.js>; rel=preload; as=script\r\n",
+    "X-Trace: early\r\n",
+    "\r\n",
+    "HTTP/1.1 200 OK\r\n",
+    "X-Final: early-hints\r\n",
+    "Content-Length: 2\r\n",
+    "\r\n",
+    "OK"
+  )
+  .as_bytes();
+
+  pub const MULTIPLE_INFORMATIONAL_WITH_FINAL: &[u8] = concat!(
+    "HTTP/1.1 100 Continue\r\n",
+    "\r\n",
+    "HTTP/1.1 103 Early Hints\r\n",
+    "Link: </style.css>; rel=preload; as=style\r\n",
+    "Link: </script.js>; rel=preload; as=script\r\n",
+    "X-Trace: early\r\n",
+    "\r\n",
+    "HTTP/1.1 102 Processing\r\n",
+    "X-Progress: accepted\r\n",
+    "\r\n",
+    "HTTP/1.1 201 Created\r\n",
+    "X-Final: multiple-informational\r\n",
+    "Content-Length: 7\r\n",
+    "\r\n",
+    "created"
+  )
+  .as_bytes();
+
+  pub const FINAL_RESPONSE_PRESERVATION: &[u8] = concat!(
+    "HTTP/1.1 103 Early Hints\r\n",
+    "Link: </asset.css>; rel=preload; as=style\r\n",
+    "\r\n",
+    "HTTP/1.1 206 Partial Content\r\n",
+    "X-Final: partial-content\r\n",
+    "Content-Range: bytes 1-3/5\r\n",
+    "Content-Length: 3\r\n",
+    "\r\n",
+    "bcd"
+  )
+  .as_bytes();
+
+  pub const SWITCHING_PROTOCOLS_HEAD: &[u8] = concat!(
+    "HTTP/1.1 101 Switching Protocols\r\n",
+    "Connection: Upgrade\r\n",
+    "Upgrade: websocket\r\n",
+    "Sec-WebSocket-Accept: shared-accept\r\n",
+    "\r\n"
+  )
+  .as_bytes();
+
+  pub const SWITCHING_PROTOCOLS_HANDOFF: &[u8] = concat!(
+    "HTTP/1.1 101 Switching Protocols\r\n",
+    "Connection: Upgrade\r\n",
+    "Upgrade: websocket\r\n",
+    "Sec-WebSocket-Accept: shared-accept\r\n",
+    "\r\n",
+    "UPGRADED-BYTES"
+  )
+  .as_bytes();
+
+  const VALID_EARLY_HINTS_EXPECTATIONS: &[InformationalExpectation] = &[InformationalExpectation {
+    code: 103,
+    reason: "Early Hints",
+    headers: &[
+      ("Link", "</style.css>; rel=preload; as=style"),
+      ("Link", "</script.js>; rel=preload; as=script"),
+      ("X-Trace", "early"),
+    ],
+  }];
+
+  const MULTIPLE_INFORMATIONAL_EXPECTATIONS: &[InformationalExpectation] = &[
+    InformationalExpectation {
+      code: 100,
+      reason: "Continue",
+      headers: &[],
+    },
+    InformationalExpectation {
+      code: 103,
+      reason: "Early Hints",
+      headers: &[
+        ("Link", "</style.css>; rel=preload; as=style"),
+        ("Link", "</script.js>; rel=preload; as=script"),
+        ("X-Trace", "early"),
+      ],
+    },
+    InformationalExpectation {
+      code: 102,
+      reason: "Processing",
+      headers: &[("X-Progress", "accepted")],
+    },
+  ];
+
+  const FINAL_RESPONSE_PRESERVATION_EXPECTATIONS: &[InformationalExpectation] =
+    &[InformationalExpectation {
+      code: 103,
+      reason: "Early Hints",
+      headers: &[("Link", "</asset.css>; rel=preload; as=style")],
+    }];
+
+  const INFORMATIONAL_RESPONSE_CASES: &[InformationalResponseCase] = &[
+    InformationalResponseCase {
+      name: "valid 103 Link metadata before final 200",
+      raw: VALID_EARLY_HINTS_WITH_FINAL,
+      informational: VALID_EARLY_HINTS_EXPECTATIONS,
+      final_status: 200,
+      final_reason: "OK",
+      final_marker: "early-hints",
+      final_body: "OK",
+    },
+    InformationalResponseCase {
+      name: "multiple informational responses before final 201",
+      raw: MULTIPLE_INFORMATIONAL_WITH_FINAL,
+      informational: MULTIPLE_INFORMATIONAL_EXPECTATIONS,
+      final_status: 201,
+      final_reason: "Created",
+      final_marker: "multiple-informational",
+      final_body: "created",
+    },
+    InformationalResponseCase {
+      name: "final response status and body preserved after 103",
+      raw: FINAL_RESPONSE_PRESERVATION,
+      informational: FINAL_RESPONSE_PRESERVATION_EXPECTATIONS,
+      final_status: 206,
+      final_reason: "Partial Content",
+      final_marker: "partial-content",
+      final_body: "bcd",
+    },
+  ];
+
+  const MALFORMED_INFORMATIONAL_RESPONSE_CASES: &[InvalidInformationalResponseCase] = &[
+    InvalidInformationalResponseCase {
+      name: "malformed informational header line",
+      raw: concat!(
+        "HTTP/1.1 103 Early Hints\r\n",
+        "BrokenHeader\r\n",
+        "\r\n",
+        "HTTP/1.1 200 OK\r\n",
+        "Content-Length: 2\r\n",
+        "\r\n",
+        "OK"
+      )
+      .as_bytes(),
+      error_contains: "Invalid informational response header",
+    },
+    InvalidInformationalResponseCase {
+      name: "informational Content-Length framing",
+      raw: concat!(
+        "HTTP/1.1 103 Early Hints\r\n",
+        "Content-Length: 2\r\n",
+        "\r\n",
+        "HTTP/1.1 200 OK\r\n",
+        "Content-Length: 2\r\n",
+        "\r\n",
+        "OK"
+      )
+      .as_bytes(),
+      error_contains: "Informational response must not declare body framing",
+    },
+    InvalidInformationalResponseCase {
+      name: "informational Transfer-Encoding framing",
+      raw: concat!(
+        "HTTP/1.1 103 Early Hints\r\n",
+        "Transfer-Encoding: chunked\r\n",
+        "\r\n",
+        "HTTP/1.1 200 OK\r\n",
+        "Content-Length: 2\r\n",
+        "\r\n",
+        "OK"
+      )
+      .as_bytes(),
+      error_contains: "Informational response must not declare body framing",
+    },
+    InvalidInformationalResponseCase {
+      name: "malformed informational status line",
+      raw: concat!(
+        "HTTP/1.0 103 Early Hints\r\n",
+        "X-Trace: early\r\n",
+        "\r\n",
+        "HTTP/1.1 200 OK\r\n",
+        "Content-Length: 2\r\n",
+        "\r\n",
+        "OK"
+      )
+      .as_bytes(),
+      error_contains: "Invalid informational response",
+    },
+  ];
+
+  const INVALID_EARLY_HINTS_METADATA_CASES: &[InvalidEarlyHintsMetadataCase] = &[
+    InvalidEarlyHintsMetadataCase {
+      name: "Link metadata field",
+      header_name: "Link",
+      value: "</other.css>; rel=preload",
+      error: "Early Hints Link headers must be provided through the links argument",
+    },
+    InvalidEarlyHintsMetadataCase {
+      name: "Content-Length metadata field",
+      header_name: "Content-Length",
+      value: "2",
+      error: "Early Hints metadata must not contain framing or connection fields",
+    },
+    InvalidEarlyHintsMetadataCase {
+      name: "Connection metadata field",
+      header_name: "Connection",
+      value: "keep-alive",
+      error: "Early Hints metadata must not contain framing or connection fields",
+    },
+  ];
+
+  pub fn informational_response_cases() -> &'static [InformationalResponseCase] {
+    INFORMATIONAL_RESPONSE_CASES
+  }
+
+  pub fn malformed_informational_response_cases() -> &'static [InvalidInformationalResponseCase] {
+    MALFORMED_INFORMATIONAL_RESPONSE_CASES
+  }
+
+  pub fn invalid_early_hints_metadata_cases() -> &'static [InvalidEarlyHintsMetadataCase] {
+    INVALID_EARLY_HINTS_METADATA_CASES
+  }
+
+  pub fn oversized_informational_response() -> Vec<u8> {
+    let oversized = "a".repeat(MAX_HEAD_BYTES);
+    format!(
+      "HTTP/1.1 103 Early Hints\r\nX-Large: {oversized}\r\n\r\nHTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nOK"
+    )
+    .into_bytes()
+  }
 
   pub const CHUNKED_WITH_EXTENSIONS_AND_TRAILERS: &[u8] = concat!(
     "HTTP/1.1 200 OK\r\n",


### PR DESCRIPTION
Added shared HTTP/1.1 Early Hints fixture coverage across rttp_client sync/async paths and rttp server/model serialization parity. Validation passed.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1615/
work_kind: code_work
branch: hbx-1615-rttp-add-cross-crate-http
base: main
commit: a6a54616a347122fe0adf75bfeffdff626061657
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1615/
    url: https://plane.kahub.in/endless/browse/HBX-1615/
    close_policy: link_only
```