### PR TITLE
feat: [rttp_client] Handle inbound h2c HTTP/2 PING frames on bounded client path

### DIFF
--- a/rttp_client/src/http2.rs
+++ b/rttp_client/src/http2.rs
@@ -385,13 +385,7 @@ fn reject_goaway_before_opening_request_stream(
         }
       }
       (FRAME_PING, 0) => {
-        if frame.payload.len() != 8 {
-          return Err(error::bad_response("invalid HTTP/2 PING frame"));
-        }
-        if frame.flags & FLAG_ACK == 0 {
-          write_frame(stream, FRAME_PING, FLAG_ACK, 0, &frame.payload)?;
-          stream.flush().map_err(error::request)?;
-        }
+        handle_ping_frame(stream, &frame)?;
       }
       (FRAME_PING, _) => {
         return Err(error::bad_response("invalid HTTP/2 PING frame"));
@@ -420,6 +414,17 @@ fn reject_goaway_before_opening_request_stream(
         ));
       }
     }
+  }
+  Ok(())
+}
+
+fn handle_ping_frame(stream: &mut TcpStream, frame: &Frame) -> error::Result<()> {
+  if frame.stream_id != 0 || frame.payload.len() != 8 {
+    return Err(error::bad_response("invalid HTTP/2 PING frame"));
+  }
+  if frame.flags & FLAG_ACK == 0 {
+    write_frame(stream, FRAME_PING, FLAG_ACK, 0, &frame.payload)?;
+    stream.flush().map_err(error::request)?;
   }
   Ok(())
 }
@@ -1100,13 +1105,7 @@ fn read_until_send_window_available(
         rst_stream_error_code(&frame)?;
       }
       (FRAME_PING, 0) => {
-        if frame.payload.len() != 8 {
-          return Err(error::bad_response("invalid HTTP/2 PING frame"));
-        }
-        if frame.flags & FLAG_ACK == 0 {
-          write_frame(stream, FRAME_PING, FLAG_ACK, 0, &frame.payload)?;
-          stream.flush().map_err(error::request)?;
-        }
+        handle_ping_frame(stream, &frame)?;
       }
       (FRAME_PING, _) => {
         return Err(error::bad_response("invalid HTTP/2 PING frame"));
@@ -1585,13 +1584,7 @@ fn read_single_stream_response_with_first_frame(
         rst_stream_error_code(&frame)?;
       }
       (FRAME_PING, 0) => {
-        if frame.payload.len() != 8 {
-          return Err(error::bad_response("invalid HTTP/2 PING frame"));
-        }
-        if frame.flags & FLAG_ACK == 0 {
-          write_frame(stream, FRAME_PING, FLAG_ACK, 0, &frame.payload)?;
-          stream.flush().map_err(error::request)?;
-        }
+        handle_ping_frame(stream, &frame)?;
       }
       (FRAME_PING, _) => {
         return Err(error::bad_response("invalid HTTP/2 PING frame"));

--- a/rttp_client/tests/http2_prior_knowledge.rs
+++ b/rttp_client/tests/http2_prior_knowledge.rs
@@ -122,6 +122,88 @@ fn prior_knowledge_get_sends_h2_handshake_and_reads_single_response_stream() {
 }
 
 #[test]
+fn prior_knowledge_client_acks_ping_and_ignores_ping_ack_during_response() {
+  let listener = TcpListener::bind("127.0.0.1:0").expect("bind h2 peer");
+  let addr = listener.local_addr().expect("h2 peer addr");
+
+  let handle = thread::spawn(move || {
+    let (mut stream, _) = listener.accept().expect("accept h2 client");
+    complete_h2_request_handshake(&mut stream);
+
+    write_frame(&mut stream, FRAME_SETTINGS, FLAG_ACK, 0, &[]);
+    write_frame(&mut stream, FRAME_PING, FLAG_ACK, 0, b"ignored!");
+    write_frame(&mut stream, FRAME_PING, 0, 0, b"rttp-png");
+
+    let ping_ack = read_frame(&mut stream);
+    assert_eq!(FRAME_PING, ping_ack.frame_type);
+    assert_eq!(FLAG_ACK, ping_ack.flags);
+    assert_eq!(0, ping_ack.stream_id);
+    assert_eq!(b"rttp-png", ping_ack.payload.as_slice());
+
+    write_frame(
+      &mut stream,
+      FRAME_HEADERS,
+      FLAG_END_HEADERS,
+      1,
+      &[
+        0x88, 0x0f, 16, 10, b't', b'e', b'x', b't', b'/', b'p', b'l', b'a', b'i', b'n',
+      ],
+    );
+    write_frame(&mut stream, FRAME_DATA, FLAG_END_STREAM, 1, b"pong body");
+  });
+
+  let response = HttpClient::new()
+    .get()
+    .url(format!("http://{}/ping", addr))
+    .emit_http2_prior_knowledge()
+    .expect("h2 response after peer PING");
+
+  assert_eq!(200, response.code());
+  assert_eq!("HTTP/2", response.version());
+  assert_eq!(
+    Some(&"text/plain".to_string()),
+    response.header_value("content-type")
+  );
+  assert_eq!("pong body", response.body().string().unwrap());
+
+  handle.join().expect("h2 ping peer thread");
+}
+
+#[test]
+fn prior_knowledge_client_rejects_malformed_ping_during_response() {
+  for (path, flags, stream_id, payload) in [
+    ("ping-stream", 0, 1, b"rttp-png".as_slice()),
+    ("ping-short", 0, 0, b"short".as_slice()),
+    ("ping-ack-short", FLAG_ACK, 0, b"short".as_slice()),
+  ] {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind h2 peer");
+    let addr = listener.local_addr().expect("h2 peer addr");
+    let payload = payload.to_vec();
+
+    let handle = thread::spawn(move || {
+      let (mut stream, _) = listener.accept().expect("accept h2 client");
+      complete_h2_request_handshake(&mut stream);
+
+      write_frame(&mut stream, FRAME_SETTINGS, FLAG_ACK, 0, &[]);
+      write_frame(&mut stream, FRAME_PING, flags, stream_id, &payload);
+    });
+
+    let error = HttpClient::new()
+      .get()
+      .url(format!("http://{}/{}", addr, path))
+      .emit_http2_prior_knowledge()
+      .expect_err("malformed PING must reject response");
+
+    assert!(
+      error.to_string().contains("invalid HTTP/2 PING frame"),
+      "unexpected error: {error}"
+    );
+
+    handle.join().expect("h2 malformed ping peer thread");
+  }
+}
+
+#[test]
 fn http2_upgrade_sends_http11_upgrade_then_runs_single_h2_stream() {
   let listener = TcpListener::bind("127.0.0.1:0").expect("bind h2c upgrade peer");
   let addr = listener.local_addr().expect("h2c upgrade peer addr");


### PR DESCRIPTION
rttp_client now handles bounded inbound h2c PING frames during prior-knowledge response processing with shared validation and ACK echo behavior, backed by focused tests and full workspace verification.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1634/
work_kind: code_work
branch: hbx-1634-rttp-client-handle-inbound-h2c
base: main
commit: a7927ada1cd2f5d6a934903bb5288d5a05cae986
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1634/
    url: https://plane.kahub.in/endless/browse/HBX-1634/
    close_policy: link_only
```