### PR TITLE
feat: [rttp] Add bounded HTTP/1.1 Content-Encoding metadata helpers

### DIFF
--- a/rttp/src/server.rs
+++ b/rttp/src/server.rs
@@ -17,6 +17,8 @@ const MAX_ALLOW_VALUE_BYTES: usize = 64 * 1024;
 const MAX_ALLOW_METHODS: usize = 32;
 const MAX_CONTENT_LANGUAGE_VALUE_BYTES: usize = 64 * 1024;
 const MAX_CONTENT_LANGUAGES: usize = 32;
+const MAX_CONTENT_ENCODING_VALUE_BYTES: usize = 64 * 1024;
+const MAX_CONTENT_ENCODINGS: usize = 32;
 const MAX_CONTENT_LOCATION_VALUE_BYTES: usize = 64 * 1024;
 const MAX_CONTENT_DISPOSITION_VALUE_BYTES: usize = 64 * 1024;
 const MAX_CONTENT_DISPOSITION_PARAMETERS: usize = 32;
@@ -4622,6 +4624,25 @@ impl HttpResponse {
     Ok(self)
   }
 
+  pub fn with_content_encoding<I, C>(
+    mut self,
+    codings: I,
+  ) -> Result<Self, HttpContentEncodingParseError>
+  where
+    I: IntoIterator<Item = C>,
+    C: AsRef<str>,
+  {
+    let content_encodings = HttpResponseContentEncodings::from_codings(codings)?;
+    self
+      .headers
+      .retain(|header| !header.name.eq_ignore_ascii_case("Content-Encoding"));
+    self.headers.push(HttpHeader::new(
+      "Content-Encoding",
+      content_encodings.header_value(),
+    ));
+    Ok(self)
+  }
+
   pub fn with_content_location<V: AsRef<str>>(
     mut self,
     value: V,
@@ -4796,6 +4817,21 @@ impl HttpResponse {
       return Ok(None);
     }
     HttpContentLanguages::parse_values(values).map(Some)
+  }
+
+  pub fn content_encoding(
+    &self,
+  ) -> Result<Option<HttpResponseContentEncodings>, HttpContentEncodingParseError> {
+    let values: Vec<&str> = self
+      .headers
+      .iter()
+      .filter(|header| header.name.eq_ignore_ascii_case("Content-Encoding"))
+      .map(|header| header.value.as_str())
+      .collect();
+    if values.is_empty() {
+      return Ok(None);
+    }
+    HttpResponseContentEncodings::parse_values(values).map(Some)
   }
 
   pub fn content_location(&self) -> Result<Option<&str>, HttpContentLocationParseError> {
@@ -5600,6 +5636,114 @@ impl fmt::Display for HttpContentLanguageParseError {
 }
 
 impl Error for HttpContentLanguageParseError {}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct HttpResponseContentEncodings {
+  codings: Vec<String>,
+}
+
+impl HttpResponseContentEncodings {
+  pub fn parse(value: impl AsRef<str>) -> Result<Self, HttpContentEncodingParseError> {
+    Self::parse_values([value.as_ref()])
+  }
+
+  pub fn parse_values<'a, I>(values: I) -> Result<Self, HttpContentEncodingParseError>
+  where
+    I: IntoIterator<Item = &'a str>,
+  {
+    let mut codings = Vec::new();
+
+    for value in values {
+      if value.len() > MAX_CONTENT_ENCODING_VALUE_BYTES {
+        return Err(HttpContentEncodingParseError::new(
+          "Content-Encoding header value is too large",
+        ));
+      }
+
+      for coding in value.split(',') {
+        let coding = coding.trim();
+        if coding.is_empty() || !is_http_token(coding) {
+          return Err(HttpContentEncodingParseError::new(
+            "invalid Content-Encoding coding",
+          ));
+        }
+        if codings
+          .iter()
+          .any(|known: &String| known.eq_ignore_ascii_case(coding))
+        {
+          return Err(HttpContentEncodingParseError::new(
+            "duplicate Content-Encoding coding",
+          ));
+        }
+        if codings.len() >= MAX_CONTENT_ENCODINGS {
+          return Err(HttpContentEncodingParseError::new(
+            "too many Content-Encoding codings",
+          ));
+        }
+        codings.push(coding.to_string());
+      }
+    }
+
+    if codings.is_empty() {
+      return Err(HttpContentEncodingParseError::new(
+        "invalid Content-Encoding coding",
+      ));
+    }
+
+    Ok(Self { codings })
+  }
+
+  pub fn from_codings<I, C>(codings: I) -> Result<Self, HttpContentEncodingParseError>
+  where
+    I: IntoIterator<Item = C>,
+    C: AsRef<str>,
+  {
+    let mut value = String::new();
+
+    for (index, coding) in codings.into_iter().enumerate() {
+      if index > 0 {
+        value.push_str(", ");
+      }
+      value.push_str(coding.as_ref());
+      if value.len() > MAX_CONTENT_ENCODING_VALUE_BYTES {
+        return Err(HttpContentEncodingParseError::new(
+          "Content-Encoding header value is too large",
+        ));
+      }
+    }
+
+    Self::parse(value)
+  }
+
+  pub fn codings(&self) -> Vec<&str> {
+    self.codings.iter().map(String::as_str).collect()
+  }
+
+  pub fn header_value(&self) -> String {
+    self.codings.join(", ")
+  }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct HttpContentEncodingParseError {
+  message: String,
+}
+
+impl HttpContentEncodingParseError {
+  fn new<S: AsRef<str>>(message: S) -> Self {
+    Self {
+      message: message.as_ref().to_string(),
+    }
+  }
+}
+
+impl fmt::Display for HttpContentEncodingParseError {
+  fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+    formatter.write_str(&self.message)
+  }
+}
+
+impl Error for HttpContentEncodingParseError {}
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct HttpContentLocationParseError {

--- a/rttp/tests/test_server_models.rs
+++ b/rttp/tests/test_server_models.rs
@@ -3,8 +3,8 @@ use std::time::{Duration, UNIX_EPOCH};
 use rttp::server::{
   HttpAcceptRanges, HttpAllowedMethods, HttpByteRange, HttpByteRangeError, HttpConditionalMetadata,
   HttpContentDisposition, HttpContentLanguages, HttpEntityTag, HttpIfRangeRequestOutcome,
-  HttpRequest, HttpRequestCacheControl, HttpResponse, HttpResponseCacheControl, HttpRetryAfter,
-  HttpVary,
+  HttpRequest, HttpRequestCacheControl, HttpResponse, HttpResponseCacheControl,
+  HttpResponseContentEncodings, HttpRetryAfter, HttpVary,
 };
 
 fn parse_request(raw: &str) -> HttpRequest {
@@ -688,6 +688,101 @@ fn raw_content_disposition_headers_are_preserved_without_helper_validation() {
   assert!(
     response.content_disposition().is_err(),
     "typed Content-Disposition parser should reject malformed raw values"
+  );
+}
+
+#[test]
+fn parses_content_encoding_and_serializes_single_header_value() {
+  let encodings =
+    HttpResponseContentEncodings::parse("gzip, br").expect("valid Content-Encoding should parse");
+
+  assert_eq!(vec!["gzip", "br"], encodings.codings());
+  assert_eq!("gzip, br", encodings.header_value());
+
+  let response = HttpResponse::ok("body")
+    .header("Content-Encoding", "old")
+    .with_content_encoding(["gzip", "br"])
+    .expect("valid Content-Encoding should be accepted");
+  let serialized = String::from_utf8(response.to_bytes()).expect("response is UTF-8");
+
+  assert!(serialized.contains("\r\nContent-Encoding: gzip, br\r\n"));
+  assert_eq!(1, serialized.matches("\r\nContent-Encoding: ").count());
+  assert_eq!(
+    Some(encodings),
+    response
+      .content_encoding()
+      .expect("Content-Encoding should parse")
+  );
+}
+
+#[test]
+fn response_content_encoding_helper_parses_attached_header_fields_in_order() {
+  let response = HttpResponse::ok("body")
+    .header("Content-Encoding", "gzip, br")
+    .header("content-encoding", "identity");
+
+  let encodings = response
+    .content_encoding()
+    .expect("Content-Encoding should parse")
+    .expect("Content-Encoding should be present");
+
+  assert_eq!(vec!["gzip", "br", "identity"], encodings.codings());
+}
+
+#[test]
+fn content_encoding_helpers_reject_malformed_duplicate_oversized_and_excessive_values() {
+  for value in [
+    "",
+    " ",
+    "gzip,",
+    ", gzip",
+    "gzip,,br",
+    "bad coding",
+    "gzip, g:zip",
+  ] {
+    assert!(
+      HttpResponseContentEncodings::parse(value).is_err(),
+      "Content-Encoding helper should reject {value:?}"
+    );
+  }
+
+  assert!(
+    HttpResponseContentEncodings::parse("gzip, br, GZIP").is_err(),
+    "Content-Encoding helper should reject duplicate codings"
+  );
+
+  let oversized = "gzip".repeat(64 * 1024);
+  assert!(
+    HttpResponseContentEncodings::parse(&oversized).is_err(),
+    "Content-Encoding helper should reject oversized values"
+  );
+
+  let too_many = (0..33)
+    .map(|index| format!("coding{index}"))
+    .collect::<Vec<_>>()
+    .join(", ");
+  assert!(
+    HttpResponseContentEncodings::parse(too_many).is_err(),
+    "Content-Encoding helper should reject excessive codings"
+  );
+
+  assert!(
+    HttpResponse::ok("body")
+      .with_content_encoding(["gzip", "bad coding"])
+      .is_err(),
+    "Content-Encoding declaration helper should reject invalid codings"
+  );
+}
+
+#[test]
+fn raw_content_encoding_headers_are_preserved_without_helper_validation() {
+  let response = HttpResponse::ok("body").header("Content-Encoding", "gzip,");
+  let serialized = String::from_utf8(response.to_bytes()).expect("response is UTF-8");
+
+  assert!(serialized.contains("\r\nContent-Encoding: gzip,\r\n"));
+  assert!(
+    response.content_encoding().is_err(),
+    "typed Content-Encoding parser should reject malformed raw values"
   );
 }
 

--- a/rttp_client/src/response/raw_response.rs
+++ b/rttp_client/src/response/raw_response.rs
@@ -249,24 +249,13 @@ impl Parser {
       return Ok(());
     }
 
-    let content_encoding = response
-      .headers_get()
-      .iter()
-      .find(|header| header.name().eq_ignore_ascii_case("Content-Encoding"));
-
-    if let Some(header) = content_encoding {
-      if header
-        .value()
-        .split(',')
-        .any(|value| value.trim().eq_ignore_ascii_case("gzip"))
-      {
-        let mut decoder = flate2::read::GzDecoder::new(binary.as_slice());
-        let mut buffer = Vec::new();
-        decoder.read_to_end(&mut buffer).map_err(error::decode)?;
-        let body = ResponseBody::new(buffer);
-        response.body(body);
-        return Ok(());
-      }
+    if has_single_gzip_content_encoding(response.headers_get()) {
+      let mut decoder = flate2::read::GzDecoder::new(binary.as_slice());
+      let mut buffer = Vec::new();
+      decoder.read_to_end(&mut buffer).map_err(error::decode)?;
+      let body = ResponseBody::new(buffer);
+      response.body(body);
+      return Ok(());
     }
 
     let body = ResponseBody::new(binary);
@@ -277,4 +266,23 @@ impl Parser {
 
 fn response_status_has_no_body(status_code: u32) -> bool {
   (100..200).contains(&status_code) || status_code == 204 || status_code == 304
+}
+
+fn has_single_gzip_content_encoding(headers: &[Header]) -> bool {
+  let mut values = headers
+    .iter()
+    .filter(|header| header.name().eq_ignore_ascii_case("Content-Encoding"));
+  let Some(header) = values.next() else {
+    return false;
+  };
+  if values.next().is_some() {
+    return false;
+  }
+
+  let mut codings = header.value().split(',').map(str::trim);
+  let Some(coding) = codings.next() else {
+    return false;
+  };
+
+  !coding.is_empty() && coding.eq_ignore_ascii_case("gzip") && codings.next().is_none()
 }

--- a/rttp_client/src/response/response.rs
+++ b/rttp_client/src/response/response.rs
@@ -20,6 +20,8 @@ const MAX_CONTENT_LOCATION_VALUE_BYTES: usize = 64 * 1024;
 const MAX_CONTENT_DISPOSITION_VALUE_BYTES: usize = 64 * 1024;
 const MAX_CONTENT_DISPOSITION_PARAMETER_VALUE_BYTES: usize = 64 * 1024;
 const MAX_CONTENT_DISPOSITION_PARAMETERS: usize = 256;
+const MAX_CONTENT_ENCODING_VALUE_BYTES: usize = 64 * 1024;
+const MAX_CONTENT_ENCODINGS: usize = 256;
 const MAX_CONTENT_LANGUAGE_VALUE_BYTES: usize = 64 * 1024;
 const MAX_CONTENT_LANGUAGE_TAGS: usize = 256;
 const MAX_VARY_VALUE_BYTES: usize = 64 * 1024;
@@ -259,6 +261,14 @@ impl Response {
       return Ok(None);
     }
     ContentLanguage::parse_values(values.into_iter().map(String::as_str)).map(Some)
+  }
+
+  pub fn content_encoding(&self) -> error::Result<Option<ContentEncoding>> {
+    let values = self.header_values("content-encoding");
+    if values.is_empty() {
+      return Ok(None);
+    }
+    ContentEncoding::parse_values(values.into_iter().map(String::as_str)).map(Some)
   }
 
   pub fn cache_control(&self) -> error::Result<Option<CacheControl>> {
@@ -992,6 +1002,59 @@ impl ContentLanguage {
 
   pub fn tags(&self) -> Vec<&str> {
     self.tags.iter().map(String::as_str).collect()
+  }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ContentEncoding {
+  codings: Vec<String>,
+}
+
+impl ContentEncoding {
+  pub fn parse(value: impl AsRef<str>) -> error::Result<Self> {
+    Self::parse_values([value.as_ref()])
+  }
+
+  fn parse_values<'a, I>(values: I) -> error::Result<Self>
+  where
+    I: IntoIterator<Item = &'a str>,
+  {
+    let mut codings = Vec::new();
+    let mut seen = HashSet::new();
+
+    for value in values {
+      if value.len() > MAX_CONTENT_ENCODING_VALUE_BYTES {
+        return Err(error::bad_response(
+          "Content-Encoding header value is too large",
+        ));
+      }
+
+      for coding in value.split(',') {
+        let coding = coding.trim();
+        if coding.is_empty() || !is_token(coding) {
+          return Err(error::bad_response("Invalid Content-Encoding coding"));
+        }
+        if codings.len() >= MAX_CONTENT_ENCODINGS {
+          return Err(error::bad_response("Too many Content-Encoding codings"));
+        }
+
+        let normalized = coding.to_ascii_lowercase();
+        if !seen.insert(normalized) {
+          return Err(error::bad_response("Duplicate Content-Encoding coding"));
+        }
+        codings.push(coding.to_string());
+      }
+    }
+
+    if codings.is_empty() {
+      return Err(error::bad_response("Invalid Content-Encoding coding"));
+    }
+
+    Ok(Self { codings })
+  }
+
+  pub fn codings(&self) -> Vec<&str> {
+    self.codings.iter().map(String::as_str).collect()
   }
 }
 

--- a/rttp_client/tests/test_response.rs
+++ b/rttp_client/tests/test_response.rs
@@ -1,4 +1,4 @@
-use rttp_client::response::{ContentDisposition, ContentLocation, Response};
+use rttp_client::response::{ContentDisposition, ContentEncoding, ContentLocation, Response};
 use rttp_client::types::{Cookie, RoUrl};
 use std::time::{Duration, UNIX_EPOCH};
 
@@ -404,6 +404,79 @@ fn test_parse_content_disposition_rejects_duplicate_singleton_duplicate_paramete
   assert!(
     response.content_disposition().is_err(),
     "content-disposition helper should reject too many parameters"
+  );
+}
+
+#[test]
+fn test_parse_content_encoding_response_helper_preserves_order_across_fields() {
+  let raw = concat!(
+    "HTTP/1.1 200 OK\r\n",
+    "Content-Encoding: compress, br\r\n",
+    "content-encoding: identity\r\n",
+    "Content-Length: 2\r\n",
+    "\r\n",
+    "OK"
+  );
+  let response = Response::new(RoUrl::with("https://example.test"), raw.as_bytes().to_vec())
+    .expect("raw response with content-encoding remains usable");
+
+  let content_encoding = response
+    .content_encoding()
+    .expect("valid content-encoding should parse")
+    .expect("content-encoding header should be present");
+
+  assert_eq!(
+    vec!["compress", "br", "identity"],
+    content_encoding.codings()
+  );
+  assert_eq!(
+    vec![&"compress, br".to_string(), &"identity".to_string()],
+    response.header_values("Content-Encoding")
+  );
+  assert_eq!("OK", response.body().string().unwrap());
+
+  assert_eq!(
+    vec!["gzip", "br"],
+    ContentEncoding::parse("gzip, br")
+      .expect("common codings should parse")
+      .codings()
+  );
+}
+
+#[test]
+fn test_parse_content_encoding_rejects_invalid_duplicate_and_excessive_values() {
+  for value in [
+    "",
+    "compress,",
+    ", compress",
+    "compress,,br",
+    "bad coding",
+    "compress, g:zip",
+  ] {
+    let raw =
+      format!("HTTP/1.1 200 OK\r\nContent-Encoding: {value}\r\nContent-Length: 2\r\n\r\nOK");
+    let response = Response::new(RoUrl::with("https://example.test"), raw.into_bytes())
+      .expect("raw response remains usable");
+
+    assert!(
+      response.content_encoding().is_err(),
+      "content-encoding helper should reject {value:?}"
+    );
+    assert_eq!("OK", response.body().string().unwrap());
+  }
+
+  assert!(
+    ContentEncoding::parse("gzip, br, GZIP").is_err(),
+    "content-encoding helper should reject duplicate codings"
+  );
+
+  let too_many = (0..257)
+    .map(|index| format!("coding{index}"))
+    .collect::<Vec<_>>()
+    .join(", ");
+  assert!(
+    ContentEncoding::parse(too_many).is_err(),
+    "content-encoding helper should reject excessive codings"
   );
 }
 

--- a/rttp_client/tests/test_response.rs
+++ b/rttp_client/tests/test_response.rs
@@ -1,6 +1,13 @@
 use rttp_client::response::{ContentDisposition, ContentEncoding, ContentLocation, Response};
 use rttp_client::types::{Cookie, RoUrl};
+use std::io::Write;
 use std::time::{Duration, UNIX_EPOCH};
+
+fn gzip_bytes(bytes: &[u8]) -> Vec<u8> {
+  let mut encoder = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+  encoder.write_all(bytes).expect("write gzip fixture");
+  encoder.finish().expect("finish gzip fixture")
+}
 
 #[test]
 fn test_parse_cookie_name_can_match_attribute_name() {
@@ -439,6 +446,52 @@ fn test_parse_content_encoding_response_helper_preserves_order_across_fields() {
     vec!["gzip", "br"],
     ContentEncoding::parse("gzip, br")
       .expect("common codings should parse")
+      .codings()
+  );
+}
+
+#[test]
+fn test_content_encoding_runtime_decodes_only_single_supported_gzip_coding() {
+  let body = gzip_bytes(b"OK");
+  let mut raw = concat!("HTTP/1.1 200 OK\r\n", "Content-Encoding: gzip\r\n")
+    .as_bytes()
+    .to_vec();
+  raw.extend_from_slice(format!("Content-Length: {}\r\n\r\n", body.len()).as_bytes());
+  raw.extend_from_slice(&body);
+
+  let response = Response::new(RoUrl::with("https://example.test"), raw)
+    .expect("single gzip response should decode");
+
+  assert_eq!("OK", response.body().string().unwrap());
+  assert_eq!(
+    vec!["gzip"],
+    response
+      .content_encoding()
+      .expect("content-encoding should parse")
+      .expect("content-encoding should be present")
+      .codings()
+  );
+}
+
+#[test]
+fn test_content_encoding_runtime_leaves_stacked_or_unsupported_codings_undecoded() {
+  let raw = concat!(
+    "HTTP/1.1 200 OK\r\n",
+    "Content-Encoding: gzip, br\r\n",
+    "Content-Length: 7\r\n",
+    "\r\n",
+    "encoded"
+  );
+  let response = Response::new(RoUrl::with("https://example.test"), raw.as_bytes().to_vec())
+    .expect("stacked unsupported content-encoding should remain usable");
+
+  assert_eq!("encoded", response.body().string().unwrap());
+  assert_eq!(
+    vec!["gzip", "br"],
+    response
+      .content_encoding()
+      .expect("content-encoding should parse")
+      .expect("content-encoding should be present")
       .codings()
   );
 }


### PR DESCRIPTION
Bounded HTTP/1.1 `Content-Encoding` metadata helpers were added for client response parsing and server response declaration/inspection, with validation, ordering, duplicate rejection, and raw header preservation covered by tests.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1625/
work_kind: code_work
branch: hbx-1625-rttp-add-bounded-http-1
base: main
commit: e23f0609c68c9bb7953cfa6fe1de2ab0b833af43
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1625/
    url: https://plane.kahub.in/endless/browse/HBX-1625/
    close_policy: link_only
```