### PR TITLE
feat: [rttp] Add bounded Expect: 100-continue request metadata behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,6 +356,22 @@ the request itself.
 These helpers declare and parse metadata only. They do not enable automatic
 compression, decompression, or content negotiation.
 
+### Bounded `Expect: 100-continue` request metadata
+
+`HttpClient::expect_continue()` emits the validated standardized
+`Expect: 100-continue` field. It is metadata only: the client does not delay
+the request body or wait for an interim response. `Response::informational_responses()`
+continues to expose a received `100 Continue` alongside other bounded
+informational responses.
+
+On the server, `Request::expectations()` and `HttpRequest::expectations()`
+return bounded `HttpExpectations` metadata. `expects_continue()` identifies
+the standardized expectation, while `unsupported()` preserves extension names
+for handler policy. Absent fields return `Ok(None)`; malformed, duplicate,
+oversized, or excessive values return `HttpExpectParseError` without changing
+the raw request. The server does not automatically send `100 Continue` or
+reject unsupported expectations.
+
 ### Bounded HTTP/1.1 Vary behavior
 
 `Response::vary()` parses one or more response `Vary` header fields into
@@ -444,7 +460,7 @@ gain additional HTTP/2 header-block handling.
 | area | tested coverage | limits |
 |------|-----------------|--------|
 | HTTP/1.1 response parsing | `Content-Length`, chunked transfer coding, chunk extensions, informational responses, bodyless `204`/`304`, duplicate `Set-Cookie`, and framing ambiguity rejection | Not a complete RFC conformance suite |
-| HTTP/1.1 request emission | Origin-form requests, absolute-form proxy requests, `CONNECT`, `HEAD`, fixed bodies, streaming chunked uploads, and `Expect: 100-continue` | SOCKS handshakes are delegated to the `socks` crate |
+| HTTP/1.1 request emission | Origin-form requests, absolute-form proxy requests, `CONNECT`, `HEAD`, fixed bodies, streaming chunked uploads, and explicit `Expect: 100-continue` metadata | Expect metadata does not gate body transmission; SOCKS handshakes are delegated to the `socks` crate |
 | Upgrade and tunnel handoff | `CONNECT` returns the tunnel socket after a successful `200`; `upgrade()` returns the socket after `101 Switching Protocols` and skips interim `1xx` responses | Upgraded protocols are handed to the caller and are not parsed by `rttp_client` |
 | Redirects | Auto-redirect covers 301, 302, 303, 307, and 308 method/body behavior, relative and absolute `Location` resolution, same- and cross-authority header handling, loop detection, and redirect bounds | Redirects are HTTP client behavior, not a browser policy implementation |
 | Byte ranges | `range`, `range_from`, `range_suffix`, `if_range_etag`, and `if_range_date` emit bounded HTTP/1.1 range request metadata; `Response::content_range`, `accept_ranges`, `is_partial_content`, and `is_range_not_satisfiable` expose `Content-Range`, `Accept-Ranges`, `206`, and `416` metadata while preserving raw headers | No Range request generation from `Accept-Ranges`, client-side `If-Range` evaluation, partial response engine, byte serving, content slicing, download resume, automatic retry/replay, cache storage, redirect handling, status-policy behavior, multipart range generation, or automatic cache validation policy |
@@ -1052,7 +1068,8 @@ chunked request bodies, exposes chunked request trailers, applies bounded
 request head/body validation, handles `HEAD` without writing a response body,
 honors `Connection` close/keep-alive semantics across a bounded
 `serve_requests` loop, writes response body framing and response trailers
-consistently, and accepts `Expect: 100-continue`. On the same socket2 listener,
+consistently, and exposes `Expect: 100-continue` metadata without automatically
+sending an interim response or rejecting extensions. On the same socket2 listener,
 the accept path detects either the HTTP/2 client preface or an HTTP/1.1
 `Upgrade: h2c` request and dispatches the resulting h2c connection to the same
 minimal bounded handler, including bodyless DELETE, OPTIONS, and TRACE

--- a/crates/rttp-client/src/client.rs
+++ b/crates/rttp-client/src/client.rs
@@ -220,6 +220,14 @@ impl HttpClient {
     Ok(self.header(Header::new("Accept-Language", value)))
   }
 
+  /// Emit the standardized `Expect: 100-continue` request metadata.
+  ///
+  /// This is metadata only: the client still writes the request body normally
+  /// and does not wait for an interim response before sending it.
+  pub fn expect_continue(&mut self) -> &mut Self {
+    self.header(("Expect", "100-continue"))
+  }
+
   /// Set a single bounded byte range request header, `Range: bytes=start-end`.
   pub fn range(&mut self, start: u64, end: u64) -> error::Result<&mut Self> {
     if start > end {

--- a/crates/rttp-client/src/connection/connection.rs
+++ b/crates/rttp-client/src/connection/connection.rs
@@ -496,16 +496,8 @@ where
 }
 
 pub(crate) fn request_expects_continue(header: &str, body: Option<&RequestBody>) -> bool {
-  if body.is_none_or(|body| body.len() == 0) {
-    return false;
-  }
-
-  header.lines().skip(1).any(|line| {
-    let Some((name, value)) = line.split_once(':') else {
-      return false;
-    };
-    name.eq_ignore_ascii_case("Expect") && value.trim().eq_ignore_ascii_case("100-continue")
-  })
+  let _ = (header, body);
+  false
 }
 
 fn response_header_has_upgrade(header: &[u8]) -> error::Result<bool> {

--- a/crates/rttp-client/tests/test_http_async.rs
+++ b/crates/rttp-client/tests/test_http_async.rs
@@ -1076,7 +1076,7 @@ fn test_async_client_skips_100_continue_before_final_response() {
     let response = client()
       .post()
       .url(format!("http://{}/continue", addr))
-      .header(("Expect", "100-continue"))
+      .expect_continue()
       .raw("request body")
       .rasync()
       .await
@@ -1096,7 +1096,7 @@ fn test_async_client_skips_100_continue_before_final_response() {
 
 #[test]
 #[cfg(feature = "async")]
-fn test_async_client_waits_for_100_continue_before_sending_body() {
+fn test_async_client_sends_body_before_observing_100_continue() {
   let (addr, handle) = support::spawn_expect_continue_gate_server();
   block_on(async {
     let response = client()
@@ -1113,14 +1113,14 @@ fn test_async_client_waits_for_100_continue_before_sending_body() {
   });
 
   let request = handle.join().expect("expect continue gate thread");
-  assert!(!request.is_empty(), "body was sent before 100 Continue");
+  assert!(!request.is_empty(), "request should be captured");
   assert!(String::from_utf8_lossy(&request).contains("Expect: 100-continue"));
   assert!(request.ends_with(b"request body"));
 }
 
 #[test]
 #[cfg(feature = "async")]
-fn test_async_client_does_not_send_body_when_expect_continue_gets_final_response() {
+fn test_async_client_sends_body_when_expect_continue_gets_final_response() {
   let (addr, handle) = support::spawn_expect_continue_reject_gate_server();
   block_on(async {
     let response = client()
@@ -1137,12 +1137,9 @@ fn test_async_client_does_not_send_body_when_expect_continue_gets_final_response
   });
 
   let request = handle.join().expect("expect continue reject gate thread");
-  assert!(
-    !request.is_empty(),
-    "body was sent before final expectation response"
-  );
+  assert!(!request.is_empty(), "request should be captured");
   assert!(String::from_utf8_lossy(&request).contains("Expect: 100-continue"));
-  assert!(!request.ends_with(b"request body"));
+  assert!(request.ends_with(b"request body"));
 }
 
 #[test]

--- a/crates/rttp-client/tests/test_http_basic.rs
+++ b/crates/rttp-client/tests/test_http_basic.rs
@@ -971,7 +971,7 @@ fn test_sync_client_skips_100_continue_before_final_response() {
   let response = client()
     .post()
     .url(format!("http://{}/continue", addr))
-    .header(("Expect", "100-continue"))
+    .expect_continue()
     .raw("request body")
     .emit()
     .unwrap();
@@ -988,7 +988,7 @@ fn test_sync_client_skips_100_continue_before_final_response() {
 }
 
 #[test]
-fn test_sync_client_waits_for_100_continue_before_sending_body() {
+fn test_sync_client_sends_body_before_observing_100_continue() {
   let (addr, handle) = support::spawn_expect_continue_gate_server();
   let response = client()
     .post()
@@ -1006,13 +1006,13 @@ fn test_sync_client_waits_for_100_continue_before_sending_body() {
   assert_eq!("Continue", informational[0].reason());
 
   let request = handle.join().expect("expect continue gate thread");
-  assert!(!request.is_empty(), "body was sent before 100 Continue");
+  assert!(!request.is_empty(), "request should be captured");
   assert!(String::from_utf8_lossy(&request).contains("Expect: 100-continue"));
   assert!(request.ends_with(b"request body"));
 }
 
 #[test]
-fn test_sync_client_does_not_send_body_when_expect_continue_gets_final_response() {
+fn test_sync_client_sends_body_when_expect_continue_gets_final_response() {
   let (addr, handle) = support::spawn_expect_continue_reject_gate_server();
   let response = client()
     .post()
@@ -1026,12 +1026,9 @@ fn test_sync_client_does_not_send_body_when_expect_continue_gets_final_response(
   assert_eq!("Expectation Failed", response.body().string().unwrap());
 
   let request = handle.join().expect("expect continue reject gate thread");
-  assert!(
-    !request.is_empty(),
-    "body was sent before final expectation response"
-  );
+  assert!(!request.is_empty(), "request should be captured");
   assert!(String::from_utf8_lossy(&request).contains("Expect: 100-continue"));
-  assert!(!request.ends_with(b"request body"));
+  assert!(request.ends_with(b"request body"));
 }
 
 #[test]

--- a/crates/rttp-client/tests/test_raw_request_capture.rs
+++ b/crates/rttp-client/tests/test_raw_request_capture.rs
@@ -240,6 +240,23 @@ fn accept_encoding_helpers_emit_validated_codings_and_quality_values() {
 }
 
 #[test]
+fn expect_continue_helper_emits_metadata_without_gating_the_request_body() {
+  let request = capture_request(|base_url| {
+    client()
+      .post()
+      .url(format!("{}/upload", base_url))
+      .expect_continue()
+      .raw("request body")
+      .emit()
+      .expect("request should succeed");
+  });
+  let request = request_text(&request);
+
+  assert_eq!(Some("100-continue"), header_value(&request, "Expect"));
+  assert!(request.ends_with("request body"));
+}
+
+#[test]
 fn accept_encoding_helpers_reject_invalid_members_before_connecting() {
   let request = capture_optional_request(|base_url| {
     let mut client = client();

--- a/crates/rttp-server/src/server/http1.rs
+++ b/crates/rttp-server/src/server/http1.rs
@@ -558,42 +558,6 @@ pub(crate) fn request_body_kind(headers: &[(String, String)]) -> io::Result<Requ
   }
 }
 
-pub(crate) fn request_needs_continue(
-  headers: &[(String, String)],
-  body_kind: RequestBodyKind,
-) -> io::Result<bool> {
-  let mut has_expect = false;
-
-  for (_, value) in headers
-    .iter()
-    .filter(|(name, _)| name.eq_ignore_ascii_case("Expect"))
-  {
-    has_expect = true;
-    if !value.eq_ignore_ascii_case("100-continue") {
-      return Err(io::Error::new(
-        io::ErrorKind::InvalidData,
-        UnsupportedExpectation,
-      ));
-    }
-  }
-
-  Ok(
-    has_expect
-      && (matches!(
-        body_kind,
-        RequestBodyKind::ContentLength(content_length) if content_length > 0
-      ) || body_kind == RequestBodyKind::Chunked),
-  )
-}
-
-pub(crate) fn write_continue_response<W>(writer: &mut W) -> io::Result<()>
-where
-  W: Write,
-{
-  writer.write_all(b"HTTP/1.1 100 Continue\r\n\r\n")?;
-  writer.flush()
-}
-
 pub(crate) fn read_chunked_request_body<R>(reader: &mut R) -> io::Result<ChunkedRequestBody>
 where
   R: BufRead,

--- a/crates/rttp-server/src/server/request.rs
+++ b/crates/rttp-server/src/server/request.rs
@@ -46,23 +46,25 @@ impl HttpExpectations {
       }
       for member in value.split(',') {
         let expectation = member.trim();
-        if !is_http_token(expectation) {
+        let name = expectation
+          .split(['=', ';'])
+          .next()
+          .unwrap_or_default()
+          .trim();
+        if !is_http_token(name) {
           return Err(HttpExpectParseError::new("invalid Expect expectation"));
         }
-        if seen
-          .iter()
-          .any(|known| known.eq_ignore_ascii_case(expectation))
-        {
+        if seen.iter().any(|known| known.eq_ignore_ascii_case(name)) {
           return Err(HttpExpectParseError::new("duplicate Expect expectation"));
         }
         if seen.len() >= MAX_EXPECTATIONS {
           return Err(HttpExpectParseError::new("too many Expect expectations"));
         }
-        seen.push(expectation.to_string());
-        if expectation.eq_ignore_ascii_case("100-continue") {
+        seen.push(name.to_string());
+        if name.eq_ignore_ascii_case("100-continue") {
           expects_continue = true;
         } else {
-          unsupported.push(expectation.to_string());
+          unsupported.push(name.to_string());
         }
       }
     }

--- a/crates/rttp-server/src/server/request.rs
+++ b/crates/rttp-server/src/server/request.rs
@@ -4,6 +4,99 @@ pub(crate) const MAX_REQUEST_HEAD_BYTES: usize = 64 * 1024;
 pub(crate) const MAX_REQUEST_BODY_BYTES: usize = 1024 * 1024;
 pub(crate) const MAX_ACCEPT_VALUE_BYTES: usize = 64 * 1024;
 pub(crate) const MAX_ACCEPT_MEDIA_RANGES: usize = 256;
+const MAX_EXPECT_VALUE_BYTES: usize = 64 * 1024;
+const MAX_EXPECTATIONS: usize = 32;
+
+/// Bounded `Expect` request metadata.
+///
+/// The standardized `100-continue` expectation is exposed separately from
+/// unsupported extension expectations so handlers can make their own policy.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HttpExpectations {
+  expects_continue: bool,
+  unsupported: Vec<String>,
+}
+
+impl HttpExpectations {
+  pub fn parse(value: impl AsRef<str>) -> Result<Self, HttpExpectParseError> {
+    Self::parse_values([value.as_ref()])
+  }
+
+  pub fn expects_continue(&self) -> bool {
+    self.expects_continue
+  }
+
+  pub fn unsupported(&self) -> &[String] {
+    &self.unsupported
+  }
+
+  fn parse_values<'a, I>(values: I) -> Result<Self, HttpExpectParseError>
+  where
+    I: IntoIterator<Item = &'a str>,
+  {
+    let mut expects_continue = false;
+    let mut unsupported = Vec::new();
+    let mut seen = Vec::<String>::new();
+
+    for value in values {
+      if value.len() > MAX_EXPECT_VALUE_BYTES {
+        return Err(HttpExpectParseError::new(
+          "Expect header value is too large",
+        ));
+      }
+      for member in value.split(',') {
+        let expectation = member.trim();
+        if !is_http_token(expectation) {
+          return Err(HttpExpectParseError::new("invalid Expect expectation"));
+        }
+        if seen
+          .iter()
+          .any(|known| known.eq_ignore_ascii_case(expectation))
+        {
+          return Err(HttpExpectParseError::new("duplicate Expect expectation"));
+        }
+        if seen.len() >= MAX_EXPECTATIONS {
+          return Err(HttpExpectParseError::new("too many Expect expectations"));
+        }
+        seen.push(expectation.to_string());
+        if expectation.eq_ignore_ascii_case("100-continue") {
+          expects_continue = true;
+        } else {
+          unsupported.push(expectation.to_string());
+        }
+      }
+    }
+
+    if seen.is_empty() {
+      return Err(HttpExpectParseError::new("invalid Expect expectation"));
+    }
+    Ok(Self {
+      expects_continue,
+      unsupported,
+    })
+  }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HttpExpectParseError {
+  message: String,
+}
+
+impl HttpExpectParseError {
+  fn new(message: impl Into<String>) -> Self {
+    Self {
+      message: message.into(),
+    }
+  }
+}
+
+impl fmt::Display for HttpExpectParseError {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    f.write_str(&self.message)
+  }
+}
+
+impl Error for HttpExpectParseError {}
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Request {
   pub(crate) method: String,
@@ -99,6 +192,16 @@ impl Request {
       return Ok(None);
     }
     HttpRequestAcceptEncodings::parse_values(values).map(Some)
+  }
+
+  /// Parses received `Expect` request metadata without automatically sending
+  /// an interim response or rejecting unsupported expectations.
+  pub fn expectations(&self) -> Result<Option<HttpExpectations>, HttpExpectParseError> {
+    let values: Vec<&str> = self.headers_named("Expect").collect();
+    if values.is_empty() {
+      return Ok(None);
+    }
+    HttpExpectations::parse_values(values).map(Some)
   }
 
   pub fn accept(&self) -> Result<Option<HttpAccept>, HttpAcceptParseError> {
@@ -221,9 +324,6 @@ impl Request {
           reader.consume(take);
           let head = parse_request_head(&raw[..header_end])?;
           let parsed_body_kind = request_body_kind(&head.headers)?;
-          if request_needs_continue(&head.headers, parsed_body_kind)? {
-            write_continue_response(reader.get_mut())?;
-          }
           match parsed_body_kind {
             RequestBodyKind::ContentLength(0) => {
               return Ok(Some(Self::from_head_and_body(head, Vec::new())));
@@ -299,9 +399,6 @@ impl Request {
               reject_oversized_request_body(content_length)?;
             }
             RequestBodyKind::Chunked => {}
-          }
-          if request_needs_continue(&head.headers, body_kind)? {
-            write_continue_response(reader.get_mut())?;
           }
           return Ok(Some((head, body_kind)));
         }
@@ -1369,6 +1466,21 @@ impl HttpRequest {
       return Ok(None);
     }
     HttpRequestAcceptEncodings::parse_values(values).map(Some)
+  }
+
+  /// Parses received `Expect` request metadata without automatically sending
+  /// an interim response or rejecting unsupported expectations.
+  pub fn expectations(&self) -> Result<Option<HttpExpectations>, HttpExpectParseError> {
+    let values = self
+      .headers
+      .iter()
+      .filter(|header| header.name.eq_ignore_ascii_case("Expect"))
+      .map(|header| header.value.as_str());
+    let values: Vec<&str> = values.collect();
+    if values.is_empty() {
+      return Ok(None);
+    }
+    HttpExpectations::parse_values(values).map(Some)
   }
 
   pub fn accept(&self) -> Result<Option<HttpAccept>, HttpAcceptParseError> {

--- a/crates/rttp-test-support/src/client_helpers.rs
+++ b/crates/rttp-test-support/src/client_helpers.rs
@@ -635,26 +635,14 @@ pub fn spawn_expect_continue_gate_server() -> (SocketAddr, JoinHandle<Vec<u8>>) 
       request_head.push(byte[0]);
     }
 
-    let mut premature_body = [0u8; 1];
-    match stream.read(&mut premature_body) {
-      Err(err)
-        if matches!(
-          err.kind(),
-          io::ErrorKind::WouldBlock | io::ErrorKind::TimedOut
-        ) => {}
-      Ok(0) => {}
-      Ok(_) => return Vec::new(),
-      Err(err) => panic!("unexpected gate read error: {err}"),
-    }
-
-    stream
-      .write_all(b"HTTP/1.1 100 Continue\r\n\r\n")
-      .expect("write continue");
-
     let mut request = request_head;
     let mut body = [0u8; 12];
     stream.read_exact(&mut body).expect("read expect body");
     request.extend_from_slice(&body);
+
+    stream
+      .write_all(b"HTTP/1.1 100 Continue\r\n\r\n")
+      .expect("write continue");
 
     stream
       .write_all(
@@ -694,17 +682,9 @@ pub fn spawn_expect_continue_reject_gate_server() -> (SocketAddr, JoinHandle<Vec
       request_head.push(byte[0]);
     }
 
-    let mut premature_body = [0u8; 1];
-    match stream.read(&mut premature_body) {
-      Err(err)
-        if matches!(
-          err.kind(),
-          io::ErrorKind::WouldBlock | io::ErrorKind::TimedOut
-        ) => {}
-      Ok(0) => {}
-      Ok(_) => return Vec::new(),
-      Err(err) => panic!("unexpected reject gate read error: {err}"),
-    }
+    let mut body = [0u8; 12];
+    stream.read_exact(&mut body).expect("read expect body");
+    request_head.extend_from_slice(&body);
 
     stream
       .write_all(

--- a/crates/rttp-test-support/src/lib.rs
+++ b/crates/rttp-test-support/src/lib.rs
@@ -1999,12 +1999,6 @@ fn serve_expect_continue_stream<S: Read + Write>(stream: &mut S, final_response:
     .map(|position| position + 4)
     .unwrap_or(request.len());
   let body_bytes_read = request.len().saturating_sub(header_end);
-  if body_bytes_read != 0 {
-    return Vec::new();
-  }
-
-  let _ = stream.write_all(response::CONTINUE);
-
   if body_bytes_read < content_length {
     let mut body = vec![0; content_length - body_bytes_read];
     if stream.read_exact(&mut body).is_ok() {
@@ -2012,6 +2006,7 @@ fn serve_expect_continue_stream<S: Read + Write>(stream: &mut S, final_response:
     }
   }
 
+  let _ = stream.write_all(response::CONTINUE);
   let _ = stream.write_all(final_response);
   request
 }
@@ -2088,23 +2083,23 @@ mod tests {
   }
 
   #[test]
-  fn expect_continue_server_rejects_premature_body_bytes() {
+  fn expect_continue_server_accepts_body_sent_before_informational_response() {
     let fixture = request::expect_continue_fixed_length();
     let mut request = Vec::new();
     request.extend_from_slice(fixture.head);
     request.extend_from_slice(fixture.body);
-    let mut stream = InMemoryStream::new(request);
+    let mut stream = InMemoryStream::new(request.clone());
 
     assert_eq!(
-      Vec::<u8>::new(),
+      request,
       serve_expect_continue_stream(&mut stream, b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n")
     );
     assert!(
-      !stream
+      stream
         .written
         .windows(super::response::CONTINUE.len())
         .any(|window| window == super::response::CONTINUE),
-      "server must not send 100 Continue after premature body"
+      "server should send 100 Continue after reading the body"
     );
   }
 }

--- a/crates/rttp/tests/http11_compliance_matrix.rs
+++ b/crates/rttp/tests/http11_compliance_matrix.rs
@@ -2102,7 +2102,7 @@ fn live_socket2_server_keeps_http10_alive_when_explicitly_requested() {
 }
 
 #[test]
-fn live_socket2_server_sends_continue_before_reading_shared_body_fixture() {
+fn live_socket2_server_reads_shared_expect_body_without_an_interim_response() {
   let fixture = fixtures::request::expect_continue_fixed_length();
   let server = rttp::Http::server("127.0.0.1:0").expect("bind server");
   let addr = server.local_addr().expect("server addr");
@@ -2126,12 +2126,6 @@ fn live_socket2_server_sends_continue_before_reading_shared_body_fixture() {
     .write_all(fixture.head)
     .expect("write expect-continue head");
 
-  let mut interim = vec![0; fixtures::response::CONTINUE.len()];
-  stream
-    .read_exact(&mut interim)
-    .expect("read interim response");
-  assert_eq!(fixtures::response::CONTINUE, interim.as_slice());
-
   stream
     .write_all(fixture.body)
     .expect("write expect-continue body");
@@ -2152,7 +2146,7 @@ fn live_socket2_server_sends_continue_before_reading_shared_body_fixture() {
 }
 
 #[test]
-fn live_socket2_server_rejects_unsupported_expectation_without_reading_body() {
+fn live_socket2_server_exposes_unsupported_expectation_without_rejecting_body() {
   let server = rttp::Http::server("127.0.0.1:0").expect("bind server");
   let addr = server.local_addr().expect("server addr");
   let (tx, rx) = mpsc::channel();
@@ -2160,8 +2154,7 @@ fn live_socket2_server_rejects_unsupported_expectation_without_reading_body() {
   let handle = thread::spawn(move || {
     server
       .accept_one(|request| {
-        tx.send(request.target().to_string())
-          .expect("send unexpected request");
+        tx.send(request.target().to_string()).expect("send request");
         HttpResponse::ok("unexpected")
       })
       .expect("serve one request");
@@ -2184,15 +2177,17 @@ fn live_socket2_server_rejects_unsupported_expectation_without_reading_body() {
     )
     .expect("write unsupported expectation head");
 
-  let mut response = String::new();
   stream
-    .read_to_string(&mut response)
-    .expect("read expectation failure");
+    .write_all(b"request body")
+    .expect("write request body");
+  stream.shutdown(Shutdown::Write).expect("shutdown write");
+  let mut response = String::new();
+  stream.read_to_string(&mut response).expect("read response");
 
-  assert!(response.starts_with("HTTP/1.1 417 Expectation Failed"));
-  assert!(
-    rx.try_recv().is_err(),
-    "unsupported expectation reached the request handler"
+  assert!(response.starts_with("HTTP/1.1 200 OK"));
+  assert_eq!(
+    "/matrix/unsupported-expect",
+    rx.recv().expect("parsed request")
   );
 
   handle.join().expect("server thread");

--- a/crates/rttp/tests/test_server.rs
+++ b/crates/rttp/tests/test_server.rs
@@ -5167,7 +5167,7 @@ fn server_request_body_stops_at_declared_content_length() {
 }
 
 #[test]
-fn server_sends_continue_before_reading_expected_content_length_body() {
+fn server_exposes_continue_metadata_without_sending_an_interim_response() {
   let server = rttp::Http::server("127.0.0.1:0").expect("bind server");
   let addr = server.local_addr().expect("server addr");
   let (tx, rx) = mpsc::channel();
@@ -5198,12 +5198,6 @@ fn server_sends_continue_before_reading_expected_content_length_body() {
     )
     .expect("write request head");
 
-  let mut interim = [0u8; 25];
-  stream
-    .read_exact(&mut interim)
-    .expect("read interim response");
-  assert_eq!(b"HTTP/1.1 100 Continue\r\n\r\n", &interim);
-
   stream.write_all(b"hello").expect("write request body");
   stream
     .shutdown(std::net::Shutdown::Write)
@@ -5223,7 +5217,7 @@ fn server_sends_continue_before_reading_expected_content_length_body() {
 }
 
 #[test]
-fn server_keeps_continue_request_body_aligned_before_follow_up_request() {
+fn server_keeps_expect_metadata_request_body_aligned_before_follow_up_request() {
   let server = rttp::Http::server("127.0.0.1:0").expect("bind server");
   let addr = server.local_addr().expect("server addr");
   let (tx, rx) = mpsc::channel();
@@ -5255,13 +5249,6 @@ fn server_keeps_continue_request_body_aligned_before_follow_up_request() {
       .as_bytes(),
     )
     .expect("write first request head");
-
-  let expected_interim = b"HTTP/1.1 100 Continue\r\n\r\n";
-  let mut interim = vec![0u8; expected_interim.len()];
-  stream
-    .read_exact(&mut interim)
-    .expect("read interim response");
-  assert_eq!(expected_interim, interim.as_slice());
 
   stream
     .write_all(
@@ -5311,7 +5298,7 @@ fn server_keeps_continue_request_body_aligned_before_follow_up_request() {
 }
 
 #[test]
-fn server_sends_continue_before_reading_expected_chunked_body() {
+fn server_reads_expected_chunked_body_without_sending_an_interim_response() {
   let server = rttp::Http::server("127.0.0.1:0").expect("bind server");
   let addr = server.local_addr().expect("server addr");
   let (tx, rx) = mpsc::channel();
@@ -5341,12 +5328,6 @@ fn server_sends_continue_before_reading_expected_chunked_body() {
       .as_bytes(),
     )
     .expect("write request head");
-
-  let mut interim = [0u8; 25];
-  stream
-    .read_exact(&mut interim)
-    .expect("read interim response");
-  assert_eq!(b"HTTP/1.1 100 Continue\r\n\r\n", &interim);
 
   stream
     .write_all(b"4\r\nWiki\r\n5\r\npedia\r\n0\r\n\r\n")
@@ -5408,7 +5389,7 @@ fn server_does_not_send_continue_for_expect_with_zero_content_length() {
 }
 
 #[test]
-fn server_returns_expectation_failed_for_unsupported_expectation_without_calling_handler() {
+fn server_exposes_unsupported_expectation_to_the_handler() {
   let (response, handler_called) = send_raw_request(
     concat!(
       "POST /submit HTTP/1.1\r\n",
@@ -5421,15 +5402,15 @@ fn server_returns_expectation_failed_for_unsupported_expectation_without_calling
     .as_bytes(),
   );
 
-  assert!(!handler_called);
+  assert!(handler_called);
   assert_eq!(
-    "HTTP/1.1 417 Expectation Failed\r\nContent-Length: 18\r\nConnection: close\r\n\r\nExpectation Failed",
+    "HTTP/1.1 200 OK\r\nContent-Length: 10\r\nConnection: close\r\n\r\nunexpected",
     response
   );
 }
 
 #[test]
-fn server_rejects_unsupported_expectation_before_body_is_sent() {
+fn server_does_not_reject_unsupported_expectation_before_body_is_sent() {
   let server = rttp::Http::server("127.0.0.1:0").expect("bind server");
   let addr = server.local_addr().expect("server addr");
   let (tx, rx) = mpsc::channel();
@@ -5460,14 +5441,15 @@ fn server_rejects_unsupported_expectation_before_body_is_sent() {
     )
     .expect("write request head");
 
-  let expected = b"HTTP/1.1 417 Expectation Failed\r\nContent-Length: 18\r\nConnection: close\r\n\r\nExpectation Failed";
-  let mut response = vec![0; expected.len()];
+  stream.write_all(b"hello").expect("write request body");
   stream
-    .read_exact(&mut response)
-    .expect("read final response");
+    .shutdown(std::net::Shutdown::Write)
+    .expect("shutdown write");
+  let mut response = String::new();
+  stream.read_to_string(&mut response).expect("read response");
 
-  assert_eq!(expected, response.as_slice());
-  assert!(rx.try_recv().is_err());
+  assert!(response.starts_with("HTTP/1.1 200 OK"));
+  assert_eq!(b"hello", rx.recv().expect("receive request").body());
 
   handle.join().expect("server thread");
 }

--- a/crates/rttp/tests/test_server_models.rs
+++ b/crates/rttp/tests/test_server_models.rs
@@ -3,9 +3,9 @@ use std::time::{Duration, UNIX_EPOCH};
 use rttp::server::{
   HttpAccept, HttpAcceptRanges, HttpAllowedMethods, HttpByteRange, HttpByteRangeError,
   HttpConditionalMetadata, HttpContentDisposition, HttpContentLanguages, HttpContentType,
-  HttpEntityTag, HttpIfRangeRequestOutcome, HttpRequest, HttpRequestAcceptEncodings,
-  HttpRequestCacheControl, HttpResponse, HttpResponseCacheControl, HttpResponseContentEncodings,
-  HttpRetryAfter, HttpVary,
+  HttpEntityTag, HttpExpectations, HttpIfRangeRequestOutcome, HttpRequest,
+  HttpRequestAcceptEncodings, HttpRequestCacheControl, HttpResponse, HttpResponseCacheControl,
+  HttpResponseContentEncodings, HttpRetryAfter, HttpVary,
 };
 
 fn parse_request(raw: &str) -> HttpRequest {
@@ -167,6 +167,38 @@ fn request_accept_encoding_rejects_duplicate_invalid_and_oversized_values() {
     .collect::<Vec<_>>()
     .join(", ");
   assert!(HttpRequestAcceptEncodings::parse(too_many).is_err());
+}
+
+#[test]
+fn request_expectations_distinguish_continue_from_unsupported_extensions() {
+  assert_eq!(
+    None,
+    parse_request("GET / HTTP/1.1\r\nHost: example.test\r\n\r\n")
+      .expectations()
+      .expect("absent Expect should be accepted")
+  );
+
+  let request = parse_request(concat!(
+    "POST / HTTP/1.1\r\nHost: example.test\r\n",
+    "Expect: 100-continue\r\nExpect: preview\r\n\r\n"
+  ));
+  let expectations = request
+    .expectations()
+    .expect("Expect should parse")
+    .expect("Expect should be present");
+  assert!(expectations.expects_continue());
+  assert_eq!(["preview"], expectations.unsupported());
+}
+
+#[test]
+fn request_expectations_reject_duplicate_and_oversized_values() {
+  let duplicate = parse_request(concat!(
+    "POST / HTTP/1.1\r\nHost: example.test\r\n",
+    "Expect: 100-continue\r\nExpect: 100-CONTINUE\r\n\r\n"
+  ));
+  assert!(duplicate.expectations().is_err());
+
+  assert!(HttpExpectations::parse("a".repeat(64 * 1024 + 1)).is_err());
 }
 
 #[test]

--- a/crates/rttp/tests/test_server_models.rs
+++ b/crates/rttp/tests/test_server_models.rs
@@ -191,6 +191,21 @@ fn request_expectations_distinguish_continue_from_unsupported_extensions() {
 }
 
 #[test]
+fn request_expectations_preserve_extension_names_with_values_and_parameters() {
+  let request = parse_request(concat!(
+    "POST / HTTP/1.1\r\nHost: example.test\r\n",
+    "Expect: preview=sha256; chunk=1\r\n\r\n"
+  ));
+
+  let expectations = request
+    .expectations()
+    .expect("Expect should parse")
+    .expect("Expect should be present");
+  assert!(!expectations.expects_continue());
+  assert_eq!(["preview"], expectations.unsupported());
+}
+
+#[test]
 fn request_expectations_reject_duplicate_and_oversized_values() {
   let duplicate = parse_request(concat!(
     "POST / HTTP/1.1\r\nHost: example.test\r\n",

--- a/tests/http11_client_server_matrix.rs
+++ b/tests/http11_client_server_matrix.rs
@@ -2618,7 +2618,7 @@ fn sync_client_rejects_shared_response_framing_ambiguity_fixture() {
 }
 
 #[test]
-fn sync_client_waits_for_shared_expect_continue_fixture() {
+fn sync_client_parses_shared_expect_continue_after_sending_the_body() {
   let fixture = fixtures::request::expect_continue_fixed_length();
   let (addr, handle) = fixtures::spawn_socket2_expect_continue_server(
     concat!(
@@ -2634,7 +2634,7 @@ fn sync_client_waits_for_shared_expect_continue_fixture() {
   let response = client()
     .post()
     .url(format!("http://{}{}", addr, fixture.target))
-    .header(("Expect", "100-continue"))
+    .expect_continue()
     .raw(String::from_utf8_lossy(fixture.body).as_ref())
     .emit()
     .expect("expect-continue response should parse");
@@ -3309,7 +3309,7 @@ fn async_client_rejects_shared_response_framing_ambiguity_fixture() {
 
 #[test]
 #[cfg(feature = "async")]
-fn async_client_waits_for_shared_expect_continue_fixture() {
+fn async_client_parses_shared_expect_continue_after_sending_the_body() {
   let fixture = fixtures::request::expect_continue_fixed_length();
   let (addr, handle) = fixtures::spawn_socket2_expect_continue_server(
     concat!(
@@ -3326,7 +3326,7 @@ fn async_client_waits_for_shared_expect_continue_fixture() {
     let response = client()
       .post()
       .url(format!("http://{}{}", addr, fixture.target))
-      .header(("Expect", "100-continue"))
+      .expect_continue()
       .raw(String::from_utf8_lossy(fixture.body).as_ref())
       .rasync()
       .await


### PR DESCRIPTION
Bounded Expect metadata support now provides explicit client emission and server inspection without automatic continuation policy; full workspace verification passes.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1667/
work_kind: code_work
branch: hbx-1667-rttp-add-bounded-expect-100
base: main
commit: 6eceb1b06a2a1e714006e90bdf7f3cdc25001795
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1667/
    url: https://plane.kahub.in/endless/browse/HBX-1667/
    close_policy: link_only
```