### PR TITLE
feat: [rttp] Add bounded Accept-Language request metadata helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,30 @@ automatic language negotiation, locale fallback, variant matching, cache
 policy, retry, replay, redirect, or status-policy behavior from
 `Content-Language`.
 
+### Bounded HTTP/1.1 Accept-Language behavior
+
+`HttpClient::accept_language(ranges)` validates and emits one
+`Accept-Language` request header from ordered language ranges. Each range may
+include an optional `q` weight, for example `fr-CA; q=0.8`; `*` is also
+accepted. The helper limits each supplied value to 64 KiB and the parsed range
+list to 32 entries, rejects malformed ranges or q-values and case-insensitive
+duplicates, and returns a builder error before opening a connection. Raw
+`header(("Accept-Language", value))` remains available when callers need to
+preserve unvalidated metadata.
+
+On the server, `Request::accept_language()` and
+`HttpRequest::accept_language()` parse received fields in wire order into
+`HttpAcceptLanguages`, returning `Ok(None)` when the header is absent.
+`HttpAcceptLanguages::ranges()` and `HttpAcceptLanguages::qualities()` expose
+the validated ranges and optional q-values. Each received field is bounded to
+64 KiB and the combined range list to 32 entries; malformed values, invalid
+q-values, and duplicate ranges return `HttpAcceptLanguageParseError` without
+changing the raw request headers.
+
+These helpers are metadata-only. RTTP does not perform locale matching,
+fallback selection, translation lookup, routing, or automatic response choice
+from `Accept-Language`.
+
 ### Bounded HTTP/1.1 Content-Location behavior
 
 `Response::content_location()` parses a response `Content-Location` header into

--- a/crates/rttp-client/src/client.rs
+++ b/crates/rttp-client/src/client.rs
@@ -206,6 +206,20 @@ impl HttpClient {
     self.header(("Cookie", cookie.as_ref()))
   }
 
+  /// Set bounded `Accept-Language` request metadata.
+  ///
+  /// Each supplied item is a language range, optionally followed by a `q`
+  /// weight such as `fr-CA; q=0.8`. This validates metadata only; it does not
+  /// perform locale matching or choose a response language.
+  pub fn accept_language<I, L>(&mut self, ranges: I) -> error::Result<&mut Self>
+  where
+    I: IntoIterator<Item = L>,
+    L: AsRef<str>,
+  {
+    let value = build_accept_language_value(ranges)?;
+    Ok(self.header(Header::new("Accept-Language", value)))
+  }
+
   /// Set a single bounded byte range request header, `Range: bytes=start-end`.
   pub fn range(&mut self, start: u64, end: u64) -> error::Result<&mut Self> {
     if start > end {
@@ -586,6 +600,119 @@ fn validate_http_date(http_date: &str) -> error::Result<&str> {
     error::builder_with_message("conditional modification time must be a valid HTTP-date")
   })?;
   Ok(http_date)
+}
+
+const MAX_ACCEPT_LANGUAGE_VALUE_BYTES: usize = 64 * 1024;
+const MAX_ACCEPT_LANGUAGE_RANGES: usize = 32;
+
+fn build_accept_language_value<I, L>(ranges: I) -> error::Result<String>
+where
+  I: IntoIterator<Item = L>,
+  L: AsRef<str>,
+{
+  let mut parsed = Vec::new();
+
+  for value in ranges {
+    if value.as_ref().len() > MAX_ACCEPT_LANGUAGE_VALUE_BYTES {
+      return Err(error::builder_with_message(
+        "Accept-Language header value is too large",
+      ));
+    }
+    for range in value.as_ref().split(',') {
+      let range = range.trim();
+      let (language_range, quality) = parse_accept_language_item(range)?;
+      if parsed.len() >= MAX_ACCEPT_LANGUAGE_RANGES {
+        return Err(error::builder_with_message(
+          "too many Accept-Language ranges",
+        ));
+      }
+      if parsed
+        .iter()
+        .any(|(known, _): &(String, Option<String>)| known.eq_ignore_ascii_case(language_range))
+      {
+        return Err(error::builder_with_message(
+          "duplicate Accept-Language range",
+        ));
+      }
+      parsed.push((language_range.to_string(), quality.map(ToString::to_string)));
+    }
+  }
+
+  if parsed.is_empty() {
+    return Err(error::builder_with_message("invalid Accept-Language range"));
+  }
+
+  let value = parsed
+    .into_iter()
+    .map(|(range, quality)| match quality {
+      Some(quality) => format!("{range}; q={quality}"),
+      None => range,
+    })
+    .collect::<Vec<_>>()
+    .join(", ");
+  if value.len() > MAX_ACCEPT_LANGUAGE_VALUE_BYTES {
+    return Err(error::builder_with_message(
+      "Accept-Language header value is too large",
+    ));
+  }
+  Ok(value)
+}
+
+fn parse_accept_language_item(value: &str) -> error::Result<(&str, Option<&str>)> {
+  let mut parts = value.split(';');
+  let range = parts.next().unwrap_or_default().trim();
+  if !is_language_range(range) {
+    return Err(error::builder_with_message("invalid Accept-Language range"));
+  }
+
+  let Some(parameter) = parts.next() else {
+    return Ok((range, None));
+  };
+  if parts.next().is_some() {
+    return Err(error::builder_with_message(
+      "invalid Accept-Language q-value",
+    ));
+  }
+  let Some((name, quality)) = parameter.trim().split_once('=') else {
+    return Err(error::builder_with_message(
+      "invalid Accept-Language q-value",
+    ));
+  };
+  let quality = quality.trim();
+  if !name.trim().eq_ignore_ascii_case("q") || !is_qvalue(quality) {
+    return Err(error::builder_with_message(
+      "invalid Accept-Language q-value",
+    ));
+  }
+  Ok((range, Some(quality)))
+}
+
+fn is_language_range(value: &str) -> bool {
+  if value == "*" {
+    return true;
+  }
+
+  let mut subtags = value.split('-');
+  let Some(primary) = subtags.next() else {
+    return false;
+  };
+  (1..=8).contains(&primary.len())
+    && primary.bytes().all(|byte| byte.is_ascii_alphabetic())
+    && subtags.all(|subtag| {
+      (1..=8).contains(&subtag.len()) && subtag.bytes().all(|byte| byte.is_ascii_alphanumeric())
+    })
+}
+
+fn is_qvalue(value: &str) -> bool {
+  match value.split_once('.') {
+    Some((whole, fraction)) => {
+      (whole == "0" || whole == "1")
+        && fraction.len() <= 3
+        && fraction.bytes().all(|byte| byte.is_ascii_digit())
+        && (whole == "0" || fraction.bytes().all(|byte| byte == b'0'))
+    }
+    None => value == "0" || value == "1",
+  }
 }
 
 fn is_forbidden_request_trailer_name(name: &str) -> bool {

--- a/crates/rttp-client/tests/test_raw_request_capture.rs
+++ b/crates/rttp-client/tests/test_raw_request_capture.rs
@@ -252,6 +252,61 @@ fn range_helper_rejects_malformed_inputs_before_connecting() {
 }
 
 #[test]
+fn accept_language_helper_emits_bounded_language_ranges() {
+  let request = capture_request(|base_url| {
+    client()
+      .get()
+      .url(format!("{}/localized", base_url))
+      .accept_language(["en-US", "fr-CA; q=0.8", "de; q=1.", "*"])
+      .expect("language ranges should be accepted")
+      .emit()
+      .expect("request should succeed");
+  });
+
+  assert_eq!(
+    Some("en-US, fr-CA; q=0.8, de; q=1., *"),
+    header_value(&request_text(&request), "Accept-Language")
+  );
+}
+
+#[test]
+fn accept_language_helper_rejects_invalid_values_before_connecting() {
+  for value in ["en_US", "en; q=1.001", "en, EN"] {
+    let request = capture_optional_request(|base_url| {
+      let mut client = client();
+      let error = client
+        .get()
+        .url(format!("{}/localized", base_url))
+        .accept_language([value])
+        .expect_err("invalid language range should be rejected");
+
+      assert!(error.is_builder());
+    });
+
+    assert!(
+      request.is_empty(),
+      "invalid Accept-Language helper input should not open a socket"
+    );
+  }
+
+  let oversized = format!("{}en", " ".repeat(64 * 1024));
+  let request = capture_optional_request(|base_url| {
+    let mut client = client();
+    let error = client
+      .get()
+      .url(format!("{}/localized", base_url))
+      .accept_language([oversized.as_str()])
+      .expect_err("oversized language value should be rejected");
+
+    assert!(error.is_builder());
+  });
+  assert!(
+    request.is_empty(),
+    "oversized Accept-Language helper input should not open a socket"
+  );
+}
+
+#[test]
 fn manual_range_header_remains_available_as_escape_hatch() {
   let request = capture_request(|base_url| {
     client()

--- a/crates/rttp-server/src/server/request.rs
+++ b/crates/rttp-server/src/server/request.rs
@@ -87,6 +87,16 @@ impl Request {
     HttpRequestCacheControl::parse_values(values).map(Some)
   }
 
+  pub fn accept_language(
+    &self,
+  ) -> Result<Option<HttpAcceptLanguages>, HttpAcceptLanguageParseError> {
+    let values: Vec<&str> = self.headers_named("Accept-Language").collect();
+    if values.is_empty() {
+      return Ok(None);
+    }
+    HttpAcceptLanguages::parse_values(values).map(Some)
+  }
+
   pub fn vary_selection(&self, vary: &HttpVary) -> HttpVarySelection {
     if vary.is_wildcard() {
       return HttpVarySelection::wildcard();
@@ -794,6 +804,174 @@ pub(crate) fn is_valid_entity_tag_opaque_tag(opaque_tag: &str) -> bool {
     .all(|byte| matches!(byte, b'\x21' | b'\x23'..=b'\x7e' | b'\x80'..=b'\xff'))
 }
 
+const MAX_ACCEPT_LANGUAGE_VALUE_BYTES: usize = 64 * 1024;
+const MAX_ACCEPT_LANGUAGE_RANGES: usize = 32;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct HttpAcceptLanguages {
+  ranges: Vec<String>,
+  qualities: Vec<Option<String>>,
+}
+
+impl HttpAcceptLanguages {
+  pub fn parse(value: impl AsRef<str>) -> Result<Self, HttpAcceptLanguageParseError> {
+    Self::parse_values([value.as_ref()])
+  }
+
+  pub fn parse_values<'a, I>(values: I) -> Result<Self, HttpAcceptLanguageParseError>
+  where
+    I: IntoIterator<Item = &'a str>,
+  {
+    let parsed = Self::parse_values_inner(values)?;
+    if parsed.ranges.is_empty() {
+      return Err(HttpAcceptLanguageParseError::new(
+        "invalid Accept-Language range",
+      ));
+    }
+    Ok(parsed)
+  }
+
+  fn parse_optional_values<'a, I>(values: I) -> Result<Option<Self>, HttpAcceptLanguageParseError>
+  where
+    I: IntoIterator<Item = &'a str>,
+  {
+    let parsed = Self::parse_values_inner(values)?;
+    if parsed.ranges.is_empty() {
+      Ok(None)
+    } else {
+      Ok(Some(parsed))
+    }
+  }
+
+  fn parse_values_inner<'a, I>(values: I) -> Result<Self, HttpAcceptLanguageParseError>
+  where
+    I: IntoIterator<Item = &'a str>,
+  {
+    let mut ranges = Vec::new();
+    let mut qualities = Vec::new();
+
+    for value in values {
+      if value.len() > MAX_ACCEPT_LANGUAGE_VALUE_BYTES {
+        return Err(HttpAcceptLanguageParseError::new(
+          "Accept-Language header value is too large",
+        ));
+      }
+      for item in value.split(',') {
+        let (range, quality) = parse_accept_language_item(item.trim())?;
+        if ranges.len() >= MAX_ACCEPT_LANGUAGE_RANGES {
+          return Err(HttpAcceptLanguageParseError::new(
+            "too many Accept-Language ranges",
+          ));
+        }
+        if ranges
+          .iter()
+          .any(|known: &String| known.eq_ignore_ascii_case(range))
+        {
+          return Err(HttpAcceptLanguageParseError::new(
+            "duplicate Accept-Language range",
+          ));
+        }
+        ranges.push(range.to_string());
+        qualities.push(quality.map(ToString::to_string));
+      }
+    }
+
+    Ok(Self { ranges, qualities })
+  }
+
+  pub fn ranges(&self) -> Vec<&str> {
+    self.ranges.iter().map(String::as_str).collect()
+  }
+
+  pub fn qualities(&self) -> Vec<Option<&str>> {
+    self
+      .qualities
+      .iter()
+      .map(|quality| quality.as_deref())
+      .collect()
+  }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct HttpAcceptLanguageParseError {
+  message: String,
+}
+
+impl HttpAcceptLanguageParseError {
+  fn new(message: impl AsRef<str>) -> Self {
+    Self {
+      message: message.as_ref().to_string(),
+    }
+  }
+}
+
+impl fmt::Display for HttpAcceptLanguageParseError {
+  fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+    formatter.write_str(&self.message)
+  }
+}
+
+impl Error for HttpAcceptLanguageParseError {}
+
+fn parse_accept_language_item(
+  value: &str,
+) -> Result<(&str, Option<&str>), HttpAcceptLanguageParseError> {
+  let mut parts = value.split(';');
+  let range = parts.next().unwrap_or_default().trim();
+  if !is_valid_accept_language_range(range) {
+    return Err(HttpAcceptLanguageParseError::new(
+      "invalid Accept-Language range",
+    ));
+  }
+  let Some(parameter) = parts.next() else {
+    return Ok((range, None));
+  };
+  if parts.next().is_some() {
+    return Err(HttpAcceptLanguageParseError::new(
+      "invalid Accept-Language q-value",
+    ));
+  }
+  let Some((name, quality)) = parameter.trim().split_once('=') else {
+    return Err(HttpAcceptLanguageParseError::new(
+      "invalid Accept-Language q-value",
+    ));
+  };
+  let quality = quality.trim();
+  if !name.trim().eq_ignore_ascii_case("q") || !is_valid_qvalue(quality) {
+    return Err(HttpAcceptLanguageParseError::new(
+      "invalid Accept-Language q-value",
+    ));
+  }
+  Ok((range, Some(quality)))
+}
+
+fn is_valid_accept_language_range(value: &str) -> bool {
+  if value == "*" {
+    return true;
+  }
+  let mut subtags = value.split('-');
+  let Some(primary) = subtags.next() else {
+    return false;
+  };
+  (1..=8).contains(&primary.len())
+    && primary.bytes().all(|byte| byte.is_ascii_alphabetic())
+    && subtags.all(|subtag| {
+      (1..=8).contains(&subtag.len()) && subtag.bytes().all(|byte| byte.is_ascii_alphanumeric())
+    })
+}
+
+fn is_valid_qvalue(value: &str) -> bool {
+  match value.split_once('.') {
+    Some((whole, fraction)) => {
+      (whole == "0" || whole == "1")
+        && fraction.len() <= 3
+        && fraction.bytes().all(|byte| byte.is_ascii_digit())
+        && (whole == "0" || fraction.bytes().all(|byte| byte == b'0'))
+    }
+    None => value == "0" || value == "1",
+  }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct HttpRequest {
   pub(crate) method: String,
@@ -896,6 +1074,18 @@ impl HttpRequest {
       return Ok(None);
     }
     HttpRequestCacheControl::parse_values(values).map(Some)
+  }
+
+  /// Parse bounded `Accept-Language` request metadata without selecting a locale.
+  pub fn accept_language(
+    &self,
+  ) -> Result<Option<HttpAcceptLanguages>, HttpAcceptLanguageParseError> {
+    let values = self
+      .headers
+      .iter()
+      .filter(|header| header.name.eq_ignore_ascii_case("Accept-Language"))
+      .map(|header| header.value.as_str());
+    HttpAcceptLanguages::parse_optional_values(values)
   }
 
   pub fn vary_selection(&self, vary: &HttpVary) -> HttpVarySelection {

--- a/crates/rttp/tests/test_server_models.rs
+++ b/crates/rttp/tests/test_server_models.rs
@@ -47,6 +47,44 @@ fn parses_request_cache_control_max_stale_without_value() {
 }
 
 #[test]
+fn parses_request_accept_language_metadata() {
+  let request = parse_request(concat!(
+    "GET /localized HTTP/1.1\r\n",
+    "Host: example.test\r\n",
+    "Accept-Language: en-US, fr-CA; q=0.8\r\n",
+    "Accept-Language: *;q=0\r\n",
+    "\r\n"
+  ));
+
+  let languages = request
+    .accept_language()
+    .expect("valid Accept-Language should parse")
+    .expect("Accept-Language header should be present");
+
+  assert_eq!(vec!["en-US", "fr-CA", "*"], languages.ranges());
+  assert_eq!(vec![None, Some("0.8"), Some("0")], languages.qualities());
+}
+
+#[test]
+fn request_accept_language_helper_rejects_invalid_wire_values() {
+  for value in [
+    "en_US",
+    "en; q=1.001",
+    "en; q=0.1234",
+    "en; level=1",
+    "en, EN",
+  ] {
+    let request = parse_request(&format!(
+      "GET /localized HTTP/1.1\r\nHost: example.test\r\nAccept-Language: {value}\r\n\r\n"
+    ));
+    assert!(
+      request.accept_language().is_err(),
+      "Accept-Language helper should reject {value:?}"
+    );
+  }
+}
+
+#[test]
 fn parses_response_cache_control_directives() {
   let response = HttpResponse::new(200, "OK")
     .header(


### PR DESCRIPTION
Added bounded Accept-Language request metadata helpers across the RTTP client and server, with validation, tests, and metadata-only documentation.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1663/
work_kind: code_work
branch: hbx-1663-rttp-add-bounded-accept-language
base: main
commit: 76068b66f0705962775dc861f7e39c03cf351c32
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1663/
    url: https://plane.kahub.in/endless/browse/HBX-1663/
    close_policy: link_only
```