### PR TITLE
feat: [rttp-server] Expose bounded h2c server policy configuration

### DIFF
--- a/crates/rttp-server/src/server.rs
+++ b/crates/rttp-server/src/server.rs
@@ -21,6 +21,7 @@ mod response;
 
 pub use connection::HttpServer;
 pub use handoff::*;
+pub use http2::Http2ServerPolicy;
 pub use request::*;
 pub use response::*;
 

--- a/crates/rttp-server/src/server/connection.rs
+++ b/crates/rttp-server/src/server/connection.rs
@@ -4,6 +4,7 @@ pub struct HttpServer {
   pub(crate) listener: TcpListener,
   pub(crate) read_timeout: Option<Duration>,
   pub(crate) write_timeout: Option<Duration>,
+  pub(crate) http2_policy: Http2ServerPolicy,
 }
 
 impl HttpServer {
@@ -39,6 +40,7 @@ impl HttpServer {
         listener: TcpListener::from(socket),
         read_timeout: None,
         write_timeout: None,
+        http2_policy: Http2ServerPolicy::default(),
       });
     }
 
@@ -61,6 +63,12 @@ impl HttpServer {
   /// Sets the write timeout applied to each accepted connection before writing responses.
   pub fn with_write_timeout(mut self, timeout: Option<Duration>) -> Self {
     self.write_timeout = timeout;
+    self
+  }
+
+  /// Sets the fixed bounds advertised and enforced for accepted h2c connections.
+  pub fn with_http2_policy(mut self, policy: Http2ServerPolicy) -> Self {
+    self.http2_policy = policy;
     self
   }
 
@@ -404,25 +412,27 @@ impl HttpServer {
     S: Read + Write,
     F: FnMut(Request) -> HttpResponse,
   {
-    let (initial_payload, acknowledge_initial_settings, upgraded) = if let Some(initial_settings) =
-      initial_settings
-    {
-      (
-        initial_settings.payload,
-        initial_settings.acknowledge,
-        initial_settings.upgraded,
-      )
-    } else {
-      let frame = self
-        .normalize_connection_error(read_http2_frame(&mut stream, HTTP2_DEFAULT_MAX_FRAME_SIZE))?;
-      if frame.frame_type != HTTP2_FRAME_SETTINGS
-        || frame.flags & HTTP2_FLAG_ACK == HTTP2_FLAG_ACK
-        || frame.stream_id != 0
-      {
-        return Err(invalid_http2_settings_error());
-      }
-      (frame.payload, true, false)
-    };
+    self.http2_policy.validate()?;
+    let (initial_payload, acknowledge_initial_settings, upgraded) =
+      if let Some(initial_settings) = initial_settings {
+        (
+          initial_settings.payload,
+          initial_settings.acknowledge,
+          initial_settings.upgraded,
+        )
+      } else {
+        let frame = self.normalize_connection_error(read_http2_frame(
+          &mut stream,
+          self.http2_policy.max_frame_size(),
+        ))?;
+        if frame.frame_type != HTTP2_FRAME_SETTINGS
+          || frame.flags & HTTP2_FLAG_ACK == HTTP2_FLAG_ACK
+          || frame.stream_id != 0
+        {
+          return Err(invalid_http2_settings_error());
+        }
+        (frame.payload, true, false)
+      };
     validate_http2_settings_payload(&initial_payload)?;
     let mut peer_max_frame_size =
       http2_settings_max_frame_size(&initial_payload).unwrap_or(HTTP2_DEFAULT_MAX_FRAME_SIZE);
@@ -437,7 +447,7 @@ impl HttpServer {
       HTTP2_FRAME_SETTINGS,
       0,
       0,
-      &server_http2_settings_payload(request_limit),
+      &server_http2_settings_payload(request_limit, &self.http2_policy),
     ))?;
     if acknowledge_initial_settings {
       self.normalize_connection_error(write_http2_frame(
@@ -480,9 +490,10 @@ impl HttpServer {
     while served < request_limit
       && ((!graceful_goaway_sent && !peer_goaway_received) || !streams.is_empty())
     {
-      let frame = match self
-        .normalize_connection_error(read_http2_frame(&mut stream, HTTP2_DEFAULT_MAX_FRAME_SIZE))
-      {
+      let frame = match self.normalize_connection_error(read_http2_frame(
+        &mut stream,
+        self.http2_policy.max_frame_size(),
+      )) {
         Ok(frame) => frame,
         Err(err)
           if err.kind() == io::ErrorKind::UnexpectedEof
@@ -638,7 +649,7 @@ impl HttpServer {
             if frame.flags & HTTP2_FLAG_END_HEADERS == HTTP2_FLAG_END_HEADERS {
               request_stream.finish_header_block(
                 &mut request_header_decoder,
-                HTTP2_MAX_HEADER_LIST_SIZE,
+                self.http2_policy.max_header_list_size(),
                 peer_enable_connect_protocol,
               )?;
             } else {
@@ -678,7 +689,7 @@ impl HttpServer {
           if frame.flags & HTTP2_FLAG_END_HEADERS == HTTP2_FLAG_END_HEADERS {
             request_stream.finish_header_block(
               &mut request_header_decoder,
-              HTTP2_MAX_HEADER_LIST_SIZE,
+              self.http2_policy.max_header_list_size(),
               peer_enable_connect_protocol,
             )?;
           }
@@ -788,6 +799,8 @@ impl HttpServer {
           &response,
           !request_is_head,
           &mut Http2ResponseFlowControl {
+            max_inbound_frame_size: self.http2_policy.max_frame_size(),
+            max_header_list_size: self.http2_policy.max_header_list_size(),
             max_frame_size: &mut peer_max_frame_size,
             peer_header_table_size: &mut peer_header_table_size,
             peer_initial_stream_send_window: &mut peer_initial_stream_send_window,

--- a/crates/rttp-server/src/server/http2.rs
+++ b/crates/rttp-server/src/server/http2.rs
@@ -31,6 +31,66 @@ pub(crate) const HTTP2_SETTINGS_ENABLE_CONNECT_PROTOCOL: u16 = 0x8;
 pub(crate) const HTTP2_ERROR_NO_ERROR: u32 = 0x0;
 pub(crate) const HTTP2_ERROR_REFUSED_STREAM: u32 = 0x7;
 
+/// Bounds advertised and accepted HTTP/2 settings on the server's h2c path.
+///
+/// The policy applies to each bounded h2c connection accepted by an
+/// [`HttpServer`]. It is fixed for that connection; changing policy at runtime
+/// would require the session management that this server deliberately does not
+/// provide.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Http2ServerPolicy {
+  max_frame_size: usize,
+  max_header_list_size: usize,
+}
+
+impl Default for Http2ServerPolicy {
+  fn default() -> Self {
+    Self {
+      max_frame_size: HTTP2_DEFAULT_MAX_FRAME_SIZE,
+      max_header_list_size: HTTP2_MAX_HEADER_LIST_SIZE,
+    }
+  }
+}
+
+impl Http2ServerPolicy {
+  /// Creates the default bounded h2c server policy.
+  pub fn new() -> Self {
+    Self::default()
+  }
+
+  /// Advertises and enforces a local `SETTINGS_MAX_FRAME_SIZE` value.
+  pub fn with_max_frame_size(mut self, max_frame_size: usize) -> Self {
+    self.max_frame_size = max_frame_size;
+    self
+  }
+
+  /// Advertises and enforces a local `SETTINGS_MAX_HEADER_LIST_SIZE` value.
+  pub fn with_max_header_list_size(mut self, max_header_list_size: usize) -> Self {
+    self.max_header_list_size = max_header_list_size;
+    self
+  }
+
+  pub fn max_frame_size(&self) -> usize {
+    self.max_frame_size
+  }
+
+  pub fn max_header_list_size(&self) -> usize {
+    self.max_header_list_size
+  }
+
+  pub(crate) fn validate(&self) -> io::Result<()> {
+    if !(16_384..=16_777_215).contains(&self.max_frame_size)
+      || u32::try_from(self.max_header_list_size).is_err()
+    {
+      return Err(io::Error::new(
+        io::ErrorKind::InvalidInput,
+        "invalid bounded HTTP/2 server policy",
+      ));
+    }
+    Ok(())
+  }
+}
+
 pub(crate) enum AcceptedConnection {
   Http1(Http1Stream),
   Http2(TcpStream),
@@ -741,11 +801,14 @@ pub(crate) fn write_http2_window_update<S: Write>(
   )
 }
 
-pub(crate) fn server_http2_settings_payload(request_limit: usize) -> Vec<u8> {
+pub(crate) fn server_http2_settings_payload(
+  request_limit: usize,
+  policy: &Http2ServerPolicy,
+) -> Vec<u8> {
   let mut payload = Vec::with_capacity(18);
   payload.extend_from_slice(&http2_setting(
     HTTP2_SETTINGS_MAX_FRAME_SIZE,
-    HTTP2_DEFAULT_MAX_FRAME_SIZE as u32,
+    policy.max_frame_size as u32,
   ));
   payload.extend_from_slice(&http2_setting(
     HTTP2_SETTINGS_MAX_CONCURRENT_STREAMS,
@@ -753,7 +816,7 @@ pub(crate) fn server_http2_settings_payload(request_limit: usize) -> Vec<u8> {
   ));
   payload.extend_from_slice(&http2_setting(
     HTTP2_SETTINGS_MAX_HEADER_LIST_SIZE,
-    HTTP2_MAX_HEADER_LIST_SIZE as u32,
+    policy.max_header_list_size as u32,
   ));
   payload
 }
@@ -1563,6 +1626,8 @@ pub(crate) const HTTP2_HUFFMAN_CODES: [(u8, u32); 257] = [
 ];
 
 pub(crate) struct Http2ResponseFlowControl<'a> {
+  pub(crate) max_inbound_frame_size: usize,
+  pub(crate) max_header_list_size: usize,
   pub(crate) max_frame_size: &'a mut usize,
   pub(crate) peer_header_table_size: &'a mut usize,
   pub(crate) peer_initial_stream_send_window: &'a mut i32,
@@ -1668,7 +1733,7 @@ pub(crate) fn read_http2_response_flow_control_frame<S: Read + Write>(
   flow_control: &mut Http2ResponseFlowControl<'_>,
 ) -> io::Result<Http2ResponseFlowControlRead> {
   loop {
-    let frame = read_http2_frame(stream, HTTP2_DEFAULT_MAX_FRAME_SIZE)?;
+    let frame = read_http2_frame(stream, flow_control.max_inbound_frame_size)?;
     if let Some(stream_id) = active_http2_header_continuation_stream(flow_control.streams) {
       if frame.frame_type != HTTP2_FRAME_CONTINUATION || frame.stream_id != stream_id {
         return Err(io::Error::new(
@@ -1796,7 +1861,7 @@ pub(crate) fn read_http2_response_flow_control_frame<S: Read + Write>(
         if frame.flags & HTTP2_FLAG_END_HEADERS == HTTP2_FLAG_END_HEADERS {
           request_stream.finish_header_block(
             flow_control.request_header_decoder,
-            HTTP2_MAX_HEADER_LIST_SIZE,
+            flow_control.max_header_list_size,
             *flow_control.peer_enable_connect_protocol,
           )?;
         } else {
@@ -1836,7 +1901,7 @@ pub(crate) fn read_http2_response_flow_control_frame<S: Read + Write>(
         if frame.flags & HTTP2_FLAG_END_HEADERS == HTTP2_FLAG_END_HEADERS {
           request_stream.finish_header_block(
             flow_control.request_header_decoder,
-            HTTP2_MAX_HEADER_LIST_SIZE,
+            flow_control.max_header_list_size,
             *flow_control.peer_enable_connect_protocol,
           )?;
         }

--- a/crates/rttp-server/src/server/server_tests.rs
+++ b/crates/rttp-server/src/server/server_tests.rs
@@ -49,6 +49,8 @@ use std::net::TcpStream as StdTcpStream;
 
     let read = {
       let mut flow_control = Http2ResponseFlowControl {
+        max_inbound_frame_size: HTTP2_DEFAULT_MAX_FRAME_SIZE,
+        max_header_list_size: HTTP2_MAX_HEADER_LIST_SIZE,
         max_frame_size: &mut max_frame_size,
         peer_header_table_size: &mut peer_header_table_size,
         peer_initial_stream_send_window: &mut peer_initial_stream_send_window,

--- a/crates/rttp/tests/http2_feature.rs
+++ b/crates/rttp/tests/http2_feature.rs
@@ -6,7 +6,7 @@ use std::sync::mpsc;
 use std::thread;
 use std::time::Duration;
 
-use rttp::server::HttpResponse;
+use rttp::server::{Http2ServerPolicy, HttpResponse};
 use rttp_client::{Config, HttpClient};
 
 const H2_FRAME_DATA: u8 = 0x0;
@@ -30,6 +30,7 @@ const H2_SETTINGS_HEADER_TABLE_SIZE: u16 = 0x1;
 const H2_SETTINGS_MAX_CONCURRENT_STREAMS: u16 = 0x3;
 const H2_SETTINGS_INITIAL_WINDOW_SIZE: u16 = 0x4;
 const H2_SETTINGS_MAX_FRAME_SIZE: u16 = 0x5;
+const H2_SETTINGS_MAX_HEADER_LIST_SIZE: u16 = 0x6;
 const H2_SETTINGS_ENABLE_CONNECT_PROTOCOL: u16 = 0x8;
 const H2_DEFAULT_MAX_FRAME_SIZE: usize = 16 * 1024;
 const H2_DEFAULT_INITIAL_WINDOW_SIZE: usize = 65_535;
@@ -2291,9 +2292,77 @@ fn prior_knowledge_server_advertises_conservative_max_frame_size() {
 }
 
 #[test]
-fn prior_knowledge_server_rejects_inbound_frame_exceeding_active_max_before_handler() {
+fn prior_knowledge_server_policy_advertises_and_enforces_frame_and_metadata_bounds() {
+  let policy = Http2ServerPolicy::new()
+    .with_max_frame_size(32_768)
+    .with_max_header_list_size(256);
   let server = rttp::Http::server("127.0.0.1:0")
     .expect("bind server")
+    .with_http2_policy(policy)
+    .with_read_timeout(Some(Duration::from_secs(2)))
+    .with_write_timeout(Some(Duration::from_secs(2)));
+  let addr = server.local_addr().expect("server addr");
+  let (tx, rx) = mpsc::channel();
+
+  let handle = thread::spawn(move || {
+    server.accept_one(|request| {
+      tx.send(request.target().to_string())
+        .expect("send unexpected bounded h2 request");
+      HttpResponse::ok("unexpected bounded h2 request")
+    })
+  });
+
+  let mut stream = TcpStream::connect(addr).expect("connect h2 server");
+  stream
+    .set_read_timeout(Some(Duration::from_millis(200)))
+    .expect("set client read timeout");
+  stream.write_all(H2_PREFACE).expect("write h2 preface");
+  write_h2_frame(&mut stream, H2_FRAME_SETTINGS, 0, 0, &[]);
+  let settings = read_h2_frame(&mut stream);
+  assert_eq!(H2_FRAME_SETTINGS, settings.frame_type);
+  assert_eq!(
+    Some(32_768),
+    h2_setting_value(&settings.payload, H2_SETTINGS_MAX_FRAME_SIZE)
+  );
+  assert_eq!(
+    Some(256),
+    h2_setting_value(&settings.payload, H2_SETTINGS_MAX_HEADER_LIST_SIZE)
+  );
+  let settings_ack = read_h2_frame(&mut stream);
+  assert_eq!(H2_FRAME_SETTINGS, settings_ack.frame_type);
+  assert_eq!(H2_FLAG_ACK, settings_ack.flags);
+
+  write_h2_frame(&mut stream, H2_FRAME_SETTINGS, H2_FLAG_ACK, 0, &[]);
+  let mut headers = h2_head_headers(b"/policy", addr.to_string().as_bytes());
+  headers.extend(h2_literal_new_name(b"x-policy-limit", &vec![b'x'; 100]));
+  write_h2_frame(
+    &mut stream,
+    H2_FRAME_HEADERS,
+    H2_FLAG_END_HEADERS | H2_FLAG_END_STREAM,
+    1,
+    &headers,
+  );
+  stream.flush().expect("flush bounded h2 request");
+  let _ = try_read_h2_frame(&mut stream);
+  drop(stream);
+
+  let error = handle
+    .join()
+    .expect("server thread")
+    .expect_err("oversized h2 metadata must reject the connection");
+  assert_eq!(io::ErrorKind::InvalidData, error.kind());
+  assert_eq!("HTTP/2 header list size exceeded", error.to_string());
+  assert!(
+    rx.try_recv().is_err(),
+    "oversized metadata must not dispatch"
+  );
+}
+
+#[test]
+fn prior_knowledge_server_policy_rejects_inbound_frame_exceeding_configured_max_before_handler() {
+  let server = rttp::Http::server("127.0.0.1:0")
+    .expect("bind server")
+    .with_http2_policy(Http2ServerPolicy::new().with_max_frame_size(32_768))
     .with_read_timeout(Some(Duration::from_secs(2)))
     .with_write_timeout(Some(Duration::from_secs(2)));
   let addr = server.local_addr().expect("server addr");
@@ -2317,7 +2386,7 @@ fn prior_knowledge_server_rejects_inbound_frame_exceeding_active_max_before_hand
     H2_FRAME_HEADERS,
     H2_FLAG_END_HEADERS | H2_FLAG_END_STREAM,
     1,
-    &vec![0x82; H2_DEFAULT_MAX_FRAME_SIZE + 1],
+    &vec![0x82; 32_768 + 1],
   );
   stream.flush().expect("flush oversized h2 frame");
   let _ = try_read_h2_frame(&mut stream);

--- a/crates/rttp/tests/test_server.rs
+++ b/crates/rttp/tests/test_server.rs
@@ -2623,6 +2623,13 @@ fn server_rejects_http2_prior_knowledge_data_beyond_receive_window() {
   );
   stream
     .shutdown(std::net::Shutdown::Write)
+    .or_else(|error| {
+      if error.kind() == ErrorKind::NotConnected {
+        Ok(())
+      } else {
+        Err(error)
+      }
+    })
     .expect("shutdown h2 write");
 
   let error = handle


### PR DESCRIPTION
rttp-server now exposes a bounded h2c policy API that advertises and enforces configurable HTTP/2 frame and metadata limits, with validated regression coverage and stable connection-rejection teardown.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1650/
work_kind: code_work
branch: hbx-1650-rttp-server-expose-bounded-h2c
base: main
commit: 3b8a66df80956a9f7990830713e1fb61565f433c
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1650/
    url: https://plane.kahub.in/endless/browse/HBX-1650/
    close_policy: link_only
```