### PR TITLE
feat: [rttp_client] Parse bounded HTTP/1.1 Content-Type response metadata

### DIFF
--- a/rttp_client/src/response/response.rs
+++ b/rttp_client/src/response/response.rs
@@ -16,6 +16,8 @@ const MAX_ALLOW_METHODS: usize = 256;
 const MAX_ACCEPT_RANGES_VALUE_BYTES: usize = 64 * 1024;
 const MAX_ACCEPT_RANGE_UNITS: usize = 256;
 const MAX_RETRY_AFTER_VALUE_BYTES: usize = 64 * 1024;
+const MAX_CONTENT_TYPE_VALUE_BYTES: usize = 64 * 1024;
+const MAX_CONTENT_TYPE_PARAMETERS: usize = 256;
 const MAX_CONTENT_LOCATION_VALUE_BYTES: usize = 64 * 1024;
 const MAX_CONTENT_DISPOSITION_VALUE_BYTES: usize = 64 * 1024;
 const MAX_CONTENT_DISPOSITION_PARAMETER_VALUE_BYTES: usize = 64 * 1024;
@@ -229,6 +231,15 @@ impl Response {
     self
       .header_value("content-range")
       .and_then(ContentRange::parse)
+  }
+
+  pub fn content_type(&self) -> error::Result<Option<ContentType>> {
+    let values = self.header_values("content-type");
+    match values.as_slice() {
+      [] => Ok(None),
+      [value] => ContentType::parse(value).map(Some),
+      _ => Err(error::bad_response("Duplicate Content-Type header values")),
+    }
   }
 
   pub fn content_location(&self) -> error::Result<Option<ContentLocation>> {
@@ -605,6 +616,213 @@ fn parse_complete_length(value: &str) -> Option<Option<u64>> {
     return Some(None);
   }
   value.parse::<u64>().ok().map(Some)
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ContentType {
+  type_: String,
+  subtype: String,
+  parameters: Vec<ContentTypeParameter>,
+}
+
+impl ContentType {
+  pub fn parse(value: impl AsRef<str>) -> error::Result<Self> {
+    let value = value.as_ref();
+    if value.len() > MAX_CONTENT_TYPE_VALUE_BYTES {
+      return Err(error::bad_response(
+        "Content-Type header value is too large",
+      ));
+    }
+    if value.contains(['\r', '\n']) {
+      return Err(error::bad_response("Invalid Content-Type value"));
+    }
+
+    let members = split_content_type_members(value)?;
+    let Some(media_type) = members.first().map(|member| member.trim()) else {
+      return Err(error::bad_response("Invalid Content-Type media type"));
+    };
+    let (type_, subtype) = media_type
+      .split_once('/')
+      .ok_or_else(|| error::bad_response("Invalid Content-Type media type"))?;
+    let type_ = type_.trim();
+    let subtype = subtype.trim();
+    if !is_token(type_) || !is_token(subtype) {
+      return Err(error::bad_response("Invalid Content-Type media type"));
+    }
+
+    let mut parameters = Vec::new();
+    let mut seen = HashSet::new();
+    for member in members.iter().skip(1) {
+      if parameters.len() >= MAX_CONTENT_TYPE_PARAMETERS {
+        return Err(error::bad_response("Too many Content-Type parameters"));
+      }
+
+      let parameter = ContentTypeParameter::parse(member)?;
+      let normalized = parameter.name.to_ascii_lowercase();
+      if !seen.insert(normalized) {
+        return Err(error::bad_response("Duplicate Content-Type parameter"));
+      }
+      parameters.push(parameter);
+    }
+
+    Ok(Self {
+      type_: type_.to_ascii_lowercase(),
+      subtype: subtype.to_ascii_lowercase(),
+      parameters,
+    })
+  }
+
+  pub fn type_(&self) -> &str {
+    &self.type_
+  }
+
+  pub fn subtype(&self) -> &str {
+    &self.subtype
+  }
+
+  pub fn essence(&self) -> String {
+    format!("{}/{}", self.type_, self.subtype)
+  }
+
+  pub fn is(&self, type_: impl AsRef<str>, subtype: impl AsRef<str>) -> bool {
+    self.type_.eq_ignore_ascii_case(type_.as_ref())
+      && self.subtype.eq_ignore_ascii_case(subtype.as_ref())
+  }
+
+  pub fn parameters(&self) -> &[ContentTypeParameter] {
+    &self.parameters
+  }
+
+  pub fn parameter(&self, name: impl AsRef<str>) -> Option<&str> {
+    self
+      .parameters
+      .iter()
+      .find(|parameter| parameter.name.eq_ignore_ascii_case(name.as_ref()))
+      .map(ContentTypeParameter::value)
+  }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ContentTypeParameter {
+  name: String,
+  value: String,
+}
+
+impl ContentTypeParameter {
+  fn parse(value: &str) -> error::Result<Self> {
+    let (name, raw_value) = value
+      .split_once('=')
+      .ok_or_else(|| error::bad_response("Invalid Content-Type parameter"))?;
+    let name = name.trim();
+    let raw_value = raw_value.trim();
+    if !is_token(name) {
+      return Err(error::bad_response("Invalid Content-Type parameter name"));
+    }
+
+    let parsed_value = parse_content_type_parameter_value(raw_value)?;
+    Ok(Self {
+      name: name.to_ascii_lowercase(),
+      value: parsed_value,
+    })
+  }
+
+  pub fn name(&self) -> &str {
+    &self.name
+  }
+
+  pub fn value(&self) -> &str {
+    &self.value
+  }
+}
+
+fn split_content_type_members(value: &str) -> error::Result<Vec<String>> {
+  let mut members = Vec::new();
+  let mut current = String::new();
+  let mut in_quote = false;
+  let mut escaped = false;
+
+  for ch in value.chars() {
+    if escaped {
+      current.push(ch);
+      escaped = false;
+      continue;
+    }
+
+    match ch {
+      '\\' if in_quote => {
+        current.push(ch);
+        escaped = true;
+      }
+      '"' => {
+        current.push(ch);
+        in_quote = !in_quote;
+      }
+      ';' if !in_quote => {
+        push_content_type_member(&mut members, &current)?;
+        current.clear();
+      }
+      _ => current.push(ch),
+    }
+  }
+
+  if in_quote || escaped {
+    return Err(error::bad_response("Malformed Content-Type quoted-string"));
+  }
+  push_content_type_member(&mut members, &current)?;
+  Ok(members)
+}
+
+fn push_content_type_member(members: &mut Vec<String>, member: &str) -> error::Result<()> {
+  let member = member.trim();
+  if member.is_empty() {
+    return Err(error::bad_response("Invalid Content-Type member"));
+  }
+  members.push(member.to_string());
+  Ok(())
+}
+
+fn parse_content_type_parameter_value(value: &str) -> error::Result<String> {
+  if value.is_empty() {
+    return Err(error::bad_response("Invalid Content-Type parameter value"));
+  }
+  if let Some(value) = value.strip_prefix('"') {
+    return parse_content_type_quoted_string(value);
+  }
+  if value.contains('"') || !is_token(value) {
+    return Err(error::bad_response("Invalid Content-Type parameter value"));
+  }
+  Ok(value.to_string())
+}
+
+fn parse_content_type_quoted_string(value: &str) -> error::Result<String> {
+  let mut chars = value.chars();
+  let mut parsed = String::new();
+  let mut closed = false;
+
+  while let Some(ch) = chars.next() {
+    match ch {
+      '"' => {
+        closed = true;
+        break;
+      }
+      '\\' => {
+        let Some(escaped) = chars.next() else {
+          return Err(error::bad_response("Malformed Content-Type quoted-string"));
+        };
+        if !is_quoted_pair_char(escaped) {
+          return Err(error::bad_response("Malformed Content-Type quoted-string"));
+        }
+        parsed.push(escaped);
+      }
+      _ if is_qdtext(ch) => parsed.push(ch),
+      _ => return Err(error::bad_response("Malformed Content-Type quoted-string")),
+    }
+  }
+
+  if !closed || chars.any(|ch| !ch.is_ascii_whitespace()) {
+    return Err(error::bad_response("Malformed Content-Type quoted-string"));
+  }
+  Ok(parsed)
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/rttp_client/tests/test_response.rs
+++ b/rttp_client/tests/test_response.rs
@@ -1,4 +1,4 @@
-use rttp_client::response::{ContentDisposition, ContentLocation, Response};
+use rttp_client::response::{ContentDisposition, ContentLocation, ContentType, Response};
 use rttp_client::types::{Cookie, RoUrl};
 use std::time::{Duration, UNIX_EPOCH};
 
@@ -166,6 +166,192 @@ fn test_parse_range_not_satisfiable_metadata_preserves_body_and_headers() {
     response.header_value("Content-Type")
   );
   assert_eq!("range unavailable", response.body().string().unwrap());
+}
+
+#[test]
+fn test_parse_content_type_response_helper_normalizes_media_type_and_preserves_parameters() {
+  let s = concat!(
+    "HTTP/1.1 200 OK\r\n",
+    "Content-Type: Text/Plain; charset=utf-8; boundary=\"AaB03x\"; format=flowed\r\n",
+    "Content-Length: 2\r\n",
+    "\r\n",
+    "OK"
+  );
+  let response = Response::new(RoUrl::with("https://example.test"), s.as_bytes().to_vec())
+    .expect("parse response with content-type");
+
+  let content_type = response
+    .content_type()
+    .expect("valid content-type should parse")
+    .expect("content-type header should be present");
+
+  assert_eq!("text", content_type.type_());
+  assert_eq!("plain", content_type.subtype());
+  assert_eq!("text/plain", content_type.essence());
+  assert!(content_type.is("TEXT", "PLAIN"));
+  assert_eq!(Some("utf-8"), content_type.parameter("charset"));
+  assert_eq!(Some("AaB03x"), content_type.parameter("BOUNDARY"));
+  assert_eq!(
+    vec![
+      ("charset", "utf-8"),
+      ("boundary", "AaB03x"),
+      ("format", "flowed")
+    ],
+    content_type
+      .parameters()
+      .iter()
+      .map(|parameter| (parameter.name(), parameter.value()))
+      .collect::<Vec<_>>()
+  );
+  assert_eq!(
+    Some(&"Text/Plain; charset=utf-8; boundary=\"AaB03x\"; format=flowed".to_string()),
+    response.header_value("Content-Type")
+  );
+}
+
+#[test]
+fn test_parse_content_type_response_helper_accepts_common_application_json() {
+  let raw = concat!(
+    "HTTP/1.1 200 OK\r\n",
+    "Content-Type: application/json\r\n",
+    "Content-Length: 2\r\n",
+    "\r\n",
+    "{}"
+  );
+  let response = Response::new(RoUrl::with("https://example.test"), raw.as_bytes().to_vec())
+    .expect("parse response with application/json content-type");
+  let content_type = response
+    .content_type()
+    .expect("valid content-type should parse")
+    .expect("content-type header should be present");
+
+  assert_eq!("application", content_type.type_());
+  assert_eq!("json", content_type.subtype());
+  assert!(content_type.parameters().is_empty());
+}
+
+#[test]
+fn test_parse_content_type_response_helper_returns_none_when_absent() {
+  let raw = concat!("HTTP/1.1 200 OK\r\n", "Content-Length: 2\r\n", "\r\n", "OK");
+  let response = Response::new(RoUrl::with("https://example.test"), raw.as_bytes().to_vec())
+    .expect("parse response without content-type");
+
+  assert_eq!(
+    None,
+    response
+      .content_type()
+      .expect("absent content-type should parse")
+  );
+}
+
+#[test]
+fn test_parse_content_type_rejects_invalid_helper_values_without_rejecting_response() {
+  let invalid_values = [
+    "",
+    "text",
+    "text/",
+    "/plain",
+    "te xt/plain",
+    "text/pla in",
+    "text/plain;",
+    "text/plain; charset",
+    "text/plain; char set=utf-8",
+    "text/plain; charset=utf 8",
+    "text/plain; charset=\"unterminated",
+    "text/plain; charset=\"bad\\\r\"",
+    "text/plain; charset=\"bad\rvalue\"",
+  ];
+
+  for value in invalid_values {
+    let raw = format!("HTTP/1.1 200 OK\r\nContent-Type: {value}\r\nContent-Length: 2\r\n\r\nOK");
+    let response = Response::new(RoUrl::with("https://example.test"), raw.into_bytes())
+      .expect("raw response remains usable");
+
+    assert!(
+      response.content_type().is_err(),
+      "content-type helper should reject {value:?}"
+    );
+    assert_eq!(
+      Some(&value.to_string()),
+      response.header_value("Content-Type")
+    );
+    assert_eq!("OK", response.body().string().unwrap());
+  }
+}
+
+#[test]
+fn test_parse_content_type_rejects_duplicate_singleton_duplicate_parameter_and_bounds() {
+  let raw = concat!(
+    "HTTP/1.1 200 OK\r\n",
+    "Content-Type: text/plain\r\n",
+    "content-type: application/json\r\n",
+    "Content-Length: 2\r\n",
+    "\r\n",
+    "OK"
+  );
+  let response = Response::new(RoUrl::with("https://example.test"), raw.as_bytes().to_vec())
+    .expect("raw response with duplicate content-type remains usable");
+
+  assert!(
+    response.content_type().is_err(),
+    "content-type helper should reject duplicate singleton fields"
+  );
+  assert_eq!(
+    vec![&"text/plain".to_string(), &"application/json".to_string()],
+    response.header_values("Content-Type")
+  );
+
+  let response = Response::new(
+    RoUrl::with("https://example.test"),
+    concat!(
+      "HTTP/1.1 200 OK\r\n",
+      "Content-Type: text/plain; charset=utf-8; CHARSET=iso-8859-1\r\n",
+      "Content-Length: 2\r\n",
+      "\r\n",
+      "OK"
+    )
+    .as_bytes()
+    .to_vec(),
+  )
+  .expect("raw response with duplicate content-type parameter remains usable");
+  assert!(
+    response.content_type().is_err(),
+    "content-type helper should reject duplicate parameters"
+  );
+
+  let oversized = format!("text/plain; charset={}", "a".repeat(64 * 1024));
+  let raw = format!("HTTP/1.1 200 OK\r\nContent-Type: {oversized}\r\nContent-Length: 2\r\n\r\nOK");
+  let response = Response::new(RoUrl::with("https://example.test"), raw.into_bytes())
+    .expect("raw response with oversized content-type remains usable");
+  assert!(
+    response.content_type().is_err(),
+    "content-type helper should reject oversized values"
+  );
+
+  let too_many = (0..257)
+    .map(|ix| format!("p{ix}=v"))
+    .collect::<Vec<_>>()
+    .join("; ");
+  let raw = format!(
+    "HTTP/1.1 200 OK\r\nContent-Type: text/plain; {too_many}\r\nContent-Length: 2\r\n\r\nOK"
+  );
+  let response = Response::new(RoUrl::with("https://example.test"), raw.into_bytes())
+    .expect("raw response with too many content-type parameters remains usable");
+  assert!(
+    response.content_type().is_err(),
+    "content-type helper should reject too many parameters"
+  );
+}
+
+#[test]
+fn test_content_type_parse_rejects_crlf_injection() {
+  let error = ContentType::parse("text/plain; charset=\"bad\r\nX-Evil: yes\"")
+    .expect_err("content-type helper should reject CR/LF injection");
+
+  assert!(
+    error.to_string().contains("Content-Type"),
+    "unexpected error: {error}"
+  );
 }
 
 #[test]


### PR DESCRIPTION
Adds bounded typed `Content-Type` response metadata parsing to `rttp_client` while preserving raw header access.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1623/
work_kind: code_work
branch: hbx-1623-rttp-client-parse-bounded-http
base: main
commit: c4ab1cd811187acb81bb9734279a7bff6ebf06cb
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1623/
    url: https://plane.kahub.in/endless/browse/HBX-1623/
    close_policy: link_only
```