### PR TITLE
feat: [rttp] Harden bounded h2c RST_STREAM and GOAWAY observability

### DIFF
--- a/crates/rttp-client/src/http2.rs
+++ b/crates/rttp-client/src/http2.rs
@@ -369,10 +369,16 @@ fn reject_goaway_before_opening_request_stream(
     let frame = read_frame(stream, local_settings)?;
     match (frame.frame_type, frame.stream_id) {
       (FRAME_GOAWAY, _) => {
-        if goaway_last_stream_id(&frame)? < stream_id {
+        let goaway = goaway_metadata(&frame)?;
+        if goaway.last_stream_id < stream_id {
           return Err(error::request(io::Error::new(
             io::ErrorKind::ConnectionAborted,
-            "HTTP/2 connection received GOAWAY before opening request stream; no new streams may be created on this connection",
+            format!(
+              "HTTP/2 connection received GOAWAY before opening request stream; no new streams may be created on this connection (last stream ID {} with error code {} ({}))",
+              goaway.last_stream_id,
+              goaway.error_code,
+              http2_error_code_name(goaway.error_code),
+            ),
           )));
         }
       }
@@ -1098,9 +1104,11 @@ fn read_until_send_window_available(
         reject_push_promise_frame(&frame)?;
       }
       (FRAME_RST_STREAM, id) if id == stream_id => {
+        let error_code = rst_stream_error_code(&frame)?;
         return Err(error::bad_response(format!(
-          "HTTP/2 stream received RST_STREAM error code {}",
-          rst_stream_error_code(&frame)?
+          "HTTP/2 stream received RST_STREAM error code {} ({})",
+          error_code,
+          http2_error_code_name(error_code),
         )));
       }
       (FRAME_RST_STREAM, _) => {
@@ -1113,8 +1121,14 @@ fn read_until_send_window_available(
         return Err(error::bad_response("invalid HTTP/2 PING frame"));
       }
       (FRAME_GOAWAY, _) => {
-        if goaway_last_stream_id(&frame)? < stream_id {
-          return Err(error::bad_response("HTTP/2 connection received GOAWAY"));
+        let goaway = goaway_metadata(&frame)?;
+        if goaway.last_stream_id < stream_id {
+          return Err(error::bad_response(format!(
+            "HTTP/2 connection received GOAWAY last stream ID {} with error code {} ({})",
+            goaway.last_stream_id,
+            goaway.error_code,
+            http2_error_code_name(goaway.error_code),
+          )));
         }
       }
       (FRAME_HEADERS, id) | (FRAME_DATA, id) | (FRAME_CONTINUATION, id) if id == stream_id => {
@@ -1577,9 +1591,11 @@ fn read_single_stream_response_with_first_frame(
         reject_push_promise_frame(&frame)?;
       }
       (FRAME_RST_STREAM, id) if id == stream_id => {
+        let error_code = rst_stream_error_code(&frame)?;
         return Err(error::bad_response(format!(
-          "HTTP/2 stream received RST_STREAM error code {}",
-          rst_stream_error_code(&frame)?
+          "HTTP/2 stream received RST_STREAM error code {} ({})",
+          error_code,
+          http2_error_code_name(error_code),
         )));
       }
       (FRAME_RST_STREAM, _) => {
@@ -1592,8 +1608,14 @@ fn read_single_stream_response_with_first_frame(
         return Err(error::bad_response("invalid HTTP/2 PING frame"));
       }
       (FRAME_GOAWAY, _) => {
-        if goaway_last_stream_id(&frame)? < stream_id {
-          return Err(error::bad_response("HTTP/2 connection received GOAWAY"));
+        let goaway = goaway_metadata(&frame)?;
+        if goaway.last_stream_id < stream_id {
+          return Err(error::bad_response(format!(
+            "HTTP/2 connection received GOAWAY last stream ID {} with error code {} ({})",
+            goaway.last_stream_id,
+            goaway.error_code,
+            http2_error_code_name(goaway.error_code),
+          )));
         }
       }
       (_, id) if id == stream_id => {}
@@ -1763,6 +1785,26 @@ fn rst_stream_error_code(frame: &Frame) -> error::Result<u32> {
   ]))
 }
 
+fn http2_error_code_name(error_code: u32) -> &'static str {
+  match error_code {
+    0 => "NO_ERROR",
+    1 => "PROTOCOL_ERROR",
+    2 => "INTERNAL_ERROR",
+    3 => "FLOW_CONTROL_ERROR",
+    4 => "SETTINGS_TIMEOUT",
+    5 => "STREAM_CLOSED",
+    6 => "FRAME_SIZE_ERROR",
+    7 => "REFUSED_STREAM",
+    8 => "CANCEL",
+    9 => "COMPRESSION_ERROR",
+    10 => "CONNECT_ERROR",
+    11 => "ENHANCE_YOUR_CALM",
+    12 => "INADEQUATE_SECURITY",
+    13 => "HTTP_1_1_REQUIRED",
+    _ => "UNKNOWN",
+  }
+}
+
 fn data_payload(frame: &Frame) -> error::Result<&[u8]> {
   if frame.flags & FLAG_PADDED == 0 {
     return Ok(&frame.payload);
@@ -1842,16 +1884,29 @@ fn is_informational_status(status: u32) -> bool {
   (100..200).contains(&status)
 }
 
-fn goaway_last_stream_id(frame: &Frame) -> error::Result<u32> {
+struct GoawayMetadata {
+  last_stream_id: u32,
+  error_code: u32,
+}
+
+fn goaway_metadata(frame: &Frame) -> error::Result<GoawayMetadata> {
   if frame.stream_id != 0 || frame.payload.len() < 8 {
     return Err(error::bad_response("invalid HTTP/2 GOAWAY frame"));
   }
-  Ok(u32::from_be_bytes([
-    frame.payload[0] & 0x7f,
-    frame.payload[1],
-    frame.payload[2],
-    frame.payload[3],
-  ]))
+  Ok(GoawayMetadata {
+    last_stream_id: u32::from_be_bytes([
+      frame.payload[0] & 0x7f,
+      frame.payload[1],
+      frame.payload[2],
+      frame.payload[3],
+    ]),
+    error_code: u32::from_be_bytes([
+      frame.payload[4],
+      frame.payload[5],
+      frame.payload[6],
+      frame.payload[7],
+    ]),
+  })
 }
 
 fn build_response(

--- a/crates/rttp-client/tests/http2_prior_knowledge.rs
+++ b/crates/rttp-client/tests/http2_prior_knowledge.rs
@@ -3827,19 +3827,64 @@ fn prior_knowledge_get_reports_stream_reset_and_goaway() {
     .emit_http2_prior_knowledge()
     .expect_err("reset stream must fail the response");
   assert!(
-    reset_error.to_string().contains("RST_STREAM error code 8"),
+    reset_error
+      .to_string()
+      .contains("RST_STREAM error code 8 (CANCEL)"),
     "unexpected error: {reset_error}"
   );
   reset_handle.join().expect("reset peer thread");
 
-  let (goaway_addr, goaway_handle) = spawn_control_frame_peer(FRAME_GOAWAY);
+  let (unknown_reset_addr, unknown_reset_handle) =
+    spawn_rst_stream_peer(1, &[0xde, 0xad, 0xbe, 0xef], None);
+  let unknown_reset_error = HttpClient::new()
+    .get()
+    .url(format!("http://{}/unknown-reset", unknown_reset_addr))
+    .emit_http2_prior_knowledge()
+    .expect_err("unknown reset code must fail the response");
+  assert!(
+    unknown_reset_error
+      .to_string()
+      .contains("RST_STREAM error code 3735928559 (UNKNOWN)"),
+    "unexpected error: {unknown_reset_error}"
+  );
+  unknown_reset_handle
+    .join()
+    .expect("unknown reset peer thread");
+
+  let (goaway_addr, goaway_handle) =
+    spawn_goaway_peer(0, &[0x80, 0, 0, 0, 0, 0, 0, 10], Some(b"ignored"));
   let goaway_error = HttpClient::new()
     .get()
     .url(format!("http://{}/goaway", goaway_addr))
     .emit_http2_prior_knowledge()
     .expect_err("goaway must fail the response");
-  assert!(goaway_error.to_string().contains("GOAWAY"));
+  assert!(
+    goaway_error
+      .to_string()
+      .contains("GOAWAY last stream ID 0 with error code 10 (CONNECT_ERROR)"),
+    "unexpected error: {goaway_error}"
+  );
   goaway_handle.join().expect("goaway peer thread");
+
+  let (unknown_goaway_addr, unknown_goaway_handle) = spawn_goaway_peer(
+    0,
+    &[0x80, 0, 0, 0, 0xde, 0xad, 0xbe, 0xef],
+    Some(b"ignored"),
+  );
+  let unknown_goaway_error = HttpClient::new()
+    .get()
+    .url(format!("http://{}/unknown-goaway", unknown_goaway_addr))
+    .emit_http2_prior_knowledge()
+    .expect_err("unknown GOAWAY code must fail the response");
+  assert!(
+    unknown_goaway_error
+      .to_string()
+      .contains("GOAWAY last stream ID 0 with error code 3735928559 (UNKNOWN)"),
+    "unexpected error: {unknown_goaway_error}"
+  );
+  unknown_goaway_handle
+    .join()
+    .expect("unknown GOAWAY peer thread");
 }
 
 #[test]
@@ -5217,23 +5262,6 @@ fn write_raw_frame(
   stream.write_all(&header).expect("write frame header");
   stream.write_all(payload).expect("write frame payload");
   stream.flush().expect("flush frame");
-}
-
-fn spawn_control_frame_peer(frame_type: u8) -> (SocketAddr, thread::JoinHandle<()>) {
-  let listener = TcpListener::bind("127.0.0.1:0").expect("bind h2 peer");
-  let addr = listener.local_addr().expect("h2 peer addr");
-
-  let handle = thread::spawn(move || {
-    let (mut stream, _) = listener.accept().expect("accept h2 client");
-    complete_h2_request_handshake(&mut stream);
-    match frame_type {
-      FRAME_RST_STREAM => write_frame(&mut stream, FRAME_RST_STREAM, 0, 1, &0u32.to_be_bytes()),
-      FRAME_GOAWAY => write_frame(&mut stream, FRAME_GOAWAY, 0, 0, &[0, 0, 0, 0, 0, 0, 0, 0]),
-      _ => unreachable!("unexpected control frame"),
-    }
-  });
-
-  (addr, handle)
 }
 
 fn spawn_rst_stream_peer(


### PR DESCRIPTION
Hardened h2c RST_STREAM and GOAWAY error observability while preserving connection policy, with regression coverage for malformed frames, unknown error codes, and masked last-stream IDs.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1677/
work_kind: code_work
branch: hbx-1677-rttp-harden-bounded-h2c-rst
base: main
commit: 774be4e872a47a3dd6c125eb24a4217c62d9aeca
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1677/
    url: https://plane.kahub.in/endless/browse/HBX-1677/
    close_policy: link_only
```