### PR TITLE
feat: [rttp] Add bounded Forwarded request metadata helpers

### DIFF
--- a/crates/rttp-client/src/client.rs
+++ b/crates/rttp-client/src/client.rs
@@ -7,6 +7,7 @@ use crate::types::{Auth, Header, IntoHeader, IntoPara, Proxy, ToFormData, ToRoUr
 use crate::{error, Config, H2cClientPolicy};
 #[cfg(feature = "async")]
 use futures::io::AsyncRead;
+use rttp_protocol::forwarded::{Forwarded, MAX_FORWARDED_VALUE_BYTES};
 use std::io;
 
 #[derive(Debug)]
@@ -218,6 +219,32 @@ impl HttpClient {
   {
     let value = build_accept_language_value(ranges)?;
     Ok(self.header(Header::new("Accept-Language", value)))
+  }
+
+  /// Append bounded RFC 7239 `Forwarded` request metadata.
+  ///
+  /// This validates and preserves forwarding elements such as `for`, `by`,
+  /// `host`, and `proto`; it does not select a proxy, establish trust, or
+  /// rewrite any address.
+  pub fn forwarded<S: AsRef<str>>(&mut self, value: S) -> error::Result<&mut Self> {
+    let forwarded = Forwarded::parse(value.as_ref())
+      .map_err(|parse_error| error::builder_with_message(parse_error.to_string()))?;
+    let headers = self.request.headers_mut();
+    if let Some(header) = headers
+      .iter_mut()
+      .find(|header| header.name().eq_ignore_ascii_case("Forwarded"))
+    {
+      let combined = Forwarded::parse_values([header.value().as_str(), value.as_ref()])
+        .map_err(|parse_error| error::builder_with_message(parse_error.to_string()))?;
+      let value = bounded_forwarded_header_value(combined)?;
+      header.replace(Header::new("Forwarded", value));
+    } else {
+      headers.push(Header::new(
+        "Forwarded",
+        bounded_forwarded_header_value(forwarded)?,
+      ));
+    }
+    Ok(self)
   }
 
   /// Set a single bounded byte range request header, `Range: bytes=start-end`.
@@ -648,6 +675,16 @@ impl HttpClient {
     self.request.clear_streaming_chunked_body_headers();
     result
   }
+}
+
+fn bounded_forwarded_header_value(forwarded: Forwarded) -> error::Result<String> {
+  let value = forwarded.header_value();
+  if value.len() > MAX_FORWARDED_VALUE_BYTES {
+    return Err(error::builder_with_message(
+      "Forwarded header value is too large",
+    ));
+  }
+  Ok(value)
 }
 
 const MAX_ACCEPT_ENCODING_VALUE_BYTES: usize = 64 * 1024;

--- a/crates/rttp-client/tests/test_raw_request_capture.rs
+++ b/crates/rttp-client/tests/test_raw_request_capture.rs
@@ -382,6 +382,86 @@ fn accept_language_helper_rejects_invalid_values_before_connecting() {
 }
 
 #[test]
+fn forwarded_helper_emits_bounded_forwarding_metadata() {
+  let request = capture_request(|base_url| {
+    client()
+      .get()
+      .url(format!("{}/asset", base_url))
+      .forwarded(r#"for=192.0.2.60;by=203.0.113.43;host=example.test;proto="https""#)
+      .expect("first forwarding element should be accepted")
+      .forwarded(r#"for="[2001:db8:cafe::17]""#)
+      .expect("second forwarding element should be accepted")
+      .emit()
+      .expect("request should succeed");
+  });
+
+  assert_eq!(
+    Some(
+      r#"for=192.0.2.60; by=203.0.113.43; host=example.test; proto=https, for="[2001:db8:cafe::17]""#
+    ),
+    header_value(&request_text(&request), "Forwarded")
+  );
+}
+
+#[test]
+fn forwarded_helper_rejects_duplicate_or_excessive_metadata_before_connecting() {
+  for value in ["for=192.0.2.60;for=198.51.100.17", "for="] {
+    let request = capture_optional_request(|base_url| {
+      let mut client = client();
+      let error = client
+        .get()
+        .url(format!("{}/asset", base_url))
+        .forwarded(value)
+        .expect_err("invalid forwarding metadata should be rejected");
+
+      assert!(error.is_builder());
+    });
+
+    assert!(
+      request.is_empty(),
+      "invalid Forwarded input should not open a socket"
+    );
+  }
+
+  let excessive = (0..257)
+    .map(|index| format!("for=192.0.2.{index}"))
+    .collect::<Vec<_>>()
+    .join(", ");
+  let request = capture_optional_request(|base_url| {
+    let mut client = client();
+    let error = client
+      .get()
+      .url(format!("{}/asset", base_url))
+      .forwarded(excessive.as_str())
+      .expect_err("too many forwarding elements should be rejected");
+
+    assert!(error.is_builder());
+  });
+  assert!(
+    request.is_empty(),
+    "excessive Forwarded input should not open a socket"
+  );
+
+  let first = format!("for={}", "a".repeat(64 * 1024 - 4));
+  let request = capture_optional_request(|base_url| {
+    let mut client = client();
+    let error = client
+      .get()
+      .url(format!("{}/asset", base_url))
+      .forwarded(first.as_str())
+      .expect("a bounded first element should be accepted")
+      .forwarded("for=second")
+      .expect_err("combined Forwarded metadata should remain bounded");
+
+    assert!(error.is_builder());
+  });
+  assert!(
+    request.is_empty(),
+    "oversized Forwarded output should not open a socket"
+  );
+}
+
+#[test]
 fn manual_range_header_remains_available_as_escape_hatch() {
   let request = capture_request(|base_url| {
     client()

--- a/crates/rttp-protocol/src/forwarded.rs
+++ b/crates/rttp-protocol/src/forwarded.rs
@@ -1,0 +1,310 @@
+use std::error::Error;
+use std::fmt;
+
+pub const MAX_FORWARDED_VALUE_BYTES: usize = 64 * 1024;
+pub const MAX_FORWARDED_ELEMENTS: usize = 256;
+pub const MAX_FORWARDED_PARAMETERS: usize = 32;
+
+/// Parsed, bounded RFC 7239 `Forwarded` request metadata.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Forwarded {
+  elements: Vec<ForwardedElement>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ForwardedElement {
+  parameters: Vec<ForwardedParameter>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ForwardedParameter {
+  name: String,
+  value: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ForwardedParseError {
+  message: String,
+}
+
+impl ForwardedParseError {
+  fn new(message: impl Into<String>) -> Self {
+    Self {
+      message: message.into(),
+    }
+  }
+}
+
+impl fmt::Display for ForwardedParseError {
+  fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+    formatter.write_str(&self.message)
+  }
+}
+
+impl Error for ForwardedParseError {}
+
+impl Forwarded {
+  pub fn parse(value: impl AsRef<str>) -> Result<Self, ForwardedParseError> {
+    Self::parse_values([value.as_ref()])
+  }
+
+  pub fn parse_values<'a, I>(values: I) -> Result<Self, ForwardedParseError>
+  where
+    I: IntoIterator<Item = &'a str>,
+  {
+    let mut elements = Vec::new();
+    for value in values {
+      if value.len() > MAX_FORWARDED_VALUE_BYTES {
+        return Err(ForwardedParseError::new(
+          "Forwarded header value is too large",
+        ));
+      }
+      parse_field(value, &mut elements)?;
+    }
+    if elements.is_empty() {
+      return Err(ForwardedParseError::new("invalid Forwarded element"));
+    }
+    Ok(Self { elements })
+  }
+
+  pub fn elements(&self) -> &[ForwardedElement] {
+    &self.elements
+  }
+
+  pub fn len(&self) -> usize {
+    self.elements.len()
+  }
+
+  pub fn is_empty(&self) -> bool {
+    self.elements.is_empty()
+  }
+
+  pub fn header_value(&self) -> String {
+    self
+      .elements
+      .iter()
+      .map(ForwardedElement::header_value)
+      .collect::<Vec<_>>()
+      .join(", ")
+  }
+}
+
+impl ForwardedElement {
+  pub fn parameters(&self) -> &[ForwardedParameter] {
+    &self.parameters
+  }
+
+  pub fn parameter(&self, name: impl AsRef<str>) -> Option<&str> {
+    self
+      .parameters
+      .iter()
+      .find(|parameter| parameter.name.eq_ignore_ascii_case(name.as_ref()))
+      .map(|parameter| parameter.value.as_str())
+  }
+
+  pub fn for_value(&self) -> Option<&str> {
+    self.parameter("for")
+  }
+
+  pub fn by(&self) -> Option<&str> {
+    self.parameter("by")
+  }
+
+  pub fn host(&self) -> Option<&str> {
+    self.parameter("host")
+  }
+
+  pub fn proto(&self) -> Option<&str> {
+    self.parameter("proto")
+  }
+
+  fn header_value(&self) -> String {
+    self
+      .parameters
+      .iter()
+      .map(ForwardedParameter::header_value)
+      .collect::<Vec<_>>()
+      .join("; ")
+  }
+}
+
+impl ForwardedParameter {
+  pub fn name(&self) -> &str {
+    &self.name
+  }
+
+  pub fn value(&self) -> &str {
+    &self.value
+  }
+
+  fn header_value(&self) -> String {
+    if is_token(&self.value) {
+      format!("{}={}", self.name, self.value)
+    } else {
+      format!(
+        "{}=\"{}\"",
+        self.name,
+        self.value.replace('\\', "\\\\").replace('"', "\\\"")
+      )
+    }
+  }
+}
+
+fn parse_field(
+  value: &str,
+  elements: &mut Vec<ForwardedElement>,
+) -> Result<(), ForwardedParseError> {
+  let bytes = value.as_bytes();
+  let mut position = 0;
+  skip_ows(bytes, &mut position);
+  if position == bytes.len() {
+    return Err(ForwardedParseError::new("invalid Forwarded element"));
+  }
+
+  loop {
+    if elements.len() >= MAX_FORWARDED_ELEMENTS {
+      return Err(ForwardedParseError::new("too many Forwarded elements"));
+    }
+    let mut parameters = Vec::new();
+    parse_element(value, &mut position, &mut parameters)?;
+    elements.push(ForwardedElement { parameters });
+    skip_ows(bytes, &mut position);
+    if position == bytes.len() {
+      return Ok(());
+    }
+    if bytes[position] != b',' {
+      return Err(ForwardedParseError::new("invalid Forwarded element"));
+    }
+    position += 1;
+    skip_ows(bytes, &mut position);
+    if position == bytes.len() {
+      return Err(ForwardedParseError::new("invalid Forwarded element"));
+    }
+  }
+}
+
+fn parse_element(
+  value: &str,
+  position: &mut usize,
+  parameters: &mut Vec<ForwardedParameter>,
+) -> Result<(), ForwardedParseError> {
+  loop {
+    let name =
+      parse_token(value, position, "invalid Forwarded parameter name")?.to_ascii_lowercase();
+    skip_ows(value.as_bytes(), position);
+    if value.as_bytes().get(*position) != Some(&b'=') {
+      return Err(ForwardedParseError::new("invalid Forwarded parameter"));
+    }
+    *position += 1;
+    skip_ows(value.as_bytes(), position);
+    let parameter_value = parse_value(value, position)?;
+    if parameters
+      .iter()
+      .any(|known: &ForwardedParameter| known.name.eq_ignore_ascii_case(&name))
+    {
+      return Err(ForwardedParseError::new("duplicate Forwarded parameter"));
+    }
+    if parameters.len() >= MAX_FORWARDED_PARAMETERS {
+      return Err(ForwardedParseError::new("too many Forwarded parameters"));
+    }
+    parameters.push(ForwardedParameter {
+      name,
+      value: parameter_value,
+    });
+    skip_ows(value.as_bytes(), position);
+    match value.as_bytes().get(*position) {
+      Some(b';') => {
+        *position += 1;
+        skip_ows(value.as_bytes(), position);
+        if *position == value.len() {
+          return Err(ForwardedParseError::new("invalid Forwarded parameter"));
+        }
+      }
+      Some(b',') | None => return Ok(()),
+      _ => return Err(ForwardedParseError::new("invalid Forwarded parameter")),
+    }
+  }
+}
+
+fn parse_value(value: &str, position: &mut usize) -> Result<String, ForwardedParseError> {
+  if value.as_bytes().get(*position) != Some(&b'"') {
+    return Ok(parse_token(value, position, "invalid Forwarded parameter value")?.to_string());
+  }
+
+  *position += 1;
+  let mut parsed = String::new();
+  while let Some(&byte) = value.as_bytes().get(*position) {
+    *position += 1;
+    match byte {
+      b'"' => return Ok(parsed),
+      b'\\' => {
+        let Some(&escaped) = value.as_bytes().get(*position) else {
+          return Err(ForwardedParseError::new("invalid Forwarded quoted-string"));
+        };
+        if !(escaped == b'\t' || (0x20..=0x7e).contains(&escaped)) {
+          return Err(ForwardedParseError::new("invalid Forwarded quoted-string"));
+        }
+        *position += 1;
+        parsed.push(escaped as char);
+      }
+      b'\t' | 0x20..=0x7e => parsed.push(byte as char),
+      _ => return Err(ForwardedParseError::new("invalid Forwarded quoted-string")),
+    }
+  }
+  Err(ForwardedParseError::new("invalid Forwarded quoted-string"))
+}
+
+fn parse_token<'a>(
+  value: &'a str,
+  position: &mut usize,
+  message: &str,
+) -> Result<&'a str, ForwardedParseError> {
+  let start = *position;
+  while value
+    .as_bytes()
+    .get(*position)
+    .is_some_and(|byte| is_token_byte(*byte))
+  {
+    *position += 1;
+  }
+  if start == *position {
+    Err(ForwardedParseError::new(message))
+  } else {
+    Ok(&value[start..*position])
+  }
+}
+
+fn skip_ows(bytes: &[u8], position: &mut usize) {
+  while bytes
+    .get(*position)
+    .is_some_and(|byte| matches!(*byte, b' ' | b'\t'))
+  {
+    *position += 1;
+  }
+}
+
+fn is_token(value: &str) -> bool {
+  !value.is_empty() && value.bytes().all(is_token_byte)
+}
+
+fn is_token_byte(byte: u8) -> bool {
+  byte.is_ascii_alphanumeric()
+    || matches!(
+      byte,
+      b'!'
+        | b'#'
+        | b'$'
+        | b'%'
+        | b'&'
+        | b'\''
+        | b'*'
+        | b'+'
+        | b'-'
+        | b'.'
+        | b'^'
+        | b'_'
+        | b'`'
+        | b'|'
+        | b'~'
+    )
+}

--- a/crates/rttp-protocol/src/lib.rs
+++ b/crates/rttp-protocol/src/lib.rs
@@ -3,5 +3,6 @@
 //! This crate is intentionally unpublished. It owns protocol syntax and framing
 //! validation only; client and server application policy remains in its callers.
 
+pub mod forwarded;
 pub mod http1;
 pub mod www_authenticate;

--- a/crates/rttp-server/src/server/request.rs
+++ b/crates/rttp-server/src/server/request.rs
@@ -1,5 +1,10 @@
 use super::*;
 
+pub use rttp_protocol::forwarded::{
+  Forwarded as HttpForwarded, ForwardedElement as HttpForwardedElement,
+  ForwardedParameter as HttpForwardedParameter, ForwardedParseError as HttpForwardedParseError,
+};
+
 pub(crate) const MAX_REQUEST_HEAD_BYTES: usize = 64 * 1024;
 pub(crate) const MAX_REQUEST_BODY_BYTES: usize = 1024 * 1024;
 pub(crate) const MAX_ACCEPT_VALUE_BYTES: usize = 64 * 1024;
@@ -117,6 +122,16 @@ impl Request {
       return Ok(None);
     }
     HttpAcceptLanguages::parse_values(values).map(Some)
+  }
+
+  /// Parses bounded RFC 7239 `Forwarded` request metadata without applying a
+  /// proxy trust policy or rewriting request addresses.
+  pub fn forwarded(&self) -> Result<Option<HttpForwarded>, HttpForwardedParseError> {
+    let values: Vec<&str> = self.headers_named("Forwarded").collect();
+    if values.is_empty() {
+      return Ok(None);
+    }
+    HttpForwarded::parse_values(values).map(Some)
   }
 
   pub fn vary_selection(&self, vary: &HttpVary) -> HttpVarySelection {
@@ -1394,6 +1409,21 @@ impl HttpRequest {
       .filter(|header| header.name.eq_ignore_ascii_case("Accept-Language"))
       .map(|header| header.value.as_str());
     HttpAcceptLanguages::parse_optional_values(values)
+  }
+
+  /// Parses bounded RFC 7239 `Forwarded` request metadata without applying a
+  /// proxy trust policy or rewriting request addresses.
+  pub fn forwarded(&self) -> Result<Option<HttpForwarded>, HttpForwardedParseError> {
+    let values: Vec<&str> = self
+      .headers
+      .iter()
+      .filter(|header| header.name.eq_ignore_ascii_case("Forwarded"))
+      .map(|header| header.value.as_str())
+      .collect();
+    if values.is_empty() {
+      return Ok(None);
+    }
+    HttpForwarded::parse_values(values).map(Some)
   }
 
   pub fn vary_selection(&self, vary: &HttpVary) -> HttpVarySelection {

--- a/crates/rttp/tests/test_server_models.rs
+++ b/crates/rttp/tests/test_server_models.rs
@@ -39,6 +39,57 @@ fn parse_request(raw: &str) -> HttpRequest {
 }
 
 #[test]
+fn request_forwarded_parses_standard_parameters_and_multiple_entries() {
+  let request = parse_request(concat!(
+    "GET /asset HTTP/1.1\r\n",
+    "Host: internal.test\r\n",
+    "Forwarded: for=192.0.2.60;by=203.0.113.43;host=example.test;proto=\"https\"\r\n",
+    "Forwarded: for=\"[2001:db8:cafe::17]\"\r\n",
+    "\r\n"
+  ));
+
+  let forwarded = request
+    .forwarded()
+    .expect("Forwarded should parse")
+    .expect("Forwarded should be present");
+
+  assert_eq!(2, forwarded.len());
+  assert_eq!(Some("192.0.2.60"), forwarded.elements()[0].for_value());
+  assert_eq!(Some("203.0.113.43"), forwarded.elements()[0].by());
+  assert_eq!(Some("example.test"), forwarded.elements()[0].host());
+  assert_eq!(Some("https"), forwarded.elements()[0].proto());
+  assert_eq!(
+    Some("[2001:db8:cafe::17]"),
+    forwarded.elements()[1].for_value()
+  );
+}
+
+#[test]
+fn request_forwarded_rejects_duplicate_and_excessive_metadata() {
+  assert_eq!(
+    None,
+    parse_request("GET / HTTP/1.1\r\nHost: example.test\r\n\r\n")
+      .forwarded()
+      .expect("absent Forwarded should be accepted")
+  );
+
+  let duplicate = parse_request(concat!(
+    "GET / HTTP/1.1\r\nHost: example.test\r\n",
+    "Forwarded: for=192.0.2.60;FOR=198.51.100.17\r\n\r\n"
+  ));
+  assert!(duplicate.forwarded().is_err());
+
+  let excessive = (0..257)
+    .map(|index| format!("for=192.0.2.{index}"))
+    .collect::<Vec<_>>()
+    .join(", ");
+  let request = parse_request(&format!(
+    "GET / HTTP/1.1\r\nHost: example.test\r\nForwarded: {excessive}\r\n\r\n"
+  ));
+  assert!(request.forwarded().is_err());
+}
+
+#[test]
 fn parses_request_accept_media_ranges_in_field_order() {
   let request = parse_request(concat!(
     "GET /resource HTTP/1.1\r\n",


### PR DESCRIPTION
Bounded RFC 7239 Forwarded request metadata helpers now validate client construction and parse server-side forwarding elements with quoted-value, duplicate, and list-size protections.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1678/
work_kind: code_work
branch: hbx-1678-rttp-add-bounded-forwarded-request
base: main
commit: 6eef0dd016b996a2c1d198f84f3249c3255e365c
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1678/
    url: https://plane.kahub.in/endless/browse/HBX-1678/
    close_policy: link_only
```