### PR TITLE
feat: [rttp_client] Expose bounded h2c client policy configuration

### DIFF
--- a/crates/rttp-client/src/client.rs
+++ b/crates/rttp-client/src/client.rs
@@ -4,7 +4,7 @@ use crate::connection::{BlockConnection, HandoffConnection, StreamingRequestBody
 use crate::request::{RawRequest, Request};
 use crate::response::Response;
 use crate::types::{Auth, Header, IntoHeader, IntoPara, Proxy, ToFormData, ToRoUrl};
-use crate::{error, Config};
+use crate::{error, Config, H2cClientPolicy};
 #[cfg(feature = "async")]
 use futures::io::AsyncRead;
 use std::io;
@@ -89,6 +89,16 @@ impl HttpClient {
   /// Set request config
   pub fn config<C: AsRef<Config>>(&mut self, config: C) -> &mut Self {
     self.request.config_set(config);
+    self
+  }
+
+  /// Configure local settings for the bounded prior-knowledge h2c client path.
+  ///
+  /// This is honored only by `emit_http2_prior_knowledge` and does not enable
+  /// pooling, retries, server push, or multiplexing. Invalid HTTP/2 settings
+  /// are rejected before the client opens its TCP socket.
+  pub fn h2c_policy(&mut self, policy: H2cClientPolicy) -> &mut Self {
+    self.request.config_mut().h2c_policy_set(policy);
     self
   }
 

--- a/crates/rttp-client/src/config.rs
+++ b/crates/rttp-client/src/config.rs
@@ -1,3 +1,41 @@
+/// Local settings for the bounded prior-knowledge h2c client path.
+///
+/// The default policy leaves both settings unadvertised, retaining the HTTP/2
+/// protocol defaults of a 16,384-byte maximum frame size and a 4,096-byte
+/// HPACK dynamic table. Configured values are validated before the client
+/// opens its h2c socket.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct H2cClientPolicy {
+  max_frame_size: Option<usize>,
+  header_table_size: Option<usize>,
+}
+
+impl H2cClientPolicy {
+  pub fn new() -> Self {
+    Self::default()
+  }
+
+  /// Advertise a local h2c `SETTINGS_MAX_FRAME_SIZE` value.
+  pub fn max_frame_size(mut self, max_frame_size: usize) -> Self {
+    self.max_frame_size = Some(max_frame_size);
+    self
+  }
+
+  /// Advertise a local h2c `SETTINGS_HEADER_TABLE_SIZE` value.
+  pub fn header_table_size(mut self, header_table_size: usize) -> Self {
+    self.header_table_size = Some(header_table_size);
+    self
+  }
+
+  pub fn configured_max_frame_size(&self) -> Option<usize> {
+    self.max_frame_size
+  }
+
+  pub fn configured_header_table_size(&self) -> Option<usize> {
+    self.header_table_size
+  }
+}
+
 #[derive(Clone, Debug)]
 pub struct Config {
   read_timeout: u64,
@@ -51,6 +89,18 @@ impl Config {
   }
   pub fn http2_header_table_size(&self) -> Option<usize> {
     self.http2_header_table_size
+  }
+  /// Return the bounded prior-knowledge h2c settings configured for this request.
+  pub fn h2c_policy(&self) -> H2cClientPolicy {
+    H2cClientPolicy {
+      max_frame_size: self.http2_max_frame_size,
+      header_table_size: self.http2_header_table_size,
+    }
+  }
+
+  pub(crate) fn h2c_policy_set(&mut self, policy: H2cClientPolicy) {
+    self.http2_max_frame_size = policy.max_frame_size;
+    self.http2_header_table_size = policy.header_table_size;
   }
 }
 
@@ -110,6 +160,11 @@ impl ConfigBuilder {
   }
   pub fn verify_ssl_cert(&mut self, verify_ssl_cert: bool) -> &mut Self {
     self.config.verify_ssl_cert = verify_ssl_cert;
+    self
+  }
+  /// Configure local settings for the bounded prior-knowledge h2c client path.
+  pub fn h2c_policy(&mut self, policy: H2cClientPolicy) -> &mut Self {
+    self.config.h2c_policy_set(policy);
     self
   }
   /// Configure the local h2c `SETTINGS_MAX_FRAME_SIZE` value.

--- a/crates/rttp-client/src/lib.rs
+++ b/crates/rttp-client/src/lib.rs
@@ -13,8 +13,8 @@
 //! With the `http2` feature enabled, `emit_http2_prior_knowledge` sends a
 //! bounded prior-knowledge h2c request over a direct socket2 TCP connection.
 //! It opens at most one stream and validates `SETTINGS_MAX_FRAME_SIZE` on both
-//! sides of the handshake. A configured local `http2_max_frame_size` is
-//! advertised only when set, must be in the legal HTTP/2 range of 16,384
+//! sides of the handshake. A configured local `H2cClientPolicy::max_frame_size`
+//! is advertised only when set, must be in the legal HTTP/2 range of 16,384
 //! through 16,777,215 bytes, and rejects inbound frame payloads larger than
 //! that active local limit. Peer-advertised values outside the same range
 //! reject the handshake, while legal peer values are used to split outbound
@@ -51,8 +51,9 @@
 //! a peer value of zero disables request dynamic indexing for HEADERS and
 //! trailers. Response decoding uses the locally advertised HPACK dynamic table
 //! limit, defaulting to 4,096 bytes unless
-//! `ConfigBuilder::http2_header_table_size` configures another `u32`-sized
-//! value. Incoming dynamic table size updates may shrink that decoder table,
+//! `H2cClientPolicy::header_table_size` configures another `u32`-sized value
+//! through `HttpClient::h2c_policy`. Incoming dynamic table size updates may
+//! shrink that decoder table,
 //! including to zero, but updates above the local advertised limit are
 //! rejected. These boundaries affect HPACK compression state only and do not
 //! change trailer validation, body framing, DATA flow control, or the

--- a/crates/rttp-client/tests/http2_prior_knowledge.rs
+++ b/crates/rttp-client/tests/http2_prior_knowledge.rs
@@ -8,7 +8,7 @@ use std::time::Duration;
 use base64::Engine;
 use rttp_client::types::Header;
 use rttp_client::types::Proxy;
-use rttp_client::{Config, HttpClient};
+use rttp_client::{Config, H2cClientPolicy, HttpClient};
 
 const FRAME_DATA: u8 = 0x0;
 const FRAME_HEADERS: u8 = 0x1;
@@ -2436,6 +2436,89 @@ fn prior_knowledge_advertises_configured_legal_max_frame_size_boundaries() {
       .join()
       .expect("configured max frame size peer thread");
   }
+}
+
+#[test]
+fn h2c_client_policy_defaults_leave_local_settings_at_protocol_defaults() {
+  let policy = H2cClientPolicy::default();
+
+  assert_eq!(None, policy.configured_max_frame_size());
+  assert_eq!(None, policy.configured_header_table_size());
+}
+
+#[test]
+fn prior_knowledge_advertises_h2c_client_policy_settings() {
+  let listener = TcpListener::bind("127.0.0.1:0").expect("bind h2 peer");
+  let addr = listener.local_addr().expect("h2 peer addr");
+
+  let handle = thread::spawn(move || {
+    let (mut stream, _) = listener.accept().expect("accept h2 client");
+    let mut preface = [0; 24];
+    stream
+      .read_exact(&mut preface)
+      .expect("read client preface");
+    assert_eq!(b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n", &preface);
+
+    let client_settings = read_frame(&mut stream);
+    assert_eq!(
+      Some(32_768),
+      h2_setting_value(&client_settings.payload, SETTING_MAX_FRAME_SIZE)
+    );
+    assert_eq!(
+      Some(64),
+      h2_setting_value(&client_settings.payload, SETTING_HEADER_TABLE_SIZE)
+    );
+
+    write_frame(&mut stream, FRAME_SETTINGS, 0, 0, &[]);
+    let client_settings_ack = read_frame(&mut stream);
+    assert_eq!(FRAME_SETTINGS, client_settings_ack.frame_type);
+    assert_eq!(FLAG_ACK, client_settings_ack.flags);
+
+    let request_headers = read_frame(&mut stream);
+    assert_eq!(FRAME_HEADERS, request_headers.frame_type);
+
+    write_frame(&mut stream, FRAME_SETTINGS, FLAG_ACK, 0, &[]);
+    write_frame(&mut stream, FRAME_HEADERS, FLAG_END_HEADERS, 1, &[0x88]);
+    write_frame(&mut stream, FRAME_DATA, FLAG_END_STREAM, 1, b"ok");
+  });
+
+  let response = HttpClient::new()
+    .h2c_policy(
+      H2cClientPolicy::default()
+        .max_frame_size(32_768)
+        .header_table_size(64),
+    )
+    .get()
+    .url(format!("http://{}/h2c-client-policy", addr))
+    .emit_http2_prior_knowledge()
+    .expect("configured h2c policy should work");
+
+  assert_eq!(200, response.code());
+  assert_eq!("ok", response.body().string().unwrap());
+  handle.join().expect("h2 policy peer thread");
+}
+
+#[test]
+fn prior_knowledge_rejects_invalid_h2c_client_policy_before_connecting() {
+  let listener = TcpListener::bind("127.0.0.1:0").expect("bind h2 peer");
+  listener
+    .set_nonblocking(true)
+    .expect("set h2 listener nonblocking");
+  let addr = listener.local_addr().expect("h2 peer addr");
+
+  let err = HttpClient::new()
+    .h2c_policy(H2cClientPolicy::default().max_frame_size(DEFAULT_MAX_FRAME_SIZE - 1))
+    .get()
+    .url(format!("http://{}/invalid-h2c-client-policy", addr))
+    .emit_http2_prior_knowledge()
+    .expect_err("invalid h2c policy must fail before connecting");
+
+  assert!(err.is_builder());
+  assert!(err.to_string().contains("SETTINGS_MAX_FRAME_SIZE"));
+  assert!(
+    listener.accept().is_err(),
+    "client must reject invalid h2c policy before connecting"
+  );
 }
 
 #[test]


### PR DESCRIPTION
`rttp_client` now exposes a public, fluent bounded h2c policy API while preserving existing defaults and validation boundaries.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1649/
work_kind: code_work
branch: hbx-1649-rttp-client-expose-bounded-h2c
base: main
commit: 0d437d5ec49e18fff2230e9a6ef69a54bb4df6e0
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1649/
    url: https://plane.kahub.in/endless/browse/HBX-1649/
    close_policy: link_only
```