### PR TITLE
feat: [rttp_client] Add bounded prior-knowledge h2c RFC 8441 extended CONNECT emit support

### DIFF
--- a/rttp/tests/test_server.rs
+++ b/rttp/tests/test_server.rs
@@ -51,6 +51,16 @@ fn write_h2_frame(
   write_raw_h2_frame(stream, frame_type, flags, stream_id & 0x7fff_ffff, payload);
 }
 
+fn try_write_h2_frame(
+  stream: &mut TcpStream,
+  frame_type: u8,
+  flags: u8,
+  stream_id: u32,
+  payload: &[u8],
+) -> io::Result<()> {
+  try_write_raw_h2_frame(stream, frame_type, flags, stream_id & 0x7fff_ffff, payload)
+}
+
 fn write_h2_header_block(stream: &mut TcpStream, stream_id: u32, end_stream: bool, block: &[u8]) {
   if block.len() <= H2_DEFAULT_MAX_FRAME_SIZE {
     let flags = H2_FLAG_END_HEADERS | if end_stream { H2_FLAG_END_STREAM } else { 0 };
@@ -84,6 +94,16 @@ fn write_raw_h2_frame(
   stream_id: u32,
   payload: &[u8],
 ) {
+  try_write_raw_h2_frame(stream, frame_type, flags, stream_id, payload).expect("write h2 frame");
+}
+
+fn try_write_raw_h2_frame(
+  stream: &mut TcpStream,
+  frame_type: u8,
+  flags: u8,
+  stream_id: u32,
+  payload: &[u8],
+) -> io::Result<()> {
   let length = payload.len();
   let mut header = [0; 9];
   header[0] = ((length >> 16) & 0xff) as u8;
@@ -92,8 +112,8 @@ fn write_raw_h2_frame(
   header[3] = frame_type;
   header[4] = flags;
   header[5..9].copy_from_slice(&stream_id.to_be_bytes());
-  stream.write_all(&header).expect("write h2 frame head");
-  stream.write_all(payload).expect("write h2 frame payload");
+  stream.write_all(&header)?;
+  stream.write_all(payload)
 }
 
 fn read_h2_frame(stream: &mut TcpStream) -> H2Frame {
@@ -3827,13 +3847,21 @@ fn server_rejects_http2_prior_knowledge_oversized_request_trailers_before_handle
     1,
     &trailers[..split],
   );
-  write_h2_frame(
+  match try_write_h2_frame(
     &mut stream,
     H2_FRAME_CONTINUATION,
     H2_FLAG_END_HEADERS,
     1,
     &trailers[split..],
-  );
+  ) {
+    Ok(()) => {}
+    Err(err)
+      if matches!(
+        err.kind(),
+        ErrorKind::BrokenPipe | ErrorKind::ConnectionReset
+      ) => {}
+    Err(err) => panic!("write oversized h2 trailer continuation: {err}"),
+  }
   let _ = stream.shutdown(std::net::Shutdown::Write);
 
   let error = handle

--- a/rttp_client/src/client.rs
+++ b/rttp_client/src/client.rs
@@ -330,6 +330,11 @@ impl HttpClient {
     if self.request.closed() {
       return Err(error::connection_closed());
     }
+    if self.request.http2_extended_connect_protocol().is_some() {
+      return Err(error::builder_with_message(
+        "HTTP/2 extended CONNECT is only supported by the prior-knowledge h2c client",
+      ));
+    }
     if self.request.proxy().is_some() {
       return Err(error::builder_with_message(
         "HTTP/2 h2c upgrade client does not support proxies",

--- a/rttp_client/tests/http2_prior_knowledge.rs
+++ b/rttp_client/tests/http2_prior_knowledge.rs
@@ -686,6 +686,89 @@ fn extended_connect_rejects_request_body_before_connecting() {
 }
 
 #[test]
+fn extended_connect_rejects_request_trailers_before_connecting() {
+  let listener = TcpListener::bind("127.0.0.1:0").expect("bind h2 peer");
+  listener
+    .set_nonblocking(true)
+    .expect("set listener nonblocking");
+  let addr = listener.local_addr().expect("h2 peer addr");
+
+  let err = HttpClient::new()
+    .http2_extended_connect("websocket")
+    .url(format!("http://{}/chat", addr))
+    .trailer(("X-Trace", "unsupported"))
+    .expect("configure request trailer")
+    .emit_http2_prior_knowledge()
+    .expect_err("extended CONNECT with trailers must be rejected");
+
+  assert!(err.is_builder());
+  assert!(
+    err
+      .to_string()
+      .contains("HTTP/2 extended CONNECT cannot send request trailers"),
+    "unexpected error: {err}"
+  );
+  assert!(
+    matches!(listener.accept(), Err(ref err) if err.kind() == io::ErrorKind::WouldBlock),
+    "extended CONNECT with trailers must not open a server connection"
+  );
+}
+
+#[test]
+fn extended_connect_rejects_empty_protocol_before_connecting() {
+  let listener = TcpListener::bind("127.0.0.1:0").expect("bind h2 peer");
+  listener
+    .set_nonblocking(true)
+    .expect("set listener nonblocking");
+  let addr = listener.local_addr().expect("h2 peer addr");
+
+  let err = HttpClient::new()
+    .http2_extended_connect("")
+    .url(format!("http://{}/chat", addr))
+    .emit_http2_prior_knowledge()
+    .expect_err("extended CONNECT with empty protocol must be rejected");
+
+  assert!(err.is_builder());
+  assert!(
+    err
+      .to_string()
+      .contains("Invalid HTTP/2 extended CONNECT protocol"),
+    "unexpected error: {err}"
+  );
+  assert!(
+    matches!(listener.accept(), Err(ref err) if err.kind() == io::ErrorKind::WouldBlock),
+    "extended CONNECT with empty protocol must not open a server connection"
+  );
+}
+
+#[test]
+fn extended_connect_rejects_h2c_upgrade_path_before_connecting() {
+  let listener = TcpListener::bind("127.0.0.1:0").expect("bind h2 peer");
+  listener
+    .set_nonblocking(true)
+    .expect("set listener nonblocking");
+  let addr = listener.local_addr().expect("h2 peer addr");
+
+  let err = HttpClient::new()
+    .http2_extended_connect("websocket")
+    .url(format!("http://{}/chat", addr))
+    .emit_http2_upgrade()
+    .expect_err("extended CONNECT over h2c upgrade must be rejected");
+
+  assert!(err.is_builder());
+  assert!(
+    err
+      .to_string()
+      .contains("HTTP/2 extended CONNECT is only supported by the prior-knowledge h2c client"),
+    "unexpected error: {err}"
+  );
+  assert!(
+    matches!(listener.accept(), Err(ref err) if err.kind() == io::ErrorKind::WouldBlock),
+    "extended CONNECT over h2c upgrade must not open a server connection"
+  );
+}
+
+#[test]
 fn extended_connect_with_proxy_is_rejected_before_connecting() {
   let listener = TcpListener::bind("127.0.0.1:0").expect("bind h2 peer");
   listener


### PR DESCRIPTION
Bounded prior-knowledge h2c extended CONNECT support is implemented and workspace verification is passing after stabilizing the related oversized HTTP/2 trailer rejection test.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1629/
work_kind: code_work
branch: hbx-1629-rttp-client-add-bounded-prior
base: main
commit: 3fe48ec62ca4dedec3f212dd7a90e2ac258f3094
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1629/
    url: https://plane.kahub.in/endless/browse/HBX-1629/
    close_policy: link_only
```