### PR TITLE
feat: [rttp] Document bounded RFC 8441 extended CONNECT support

### DIFF
--- a/README.md
+++ b/README.md
@@ -540,6 +540,20 @@ provide a dynamic policy API for changing h2c frame-size or metadata limits at
 runtime.
 
 ```rust,no_run
+# #[cfg(feature = "http2")]
+# fn example() -> Result<(), Box<dyn std::error::Error>> {
+use rttp_client::HttpClient;
+
+let response = HttpClient::new()
+  .get()
+  .url("http://127.0.0.1:8080/chat")
+  .http2_extended_connect("websocket")
+  .emit_http2_prior_knowledge()?;
+# Ok(())
+# }
+```
+
+```rust,no_run
 use rttp_client::HttpClient;
 
 let response = HttpClient::new()
@@ -1100,6 +1114,25 @@ general multiplexing, general tunnel scheduling, server push, and priority
 scheduling remain outside this bounded prior-knowledge server path. RTTP does
 not expose a dynamic policy API for changing the h2c frame-size or metadata
 limit at runtime.
+
+```rust,no_run
+use rttp::server::HttpResponse;
+
+fn main() -> std::io::Result<()> {
+  let server = rttp::Http::server("127.0.0.1:8080")?;
+
+  server.accept_one(|request| {
+    if request.method() == "CONNECT"
+      && request.version() == "HTTP/2"
+      && request.extended_connect_protocol() == Some("websocket")
+    {
+      return HttpResponse::ok("accepted extended CONNECT metadata");
+    }
+
+    HttpResponse::new(400, "Bad Request")
+  })
+}
+```
 
 It is not a full RFC-covering web server and still does not implement server
 TLS or async accept loops.

--- a/rttp/README.md
+++ b/rttp/README.md
@@ -619,6 +619,25 @@ authority-form requests and `HttpResponse::upgrade` for non-h2c protocols
 remain separate handoff paths for caller-owned protocols, and the h2c Upgrade
 detection preserves those existing handoffs when `Upgrade` is not `h2c`.
 
+```rust,no_run
+use rttp::server::HttpResponse;
+
+fn main() -> std::io::Result<()> {
+  let server = rttp::Http::server("127.0.0.1:8080")?;
+
+  server.accept_one(|request| {
+    if request.method() == "CONNECT"
+      && request.version() == "HTTP/2"
+      && request.extended_connect_protocol() == Some("websocket")
+    {
+      return HttpResponse::ok("accepted extended CONNECT metadata");
+    }
+
+    HttpResponse::new(400, "Bad Request")
+  })
+}
+```
+
 The server is intentionally not a full RFC-covering web server and still does
 not implement server TLS, TLS ALPN, extension callback APIs, full extension
 negotiation, external h2 integration, full WebSocket-over-h2, proxy h2, h2c
@@ -769,6 +788,18 @@ scheduling, general multiplexing, and priority scheduling remain outside that
 bounded prior-knowledge path. RTTP does not expose a dynamic policy API for
 changing h2c frame-size or metadata limits at
 runtime.
+
+```rust,no_run
+# #[cfg(feature = "http2")]
+# fn example() -> Result<(), Box<dyn std::error::Error>> {
+let response = rttp::Http::client()
+  .get()
+  .url("http://127.0.0.1:8080/chat")
+  .http2_extended_connect("websocket")
+  .emit_http2_prior_knowledge()?;
+# Ok(())
+# }
+```
 
 Direct TCP client connections use `socket2`. SOCKS proxy handshakes remain
 delegated to the `socks` crate.

--- a/rttp/src/lib.rs
+++ b/rttp/src/lib.rs
@@ -27,13 +27,24 @@
 //! other value rejects the bounded h2c handshake. `PUSH_PROMISE` frames are
 //! rejected before handler dispatch, and this path does not implement
 //! server-side push state.
+//! Peer `SETTINGS_ENABLE_CONNECT_PROTOCOL` values are validated as only `0` or
+//! `1`. After a peer sends `SETTINGS_ENABLE_CONNECT_PROTOCOL = 1`, the server
+//! accepts RFC 8441 extended CONNECT request HEADERS with method `CONNECT` and
+//! required `:protocol`, `:scheme`, `:authority`, and `:path` metadata. The
+//! handler receives a normal `Request` with version `HTTP/2`, target from
+//! `:path`, host from `:authority`, and
+//! `Request::extended_connect_protocol()` set to the `:protocol` value, then
+//! returns a normal `HttpResponse`. Missing negotiation, ordinary h2c
+//! `CONNECT`, non-CONNECT `:protocol`, request bodies, and request trailers are
+//! rejected before handler dispatch.
 //! It remains a bounded prior-knowledge server path: it can accept multiple
 //! open streams only up to the advertised active-stream allowance, uses
 //! synchronous response writes, and does not provide full multiplex scheduling,
 //! persistent HTTP/2 session management, dynamic policy APIs, extension
 //! callbacks, full extension negotiation, TLS ALPN, server push, proxy h2,
-//! tunnel handoff, or a full
-//! HTTP/2 server feature set.
+//! tunnel handoff, full WebSocket-over-h2, arbitrary tunnel scheduling, or a
+//! full HTTP/2 server feature set. HTTP/1.1 `CONNECT` and non-h2c `Upgrade`
+//! handoff semantics are unchanged and remain separate caller-owned paths.
 //!
 //! With the `client` or `http2` feature enabled, the wrapper exposes the
 //! `rttp_client` bounded prior-knowledge h2c client behavior. The client opens

--- a/rttp_client/README.md
+++ b/rttp_client/README.md
@@ -579,6 +579,38 @@ and priority scheduling are not part of that bounded prior-knowledge client
 path. RTTP does not expose a dynamic policy API for changing h2c frame-size or
 metadata limits at runtime.
 
+### Bounded RFC 8441 extended CONNECT
+
+`HttpClient::http2_extended_connect(protocol)` is the supported client entry
+point for RFC 8441 metadata on RTTP's bounded HTTP/2 path. It is prior-knowledge
+h2c only, runs over the direct `socket2` TCP transport used by
+`emit_http2_prior_knowledge`, and opens at most one request stream. The client
+advertises `SETTINGS_ENABLE_CONNECT_PROTOCOL = 1` only for this explicit mode,
+then emits `:method CONNECT` with required `:protocol`, `:scheme`,
+`:authority`, and `:path` pseudo-header metadata. The peer's result is returned
+as a normal `Response`.
+
+```rust,no_run
+# #[cfg(feature = "http2")]
+# fn example() -> Result<(), Box<dyn std::error::Error>> {
+use rttp_client::HttpClient;
+
+let response = HttpClient::new()
+  .get()
+  .url("http://127.0.0.1:8080/chat")
+  .http2_extended_connect("websocket")
+  .emit_http2_prior_knowledge()?;
+# Ok(())
+# }
+```
+
+This is not a full WebSocket-over-h2 implementation, arbitrary tunnel
+scheduler, upgraded socket handoff, or general multiplexing guarantee beyond
+the bounded single-stream request/response path. It does not alter HTTP/1.1
+`CONNECT` tunnel handoff or `Upgrade` semantics. Ordinary `CONNECT`,
+header-configured `:protocol` metadata, HTTP/1.1 `Upgrade` handoff requests,
+proxies, request bodies, and request trailers are rejected for this path.
+
 ## Examples
 
 ```rust,no_run

--- a/rttp_client/src/client.rs
+++ b/rttp_client/src/client.rs
@@ -119,8 +119,11 @@ impl HttpClient {
   /// Use RFC 8441 extended CONNECT on the bounded prior-knowledge h2c path.
   ///
   /// This is only honored by `emit_http2_prior_knowledge` with the `http2`
-  /// feature enabled. The request is emitted as `:method CONNECT` and includes
-  /// the configured `:protocol` pseudo-header.
+  /// feature enabled. The client opens a direct `socket2` h2c TCP connection,
+  /// advertises `SETTINGS_ENABLE_CONNECT_PROTOCOL = 1`, emits `:method
+  /// CONNECT`, and includes the configured `:protocol` pseudo-header. It
+  /// returns the peer's HTTP/2 response through the normal `Response` API; it
+  /// does not hand an upgraded socket to the caller.
   #[cfg(feature = "http2")]
   pub fn http2_extended_connect<S: AsRef<str>>(&mut self, protocol: S) -> &mut Self {
     self

--- a/rttp_client/src/lib.rs
+++ b/rttp_client/src/lib.rs
@@ -30,6 +30,15 @@
 //! disabled, validates received `SETTINGS_ENABLE_PUSH` values as only `0` or
 //! `1`, and rejects any incoming `PUSH_PROMISE` frame instead of creating or
 //! tracking push state.
+//! `HttpClient::http2_extended_connect(protocol)` is the only public RFC 8441
+//! entry point on this bounded path. It is prior-knowledge h2c only over the
+//! direct `socket2` transport boundary: the client advertises
+//! `SETTINGS_ENABLE_CONNECT_PROTOCOL = 1`, emits `:method CONNECT` with
+//! `:protocol`, `:scheme`, `:authority`, and `:path`, and returns the peer's
+//! response through the normal `Response` API. Ordinary `CONNECT`,
+//! header-configured `:protocol` metadata, HTTP/1.1 `Upgrade` handoff requests,
+//! proxies, request bodies, and request trailers are rejected before the h2c
+//! request is sent.
 //! It decodes incoming padded HEADERS, DATA, and trailer frames without
 //! exposing padding bytes, including response HPACK dynamic table entries.
 //! Peer `SETTINGS_HEADER_TABLE_SIZE` bounds outbound request dynamic indexing;
@@ -47,10 +56,12 @@
 //! `last-stream-id` includes stream 1, and pre-stream `GOAWAY` refuses the
 //! request before request HEADERS are sent. RTTP reports those conditions to
 //! the caller and does not retry automatically; transport disconnects remain
-//! ordinary socket errors without an HTTP/2 stream boundary. TLS ALPN, proxy
-//! h2, full extension negotiation, full HTTP/2 multiplexing, dynamic policy
-//! APIs, server push, and priority scheduling are not part of that
-//! single-stream path.
+//! ordinary socket errors without an HTTP/2 stream boundary. This is not a full
+//! WebSocket-over-h2 implementation, arbitrary tunnel scheduler, or general
+//! multiplexing guarantee beyond the bounded single-stream path, and it does
+//! not change HTTP/1.1 `CONNECT` or `Upgrade` semantics. TLS ALPN, proxy h2,
+//! full extension negotiation, full HTTP/2 multiplexing, dynamic policy APIs,
+//! server push, and priority scheduling are not part of that path.
 //!
 //! ```rust,no_run
 //! use rttp_client::HttpClient;
@@ -60,6 +71,20 @@
 //!   .url("http://127.0.0.1:8080/health")
 //!   .emit()?;
 //! # Ok::<(), Box<dyn std::error::Error>>(())
+//! ```
+//!
+//! ```rust,no_run
+//! # #[cfg(feature = "http2")]
+//! # fn example() -> Result<(), Box<dyn std::error::Error>> {
+//! use rttp_client::HttpClient;
+//!
+//! let response = HttpClient::new()
+//!   .get()
+//!   .url("http://127.0.0.1:8080/chat")
+//!   .http2_extended_connect("websocket")
+//!   .emit_http2_prior_knowledge()?;
+//! # Ok(())
+//! # }
 //! ```
 //!
 //! ```rust,no_run


### PR DESCRIPTION
Documentation now covers the bounded RFC 8441 extended CONNECT behavior and public usage boundaries for rttp and rttp_client, with verification passing across formatting, workspace tests, and diff checks.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1632/
work_kind: code_work
branch: hbx-1632-rttp-document-bounded-rfc-8441
base: main
commit: 46b4cd2f9f9a8dcbdbcf0128e7d5afdca0a73a62
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1632/
    url: https://plane.kahub.in/endless/browse/HBX-1632/
    close_policy: link_only
```