### PR TITLE
feat: [rttp-server] Parse bounded Accept request metadata

### DIFF
--- a/crates/rttp-server/src/server/request.rs
+++ b/crates/rttp-server/src/server/request.rs
@@ -504,21 +504,32 @@ impl HttpMediaRange {
 
     let mut parameters = Vec::new();
     let mut quality = None;
+    let mut parsing_extensions = false;
     for part in parts {
       let part = part.trim();
-      let Some((name, value)) = part.split_once('=') else {
-        return Err(HttpAcceptParseError::new("invalid Accept parameter"));
+      let (name, value) = match part.split_once('=') {
+        Some((name, value)) => (name.trim().to_ascii_lowercase(), Some(value.trim())),
+        None if parsing_extensions => (part.to_ascii_lowercase(), None),
+        None => return Err(HttpAcceptParseError::new("invalid Accept parameter")),
       };
-      let name = name.trim().to_ascii_lowercase();
-      let value = value.trim();
       if !is_http_token(&name) {
         return Err(HttpAcceptParseError::new("invalid Accept parameter name"));
       }
+      if parsing_extensions {
+        if let Some(value) = value {
+          parse_accept_parameter_value(value)?;
+        }
+        continue;
+      }
+      let Some(value) = value else {
+        return Err(HttpAcceptParseError::new("invalid Accept parameter"));
+      };
       if name == "q" {
         if quality.is_some() {
           return Err(HttpAcceptParseError::new("duplicate Accept quality value"));
         }
         quality = Some(parse_accept_quality(value)?);
+        parsing_extensions = true;
         continue;
       }
       if parameters.iter().any(|(known, _)| known == &name) {

--- a/crates/rttp-server/src/server/request.rs
+++ b/crates/rttp-server/src/server/request.rs
@@ -2,6 +2,8 @@ use super::*;
 
 pub(crate) const MAX_REQUEST_HEAD_BYTES: usize = 64 * 1024;
 pub(crate) const MAX_REQUEST_BODY_BYTES: usize = 1024 * 1024;
+pub(crate) const MAX_ACCEPT_VALUE_BYTES: usize = 64 * 1024;
+pub(crate) const MAX_ACCEPT_MEDIA_RANGES: usize = 256;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Request {
   pub(crate) method: String,
@@ -85,6 +87,14 @@ impl Request {
       return Ok(None);
     }
     HttpRequestCacheControl::parse_values(values).map(Some)
+  }
+
+  pub fn accept(&self) -> Result<Option<HttpAccept>, HttpAcceptParseError> {
+    let values: Vec<&str> = self.headers_named("Accept").collect();
+    if values.is_empty() {
+      return Ok(None);
+    }
+    HttpAccept::parse_values(values).map(Some)
   }
 
   pub fn vary_selection(&self, vary: &HttpVary) -> HttpVarySelection {
@@ -429,6 +439,251 @@ impl Request {
       extended_connect_protocol: None,
     }
   }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct HttpAccept {
+  media_ranges: Vec<HttpMediaRange>,
+}
+
+impl HttpAccept {
+  pub fn parse(value: impl AsRef<str>) -> Result<Self, HttpAcceptParseError> {
+    Self::parse_values(std::iter::once(value.as_ref()))
+  }
+
+  pub fn parse_values<'a, I>(values: I) -> Result<Self, HttpAcceptParseError>
+  where
+    I: IntoIterator<Item = &'a str>,
+  {
+    let mut media_ranges = Vec::new();
+    for value in values {
+      if value.len() > MAX_ACCEPT_VALUE_BYTES {
+        return Err(HttpAcceptParseError::new(
+          "Accept header value is too large",
+        ));
+      }
+      if value.bytes().any(|byte| byte.is_ascii_control()) {
+        return Err(HttpAcceptParseError::new("invalid Accept header value"));
+      }
+
+      for member in split_accept_members(value)? {
+        if media_ranges.len() >= MAX_ACCEPT_MEDIA_RANGES {
+          return Err(HttpAcceptParseError::new("too many Accept media ranges"));
+        }
+        media_ranges.push(HttpMediaRange::parse(member)?);
+      }
+    }
+
+    if media_ranges.is_empty() {
+      return Err(HttpAcceptParseError::new("invalid Accept header value"));
+    }
+
+    Ok(Self { media_ranges })
+  }
+
+  pub fn media_ranges(&self) -> &[HttpMediaRange] {
+    &self.media_ranges
+  }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct HttpMediaRange {
+  media_type: String,
+  parameters: Vec<(String, String)>,
+  quality: Option<u16>,
+}
+
+impl HttpMediaRange {
+  fn parse(value: &str) -> Result<Self, HttpAcceptParseError> {
+    let mut parts = split_accept_parameters(value)?;
+    let Some(media_type) = parts.first() else {
+      return Err(HttpAcceptParseError::new("invalid Accept media range"));
+    };
+    let media_type = parse_accept_media_type(media_type.trim())?;
+    parts.remove(0);
+
+    let mut parameters = Vec::new();
+    let mut quality = None;
+    for part in parts {
+      let part = part.trim();
+      let Some((name, value)) = part.split_once('=') else {
+        return Err(HttpAcceptParseError::new("invalid Accept parameter"));
+      };
+      let name = name.trim().to_ascii_lowercase();
+      let value = value.trim();
+      if !is_http_token(&name) {
+        return Err(HttpAcceptParseError::new("invalid Accept parameter name"));
+      }
+      if name == "q" {
+        if quality.is_some() {
+          return Err(HttpAcceptParseError::new("duplicate Accept quality value"));
+        }
+        quality = Some(parse_accept_quality(value)?);
+        continue;
+      }
+      if parameters.iter().any(|(known, _)| known == &name) {
+        return Err(HttpAcceptParseError::new("duplicate Accept parameter"));
+      }
+      parameters.push((name, parse_accept_parameter_value(value)?));
+    }
+
+    Ok(Self {
+      media_type,
+      parameters,
+      quality,
+    })
+  }
+
+  pub fn media_type(&self) -> &str {
+    &self.media_type
+  }
+
+  pub fn parameters(&self) -> Vec<(&str, &str)> {
+    self
+      .parameters
+      .iter()
+      .map(|(name, value)| (name.as_str(), value.as_str()))
+      .collect()
+  }
+
+  pub fn parameter(&self, name: impl AsRef<str>) -> Option<&str> {
+    self
+      .parameters
+      .iter()
+      .find(|(known, _)| known.eq_ignore_ascii_case(name.as_ref()))
+      .map(|(_, value)| value.as_str())
+  }
+
+  pub fn quality(&self) -> Option<u16> {
+    self.quality
+  }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct HttpAcceptParseError {
+  message: String,
+}
+
+impl HttpAcceptParseError {
+  fn new(message: impl Into<String>) -> Self {
+    Self {
+      message: message.into(),
+    }
+  }
+}
+
+impl fmt::Display for HttpAcceptParseError {
+  fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+    formatter.write_str(&self.message)
+  }
+}
+
+impl Error for HttpAcceptParseError {}
+
+fn split_accept_members(value: &str) -> Result<Vec<&str>, HttpAcceptParseError> {
+  split_accept_delimited(value, b',', "invalid Accept header value")
+}
+
+fn split_accept_parameters(value: &str) -> Result<Vec<&str>, HttpAcceptParseError> {
+  split_accept_delimited(value, b';', "invalid Accept parameter")
+}
+
+fn split_accept_delimited<'a>(
+  value: &'a str,
+  delimiter: u8,
+  error: &'static str,
+) -> Result<Vec<&'a str>, HttpAcceptParseError> {
+  let mut members = Vec::new();
+  let mut quoted = false;
+  let mut escaped = false;
+  let mut start = 0usize;
+
+  for (index, byte) in value.bytes().enumerate() {
+    if escaped {
+      if !is_content_type_quoted_pair_byte(byte) {
+        return Err(HttpAcceptParseError::new(error));
+      }
+      escaped = false;
+      continue;
+    }
+    match byte {
+      b'\\' if quoted => escaped = true,
+      b'"' => quoted = !quoted,
+      byte if byte == delimiter && !quoted => {
+        let member = value[start..index].trim();
+        if member.is_empty() {
+          return Err(HttpAcceptParseError::new(error));
+        }
+        members.push(member);
+        start = index + 1;
+      }
+      _ => {}
+    }
+  }
+
+  if quoted || escaped {
+    return Err(HttpAcceptParseError::new(error));
+  }
+  let member = value[start..].trim();
+  if member.is_empty() {
+    return Err(HttpAcceptParseError::new(error));
+  }
+  members.push(member);
+  Ok(members)
+}
+
+fn parse_accept_media_type(value: &str) -> Result<String, HttpAcceptParseError> {
+  let Some((type_name, subtype)) = value.split_once('/') else {
+    return Err(HttpAcceptParseError::new("invalid Accept media range"));
+  };
+  if subtype.contains('/') {
+    return Err(HttpAcceptParseError::new("invalid Accept media range"));
+  }
+  let type_name = type_name.trim().to_ascii_lowercase();
+  let subtype = subtype.trim().to_ascii_lowercase();
+  if type_name == "*" && subtype != "*" {
+    return Err(HttpAcceptParseError::new("invalid Accept media range"));
+  }
+  if !(type_name == "*" || is_http_token(&type_name))
+    || !(subtype == "*" || is_http_token(&subtype))
+  {
+    return Err(HttpAcceptParseError::new("invalid Accept media range"));
+  }
+  Ok(format!("{type_name}/{subtype}"))
+}
+
+fn parse_accept_parameter_value(value: &str) -> Result<String, HttpAcceptParseError> {
+  parse_content_type_parameter_value(value)
+    .map_err(|_| HttpAcceptParseError::new("invalid Accept parameter value"))
+}
+
+fn parse_accept_quality(value: &str) -> Result<u16, HttpAcceptParseError> {
+  let value = value.trim();
+  let valid = match value {
+    "0" => Some(0),
+    "1" => Some(1000),
+    _ => {
+      let Some((whole, fractional)) = value.split_once('.') else {
+        return Err(HttpAcceptParseError::new("invalid Accept quality value"));
+      };
+      if fractional.is_empty()
+        || fractional.len() > 3
+        || !fractional.bytes().all(|byte| byte.is_ascii_digit())
+      {
+        return Err(HttpAcceptParseError::new("invalid Accept quality value"));
+      }
+      let scale = 10u16.pow((3 - fractional.len()) as u32);
+      match whole {
+        "0" => fractional
+          .parse::<u16>()
+          .ok()
+          .map(|fraction| fraction * scale),
+        "1" if fractional.bytes().all(|byte| byte == b'0') => Some(1000),
+        _ => None,
+      }
+    }
+  };
+  valid.ok_or_else(|| HttpAcceptParseError::new("invalid Accept quality value"))
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
@@ -896,6 +1151,19 @@ impl HttpRequest {
       return Ok(None);
     }
     HttpRequestCacheControl::parse_values(values).map(Some)
+  }
+
+  pub fn accept(&self) -> Result<Option<HttpAccept>, HttpAcceptParseError> {
+    let values: Vec<&str> = self
+      .headers
+      .iter()
+      .filter(|header| header.name.eq_ignore_ascii_case("Accept"))
+      .map(|header| header.value.as_str())
+      .collect();
+    if values.is_empty() {
+      return Ok(None);
+    }
+    HttpAccept::parse_values(values).map(Some)
   }
 
   pub fn vary_selection(&self, vary: &HttpVary) -> HttpVarySelection {

--- a/crates/rttp/tests/test_server.rs
+++ b/crates/rttp/tests/test_server.rs
@@ -845,6 +845,51 @@ fn server_handler_can_parse_request_cache_control_directives() {
 }
 
 #[test]
+fn rttp_client_accept_header_exposes_ordered_server_media_ranges() {
+  let server = rttp::Http::server("127.0.0.1:0").expect("bind server");
+  let addr = server.local_addr().expect("server addr");
+  let (tx, rx) = mpsc::channel();
+
+  let handle = thread::spawn(move || {
+    server
+      .accept_one(|request| {
+        let accept = request
+          .accept()
+          .expect("valid Accept should parse")
+          .expect("Accept header should be present");
+        tx.send(
+          accept
+            .media_ranges()
+            .iter()
+            .map(|range| (range.media_type().to_string(), range.quality()))
+            .collect::<Vec<_>>(),
+        )
+        .expect("send parsed Accept metadata");
+        HttpResponse::ok("accepted")
+      })
+      .expect("serve one request");
+  });
+
+  let response = HttpClient::new()
+    .get()
+    .url(format!("http://{addr}/resource"))
+    .header(("Accept", "application/json; q=1, text/plain; q=0.5"))
+    .emit()
+    .expect("client request");
+
+  assert_eq!(
+    vec![
+      ("application/json".to_string(), Some(1000)),
+      ("text/plain".to_string(), Some(500)),
+    ],
+    rx.recv().expect("parsed Accept metadata")
+  );
+  assert_eq!("accepted", response.body().string().expect("response body"));
+
+  handle.join().expect("server thread");
+}
+
+#[test]
 fn server_accepts_absolute_form_get_request_as_origin_target() {
   let server = rttp::Http::server("127.0.0.1:0").expect("bind server");
   let addr = server.local_addr().expect("server addr");

--- a/crates/rttp/tests/test_server_models.rs
+++ b/crates/rttp/tests/test_server_models.rs
@@ -1,14 +1,67 @@
 use std::time::{Duration, UNIX_EPOCH};
 
 use rttp::server::{
-  HttpAcceptRanges, HttpAllowedMethods, HttpByteRange, HttpByteRangeError, HttpConditionalMetadata,
-  HttpContentDisposition, HttpContentLanguages, HttpContentType, HttpEntityTag,
-  HttpIfRangeRequestOutcome, HttpRequest, HttpRequestCacheControl, HttpResponse,
+  HttpAccept, HttpAcceptRanges, HttpAllowedMethods, HttpByteRange, HttpByteRangeError,
+  HttpConditionalMetadata, HttpContentDisposition, HttpContentLanguages, HttpContentType,
+  HttpEntityTag, HttpIfRangeRequestOutcome, HttpRequest, HttpRequestCacheControl, HttpResponse,
   HttpResponseCacheControl, HttpResponseContentEncodings, HttpRetryAfter, HttpVary,
 };
 
 fn parse_request(raw: &str) -> HttpRequest {
   HttpRequest::parse(raw.as_bytes()).expect("request should parse")
+}
+
+#[test]
+fn parses_request_accept_media_ranges_in_field_order() {
+  let request = parse_request(concat!(
+    "GET /resource HTTP/1.1\r\n",
+    "Host: example.test\r\n",
+    "Accept: text/html; level=1; q=0.7, application/json\r\n",
+    "Accept: application/*; profile=compact; q=1, */*; q=0\r\n",
+    "\r\n"
+  ));
+
+  let accept = request
+    .accept()
+    .expect("valid Accept should parse")
+    .expect("Accept header should be present");
+
+  assert_eq!(
+    vec!["text/html", "application/json", "application/*", "*/*"],
+    accept
+      .media_ranges()
+      .iter()
+      .map(|range| range.media_type())
+      .collect::<Vec<_>>()
+  );
+  assert_eq!(Some(700), accept.media_ranges()[0].quality());
+  assert_eq!(vec![("level", "1")], accept.media_ranges()[0].parameters());
+  assert_eq!(None, accept.media_ranges()[1].quality());
+  assert_eq!(Some(1000), accept.media_ranges()[2].quality());
+  assert_eq!(Some(0), accept.media_ranges()[3].quality());
+}
+
+#[test]
+fn request_accept_helper_is_optional_and_keeps_raw_invalid_headers() {
+  let missing = parse_request("GET / HTTP/1.1\r\nHost: example.test\r\n\r\n");
+  assert_eq!(
+    None,
+    missing.accept().expect("missing Accept should be valid")
+  );
+
+  let malformed = parse_request(concat!(
+    "GET / HTTP/1.1\r\n",
+    "Host: example.test\r\n",
+    "Accept: text/plain; q=1.001\r\n",
+    "\r\n"
+  ));
+  assert!(malformed.accept().is_err());
+  assert_eq!(Some("text/plain; q=1.001"), malformed.header("Accept"));
+
+  assert!(HttpAccept::parse("*/json").is_err());
+  let oversized = "text/plain,".repeat(257);
+  assert!(HttpAccept::parse(&oversized).is_err());
+  assert!(HttpAccept::parse("a".repeat(64 * 1024 + 1)).is_err());
 }
 
 #[test]

--- a/crates/rttp/tests/test_server_models.rs
+++ b/crates/rttp/tests/test_server_models.rs
@@ -65,6 +65,17 @@ fn request_accept_helper_is_optional_and_keeps_raw_invalid_headers() {
 }
 
 #[test]
+fn request_accept_ignores_extensions_after_quality() {
+  let accept = HttpAccept::parse("text/html; level=1; q=0.8; foo; bar=quoted")
+    .expect("Accept extensions after quality should parse");
+  let range = &accept.media_ranges()[0];
+
+  assert_eq!("text/html", range.media_type());
+  assert_eq!(vec![("level", "1")], range.parameters());
+  assert_eq!(Some(800), range.quality());
+}
+
+#[test]
 fn parses_request_cache_control_directives() {
   let request = parse_request(concat!(
     "GET /cached HTTP/1.1\r\n",


### PR DESCRIPTION
Implemented bounded typed `Accept` metadata parsing for server requests, with raw-header preservation on parse errors and verified workspace-wide behavior.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1661/
work_kind: code_work
branch: hbx-1661-rttp-server-parse-bounded-accept
base: main
commit: ed8fc6ce1df45108dfe1fb1d810fa703cfb61bbc
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1661/
    url: https://plane.kahub.in/endless/browse/HBX-1661/
    close_policy: link_only
```