### PR TITLE
feat: [rttp_client] Parse bounded HTTP/1.1 Content-Disposition response metadata

### DIFF
--- a/rttp_client/README.md
+++ b/rttp_client/README.md
@@ -276,6 +276,28 @@ does not treat `Content-Location` as redirect behavior, cache variant
 selection, representation replacement, retry/replay behavior, route
 generation, or status-policy behavior.
 
+## Bounded HTTP/1.1 Content-Disposition behavior
+
+`Response::content_disposition()` parses a singleton response
+`Content-Disposition` header into `ContentDisposition` metadata. It returns
+`Ok(None)` when the header is absent and rejects duplicate header fields.
+Present values expose the disposition type, ordered parameters, `filename`,
+and `filename*`; `ContentDisposition::parse(value)` is available when callers
+want to validate a single raw field value directly.
+
+The helper is bounded and validation-oriented. The field value is limited to
+64 KiB, the parameter list is limited to 256 entries, disposition type and
+unquoted parameter values must be valid HTTP tokens, quoted strings must be
+well formed, and `filename*` must be an extended value with valid percent
+encoding. Duplicate parameters, malformed quoted strings, CR/LF injection,
+oversized values, and too many parameters make
+`Response::content_disposition()` return an error while leaving the original
+response headers and body available through the ordinary response APIs.
+
+The helper is metadata-only. `rttp_client` does not infer download policy,
+filesystem paths, MIME behavior, redirects, retries, cache behavior, or status
+handling from `Content-Disposition`.
+
 ## Bounded HTTP/1.1 Vary behavior
 
 `Response::vary()` parses one or more response `Vary` header fields into
@@ -373,6 +395,7 @@ header-block model.
 | Allow | `Response::allow` parses bounded response `Allow` fields into an ordered HTTP method-token list | No fallback method selection, automatic retry/replay, or status-code policy behavior for `405` or `OPTIONS` |
 | Content-Language | `Response::content_language` parses bounded response `Content-Language` fields into ordered language metadata while preserving raw headers | No automatic language negotiation, locale fallback, variant matching, cache policy, retry, replay, redirect, or status-policy behavior |
 | Content-Location | `Response::content_location` and `ContentLocation::parse` parse bounded singleton response `Content-Location` metadata while preserving raw headers | No redirect behavior, cache variant selection, representation replacement, retry/replay, route generation, or status-policy behavior |
+| Content-Disposition | `Response::content_disposition` and `ContentDisposition::parse` parse bounded singleton response `Content-Disposition` metadata into disposition type plus ordered parameters, including `filename` and `filename*`, while preserving raw headers | No download policy, filesystem path handling, MIME behavior, redirect behavior, retry/replay, cache behavior, or status-policy behavior |
 | Vary | `Response::vary` parses bounded response `Vary` fields into wildcard or normalized case-insensitive field-name metadata | No cache storage, stored-response matching engine, cache key persistence, automatic request replay, shared-cache policy enforcement, or automatic conditional requests |
 | Trailers | Chunked response trailers are exposed for blocking and async APIs; streaming chunked uploads can send declared request trailers | Application metadata trailers such as `X-Trace` are allowed; pseudo-header, connection-specific, routing, authentication/cookie, and framing trailer fields are rejected |
 | Bounded h2c client | With `http2`, direct `socket2` h2c sends GET, HEAD, bodyless DELETE, OPTIONS, or TRACE, buffered POST, PUT, or PATCH requests, and opt-in RFC 8441 extended CONNECT request HEADERS via `http2_extended_connect`, opens at most one request stream, supports prior-knowledge with `emit_http2_prior_knowledge`, supports explicit HTTP/1.1 `Upgrade: h2c` negotiation with `emit_http2_upgrade`, advertises `SETTINGS_ENABLE_PUSH = 0`, advertises `SETTINGS_ENABLE_CONNECT_PROTOCOL = 1` only for the explicit extended CONNECT path, validates received `SETTINGS_ENABLE_PUSH` values as only `0` or `1`, honors initial peer `SETTINGS_MAX_CONCURRENT_STREAMS` by failing before request HEADERS when the peer allows zero streams, honors peer-advertised `SETTINGS_MAX_HEADER_LIST_SIZE` request metadata limits, accepts only legal `SETTINGS_MAX_FRAME_SIZE` values from 16,384 through 16,777,215 bytes, splits outbound HEADERS, DATA, and trailers to the active peer frame-size limit, rejects oversized inbound frames when a configured local frame-size limit is exceeded, bounds HPACK dynamic table use with `SETTINGS_HEADER_TABLE_SIZE`, strips HTTP/1.x connection-specific request fields before emission, rejects connection-specific peer response fields, suppresses HEAD response bodies, treats `RST_STREAM` on the active stream as a bounded reset/cancellation signal, acknowledges valid PING frames with matching opaque data, DATA bodies, trailers, HPACK static Huffman strings, bounded large header blocks, padded incoming frames, `GOAWAY` shutdown boundaries, PRIORITY metadata validation without scheduling, HTTP/2-allowed unknown/extension frame ignoring inside this bounded path, reserved stream-id high-bit normalization, and conservative DATA flow control | Ordinary `CONNECT`, header-configured `:protocol` metadata, non-h2c HTTP/1.1 `Upgrade` handoff requests, and proxies are rejected deterministically, and `PUSH_PROMISE`/server push is rejected instead of managed; bounded direct h2c only, with no public cancellation callback API, no dynamic policy API, no extension callback API, no full extension negotiation, TLS ALPN, external h2 integration, proxy tunneling to h2, proxy h2, tunnel handoff, connection pooling, persistent HTTP/2 session management, automatic retry, server push, full stream state machine, unbounded multiplex scheduling, general multiplexing, priority scheduling, request bodies or trailers for extended CONNECT, or request bodies for GET, HEAD, DELETE, OPTIONS, or TRACE |

--- a/rttp_client/src/response/response.rs
+++ b/rttp_client/src/response/response.rs
@@ -17,6 +17,9 @@ const MAX_ACCEPT_RANGES_VALUE_BYTES: usize = 64 * 1024;
 const MAX_ACCEPT_RANGE_UNITS: usize = 256;
 const MAX_RETRY_AFTER_VALUE_BYTES: usize = 64 * 1024;
 const MAX_CONTENT_LOCATION_VALUE_BYTES: usize = 64 * 1024;
+const MAX_CONTENT_DISPOSITION_VALUE_BYTES: usize = 64 * 1024;
+const MAX_CONTENT_DISPOSITION_PARAMETER_VALUE_BYTES: usize = 64 * 1024;
+const MAX_CONTENT_DISPOSITION_PARAMETERS: usize = 256;
 const MAX_CONTENT_LANGUAGE_VALUE_BYTES: usize = 64 * 1024;
 const MAX_CONTENT_LANGUAGE_TAGS: usize = 256;
 const MAX_VARY_VALUE_BYTES: usize = 64 * 1024;
@@ -235,6 +238,17 @@ impl Response {
       [value] => ContentLocation::parse(value).map(Some),
       _ => Err(error::bad_response(
         "Duplicate Content-Location header values",
+      )),
+    }
+  }
+
+  pub fn content_disposition(&self) -> error::Result<Option<ContentDisposition>> {
+    let values = self.header_values("content-disposition");
+    match values.as_slice() {
+      [] => Ok(None),
+      [value] => ContentDisposition::parse(value).map(Some),
+      _ => Err(error::bad_response(
+        "Duplicate Content-Disposition header values",
       )),
     }
   }
@@ -638,6 +652,294 @@ impl ContentLocation {
   pub fn as_str(&self) -> &str {
     &self.value
   }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ContentDisposition {
+  disposition_type: String,
+  parameters: Vec<ContentDispositionParameter>,
+}
+
+impl ContentDisposition {
+  pub fn parse(value: impl AsRef<str>) -> error::Result<Self> {
+    let value = value.as_ref();
+    if value.len() > MAX_CONTENT_DISPOSITION_VALUE_BYTES {
+      return Err(error::bad_response(
+        "Content-Disposition header value is too large",
+      ));
+    }
+    if value.contains(['\r', '\n']) {
+      return Err(error::bad_response("Invalid Content-Disposition value"));
+    }
+
+    let members = split_content_disposition_members(value)?;
+    let Some(disposition_type) = members.first().map(|member| member.trim()) else {
+      return Err(error::bad_response(
+        "Invalid Content-Disposition disposition type",
+      ));
+    };
+    if !is_token(disposition_type) {
+      return Err(error::bad_response(
+        "Invalid Content-Disposition disposition type",
+      ));
+    }
+
+    let mut parameters = Vec::new();
+    let mut seen = HashSet::new();
+    for member in members.iter().skip(1) {
+      if parameters.len() >= MAX_CONTENT_DISPOSITION_PARAMETERS {
+        return Err(error::bad_response(
+          "Too many Content-Disposition parameters",
+        ));
+      }
+
+      let parameter = ContentDispositionParameter::parse(member)?;
+      let normalized = parameter.name.to_ascii_lowercase();
+      if !seen.insert(normalized) {
+        return Err(error::bad_response(
+          "Duplicate Content-Disposition parameter",
+        ));
+      }
+      parameters.push(parameter);
+    }
+
+    Ok(Self {
+      disposition_type: disposition_type.to_string(),
+      parameters,
+    })
+  }
+
+  pub fn disposition_type(&self) -> &str {
+    &self.disposition_type
+  }
+
+  pub fn parameters(&self) -> &[ContentDispositionParameter] {
+    &self.parameters
+  }
+
+  pub fn parameter(&self, name: impl AsRef<str>) -> Option<&ContentDispositionParameter> {
+    self
+      .parameters
+      .iter()
+      .find(|parameter| parameter.name.eq_ignore_ascii_case(name.as_ref()))
+  }
+
+  pub fn filename(&self) -> Option<&str> {
+    self
+      .parameter("filename")
+      .map(ContentDispositionParameter::value)
+  }
+
+  pub fn filename_ext(&self) -> Option<&str> {
+    self
+      .parameter("filename*")
+      .map(ContentDispositionParameter::value)
+  }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ContentDispositionParameter {
+  name: String,
+  value: String,
+}
+
+impl ContentDispositionParameter {
+  fn parse(value: &str) -> error::Result<Self> {
+    let (name, raw_value) = value
+      .split_once('=')
+      .ok_or_else(|| error::bad_response("Invalid Content-Disposition parameter"))?;
+    let name = name.trim();
+    let raw_value = raw_value.trim();
+    if !is_token(name) {
+      return Err(error::bad_response(
+        "Invalid Content-Disposition parameter name",
+      ));
+    }
+    if raw_value.len() > MAX_CONTENT_DISPOSITION_PARAMETER_VALUE_BYTES {
+      return Err(error::bad_response(
+        "Content-Disposition parameter value is too large",
+      ));
+    }
+
+    let (parsed_value, value_was_quoted) = parse_content_disposition_parameter_value(raw_value)?;
+    if name.eq_ignore_ascii_case("filename*") {
+      if value_was_quoted || !is_content_disposition_ext_value(&parsed_value) {
+        return Err(error::bad_response(
+          "Invalid Content-Disposition filename* parameter",
+        ));
+      }
+    }
+
+    Ok(Self {
+      name: name.to_string(),
+      value: parsed_value,
+    })
+  }
+
+  pub fn name(&self) -> &str {
+    &self.name
+  }
+
+  pub fn value(&self) -> &str {
+    &self.value
+  }
+}
+
+fn split_content_disposition_members(value: &str) -> error::Result<Vec<String>> {
+  let mut members = Vec::new();
+  let mut current = String::new();
+  let mut in_quote = false;
+  let mut escaped = false;
+
+  for ch in value.chars() {
+    if escaped {
+      current.push(ch);
+      escaped = false;
+      continue;
+    }
+
+    match ch {
+      '\\' if in_quote => {
+        current.push(ch);
+        escaped = true;
+      }
+      '"' => {
+        current.push(ch);
+        in_quote = !in_quote;
+      }
+      ';' if !in_quote => {
+        push_content_disposition_member(&mut members, &current)?;
+        current.clear();
+      }
+      _ => current.push(ch),
+    }
+  }
+
+  if in_quote || escaped {
+    return Err(error::bad_response(
+      "Malformed Content-Disposition quoted-string",
+    ));
+  }
+  push_content_disposition_member(&mut members, &current)?;
+  Ok(members)
+}
+
+fn push_content_disposition_member(members: &mut Vec<String>, member: &str) -> error::Result<()> {
+  let member = member.trim();
+  if member.is_empty() {
+    return Err(error::bad_response("Invalid Content-Disposition member"));
+  }
+  members.push(member.to_string());
+  Ok(())
+}
+
+fn parse_content_disposition_parameter_value(value: &str) -> error::Result<(String, bool)> {
+  if value.is_empty() {
+    return Err(error::bad_response(
+      "Invalid Content-Disposition parameter value",
+    ));
+  }
+  if let Some(value) = value.strip_prefix('"') {
+    return parse_content_disposition_quoted_string(value).map(|value| (value, true));
+  }
+  if value.contains('"') || !is_token(value) {
+    return Err(error::bad_response(
+      "Invalid Content-Disposition parameter value",
+    ));
+  }
+  Ok((value.to_string(), false))
+}
+
+fn parse_content_disposition_quoted_string(value: &str) -> error::Result<String> {
+  let mut chars = value.chars();
+  let mut parsed = String::new();
+  let mut closed = false;
+
+  while let Some(ch) = chars.next() {
+    match ch {
+      '"' => {
+        closed = true;
+        break;
+      }
+      '\\' => {
+        let Some(escaped) = chars.next() else {
+          return Err(error::bad_response(
+            "Malformed Content-Disposition quoted-string",
+          ));
+        };
+        if !is_quoted_pair_char(escaped) {
+          return Err(error::bad_response(
+            "Malformed Content-Disposition quoted-string",
+          ));
+        }
+        parsed.push(escaped);
+      }
+      _ if is_qdtext(ch) => parsed.push(ch),
+      _ => {
+        return Err(error::bad_response(
+          "Malformed Content-Disposition quoted-string",
+        ))
+      }
+    }
+  }
+
+  if !closed || chars.any(|ch| !ch.is_ascii_whitespace()) {
+    return Err(error::bad_response(
+      "Malformed Content-Disposition quoted-string",
+    ));
+  }
+  Ok(parsed)
+}
+
+fn is_content_disposition_ext_value(value: &str) -> bool {
+  let mut parts = value.splitn(3, '\'');
+  let Some(charset) = parts.next() else {
+    return false;
+  };
+  let Some(language) = parts.next() else {
+    return false;
+  };
+  let Some(encoded_value) = parts.next() else {
+    return false;
+  };
+
+  !charset.is_empty()
+    && is_token(charset)
+    && language.bytes().all(is_content_disposition_language_byte)
+    && !encoded_value.is_empty()
+    && is_content_disposition_ext_value_chars(encoded_value)
+}
+
+fn is_content_disposition_ext_value_chars(value: &str) -> bool {
+  let mut bytes = value.bytes().peekable();
+  while let Some(byte) = bytes.next() {
+    if byte == b'%' {
+      let Some(first) = bytes.next() else {
+        return false;
+      };
+      let Some(second) = bytes.next() else {
+        return false;
+      };
+      if !first.is_ascii_hexdigit() || !second.is_ascii_hexdigit() {
+        return false;
+      }
+    } else if !is_content_disposition_attr_char(byte) {
+      return false;
+    }
+  }
+  true
+}
+
+fn is_content_disposition_attr_char(byte: u8) -> bool {
+  byte.is_ascii_alphanumeric()
+    || matches!(
+      byte,
+      b'!' | b'#' | b'$' | b'&' | b'+' | b'-' | b'.' | b'^' | b'_' | b'`' | b'|' | b'~'
+    )
+}
+
+fn is_content_disposition_language_byte(byte: u8) -> bool {
+  byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'.')
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/rttp_client/src/response/response.rs
+++ b/rttp_client/src/response/response.rs
@@ -762,12 +762,12 @@ impl ContentDispositionParameter {
     }
 
     let (parsed_value, value_was_quoted) = parse_content_disposition_parameter_value(raw_value)?;
-    if name.eq_ignore_ascii_case("filename*") {
-      if value_was_quoted || !is_content_disposition_ext_value(&parsed_value) {
-        return Err(error::bad_response(
-          "Invalid Content-Disposition filename* parameter",
-        ));
-      }
+    if name.eq_ignore_ascii_case("filename*")
+      && (value_was_quoted || !is_content_disposition_ext_value(&parsed_value))
+    {
+      return Err(error::bad_response(
+        "Invalid Content-Disposition filename* parameter",
+      ));
     }
 
     Ok(Self {

--- a/rttp_client/tests/test_response.rs
+++ b/rttp_client/tests/test_response.rs
@@ -1,4 +1,4 @@
-use rttp_client::response::{ContentLocation, Response};
+use rttp_client::response::{ContentDisposition, ContentLocation, Response};
 use rttp_client::types::{Cookie, RoUrl};
 use std::time::{Duration, UNIX_EPOCH};
 
@@ -246,6 +246,176 @@ fn test_parse_content_location_response_helper_accepts_uri_references() {
       response.header_value("Content-Location")
     );
   }
+}
+
+#[test]
+fn test_parse_content_disposition_response_helper_preserves_ordered_parameters() {
+  let s = concat!(
+    "HTTP/1.1 200 OK\r\n",
+    "Content-Disposition: attachment; filename=\"report \\\"final\\\".txt\"; filename*=UTF-8''report-final.txt; preview=yes\r\n",
+    "Content-Length: 2\r\n",
+    "\r\n",
+    "OK"
+  );
+  let response = Response::new(
+    RoUrl::with("https://example.test/download"),
+    s.as_bytes().to_vec(),
+  )
+  .expect("parse response with content-disposition");
+
+  let content_disposition = response
+    .content_disposition()
+    .expect("valid content-disposition should parse")
+    .expect("content-disposition header should be present");
+
+  assert_eq!("attachment", content_disposition.disposition_type());
+  assert_eq!(Some("report \"final\".txt"), content_disposition.filename());
+  assert_eq!(
+    Some("UTF-8''report-final.txt"),
+    content_disposition.filename_ext()
+  );
+  assert_eq!(
+    vec![
+      ("filename", "report \"final\".txt"),
+      ("filename*", "UTF-8''report-final.txt"),
+      ("preview", "yes")
+    ],
+    content_disposition
+      .parameters()
+      .iter()
+      .map(|parameter| (parameter.name(), parameter.value()))
+      .collect::<Vec<_>>()
+  );
+  assert_eq!(
+    Some(
+      &"attachment; filename=\"report \\\"final\\\".txt\"; filename*=UTF-8''report-final.txt; preview=yes"
+        .to_string()
+    ),
+    response.header_value("Content-Disposition")
+  );
+  assert_eq!("OK", response.body().string().unwrap());
+}
+
+#[test]
+fn test_parse_content_disposition_response_helper_returns_none_when_absent() {
+  let s = concat!("HTTP/1.1 200 OK\r\n", "Content-Length: 2\r\n", "\r\n", "OK");
+  let response = Response::new(RoUrl::with("https://example.test"), s.as_bytes().to_vec())
+    .expect("parse response without content-disposition");
+
+  assert_eq!(
+    None,
+    response
+      .content_disposition()
+      .expect("absent content-disposition should parse")
+  );
+}
+
+#[test]
+fn test_parse_content_disposition_rejects_invalid_helper_values_without_rejecting_response() {
+  let invalid_values = [
+    "",
+    "attach ment",
+    "attachment;",
+    "attachment; filename",
+    "attachment; file name=report.txt",
+    "attachment; filename=report txt",
+    "attachment; filename=\"unterminated",
+    "attachment; filename=\"bad\\\r\"",
+    "attachment; filename=\"bad\rname\"",
+    "attachment; filename*=UTF-8''bad%ZZname",
+  ];
+
+  for value in invalid_values {
+    let raw =
+      format!("HTTP/1.1 200 OK\r\nContent-Disposition: {value}\r\nContent-Length: 2\r\n\r\nOK");
+    let response = Response::new(RoUrl::with("https://example.test"), raw.into_bytes())
+      .expect("raw response remains usable");
+
+    assert!(
+      response.content_disposition().is_err(),
+      "content-disposition helper should reject {value:?}"
+    );
+    assert_eq!(
+      Some(&value.to_string()),
+      response.header_value("Content-Disposition")
+    );
+    assert_eq!("OK", response.body().string().unwrap());
+  }
+}
+
+#[test]
+fn test_parse_content_disposition_rejects_duplicate_singleton_duplicate_parameter_and_bounds() {
+  let raw = concat!(
+    "HTTP/1.1 200 OK\r\n",
+    "Content-Disposition: attachment; filename=one.txt\r\n",
+    "content-disposition: inline; filename=two.txt\r\n",
+    "Content-Length: 2\r\n",
+    "\r\n",
+    "OK"
+  );
+  let response = Response::new(RoUrl::with("https://example.test"), raw.as_bytes().to_vec())
+    .expect("raw response with duplicate content-disposition remains usable");
+
+  assert!(
+    response.content_disposition().is_err(),
+    "content-disposition helper should reject duplicate singleton fields"
+  );
+  assert_eq!(
+    vec![
+      &"attachment; filename=one.txt".to_string(),
+      &"inline; filename=two.txt".to_string()
+    ],
+    response.header_values("Content-Disposition")
+  );
+
+  let raw = concat!(
+    "HTTP/1.1 200 OK\r\n",
+    "Content-Disposition: attachment; filename=one.txt; FILENAME=two.txt\r\n",
+    "Content-Length: 2\r\n",
+    "\r\n",
+    "OK"
+  );
+  let response = Response::new(RoUrl::with("https://example.test"), raw.as_bytes().to_vec())
+    .expect("raw response with duplicate parameter remains usable");
+  assert!(
+    response.content_disposition().is_err(),
+    "content-disposition helper should reject duplicate parameters"
+  );
+
+  let oversized = "a".repeat(64 * 1024 + 1);
+  let raw =
+    format!("HTTP/1.1 200 OK\r\nContent-Disposition: {oversized}\r\nContent-Length: 2\r\n\r\nOK");
+  let response = Response::new(RoUrl::with("https://example.test"), raw.into_bytes())
+    .expect("raw response with oversized content-disposition remains usable");
+  assert!(
+    response.content_disposition().is_err(),
+    "content-disposition helper should reject oversized values"
+  );
+
+  let too_many = (0..257)
+    .map(|ix| format!("p{ix}=v"))
+    .collect::<Vec<_>>()
+    .join("; ");
+  let raw = format!(
+    "HTTP/1.1 200 OK\r\nContent-Disposition: attachment; {too_many}\r\nContent-Length: 2\r\n\r\nOK"
+  );
+  let response = Response::new(RoUrl::with("https://example.test"), raw.into_bytes())
+    .expect("raw response with too many content-disposition parameters remains usable");
+  assert!(
+    response.content_disposition().is_err(),
+    "content-disposition helper should reject too many parameters"
+  );
+}
+
+#[test]
+fn test_content_disposition_parse_rejects_crlf_injection() {
+  let error = ContentDisposition::parse("attachment; filename=\"bad\r\nX-Evil: yes\"")
+    .expect_err("content-disposition helper should reject CR/LF injection");
+
+  assert!(
+    error.to_string().contains("Content-Disposition"),
+    "unexpected error: {error}"
+  );
 }
 
 #[test]


### PR DESCRIPTION
Adds bounded `rttp_client` response `Content-Disposition` metadata parsing with ordered parameters, filename helpers, validation failures that preserve raw responses, targeted tests, and README coverage.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1618/
work_kind: code_work
branch: hbx-1618-rttp-client-parse-bounded-http
base: main
commit: c1a3b64e349562c06cc61dfd63f94f5fe5199d4b
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1618/
    url: https://plane.kahub.in/endless/browse/HBX-1618/
    close_policy: link_only
```