### PR TITLE
feat: [rttp] Add bounded Accept-Encoding request metadata helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,27 @@ compression or decompression policy, negotiation, cache policy, redirects,
 retry/replay, or filesystem serving from `Content-Type` or
 `Content-Encoding`.
 
+### Bounded Accept-Encoding request metadata
+
+`HttpClient::accept_encoding()` appends a validated request coding, while
+`accept_encoding_with_q()` accepts an HTTP q-value from `0` through `1` with
+at most three fractional digits. Convenience helpers cover `gzip`, `deflate`,
+`br`, and `identity`, including q-value variants. The helpers emit one
+comma-separated `Accept-Encoding` field and reject invalid coding tokens,
+q-values, duplicates, oversized values, and more than 32 codings before a
+connection is opened.
+
+On the server, `Request::accept_encoding()` and
+`HttpRequest::accept_encoding()` parse all received `Accept-Encoding` fields
+in wire order into `HttpRequestAcceptEncodings`. Each entry provides its
+`coding()` and q-value `quality()` in thousandths (`1000` is the default
+quality of `1`). Absent metadata returns `Ok(None)`; malformed, duplicate,
+empty, oversized, or excessive entries return a parse error without changing
+the request itself.
+
+These helpers declare and parse metadata only. They do not enable automatic
+compression, decompression, or content negotiation.
+
 ### Bounded HTTP/1.1 Vary behavior
 
 `Response::vary()` parses one or more response `Vary` header fields into

--- a/crates/rttp-client/README.md
+++ b/crates/rttp-client/README.md
@@ -320,6 +320,19 @@ compression or decompression policy, negotiation, cache policy, redirects,
 retry/replay, or filesystem serving from `Content-Type` or
 `Content-Encoding`.
 
+## Bounded Accept-Encoding request metadata
+
+`HttpClient::accept_encoding()` appends a validated request coding, while
+`accept_encoding_with_q()` accepts an HTTP q-value from `0` through `1` with
+at most three fractional digits. Convenience helpers cover `gzip`, `deflate`,
+`br`, and `identity`, including q-value variants. The helpers emit one
+comma-separated `Accept-Encoding` field and reject invalid coding tokens,
+q-values, duplicates, oversized values, and more than 32 codings before a
+connection is opened.
+
+These helpers declare request metadata only. They do not enable automatic
+compression, decompression, or content negotiation.
+
 ## Bounded HTTP/1.1 Content-Disposition behavior
 
 `Response::content_disposition()` parses a singleton response

--- a/crates/rttp-client/src/client.rs
+++ b/crates/rttp-client/src/client.rs
@@ -231,6 +231,66 @@ impl HttpClient {
     Ok(self.header(("Range", format!("bytes=-{}", suffix).as_str())))
   }
 
+  /// Append a validated `Accept-Encoding` coding with the default quality of
+  /// `1`. This declares request metadata only; it does not enable compression
+  /// or decompression.
+  pub fn accept_encoding<S: AsRef<str>>(&mut self, coding: S) -> error::Result<&mut Self> {
+    self.accept_encoding_member(coding.as_ref(), None)
+  }
+
+  /// Append a validated `Accept-Encoding` coding with an HTTP q-value.
+  ///
+  /// The q-value must be between `0` and `1` with at most three fractional
+  /// digits. This declares request metadata only; it does not enable
+  /// compression or decompression.
+  pub fn accept_encoding_with_q<C: AsRef<str>, Q: AsRef<str>>(
+    &mut self,
+    coding: C,
+    qvalue: Q,
+  ) -> error::Result<&mut Self> {
+    self.accept_encoding_member(coding.as_ref(), Some(qvalue.as_ref()))
+  }
+
+  /// Append `gzip` to `Accept-Encoding`.
+  pub fn accept_gzip(&mut self) -> error::Result<&mut Self> {
+    self.accept_encoding("gzip")
+  }
+
+  /// Append `gzip` to `Accept-Encoding` with an HTTP q-value.
+  pub fn accept_gzip_with_q<Q: AsRef<str>>(&mut self, qvalue: Q) -> error::Result<&mut Self> {
+    self.accept_encoding_with_q("gzip", qvalue)
+  }
+
+  /// Append `deflate` to `Accept-Encoding`.
+  pub fn accept_deflate(&mut self) -> error::Result<&mut Self> {
+    self.accept_encoding("deflate")
+  }
+
+  /// Append `deflate` to `Accept-Encoding` with an HTTP q-value.
+  pub fn accept_deflate_with_q<Q: AsRef<str>>(&mut self, qvalue: Q) -> error::Result<&mut Self> {
+    self.accept_encoding_with_q("deflate", qvalue)
+  }
+
+  /// Append `br` to `Accept-Encoding`.
+  pub fn accept_br(&mut self) -> error::Result<&mut Self> {
+    self.accept_encoding("br")
+  }
+
+  /// Append `br` to `Accept-Encoding` with an HTTP q-value.
+  pub fn accept_br_with_q<Q: AsRef<str>>(&mut self, qvalue: Q) -> error::Result<&mut Self> {
+    self.accept_encoding_with_q("br", qvalue)
+  }
+
+  /// Append `identity` to `Accept-Encoding`.
+  pub fn accept_identity(&mut self) -> error::Result<&mut Self> {
+    self.accept_encoding("identity")
+  }
+
+  /// Append `identity` to `Accept-Encoding` with an HTTP q-value.
+  pub fn accept_identity_with_q<Q: AsRef<str>>(&mut self, qvalue: Q) -> error::Result<&mut Self> {
+    self.accept_encoding_with_q("identity", qvalue)
+  }
+
   /// Set an `If-Range` validator with a single strong entity tag.
   ///
   /// `If-Range` only permits strong entity-tag validators. Use `header`
@@ -279,6 +339,55 @@ impl HttpClient {
   /// Set request content type
   pub fn content_type<S: AsRef<str>>(&mut self, content_type: S) -> &mut Self {
     self.header(("Content-Type", content_type.as_ref()))
+  }
+
+  fn accept_encoding_member(
+    &mut self,
+    coding: &str,
+    qvalue: Option<&str>,
+  ) -> error::Result<&mut Self> {
+    let coding = coding.trim();
+    if !is_http_token(coding) {
+      return Err(error::builder_with_message(
+        "invalid Accept-Encoding coding",
+      ));
+    }
+    let qvalue = qvalue.map(validate_accept_encoding_qvalue).transpose()?;
+    let member = qvalue.map_or_else(
+      || coding.to_string(),
+      |qvalue| format!("{coding};q={qvalue}"),
+    );
+
+    let headers = self.request.headers_mut();
+    let existing = headers
+      .iter_mut()
+      .find(|header| header.name().eq_ignore_ascii_case("Accept-Encoding"));
+    if let Some(header) = existing {
+      let existing_codings = parse_accept_encoding_codings(header.value())?;
+      if existing_codings
+        .iter()
+        .any(|known| known.eq_ignore_ascii_case(coding))
+      {
+        return Err(error::builder_with_message(
+          "duplicate Accept-Encoding coding",
+        ));
+      }
+      if existing_codings.len() >= MAX_ACCEPT_ENCODINGS {
+        return Err(error::builder_with_message(
+          "too many Accept-Encoding codings",
+        ));
+      }
+      let value = format!("{}, {member}", header.value());
+      if value.len() > MAX_ACCEPT_ENCODING_VALUE_BYTES {
+        return Err(error::builder_with_message(
+          "Accept-Encoding header value is too large",
+        ));
+      }
+      header.replace(Header::new("Accept-Encoding", value));
+    } else {
+      headers.push(Header::new("Accept-Encoding", member));
+    }
+    Ok(self)
   }
 
   /// Add request para
@@ -519,6 +628,86 @@ impl HttpClient {
     .await;
     self.request.clear_streaming_chunked_body_headers();
     result
+  }
+}
+
+const MAX_ACCEPT_ENCODING_VALUE_BYTES: usize = 64 * 1024;
+const MAX_ACCEPT_ENCODINGS: usize = 32;
+
+fn parse_accept_encoding_codings(value: &str) -> error::Result<Vec<&str>> {
+  if value.len() > MAX_ACCEPT_ENCODING_VALUE_BYTES {
+    return Err(error::builder_with_message(
+      "Accept-Encoding header value is too large",
+    ));
+  }
+
+  let mut codings = Vec::new();
+  for member in value.split(',') {
+    let (coding, _) = split_accept_encoding_member(member)?;
+    if codings
+      .iter()
+      .any(|known: &&str| known.eq_ignore_ascii_case(coding))
+    {
+      return Err(error::builder_with_message(
+        "duplicate Accept-Encoding coding",
+      ));
+    }
+    if codings.len() >= MAX_ACCEPT_ENCODINGS {
+      return Err(error::builder_with_message(
+        "too many Accept-Encoding codings",
+      ));
+    }
+    codings.push(coding);
+  }
+  Ok(codings)
+}
+
+fn split_accept_encoding_member(member: &str) -> error::Result<(&str, Option<&str>)> {
+  let mut parts = member.split(';');
+  let coding = parts.next().unwrap_or_default().trim();
+  if !is_http_token(coding) {
+    return Err(error::builder_with_message(
+      "invalid Accept-Encoding coding",
+    ));
+  }
+  let Some(parameter) = parts.next() else {
+    return Ok((coding, None));
+  };
+  if parts.next().is_some() {
+    return Err(error::builder_with_message(
+      "invalid Accept-Encoding q-value",
+    ));
+  }
+  let Some((name, qvalue)) = parameter.trim().split_once('=') else {
+    return Err(error::builder_with_message(
+      "invalid Accept-Encoding q-value",
+    ));
+  };
+  if !name.trim().eq_ignore_ascii_case("q") {
+    return Err(error::builder_with_message(
+      "invalid Accept-Encoding q-value",
+    ));
+  }
+  let qvalue = validate_accept_encoding_qvalue(qvalue.trim())?;
+  Ok((coding, Some(qvalue)))
+}
+
+fn validate_accept_encoding_qvalue(qvalue: &str) -> error::Result<&str> {
+  let valid = match qvalue.split_once('.') {
+    Some((whole, fraction)) => {
+      fraction.len() <= 3
+        && fraction.bytes().all(|byte| byte.is_ascii_digit())
+        && matches!(whole, "0" | "1")
+        && (whole == "0" || fraction.bytes().all(|byte| byte == b'0'))
+    }
+    None => matches!(qvalue, "0" | "1"),
+  };
+  if valid {
+    Ok(qvalue)
+  } else {
+    Err(error::builder_with_message(
+      "invalid Accept-Encoding q-value",
+    ))
   }
 }
 

--- a/crates/rttp-client/src/client.rs
+++ b/crates/rttp-client/src/client.rs
@@ -357,6 +357,11 @@ impl HttpClient {
       || coding.to_string(),
       |qvalue| format!("{coding};q={qvalue}"),
     );
+    if member.len() > MAX_ACCEPT_ENCODING_VALUE_BYTES {
+      return Err(error::builder_with_message(
+        "Accept-Encoding header value is too large",
+      ));
+    }
 
     let headers = self.request.headers_mut();
     let existing = headers

--- a/crates/rttp-client/tests/test_raw_request_capture.rs
+++ b/crates/rttp-client/tests/test_raw_request_capture.rs
@@ -217,6 +217,64 @@ fn range_helpers_emit_single_byte_range_headers() {
 }
 
 #[test]
+fn accept_encoding_helpers_emit_validated_codings_and_quality_values() {
+  let request = capture_request(|base_url| {
+    client()
+      .get()
+      .url(format!("{}/asset", base_url))
+      .accept_gzip()
+      .expect("gzip should be accepted")
+      .accept_br_with_q("0.8")
+      .expect("br quality should be accepted")
+      .accept_identity_with_q("0")
+      .expect("identity quality should be accepted")
+      .emit()
+      .expect("request should succeed");
+  });
+  let request = request_text(&request);
+
+  assert_eq!(
+    Some("gzip, br;q=0.8, identity;q=0"),
+    header_value(&request, "Accept-Encoding")
+  );
+}
+
+#[test]
+fn accept_encoding_helpers_reject_invalid_members_before_connecting() {
+  let request = capture_optional_request(|base_url| {
+    let mut client = client();
+    let error = client
+      .get()
+      .url(format!("{}/asset", base_url))
+      .accept_encoding_with_q("bad coding", "1.1")
+      .expect_err("invalid coding should be rejected");
+
+    assert!(error.is_builder());
+  });
+
+  assert!(
+    request.is_empty(),
+    "invalid Accept-Encoding helper input should not open a socket"
+  );
+
+  let request = capture_optional_request(|base_url| {
+    let mut client = client();
+    let error = client
+      .get()
+      .url(format!("{}/asset", base_url))
+      .accept_encoding_with_q("gzip", "1.1")
+      .expect_err("invalid q-value should be rejected");
+
+    assert!(error.is_builder());
+  });
+
+  assert!(
+    request.is_empty(),
+    "invalid Accept-Encoding q-value should not open a socket"
+  );
+}
+
+#[test]
 fn range_helper_rejects_malformed_inputs_before_connecting() {
   let request = capture_optional_request(|base_url| {
     let mut client = client();

--- a/crates/rttp-client/tests/test_raw_request_capture.rs
+++ b/crates/rttp-client/tests/test_raw_request_capture.rs
@@ -272,6 +272,23 @@ fn accept_encoding_helpers_reject_invalid_members_before_connecting() {
     request.is_empty(),
     "invalid Accept-Encoding q-value should not open a socket"
   );
+
+  let request = capture_optional_request(|base_url| {
+    let oversized_coding = "a".repeat(64 * 1024 + 1);
+    let mut client = client();
+    let error = client
+      .get()
+      .url(format!("{}/asset", base_url))
+      .accept_encoding(&oversized_coding)
+      .expect_err("oversized first coding should be rejected");
+
+    assert!(error.is_builder());
+  });
+
+  assert!(
+    request.is_empty(),
+    "oversized first Accept-Encoding coding should not open a socket"
+  );
 }
 
 #[test]

--- a/crates/rttp-server/src/server/request.rs
+++ b/crates/rttp-server/src/server/request.rs
@@ -87,6 +87,18 @@ impl Request {
     HttpRequestCacheControl::parse_values(values).map(Some)
   }
 
+  /// Parses received `Accept-Encoding` request metadata without enabling
+  /// automatic compression, decompression, or content negotiation.
+  pub fn accept_encoding(
+    &self,
+  ) -> Result<Option<HttpRequestAcceptEncodings>, HttpAcceptEncodingParseError> {
+    let values: Vec<&str> = self.headers_named("Accept-Encoding").collect();
+    if values.is_empty() {
+      return Ok(None);
+    }
+    HttpRequestAcceptEncodings::parse_values(values).map(Some)
+  }
+
   pub fn vary_selection(&self, vary: &HttpVary) -> HttpVarySelection {
     if vary.is_wildcard() {
       return HttpVarySelection::wildcard();
@@ -896,6 +908,23 @@ impl HttpRequest {
       return Ok(None);
     }
     HttpRequestCacheControl::parse_values(values).map(Some)
+  }
+
+  /// Parses received `Accept-Encoding` request metadata without enabling
+  /// automatic compression, decompression, or content negotiation.
+  pub fn accept_encoding(
+    &self,
+  ) -> Result<Option<HttpRequestAcceptEncodings>, HttpAcceptEncodingParseError> {
+    let values: Vec<&str> = self
+      .headers
+      .iter()
+      .filter(|header| header.name.eq_ignore_ascii_case("Accept-Encoding"))
+      .map(|header| header.value.as_str())
+      .collect();
+    if values.is_empty() {
+      return Ok(None);
+    }
+    HttpRequestAcceptEncodings::parse_values(values).map(Some)
   }
 
   pub fn vary_selection(&self, vary: &HttpVary) -> HttpVarySelection {

--- a/crates/rttp-server/src/server/response.rs
+++ b/crates/rttp-server/src/server/response.rs
@@ -10,6 +10,8 @@ pub(crate) const MAX_CONTENT_LANGUAGE_VALUE_BYTES: usize = 64 * 1024;
 pub(crate) const MAX_CONTENT_LANGUAGES: usize = 32;
 pub(crate) const MAX_CONTENT_ENCODING_VALUE_BYTES: usize = 64 * 1024;
 pub(crate) const MAX_CONTENT_ENCODINGS: usize = 32;
+pub(crate) const MAX_ACCEPT_ENCODING_VALUE_BYTES: usize = 64 * 1024;
+pub(crate) const MAX_ACCEPT_ENCODINGS: usize = 32;
 pub(crate) const MAX_CONTENT_LOCATION_VALUE_BYTES: usize = 64 * 1024;
 pub(crate) const MAX_CONTENT_DISPOSITION_VALUE_BYTES: usize = 64 * 1024;
 pub(crate) const MAX_CONTENT_DISPOSITION_PARAMETERS: usize = 32;
@@ -1460,6 +1462,171 @@ impl fmt::Display for HttpContentEncodingParseError {
 }
 
 impl Error for HttpContentEncodingParseError {}
+
+/// A validated `Accept-Encoding` coding received on an HTTP request.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct HttpAcceptEncoding {
+  coding: String,
+  quality: u16,
+}
+
+impl HttpAcceptEncoding {
+  pub fn coding(&self) -> &str {
+    &self.coding
+  }
+
+  /// Returns the q-value as thousandths, where `1000` is the default quality
+  /// of `1` and `0` means not acceptable.
+  pub fn quality(&self) -> u16 {
+    self.quality
+  }
+}
+
+/// Bounded `Accept-Encoding` request metadata.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct HttpRequestAcceptEncodings {
+  codings: Vec<HttpAcceptEncoding>,
+}
+
+impl HttpRequestAcceptEncodings {
+  pub fn parse(value: impl AsRef<str>) -> Result<Self, HttpAcceptEncodingParseError> {
+    Self::parse_values([value.as_ref()])
+  }
+
+  pub fn parse_values<'a, I>(values: I) -> Result<Self, HttpAcceptEncodingParseError>
+  where
+    I: IntoIterator<Item = &'a str>,
+  {
+    let mut codings = Vec::new();
+    for value in values {
+      if value.len() > MAX_ACCEPT_ENCODING_VALUE_BYTES {
+        return Err(HttpAcceptEncodingParseError::new(
+          "Accept-Encoding header value is too large",
+        ));
+      }
+      for member in value.split(',') {
+        let (coding, quality) = parse_accept_encoding_member(member)?;
+        if codings
+          .iter()
+          .any(|known: &HttpAcceptEncoding| known.coding.eq_ignore_ascii_case(coding))
+        {
+          return Err(HttpAcceptEncodingParseError::new(
+            "duplicate Accept-Encoding coding",
+          ));
+        }
+        if codings.len() >= MAX_ACCEPT_ENCODINGS {
+          return Err(HttpAcceptEncodingParseError::new(
+            "too many Accept-Encoding codings",
+          ));
+        }
+        codings.push(HttpAcceptEncoding {
+          coding: coding.to_string(),
+          quality,
+        });
+      }
+    }
+
+    if codings.is_empty() {
+      return Err(HttpAcceptEncodingParseError::new(
+        "invalid Accept-Encoding coding",
+      ));
+    }
+    Ok(Self { codings })
+  }
+
+  pub fn codings(&self) -> &[HttpAcceptEncoding] {
+    &self.codings
+  }
+
+  pub fn len(&self) -> usize {
+    self.codings.len()
+  }
+
+  pub fn is_empty(&self) -> bool {
+    self.codings.is_empty()
+  }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct HttpAcceptEncodingParseError {
+  pub(crate) message: String,
+}
+
+impl HttpAcceptEncodingParseError {
+  pub(crate) fn new<S: AsRef<str>>(message: S) -> Self {
+    Self {
+      message: message.as_ref().to_string(),
+    }
+  }
+}
+
+impl fmt::Display for HttpAcceptEncodingParseError {
+  fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+    formatter.write_str(&self.message)
+  }
+}
+
+impl Error for HttpAcceptEncodingParseError {}
+
+fn parse_accept_encoding_member(member: &str) -> Result<(&str, u16), HttpAcceptEncodingParseError> {
+  let mut parts = member.split(';');
+  let coding = parts.next().unwrap_or_default().trim();
+  if coding.is_empty() || !is_http_token(coding) {
+    return Err(HttpAcceptEncodingParseError::new(
+      "invalid Accept-Encoding coding",
+    ));
+  }
+  let Some(parameter) = parts.next() else {
+    return Ok((coding, 1000));
+  };
+  if parts.next().is_some() {
+    return Err(HttpAcceptEncodingParseError::new(
+      "invalid Accept-Encoding q-value",
+    ));
+  }
+  let Some((name, qvalue)) = parameter.trim().split_once('=') else {
+    return Err(HttpAcceptEncodingParseError::new(
+      "invalid Accept-Encoding q-value",
+    ));
+  };
+  if !name.trim().eq_ignore_ascii_case("q") {
+    return Err(HttpAcceptEncodingParseError::new(
+      "invalid Accept-Encoding q-value",
+    ));
+  }
+  Ok((coding, parse_accept_encoding_qvalue(qvalue.trim())?))
+}
+
+fn parse_accept_encoding_qvalue(qvalue: &str) -> Result<u16, HttpAcceptEncodingParseError> {
+  let Some((whole, fraction)) = qvalue.split_once('.') else {
+    return match qvalue {
+      "0" => Ok(0),
+      "1" => Ok(1000),
+      _ => Err(HttpAcceptEncodingParseError::new(
+        "invalid Accept-Encoding q-value",
+      )),
+    };
+  };
+  if !matches!(whole, "0" | "1")
+    || fraction.len() > 3
+    || !fraction.bytes().all(|byte| byte.is_ascii_digit())
+    || (whole == "1" && !fraction.bytes().all(|byte| byte == b'0'))
+  {
+    return Err(HttpAcceptEncodingParseError::new(
+      "invalid Accept-Encoding q-value",
+    ));
+  }
+  let fractional = if fraction.is_empty() {
+    0
+  } else {
+    fraction.parse::<u16>().expect("validated q-value digits")
+  };
+  Ok(if whole == "1" {
+    1000
+  } else {
+    fractional * 10_u16.pow(3 - fraction.len() as u32)
+  })
+}
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct HttpContentLocationParseError {

--- a/crates/rttp/tests/http2_feature.rs
+++ b/crates/rttp/tests/http2_feature.rs
@@ -4570,8 +4570,8 @@ fn wrapper_http2_feature_exposes_response_trailers_from_prior_knowledge_server()
 fn wrapper_http2_prior_knowledge_large_request_header_reaches_socket2_server() {
   let server = rttp::Http::server("127.0.0.1:0")
     .expect("bind server")
-    .with_read_timeout(Some(Duration::from_secs(2)))
-    .with_write_timeout(Some(Duration::from_secs(2)));
+    .with_read_timeout(Some(Duration::from_secs(10)))
+    .with_write_timeout(Some(Duration::from_secs(10)));
   let addr = server.local_addr().expect("server addr");
   let large_header_value = "r".repeat(16 * 1024 + 512);
   let expected_header_value = large_header_value.clone();

--- a/crates/rttp/tests/test_server_models.rs
+++ b/crates/rttp/tests/test_server_models.rs
@@ -3,8 +3,8 @@ use std::time::{Duration, UNIX_EPOCH};
 use rttp::server::{
   HttpAcceptRanges, HttpAllowedMethods, HttpByteRange, HttpByteRangeError, HttpConditionalMetadata,
   HttpContentDisposition, HttpContentLanguages, HttpContentType, HttpEntityTag,
-  HttpIfRangeRequestOutcome, HttpRequest, HttpRequestCacheControl, HttpResponse,
-  HttpResponseCacheControl, HttpResponseContentEncodings, HttpRetryAfter, HttpVary,
+  HttpIfRangeRequestOutcome, HttpRequest, HttpRequestAcceptEncodings, HttpRequestCacheControl,
+  HttpResponse, HttpResponseCacheControl, HttpResponseContentEncodings, HttpRetryAfter, HttpVary,
 };
 
 fn parse_request(raw: &str) -> HttpRequest {
@@ -36,6 +36,72 @@ fn parses_request_cache_control_directives() {
   assert_eq!(1, cache_control.extensions().len());
   assert_eq!("ext", cache_control.extensions()[0].name());
   assert_eq!(Some("a,b"), cache_control.extensions()[0].value());
+}
+
+#[test]
+fn request_accept_encoding_parses_codings_and_quality_values() {
+  let request = parse_request(concat!(
+    "GET /asset HTTP/1.1\r\n",
+    "Host: example.test\r\n",
+    "Accept-Encoding: gzip, br;q=0.8\r\n",
+    "accept-encoding: identity; q=0\r\n",
+    "\r\n"
+  ));
+
+  let encodings = request
+    .accept_encoding()
+    .expect("Accept-Encoding should parse")
+    .expect("Accept-Encoding should be present");
+
+  assert_eq!(3, encodings.len());
+  assert_eq!("gzip", encodings.codings()[0].coding());
+  assert_eq!(1000, encodings.codings()[0].quality());
+  assert_eq!("br", encodings.codings()[1].coding());
+  assert_eq!(800, encodings.codings()[1].quality());
+  assert_eq!("identity", encodings.codings()[2].coding());
+  assert_eq!(0, encodings.codings()[2].quality());
+}
+
+#[test]
+fn request_accept_encoding_rejects_duplicate_invalid_and_oversized_values() {
+  assert_eq!(
+    None,
+    parse_request("GET / HTTP/1.1\r\nHost: example.test\r\n\r\n")
+      .accept_encoding()
+      .expect("absent Accept-Encoding should be accepted")
+  );
+
+  for value in [
+    "",
+    "gzip,",
+    ", gzip",
+    "gzip,,br",
+    "bad coding",
+    "gzip;q=1.1",
+  ] {
+    let request = parse_request(&format!(
+      "GET / HTTP/1.1\r\nHost: example.test\r\nAccept-Encoding: {value}\r\n\r\n"
+    ));
+    assert!(
+      request.accept_encoding().is_err(),
+      "should reject {value:?}"
+    );
+  }
+
+  let duplicate = parse_request(concat!(
+    "GET / HTTP/1.1\r\nHost: example.test\r\n",
+    "Accept-Encoding: gzip\r\naccept-encoding: GZIP;q=0.5\r\n\r\n"
+  ));
+  assert!(duplicate.accept_encoding().is_err());
+
+  let oversized = "gzip".repeat(64 * 1024);
+  assert!(HttpRequestAcceptEncodings::parse(oversized).is_err());
+
+  let too_many = (0..33)
+    .map(|index| format!("coding{index}"))
+    .collect::<Vec<_>>()
+    .join(", ");
+  assert!(HttpRequestAcceptEncodings::parse(too_many).is_err());
 }
 
 #[test]


### PR DESCRIPTION
Bounded Accept-Encoding request metadata helpers are implemented for client construction and server parsing, with strict validation, capture/parser coverage, and no change to existing response content-encoding behavior.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1662/
work_kind: code_work
branch: hbx-1662-rttp-add-bounded-accept-encoding
base: main
commit: cca62d6ce65953825ee2259b10cd705bf5af3113
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1662/
    url: https://plane.kahub.in/endless/browse/HBX-1662/
    close_policy: link_only
```