### PR TITLE
feat: [rttp] Clarify workspace crate layout and test-support boundaries

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,6 @@
 members = [
   "rttp",
   "rttp_client",
-  "rttp_http11_test_fixtures",
+  "rttp_test_support",
 ]
 resolver = "2"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@ rttp
 ====
 
 A small Rust HTTP workspace with a client crate (`rttp_client`) and a wrapper
-crate (`rttp`) that also provides a minimal blocking HTTP server.
+crate (`rttp`) that also provides a minimal blocking HTTP server. The private,
+unpublished `rttp_test_support` crate contains shared test fixtures and local
+socket helpers for those workspace crates.
 
 ## Client
 

--- a/rttp/Cargo.toml
+++ b/rttp/Cargo.toml
@@ -27,7 +27,7 @@ rttp_client = { optional = true, path = "../rttp_client", features = [ "tls-nati
 async-std = { version = "1" }
 rcgen = "0.11"
 rustls = "0.23"
-rttp_http11_test_fixtures = { path = "../rttp_http11_test_fixtures" }
+rttp_test_support = { path = "../rttp_test_support" }
 rttp_client = { path = "../rttp_client", features = ["http2"] }
 
 

--- a/rttp/tests/http11_compliance_matrix.rs
+++ b/rttp/tests/http11_compliance_matrix.rs
@@ -8,7 +8,7 @@ use rttp::server::{
   HttpAcceptRanges, HttpAllowedMethods, HttpContentDisposition, HttpContentLanguages, HttpRequest,
   HttpRequestCacheControl, HttpResponse, HttpResponseCacheControl, HttpRetryAfter, HttpVary,
 };
-use rttp_http11_test_fixtures as fixtures;
+use rttp_test_support as fixtures;
 
 #[derive(Debug)]
 struct ParsedResponse<'a> {

--- a/rttp_client/Cargo.toml
+++ b/rttp_client/Cargo.toml
@@ -67,4 +67,4 @@ tls-rustls  = ["rustls", "webpki-roots", "futures-rustls"]
 [dev-dependencies]
 rcgen = "0.11"
 rttp = { path = "../rttp" }
-rttp_http11_test_fixtures = { path = "../rttp_http11_test_fixtures" }
+rttp_test_support = { path = "../rttp_test_support" }

--- a/rttp_client/tests/http11_compliance_matrix.rs
+++ b/rttp_client/tests/http11_compliance_matrix.rs
@@ -14,7 +14,7 @@ use rttp::server::{
   Request,
 };
 use rttp_client::HttpClient;
-use rttp_http11_test_fixtures as fixtures;
+use rttp_test_support as fixtures;
 
 fn client() -> HttpClient {
   HttpClient::new()

--- a/rttp_test_support/Cargo.toml
+++ b/rttp_test_support/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "rttp_http11_test_fixtures"
+name = "rttp_test_support"
 version = "0.0.0"
 edition = "2021"
 publish = false

--- a/rttp_test_support/src/lib.rs
+++ b/rttp_test_support/src/lib.rs
@@ -1,3 +1,8 @@
+//! Private shared support for the RTTP workspace test suites.
+//!
+//! This crate is intentionally unpublished and is only consumed through
+//! development dependencies by workspace members.
+
 use std::io::{Read, Write};
 use std::net::{SocketAddr, TcpListener};
 use std::thread::{self, JoinHandle};


### PR DESCRIPTION
Clarified RTTP workspace boundaries by renaming the shared fixture crate to the private `rttp_test_support` crate and updating internal test dependencies. Public behavior is unchanged and the full workspace verification passes.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1638/
work_kind: code_work
branch: hbx-1638-rttp-clarify-workspace-crate-layout
base: main
commit: af8fbffdba7586e391a4a18b33ea6c616772baee
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1638/
    url: https://plane.kahub.in/endless/browse/HBX-1638/
    close_policy: link_only
```