### PR TITLE
feat: [rttp-client] Add bounded Accept request helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,6 +356,21 @@ the request itself.
 These helpers declare and parse metadata only. They do not enable automatic
 compression, decompression, or content negotiation.
 
+### Bounded Accept request metadata
+
+`HttpClient::accept()` appends one validated media range, while
+`accept_with_q()` adds a q-value from `0` through `1` with at most three
+fractional digits. Convenience helpers cover `*/*`, JSON, HTML, XML, and plain
+text, including q-value variants. The client rejects malformed media types or
+parameters, duplicate parameters, invalid q-values, oversized fields, and more
+than 32 media ranges before opening a connection. Raw
+`header(("Accept", value))` remains available for values outside the bounded
+helper API.
+
+These helpers only declare request metadata. RTTP does not perform automatic
+representation selection, retries, redirects, caching, or server policy from
+`Accept`.
+
 ### Bounded HTTP/1.1 Vary behavior
 
 `Response::vary()` parses one or more response `Vary` header fields into

--- a/crates/rttp-client/README.md
+++ b/crates/rttp-client/README.md
@@ -333,6 +333,19 @@ connection is opened.
 These helpers declare request metadata only. They do not enable automatic
 compression, decompression, or content negotiation.
 
+## Bounded Accept request metadata
+
+`HttpClient::accept()` appends one validated media range, and
+`accept_with_q()` adds a q-value from `0` through `1` with at most three
+fractional digits. Convenience helpers cover `*/*`, JSON, HTML, XML, and plain
+text, including q-value variants. Media types, parameter names, parameter
+values, and q-values are validated; duplicate parameters, oversized values,
+and more than 32 media ranges are rejected before a connection is opened.
+
+The helpers emit one comma-separated `Accept` field and do not choose a
+response representation. `header(("Accept", value))` remains available for
+media ranges or extensions outside this bounded helper API.
+
 ## Bounded HTTP/1.1 Content-Disposition behavior
 
 `Response::content_disposition()` parses a singleton response

--- a/crates/rttp-client/src/client.rs
+++ b/crates/rttp-client/src/client.rs
@@ -220,6 +220,77 @@ impl HttpClient {
     Ok(self.header(Header::new("Accept-Language", value)))
   }
 
+  /// Append a validated `Accept` media range with its supplied quality value.
+  ///
+  /// This declares request metadata only; it does not select a response
+  /// representation.
+  pub fn accept<S: AsRef<str>>(&mut self, media_range: S) -> error::Result<&mut Self> {
+    self.accept_member(media_range.as_ref(), None)
+  }
+
+  /// Append a validated `Accept` media range with an HTTP q-value.
+  ///
+  /// The q-value must be between `0` and `1` with at most three fractional
+  /// digits. This declares request metadata only; it does not select a
+  /// response representation.
+  pub fn accept_with_q<M: AsRef<str>, Q: AsRef<str>>(
+    &mut self,
+    media_range: M,
+    qvalue: Q,
+  ) -> error::Result<&mut Self> {
+    self.accept_member(media_range.as_ref(), Some(qvalue.as_ref()))
+  }
+
+  /// Append `*/*` to `Accept`.
+  pub fn accept_any(&mut self) -> error::Result<&mut Self> {
+    self.accept("*/*")
+  }
+
+  /// Append `*/*` to `Accept` with an HTTP q-value.
+  pub fn accept_any_with_q<Q: AsRef<str>>(&mut self, qvalue: Q) -> error::Result<&mut Self> {
+    self.accept_with_q("*/*", qvalue)
+  }
+
+  /// Append `application/json` to `Accept`.
+  pub fn accept_json(&mut self) -> error::Result<&mut Self> {
+    self.accept("application/json")
+  }
+
+  /// Append `application/json` to `Accept` with an HTTP q-value.
+  pub fn accept_json_with_q<Q: AsRef<str>>(&mut self, qvalue: Q) -> error::Result<&mut Self> {
+    self.accept_with_q("application/json", qvalue)
+  }
+
+  /// Append `text/html` to `Accept`.
+  pub fn accept_html(&mut self) -> error::Result<&mut Self> {
+    self.accept("text/html")
+  }
+
+  /// Append `text/html` to `Accept` with an HTTP q-value.
+  pub fn accept_html_with_q<Q: AsRef<str>>(&mut self, qvalue: Q) -> error::Result<&mut Self> {
+    self.accept_with_q("text/html", qvalue)
+  }
+
+  /// Append `application/xml` to `Accept`.
+  pub fn accept_xml(&mut self) -> error::Result<&mut Self> {
+    self.accept("application/xml")
+  }
+
+  /// Append `application/xml` to `Accept` with an HTTP q-value.
+  pub fn accept_xml_with_q<Q: AsRef<str>>(&mut self, qvalue: Q) -> error::Result<&mut Self> {
+    self.accept_with_q("application/xml", qvalue)
+  }
+
+  /// Append `text/plain` to `Accept`.
+  pub fn accept_plain_text(&mut self) -> error::Result<&mut Self> {
+    self.accept("text/plain")
+  }
+
+  /// Append `text/plain` to `Accept` with an HTTP q-value.
+  pub fn accept_plain_text_with_q<Q: AsRef<str>>(&mut self, qvalue: Q) -> error::Result<&mut Self> {
+    self.accept_with_q("text/plain", qvalue)
+  }
+
   /// Set a single bounded byte range request header, `Range: bytes=start-end`.
   pub fn range(&mut self, start: u64, end: u64) -> error::Result<&mut Self> {
     if start > end {
@@ -405,6 +476,47 @@ impl HttpClient {
       header.replace(Header::new("Accept-Encoding", value));
     } else {
       headers.push(Header::new("Accept-Encoding", member));
+    }
+    Ok(self)
+  }
+
+  fn accept_member(&mut self, media_range: &str, qvalue: Option<&str>) -> error::Result<&mut Self> {
+    let media_range = media_range.trim();
+    let has_quality = validate_accept_media_range(media_range)?;
+    let qvalue = qvalue.map(validate_accept_qvalue).transpose()?;
+    if has_quality && qvalue.is_some() {
+      return Err(error::builder_with_message(
+        "duplicate Accept quality value",
+      ));
+    }
+    let member = qvalue.map_or_else(
+      || media_range.to_string(),
+      |qvalue| format!("{media_range};q={qvalue}"),
+    );
+    if member.len() > MAX_ACCEPT_VALUE_BYTES {
+      return Err(error::builder_with_message(
+        "Accept header value is too large",
+      ));
+    }
+
+    let headers = self.request.headers_mut();
+    let existing = headers
+      .iter_mut()
+      .find(|header| header.name().eq_ignore_ascii_case("Accept"));
+    if let Some(header) = existing {
+      let existing_ranges = parse_accept_media_ranges(header.value())?;
+      if existing_ranges >= MAX_ACCEPT_MEDIA_RANGES {
+        return Err(error::builder_with_message("too many Accept media ranges"));
+      }
+      let value = format!("{}, {member}", header.value());
+      if value.len() > MAX_ACCEPT_VALUE_BYTES {
+        return Err(error::builder_with_message(
+          "Accept header value is too large",
+        ));
+      }
+      header.replace(Header::new("Accept", value));
+    } else {
+      headers.push(Header::new("Accept", member));
     }
     Ok(self)
   }
@@ -648,6 +760,149 @@ impl HttpClient {
     self.request.clear_streaming_chunked_body_headers();
     result
   }
+}
+
+const MAX_ACCEPT_VALUE_BYTES: usize = 64 * 1024;
+const MAX_ACCEPT_MEDIA_RANGES: usize = 32;
+
+fn parse_accept_media_ranges(value: &str) -> error::Result<usize> {
+  if value.len() > MAX_ACCEPT_VALUE_BYTES {
+    return Err(error::builder_with_message(
+      "Accept header value is too large",
+    ));
+  }
+  let members = split_accept_delimited(value, b',')?;
+  if members.len() > MAX_ACCEPT_MEDIA_RANGES {
+    return Err(error::builder_with_message("too many Accept media ranges"));
+  }
+  for member in &members {
+    validate_accept_media_range(member)?;
+  }
+  Ok(members.len())
+}
+
+fn validate_accept_media_range(value: &str) -> error::Result<bool> {
+  let parts = split_accept_delimited(value, b';')?;
+  let Some(media_type) = parts.first() else {
+    return Err(error::builder_with_message("invalid Accept media range"));
+  };
+  validate_accept_media_type(media_type.trim())?;
+
+  let mut names = Vec::new();
+  let mut has_quality = false;
+  for parameter in parts.iter().skip(1) {
+    let Some((name, value)) = parameter.trim().split_once('=') else {
+      return Err(error::builder_with_message("invalid Accept parameter"));
+    };
+    let name = name.trim();
+    let value = value.trim();
+    if !is_http_token(name) || !is_accept_parameter_value(value) {
+      return Err(error::builder_with_message("invalid Accept parameter"));
+    }
+    if names
+      .iter()
+      .any(|known: &&str| known.eq_ignore_ascii_case(name))
+    {
+      return Err(error::builder_with_message("duplicate Accept parameter"));
+    }
+    if name.eq_ignore_ascii_case("q") {
+      validate_accept_qvalue(value)?;
+      has_quality = true;
+    }
+    names.push(name);
+  }
+  Ok(has_quality)
+}
+
+fn validate_accept_media_type(value: &str) -> error::Result<()> {
+  let Some((type_name, subtype)) = value.split_once('/') else {
+    return Err(error::builder_with_message("invalid Accept media range"));
+  };
+  if subtype.contains('/') {
+    return Err(error::builder_with_message("invalid Accept media range"));
+  }
+  let type_name = type_name.trim();
+  let subtype = subtype.trim();
+  if (type_name == "*" && subtype != "*")
+    || !(type_name == "*" || is_http_token(type_name))
+    || !(subtype == "*" || is_http_token(subtype))
+  {
+    return Err(error::builder_with_message("invalid Accept media range"));
+  }
+  Ok(())
+}
+
+fn validate_accept_qvalue(qvalue: &str) -> error::Result<&str> {
+  if is_qvalue(qvalue) {
+    Ok(qvalue)
+  } else {
+    Err(error::builder_with_message("invalid Accept quality value"))
+  }
+}
+
+fn split_accept_delimited(value: &str, delimiter: u8) -> error::Result<Vec<&str>> {
+  let mut members = Vec::new();
+  let mut quoted = false;
+  let mut escaped = false;
+  let mut start = 0usize;
+  for (index, byte) in value.bytes().enumerate() {
+    if escaped {
+      if byte.is_ascii_control() {
+        return Err(error::builder_with_message("invalid Accept parameter"));
+      }
+      escaped = false;
+      continue;
+    }
+    match byte {
+      b'\\' if quoted => escaped = true,
+      b'"' => quoted = !quoted,
+      byte if byte == delimiter && !quoted => {
+        let member = value[start..index].trim();
+        if member.is_empty() {
+          return Err(error::builder_with_message("invalid Accept media range"));
+        }
+        members.push(member);
+        start = index + 1;
+      }
+      _ => {}
+    }
+  }
+  if quoted || escaped {
+    return Err(error::builder_with_message("invalid Accept parameter"));
+  }
+  let member = value[start..].trim();
+  if member.is_empty() {
+    return Err(error::builder_with_message("invalid Accept media range"));
+  }
+  members.push(member);
+  Ok(members)
+}
+
+fn is_accept_parameter_value(value: &str) -> bool {
+  is_http_token(value) || is_accept_quoted_string(value)
+}
+
+fn is_accept_quoted_string(value: &str) -> bool {
+  let Some(value) = value
+    .strip_prefix('"')
+    .and_then(|value| value.strip_suffix('"'))
+  else {
+    return false;
+  };
+  let mut escaped = false;
+  for byte in value.bytes() {
+    if escaped {
+      if byte.is_ascii_control() {
+        return false;
+      }
+      escaped = false;
+    } else if byte == b'\\' {
+      escaped = true;
+    } else if byte == b'"' || byte.is_ascii_control() && byte != b'\t' {
+      return false;
+    }
+  }
+  !escaped
 }
 
 const MAX_ACCEPT_ENCODING_VALUE_BYTES: usize = 64 * 1024;

--- a/crates/rttp-client/src/client.rs
+++ b/crates/rttp-client/src/client.rs
@@ -481,6 +481,9 @@ impl HttpClient {
   }
 
   fn accept_member(&mut self, media_range: &str, qvalue: Option<&str>) -> error::Result<&mut Self> {
+    if media_range.bytes().any(|byte| byte.is_ascii_control()) {
+      return Err(error::builder_with_message("invalid Accept media range"));
+    }
     let media_range = media_range.trim();
     let has_quality = validate_accept_media_range(media_range)?;
     let qvalue = qvalue.map(validate_accept_qvalue).transpose()?;

--- a/crates/rttp-client/tests/test_raw_request_capture.rs
+++ b/crates/rttp-client/tests/test_raw_request_capture.rs
@@ -316,7 +316,13 @@ fn accept_helpers_emit_validated_media_ranges_and_quality_values() {
 
 #[test]
 fn accept_helpers_reject_invalid_values_before_connecting() {
-  for value in ["text", "text/html; q=0.8; q=0.5", "text/html; q=1.001"] {
+  for value in [
+    "text",
+    "text/html; q=0.8; q=0.5",
+    "text/html; q=1.001",
+    "text/html\n;level=1",
+    "text/html\r;level=1",
+  ] {
     let request = capture_optional_request(|base_url| {
       let mut client = client();
       let error = client

--- a/crates/rttp-client/tests/test_raw_request_capture.rs
+++ b/crates/rttp-client/tests/test_raw_request_capture.rs
@@ -292,6 +292,105 @@ fn accept_encoding_helpers_reject_invalid_members_before_connecting() {
 }
 
 #[test]
+fn accept_helpers_emit_validated_media_ranges_and_quality_values() {
+  let request = capture_request(|base_url| {
+    client()
+      .get()
+      .url(format!("{}/document", base_url))
+      .accept_json()
+      .expect("JSON should be accepted")
+      .accept_html_with_q("0.8")
+      .expect("HTML quality should be accepted")
+      .accept("text/plain; charset=utf-8; q=0.5")
+      .expect("parameterized media range should be accepted")
+      .emit()
+      .expect("request should succeed");
+  });
+  let request = request_text(&request);
+
+  assert_eq!(
+    Some("application/json, text/html;q=0.8, text/plain; charset=utf-8; q=0.5"),
+    header_value(&request, "Accept")
+  );
+}
+
+#[test]
+fn accept_helpers_reject_invalid_values_before_connecting() {
+  for value in ["text", "text/html; q=0.8; q=0.5", "text/html; q=1.001"] {
+    let request = capture_optional_request(|base_url| {
+      let mut client = client();
+      let error = client
+        .get()
+        .url(format!("{}/document", base_url))
+        .accept(value)
+        .expect_err("invalid Accept media range should be rejected");
+
+      assert!(error.is_builder());
+    });
+
+    assert!(
+      request.is_empty(),
+      "invalid Accept helper input should not open a socket"
+    );
+  }
+
+  let request = capture_optional_request(|base_url| {
+    let mut client = client();
+    client.get().url(format!("{}/document", base_url));
+    for index in 0..32 {
+      client
+        .accept(format!("application/x-{index}"))
+        .expect("bounded Accept media range should be accepted");
+    }
+    let error = client
+      .accept("application/x-overflow")
+      .expect_err("too many media ranges should be rejected");
+
+    assert!(error.is_builder());
+  });
+
+  assert!(
+    request.is_empty(),
+    "oversized Accept media range list should not open a socket"
+  );
+
+  let oversized = format!("application/{}", "a".repeat(64 * 1024));
+  let request = capture_optional_request(|base_url| {
+    let mut client = client();
+    let error = client
+      .get()
+      .url(format!("{}/document", base_url))
+      .accept(&oversized)
+      .expect_err("oversized media range should be rejected");
+
+    assert!(error.is_builder());
+  });
+
+  assert!(
+    request.is_empty(),
+    "oversized Accept helper input should not open a socket"
+  );
+}
+
+#[test]
+fn manual_accept_header_remains_available_as_escape_hatch() {
+  let request = capture_request(|base_url| {
+    client()
+      .get()
+      .url(format!("{}/document", base_url))
+      .header(("Accept", "application/example; feature=?experimental"))
+      .emit()
+      .expect("request should succeed");
+  });
+  let request = request_text(&request);
+
+  assert_eq!(
+    Some("application/example; feature=?experimental"),
+    header_value(&request, "Accept")
+  );
+}
+
+#[test]
 fn range_helper_rejects_malformed_inputs_before_connecting() {
   let request = capture_optional_request(|base_url| {
     let mut client = client();


### PR DESCRIPTION
Implemented bounded `Accept` request helpers with validated media ranges, q-values, common convenience methods, request-capture coverage, and documentation.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1660/
work_kind: code_work
branch: hbx-1660-rttp-client-add-bounded-accept
base: main
commit: 914a050e6a05aec2bc96555a2c95fafd34582fb7
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1660/
    url: https://plane.kahub.in/endless/browse/HBX-1660/
    close_policy: link_only
```