### PR TITLE
feat: [rttp] Introduce private protocol ownership for shared HTTP wire primitives

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
   "crates/rttp",
   "crates/rttp-client",
+  "crates/rttp-protocol",
   "crates/rttp-server",
   "crates/rttp-test-support",
   "tests",

--- a/crates/rttp-client/Cargo.toml
+++ b/crates/rttp-client/Cargo.toml
@@ -33,7 +33,7 @@ socks    = "0.3"
 base64   = "0.22"
 flate2   = "1.0"
 httpdate = "1.0"
-rttp-protocol = { path = "../rttp-protocol" }
+rttp-protocol = { version = "0.1.0", path = "../rttp-protocol" }
 
 
 native-tls       = { optional = true, version = "0.2" }

--- a/crates/rttp-client/Cargo.toml
+++ b/crates/rttp-client/Cargo.toml
@@ -33,6 +33,7 @@ socks    = "0.3"
 base64   = "0.22"
 flate2   = "1.0"
 httpdate = "1.0"
+rttp-protocol = { path = "../rttp-protocol" }
 
 
 native-tls       = { optional = true, version = "0.2" }

--- a/crates/rttp-client/src/connection/async_connection.rs
+++ b/crates/rttp-client/src/connection/async_connection.rs
@@ -2,6 +2,7 @@ use std::collections::HashSet;
 use std::net::TcpStream;
 
 use futures::io::{AllowStdIo, AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+use rttp_protocol::http1::{parse_chunk_size as parse_protocol_chunk_size, ChunkSizeError};
 use socks::{Socks4Stream, Socks5Stream};
 use std::io::{self, Write};
 use url::Url;
@@ -595,122 +596,20 @@ where
 }
 
 fn parse_chunk_size(line: &[u8]) -> error::Result<usize> {
-  let line = line.strip_suffix(CRLF).unwrap_or(line);
-  let (size, extensions) = line
-    .iter()
-    .position(|byte| *byte == b';')
-    .map_or((line, None), |index| {
-      (&line[..index], Some(&line[index + 1..]))
-    });
-  let size = std::str::from_utf8(size).map_err(error::response)?.trim();
-  if size.is_empty() {
-    return Err(error::bad_response("Chunk size line is empty"));
-  }
-  if let Some(extensions) = extensions {
-    validate_chunk_extensions(extensions)?;
-  }
-
-  usize::from_str_radix(size, 16).map_err(|_| error::bad_response("Invalid chunk size"))
-}
-
-fn validate_chunk_extensions(mut bytes: &[u8]) -> error::Result<()> {
-  loop {
-    bytes = trim_bws(bytes);
-    let token_len = bytes
-      .iter()
-      .position(|byte| !is_tchar(*byte))
-      .unwrap_or(bytes.len());
-    if token_len == 0 {
-      return Err(error::bad_response("Invalid chunk extension"));
+  parse_protocol_chunk_size(line).map_err(|error| match error {
+    ChunkSizeError::NotUtf8 => {
+      let size = line
+        .strip_suffix(CRLF)
+        .unwrap_or(line)
+        .splitn(2, |byte| *byte == b';')
+        .next()
+        .expect("split always returns the first chunk size segment");
+      error::response(std::str::from_utf8(size).expect_err("chunk size is not UTF-8"))
     }
-    bytes = trim_bws(&bytes[token_len..]);
-
-    if let Some(rest) = bytes.strip_prefix(b"=") {
-      bytes = trim_bws(rest);
-      if let Some(rest) = bytes.strip_prefix(b"\"") {
-        bytes = parse_quoted_chunk_extension(rest)?;
-      } else {
-        let value_len = bytes
-          .iter()
-          .position(|byte| !is_tchar(*byte))
-          .unwrap_or(bytes.len());
-        if value_len == 0 {
-          return Err(error::bad_response("Invalid chunk extension"));
-        }
-        bytes = &bytes[value_len..];
-      }
-      bytes = trim_bws(bytes);
-    }
-
-    if bytes.is_empty() {
-      return Ok(());
-    }
-    if let Some(rest) = bytes.strip_prefix(b";") {
-      bytes = rest;
-    } else {
-      return Err(error::bad_response("Invalid chunk extension"));
-    }
-  }
-}
-
-fn parse_quoted_chunk_extension(mut bytes: &[u8]) -> error::Result<&[u8]> {
-  loop {
-    let Some((&byte, rest)) = bytes.split_first() else {
-      return Err(error::bad_response("Invalid chunk extension"));
-    };
-    match byte {
-      b'"' => return Ok(rest),
-      b'\\' => {
-        let Some((&escaped, rest)) = rest.split_first() else {
-          return Err(error::bad_response("Invalid chunk extension"));
-        };
-        if !is_quoted_pair_char(escaped) {
-          return Err(error::bad_response("Invalid chunk extension"));
-        }
-        bytes = rest;
-      }
-      byte if is_qdtext(byte) => bytes = rest,
-      _ => return Err(error::bad_response("Invalid chunk extension")),
-    }
-  }
-}
-
-fn trim_bws(bytes: &[u8]) -> &[u8] {
-  let start = bytes
-    .iter()
-    .position(|byte| *byte != b' ' && *byte != b'\t')
-    .unwrap_or(bytes.len());
-  &bytes[start..]
-}
-
-fn is_tchar(byte: u8) -> bool {
-  byte.is_ascii_alphanumeric()
-    || matches!(
-      byte,
-      b'!'
-        | b'#'
-        | b'$'
-        | b'%'
-        | b'&'
-        | b'\''
-        | b'*'
-        | b'+'
-        | b'-'
-        | b'.'
-        | b'^'
-        | b'_'
-        | b'`'
-        | b'|'
-        | b'~'
-    )
-}
-
-fn is_qdtext(byte: u8) -> bool {
-  matches!(byte, b'\t' | b' ' | b'!' | 0x23..=0x5b | 0x5d..=0x7e | 0x80..=0xff)
-}
-
-fn is_quoted_pair_char(byte: u8) -> bool {
-  matches!(byte, b'\t' | b' ' | 0x21..=0x7e | 0x80..=0xff)
+    ChunkSizeError::Empty => error::bad_response("Chunk size line is empty"),
+    ChunkSizeError::Invalid => error::bad_response("Invalid chunk size"),
+    ChunkSizeError::InvalidExtension => error::bad_response("Invalid chunk extension"),
+  })
 }
 
 async fn async_consume_crlf<S>(stream: &mut S) -> error::Result<()>

--- a/crates/rttp-client/src/connection/connection_reader.rs
+++ b/crates/rttp-client/src/connection/connection_reader.rs
@@ -1,6 +1,10 @@
 use std::io;
 use std::io::Read;
 
+use rttp_protocol::http1::{
+  is_header_value_byte, is_reason_phrase_byte, is_token as is_http_token,
+  parse_chunk_size as parse_protocol_chunk_size, ChunkSizeError,
+};
 use url::Url;
 
 use crate::error;
@@ -670,122 +674,20 @@ where
 }
 
 fn parse_chunk_size(line: &[u8]) -> error::Result<usize> {
-  let line = line.strip_suffix(CRLF).unwrap_or(line);
-  let (size, extensions) = line
-    .iter()
-    .position(|byte| *byte == b';')
-    .map_or((line, None), |index| {
-      (&line[..index], Some(&line[index + 1..]))
-    });
-  let size = std::str::from_utf8(size).map_err(error::response)?.trim();
-  if size.is_empty() {
-    return Err(error::bad_response("Chunk size line is empty"));
-  }
-  if let Some(extensions) = extensions {
-    validate_chunk_extensions(extensions)?;
-  }
-
-  usize::from_str_radix(size, 16).map_err(|_| error::bad_response("Invalid chunk size"))
-}
-
-fn validate_chunk_extensions(mut bytes: &[u8]) -> error::Result<()> {
-  loop {
-    bytes = trim_bws(bytes);
-    let token_len = bytes
-      .iter()
-      .position(|byte| !is_tchar(*byte))
-      .unwrap_or(bytes.len());
-    if token_len == 0 {
-      return Err(error::bad_response("Invalid chunk extension"));
+  parse_protocol_chunk_size(line).map_err(|error| match error {
+    ChunkSizeError::NotUtf8 => {
+      let size = line
+        .strip_suffix(CRLF)
+        .unwrap_or(line)
+        .splitn(2, |byte| *byte == b';')
+        .next()
+        .expect("split always returns the first chunk size segment");
+      error::response(std::str::from_utf8(size).expect_err("chunk size is not UTF-8"))
     }
-    bytes = trim_bws(&bytes[token_len..]);
-
-    if let Some(rest) = bytes.strip_prefix(b"=") {
-      bytes = trim_bws(rest);
-      if let Some(rest) = bytes.strip_prefix(b"\"") {
-        bytes = parse_quoted_chunk_extension(rest)?;
-      } else {
-        let value_len = bytes
-          .iter()
-          .position(|byte| !is_tchar(*byte))
-          .unwrap_or(bytes.len());
-        if value_len == 0 {
-          return Err(error::bad_response("Invalid chunk extension"));
-        }
-        bytes = &bytes[value_len..];
-      }
-      bytes = trim_bws(bytes);
-    }
-
-    if bytes.is_empty() {
-      return Ok(());
-    }
-    if let Some(rest) = bytes.strip_prefix(b";") {
-      bytes = rest;
-    } else {
-      return Err(error::bad_response("Invalid chunk extension"));
-    }
-  }
-}
-
-fn parse_quoted_chunk_extension(mut bytes: &[u8]) -> error::Result<&[u8]> {
-  loop {
-    let Some((&byte, rest)) = bytes.split_first() else {
-      return Err(error::bad_response("Invalid chunk extension"));
-    };
-    match byte {
-      b'"' => return Ok(rest),
-      b'\\' => {
-        let Some((&escaped, rest)) = rest.split_first() else {
-          return Err(error::bad_response("Invalid chunk extension"));
-        };
-        if !is_quoted_pair_char(escaped) {
-          return Err(error::bad_response("Invalid chunk extension"));
-        }
-        bytes = rest;
-      }
-      byte if is_qdtext(byte) => bytes = rest,
-      _ => return Err(error::bad_response("Invalid chunk extension")),
-    }
-  }
-}
-
-fn trim_bws(bytes: &[u8]) -> &[u8] {
-  let start = bytes
-    .iter()
-    .position(|byte| *byte != b' ' && *byte != b'\t')
-    .unwrap_or(bytes.len());
-  &bytes[start..]
-}
-
-fn is_tchar(byte: u8) -> bool {
-  byte.is_ascii_alphanumeric()
-    || matches!(
-      byte,
-      b'!'
-        | b'#'
-        | b'$'
-        | b'%'
-        | b'&'
-        | b'\''
-        | b'*'
-        | b'+'
-        | b'-'
-        | b'.'
-        | b'^'
-        | b'_'
-        | b'`'
-        | b'|'
-        | b'~'
-    )
-}
-
-fn is_qdtext(byte: u8) -> bool {
-  matches!(byte, b'\t' | b' ' | b'!' | 0x23..=0x5b | 0x5d..=0x7e | 0x80..=0xff)
-}
-
-fn is_quoted_pair_char(byte: u8) -> bool {
-  matches!(byte, b'\t' | b' ' | 0x21..=0x7e | 0x80..=0xff)
+    ChunkSizeError::Empty => error::bad_response("Chunk size line is empty"),
+    ChunkSizeError::Invalid => error::bad_response("Invalid chunk size"),
+    ChunkSizeError::InvalidExtension => error::bad_response("Invalid chunk extension"),
+  })
 }
 
 fn consume_crlf<R>(reader: &mut R) -> error::Result<()>
@@ -882,40 +784,6 @@ fn is_forbidden_response_trailer_name(name: &str) -> bool {
       | "transfer-encoding"
       | "upgrade"
   )
-}
-
-fn is_http_token(value: &str) -> bool {
-  !value.is_empty() && value.bytes().all(is_http_token_byte)
-}
-
-fn is_http_token_byte(byte: u8) -> bool {
-  byte.is_ascii_alphanumeric()
-    || matches!(
-      byte,
-      b'!'
-        | b'#'
-        | b'$'
-        | b'%'
-        | b'&'
-        | b'\''
-        | b'*'
-        | b'+'
-        | b'-'
-        | b'.'
-        | b'^'
-        | b'_'
-        | b'`'
-        | b'|'
-        | b'~'
-    )
-}
-
-fn is_header_value_byte(byte: u8) -> bool {
-  byte == b'\t' || byte == b' ' || (0x21..=0x7e).contains(&byte) || byte >= 0x80
-}
-
-fn is_reason_phrase_byte(byte: u8) -> bool {
-  byte == b'\t' || byte == b' ' || (0x21..=0x7e).contains(&byte) || byte >= 0x80
 }
 
 #[cfg(test)]

--- a/crates/rttp-protocol/Cargo.toml
+++ b/crates/rttp-protocol/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "rttp-protocol"
+version = "0.1.0"
+description = "Internal HTTP wire protocol primitives for rttp"
+publish = false
+edition = "2021"
+
+[lib]
+name = "rttp_protocol"
+path = "src/lib.rs"

--- a/crates/rttp-protocol/Cargo.toml
+++ b/crates/rttp-protocol/Cargo.toml
@@ -2,7 +2,17 @@
 name = "rttp-protocol"
 version = "0.1.0"
 description = "Internal HTTP wire protocol primitives for rttp"
-publish = false
+homepage = "https://github.com/fewensa/rttp"
+repository = "https://github.com/fewensa/rttp"
+license = "MIT"
+keywords = ["http"]
+include = [
+  "Cargo.toml",
+  "**/*.rs",
+  "README.md",
+  "LICENSE"
+]
+readme = "README.md"
 edition = "2021"
 
 [lib]

--- a/crates/rttp-protocol/README.md
+++ b/crates/rttp-protocol/README.md
@@ -1,0 +1,6 @@
+# rttp-protocol
+
+Shared HTTP wire syntax and framing primitives for the rttp client and server crates.
+
+This crate supports rttp's implementation; its public API is not a standalone
+application-level HTTP interface.

--- a/crates/rttp-protocol/src/http1.rs
+++ b/crates/rttp-protocol/src/http1.rs
@@ -1,0 +1,187 @@
+//! HTTP/1.x syntax primitives that are independent of endpoint policy.
+
+use std::fmt;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ChunkSizeError {
+  NotUtf8,
+  Empty,
+  Invalid,
+  InvalidExtension,
+}
+
+impl fmt::Display for ChunkSizeError {
+  fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+    formatter.write_str(match self {
+      Self::NotUtf8 => "chunk size is not UTF-8",
+      Self::Empty => "empty chunk size",
+      Self::Invalid => "invalid chunk size",
+      Self::InvalidExtension => "invalid chunk extension",
+    })
+  }
+}
+
+impl std::error::Error for ChunkSizeError {}
+
+pub fn parse_chunk_size(line: &[u8]) -> Result<usize, ChunkSizeError> {
+  let line = line.strip_suffix(b"\r\n").unwrap_or(line);
+  let (size, extensions) = line
+    .iter()
+    .position(|byte| *byte == b';')
+    .map_or((line, None), |index| {
+      (&line[..index], Some(&line[index + 1..]))
+    });
+  let size = std::str::from_utf8(size)
+    .map_err(|_| ChunkSizeError::NotUtf8)?
+    .trim();
+  if size.is_empty() {
+    return Err(ChunkSizeError::Empty);
+  }
+  if let Some(extensions) = extensions {
+    validate_chunk_extensions(extensions)?;
+  }
+
+  usize::from_str_radix(size, 16).map_err(|_| ChunkSizeError::Invalid)
+}
+
+pub fn is_token(value: &str) -> bool {
+  !value.is_empty() && value.bytes().all(is_token_byte)
+}
+
+pub fn is_token_byte(byte: u8) -> bool {
+  byte.is_ascii_alphanumeric()
+    || matches!(
+      byte,
+      b'!'
+        | b'#'
+        | b'$'
+        | b'%'
+        | b'&'
+        | b'\''
+        | b'*'
+        | b'+'
+        | b'-'
+        | b'.'
+        | b'^'
+        | b'_'
+        | b'`'
+        | b'|'
+        | b'~'
+    )
+}
+
+pub fn is_header_value_byte(byte: u8) -> bool {
+  byte == b'\t' || byte == b' ' || (0x21..=0x7e).contains(&byte) || byte >= 0x80
+}
+
+pub fn is_reason_phrase_byte(byte: u8) -> bool {
+  is_header_value_byte(byte)
+}
+
+pub fn is_tchar(byte: u8) -> bool {
+  is_token_byte(byte)
+}
+
+pub fn is_qdtext(byte: u8) -> bool {
+  matches!(byte, b'\t' | b' ' | b'!' | 0x23..=0x5b | 0x5d..=0x7e | 0x80..=0xff)
+}
+
+pub fn is_quoted_pair_char(byte: u8) -> bool {
+  matches!(byte, b'\t' | b' ' | 0x21..=0x7e | 0x80..=0xff)
+}
+
+fn validate_chunk_extensions(mut bytes: &[u8]) -> Result<(), ChunkSizeError> {
+  loop {
+    bytes = trim_bws(bytes);
+    let token_len = bytes
+      .iter()
+      .position(|byte| !is_tchar(*byte))
+      .unwrap_or(bytes.len());
+    if token_len == 0 {
+      return Err(ChunkSizeError::InvalidExtension);
+    }
+    bytes = trim_bws(&bytes[token_len..]);
+
+    if let Some(rest) = bytes.strip_prefix(b"=") {
+      bytes = trim_bws(rest);
+      if let Some(rest) = bytes.strip_prefix(b"\"") {
+        bytes = parse_quoted_chunk_extension(rest)?;
+      } else {
+        let value_len = bytes
+          .iter()
+          .position(|byte| !is_tchar(*byte))
+          .unwrap_or(bytes.len());
+        if value_len == 0 {
+          return Err(ChunkSizeError::InvalidExtension);
+        }
+        bytes = &bytes[value_len..];
+      }
+      bytes = trim_bws(bytes);
+    }
+
+    if bytes.is_empty() {
+      return Ok(());
+    }
+    if let Some(rest) = bytes.strip_prefix(b";") {
+      bytes = rest;
+    } else {
+      return Err(ChunkSizeError::InvalidExtension);
+    }
+  }
+}
+
+fn parse_quoted_chunk_extension(mut bytes: &[u8]) -> Result<&[u8], ChunkSizeError> {
+  loop {
+    let Some((&byte, rest)) = bytes.split_first() else {
+      return Err(ChunkSizeError::InvalidExtension);
+    };
+    match byte {
+      b'\"' => return Ok(rest),
+      b'\\' => {
+        let Some((&escaped, rest)) = rest.split_first() else {
+          return Err(ChunkSizeError::InvalidExtension);
+        };
+        if !is_quoted_pair_char(escaped) {
+          return Err(ChunkSizeError::InvalidExtension);
+        }
+        bytes = rest;
+      }
+      byte if is_qdtext(byte) => bytes = rest,
+      _ => return Err(ChunkSizeError::InvalidExtension),
+    }
+  }
+}
+
+fn trim_bws(bytes: &[u8]) -> &[u8] {
+  let start = bytes
+    .iter()
+    .position(|byte| *byte != b' ' && *byte != b'\t')
+    .unwrap_or(bytes.len());
+  &bytes[start..]
+}
+
+#[cfg(test)]
+mod tests {
+  use super::{is_header_value_byte, is_token, parse_chunk_size, ChunkSizeError};
+
+  #[test]
+  fn parses_chunk_sizes_with_valid_extensions() {
+    assert_eq!(parse_chunk_size(b"A;foo=bar;quoted=\"a\\\"b\"\r\n"), Ok(10));
+  }
+
+  #[test]
+  fn rejects_invalid_chunk_extensions() {
+    assert_eq!(
+      parse_chunk_size(b"A;foo=\"unterminated\r\n"),
+      Err(ChunkSizeError::InvalidExtension)
+    );
+  }
+
+  #[test]
+  fn validates_http_field_syntax_bytes() {
+    assert!(is_token("X-Request_Id"));
+    assert!(!is_token("bad name"));
+    assert!(is_header_value_byte(0x80));
+    assert!(!is_header_value_byte(b'\n'));
+  }
+}

--- a/crates/rttp-protocol/src/lib.rs
+++ b/crates/rttp-protocol/src/lib.rs
@@ -1,0 +1,6 @@
+//! Internal, transport-independent HTTP wire primitives shared by rttp crates.
+//!
+//! This crate is intentionally unpublished. It owns protocol syntax and framing
+//! validation only; client and server application policy remains in its callers.
+
+pub mod http1;

--- a/crates/rttp-server/Cargo.toml
+++ b/crates/rttp-server/Cargo.toml
@@ -19,4 +19,4 @@ edition = "2021"
 [dependencies]
 httpdate = "1.0"
 socket2 = "0.5"
-rttp-protocol = { path = "../rttp-protocol" }
+rttp-protocol = { version = "0.1.0", path = "../rttp-protocol" }

--- a/crates/rttp-server/Cargo.toml
+++ b/crates/rttp-server/Cargo.toml
@@ -19,3 +19,4 @@ edition = "2021"
 [dependencies]
 httpdate = "1.0"
 socket2 = "0.5"
+rttp-protocol = { path = "../rttp-protocol" }

--- a/crates/rttp-server/src/server/http1.rs
+++ b/crates/rttp-server/src/server/http1.rs
@@ -1,4 +1,8 @@
 use super::*;
+pub(crate) use rttp_protocol::http1::{
+  is_header_value_byte, is_qdtext, is_quoted_pair_char, is_token as is_http_token,
+  parse_chunk_size as parse_protocol_chunk_size,
+};
 
 pub struct RequestBodyReader<'a, R: BufRead> {
   pub(crate) reader: &'a mut R,
@@ -475,38 +479,8 @@ pub(crate) fn validate_host_header(
   Ok(())
 }
 
-pub(crate) fn is_http_token(value: &str) -> bool {
-  !value.is_empty() && value.bytes().all(is_token_byte)
-}
-
-pub(crate) fn is_token_byte(byte: u8) -> bool {
-  byte.is_ascii_alphanumeric()
-    || matches!(
-      byte,
-      b'!'
-        | b'#'
-        | b'$'
-        | b'%'
-        | b'&'
-        | b'\''
-        | b'*'
-        | b'+'
-        | b'-'
-        | b'.'
-        | b'^'
-        | b'_'
-        | b'`'
-        | b'|'
-        | b'~'
-    )
-}
-
 pub(crate) fn is_request_target_byte(byte: u8) -> bool {
   byte > 0x20 && byte != 0x7f
-}
-
-pub(crate) fn is_header_value_byte(byte: u8) -> bool {
-  byte == b'\t' || byte == b' ' || (0x21..=0x7e).contains(&byte) || byte >= 0x80
 }
 
 pub(crate) fn optional_header_content_length(
@@ -693,132 +667,7 @@ where
 }
 
 pub(crate) fn parse_chunk_size(line: &[u8]) -> io::Result<usize> {
-  let line = line.strip_suffix(b"\r\n").unwrap_or(line);
-  let (size, extensions) = line
-    .iter()
-    .position(|byte| *byte == b';')
-    .map_or((line, None), |index| {
-      (&line[..index], Some(&line[index + 1..]))
-    });
-  let size = std::str::from_utf8(size)
-    .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "chunk size is not UTF-8"))?
-    .trim();
-  if size.is_empty() {
-    return Err(io::Error::new(
-      io::ErrorKind::InvalidData,
-      "empty chunk size",
-    ));
-  }
-  if let Some(extensions) = extensions {
-    validate_chunk_extensions(extensions)?;
-  }
-
-  usize::from_str_radix(size, 16)
-    .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "invalid chunk size"))
-}
-
-pub(crate) fn validate_chunk_extensions(mut bytes: &[u8]) -> io::Result<()> {
-  loop {
-    bytes = trim_bws(bytes);
-    let token_len = bytes
-      .iter()
-      .position(|byte| !is_tchar(*byte))
-      .unwrap_or(bytes.len());
-    if token_len == 0 {
-      return Err(invalid_chunk_extension());
-    }
-    bytes = trim_bws(&bytes[token_len..]);
-
-    if let Some(rest) = bytes.strip_prefix(b"=") {
-      bytes = trim_bws(rest);
-      if let Some(rest) = bytes.strip_prefix(b"\"") {
-        bytes = parse_quoted_chunk_extension(rest)?;
-      } else {
-        let value_len = bytes
-          .iter()
-          .position(|byte| !is_tchar(*byte))
-          .unwrap_or(bytes.len());
-        if value_len == 0 {
-          return Err(invalid_chunk_extension());
-        }
-        bytes = &bytes[value_len..];
-      }
-      bytes = trim_bws(bytes);
-    }
-
-    if bytes.is_empty() {
-      return Ok(());
-    }
-    if let Some(rest) = bytes.strip_prefix(b";") {
-      bytes = rest;
-    } else {
-      return Err(invalid_chunk_extension());
-    }
-  }
-}
-
-pub(crate) fn parse_quoted_chunk_extension(mut bytes: &[u8]) -> io::Result<&[u8]> {
-  loop {
-    let Some((&byte, rest)) = bytes.split_first() else {
-      return Err(invalid_chunk_extension());
-    };
-    match byte {
-      b'"' => return Ok(rest),
-      b'\\' => {
-        let Some((&escaped, rest)) = rest.split_first() else {
-          return Err(invalid_chunk_extension());
-        };
-        if !is_quoted_pair_char(escaped) {
-          return Err(invalid_chunk_extension());
-        }
-        bytes = rest;
-      }
-      byte if is_qdtext(byte) => bytes = rest,
-      _ => return Err(invalid_chunk_extension()),
-    }
-  }
-}
-
-pub(crate) fn trim_bws(bytes: &[u8]) -> &[u8] {
-  let start = bytes
-    .iter()
-    .position(|byte| *byte != b' ' && *byte != b'\t')
-    .unwrap_or(bytes.len());
-  &bytes[start..]
-}
-
-pub(crate) fn is_tchar(byte: u8) -> bool {
-  byte.is_ascii_alphanumeric()
-    || matches!(
-      byte,
-      b'!'
-        | b'#'
-        | b'$'
-        | b'%'
-        | b'&'
-        | b'\''
-        | b'*'
-        | b'+'
-        | b'-'
-        | b'.'
-        | b'^'
-        | b'_'
-        | b'`'
-        | b'|'
-        | b'~'
-    )
-}
-
-pub(crate) fn is_qdtext(byte: u8) -> bool {
-  matches!(byte, b'\t' | b' ' | b'!' | 0x23..=0x5b | 0x5d..=0x7e | 0x80..=0xff)
-}
-
-pub(crate) fn is_quoted_pair_char(byte: u8) -> bool {
-  matches!(byte, b'\t' | b' ' | 0x21..=0x7e | 0x80..=0xff)
-}
-
-pub(crate) fn invalid_chunk_extension() -> io::Error {
-  io::Error::new(io::ErrorKind::InvalidData, "invalid chunk extension")
+  parse_protocol_chunk_size(line).map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))
 }
 
 pub(crate) fn consume_crlf<R>(reader: &mut R, body_bytes_read: &mut usize) -> io::Result<()>


### PR DESCRIPTION
Added an unpublished internal protocol crate and migrated the first shared HTTP/1.x framing and validation slice from client and server. Published APIs and behavior remain intact; full all-feature workspace verification passes.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1640/
work_kind: code_work
branch: hbx-1640-rttp-introduce-private-protocol-ownership
base: main
commit: cadd01bde0886af5fe2a07be11daa9882b7b2d28
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1640/
    url: https://plane.kahub.in/endless/browse/HBX-1640/
    close_policy: link_only
```