### PR TITLE
feat: [rttp] Add bounded Alt-Svc response metadata helpers

### DIFF
--- a/crates/rttp-client/src/response/mod.rs
+++ b/crates/rttp-client/src/response/mod.rs
@@ -5,6 +5,7 @@ pub use self::response::*;
 mod raw_response;
 mod response;
 
+pub use rttp_protocol::alt_svc::{AltSvc, AltSvcAlternative, AltSvcParameter, AltSvcParseError};
 pub use rttp_protocol::digest::{
   Digest, DigestEntry, DigestParseError, ReprDigest, ReprDigestEntry,
 };

--- a/crates/rttp-client/src/response/response.rs
+++ b/crates/rttp-client/src/response/response.rs
@@ -7,6 +7,7 @@ use url::Url;
 
 use crate::error;
 use crate::response::raw_response::RawResponse;
+use crate::response::AltSvc;
 use crate::response::Digest;
 use crate::response::Priority;
 use crate::response::ReprDigest;
@@ -336,6 +337,18 @@ impl Response {
       return Ok(None);
     }
     ServerTiming::parse_values(values.into_iter().map(String::as_str))
+      .map(Some)
+      .map_err(|parse_error| error::bad_response(parse_error.to_string()))
+  }
+
+  /// Parses all `Alt-Svc` fields as bounded alternative-service metadata.
+  /// This does not migrate connections or select an alternative endpoint.
+  pub fn alt_svc(&self) -> error::Result<Option<AltSvc>> {
+    let values = self.header_values("alt-svc");
+    if values.is_empty() {
+      return Ok(None);
+    }
+    AltSvc::parse_values(values.into_iter().map(String::as_str))
       .map(Some)
       .map_err(|parse_error| error::bad_response(parse_error.to_string()))
   }

--- a/crates/rttp-client/tests/test_response.rs
+++ b/crates/rttp-client/tests/test_response.rs
@@ -1,5 +1,5 @@
 use rttp_client::response::{
-  ContentDisposition, ContentEncoding, ContentLocation, ContentType, Digest, Response,
+  AltSvc, ContentDisposition, ContentEncoding, ContentLocation, ContentType, Digest, Response,
   ServerTiming, WwwAuthenticate,
 };
 use rttp_client::types::{Cookie, RoUrl};
@@ -683,6 +683,81 @@ fn test_server_timing_response_helper_parses_metrics_extensions_and_duplicates()
   assert_eq!(Some(4.0), timing.metrics()[1].duration());
   assert_eq!(Some("render \"home\""), timing.metrics()[2].description());
   assert_eq!("db; dur=53.2; desc=\"primary database\"; region=us-east; cached, db; dur=4, app; desc=\"render \\\"home\\\"\"; build=2026", timing.header_value());
+}
+
+#[test]
+fn test_alt_svc_response_helper_parses_and_round_trips_alternatives() {
+  let raw = concat!(
+    "HTTP/1.1 200 OK\r\n",
+    "Alt-Svc: h3=\":443\"; ma=3600; persist=1; region=\"us-east\", h2=\"alt.example:8443\"; ma=60\r\n",
+    "Content-Length: 0\r\n\r\n"
+  );
+  let response = Response::new(RoUrl::with("https://example.test"), raw.as_bytes().to_vec())
+    .expect("raw response should remain usable");
+  let alt_svc = response
+    .alt_svc()
+    .expect("Alt-Svc should parse")
+    .expect("Alt-Svc should be present");
+
+  assert!(!alt_svc.is_clear());
+  assert_eq!(2, alt_svc.len());
+  assert_eq!("h3", alt_svc.alternatives()[0].protocol_id());
+  assert_eq!(":443", alt_svc.alternatives()[0].authority());
+  assert_eq!(Some(3600), alt_svc.alternatives()[0].max_age());
+  assert_eq!(Some(true), alt_svc.alternatives()[0].persist());
+  assert_eq!(
+    vec![("region", Some("us-east"))],
+    alt_svc.alternatives()[0]
+      .parameters()
+      .iter()
+      .map(|parameter| (parameter.name(), parameter.value()))
+      .collect::<Vec<_>>()
+  );
+  assert_eq!(
+    "h3=\":443\"; ma=3600; persist=1; region=us-east, h2=\"alt.example:8443\"; ma=60",
+    alt_svc.header_value()
+  );
+  assert_eq!(
+    alt_svc,
+    AltSvc::parse(alt_svc.header_value()).expect("round-tripped Alt-Svc should parse")
+  );
+}
+
+#[test]
+fn test_alt_svc_rejects_invalid_or_unbounded_metadata_without_hiding_headers() {
+  for value in [
+    "h3=:443",
+    "h 3=\":443\"",
+    "h3=\"unterminated",
+    "clear, h3=\":443\"",
+    "h3=\":443\"; ma=forever",
+    "h3=\":443\"; ma=\"60\"",
+    "h3=\":443\"; region",
+  ] {
+    let raw = format!("HTTP/1.1 200 OK\r\nAlt-Svc: {value}\r\nContent-Length: 0\r\n\r\n");
+    let response = Response::new(RoUrl::with("https://example.test"), raw.into_bytes())
+      .expect("raw response should remain usable");
+    assert!(response.alt_svc().is_err(), "should reject {value:?}");
+    assert_eq!(Some(&value.to_string()), response.header_value("Alt-Svc"));
+  }
+
+  assert!(AltSvc::parse(format!("h3=\":443\"; x=\"{}\"", "a".repeat(64 * 1024))).is_err());
+  assert!(AltSvc::parse(
+    (0..257)
+      .map(|index| format!("h{index}=\":443\""))
+      .collect::<Vec<_>>()
+      .join(", ")
+  )
+  .is_err());
+}
+
+#[test]
+fn test_alt_svc_clear_is_an_exclusive_sentinel() {
+  let alt_svc = AltSvc::parse("clear").expect("clear should parse");
+  assert!(alt_svc.is_clear());
+  assert!(alt_svc.is_empty());
+  assert_eq!("clear", alt_svc.header_value());
+  assert!(AltSvc::parse_values(["clear", "h3=\":443\""]).is_err());
 }
 
 #[test]

--- a/crates/rttp-protocol/src/alt_svc.rs
+++ b/crates/rttp-protocol/src/alt_svc.rs
@@ -1,0 +1,430 @@
+use std::error::Error;
+use std::fmt;
+
+pub const MAX_ALT_SVC_VALUE_BYTES: usize = 64 * 1024;
+pub const MAX_ALT_SVC_ALTERNATIVES: usize = 256;
+pub const MAX_ALT_SVC_PARAMETERS: usize = 256;
+pub const MAX_ALT_SVC_PARAMETER_VALUE_BYTES: usize = 64 * 1024;
+
+/// Parsed, bounded `Alt-Svc` response metadata. This metadata does not select
+/// endpoints or migrate connections.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AltSvc {
+  clear: bool,
+  alternatives: Vec<AltSvcAlternative>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AltSvcAlternative {
+  protocol_id: String,
+  authority: String,
+  max_age: Option<u64>,
+  persist: Option<bool>,
+  parameters: Vec<AltSvcParameter>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AltSvcParameter {
+  name: String,
+  value: Option<String>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AltSvcParseError {
+  message: String,
+}
+
+impl AltSvcParseError {
+  fn new(message: impl Into<String>) -> Self {
+    Self {
+      message: message.into(),
+    }
+  }
+}
+
+impl fmt::Display for AltSvcParseError {
+  fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+    formatter.write_str(&self.message)
+  }
+}
+
+impl Error for AltSvcParseError {}
+
+impl AltSvc {
+  pub fn parse(value: impl AsRef<str>) -> Result<Self, AltSvcParseError> {
+    Self::parse_values([value.as_ref()])
+  }
+
+  pub fn parse_values<'a, I>(values: I) -> Result<Self, AltSvcParseError>
+  where
+    I: IntoIterator<Item = &'a str>,
+  {
+    let mut alternatives = Vec::new();
+    let mut clear = false;
+    let mut seen_field = false;
+    for value in values {
+      if value.len() > MAX_ALT_SVC_VALUE_BYTES {
+        return Err(AltSvcParseError::new("Alt-Svc header value is too large"));
+      }
+      if value.trim().is_empty() {
+        return Err(AltSvcParseError::new("invalid Alt-Svc entry"));
+      }
+      seen_field = true;
+      let mut position = 0;
+      loop {
+        skip_ows(value.as_bytes(), &mut position);
+        if alternatives.len() >= MAX_ALT_SVC_ALTERNATIVES {
+          return Err(AltSvcParseError::new("too many Alt-Svc alternatives"));
+        }
+        if value[position..].starts_with("clear") {
+          let after_clear = position + "clear".len();
+          let next = value.as_bytes().get(after_clear);
+          if matches!(next, None | Some(b' ' | b'\t' | b',')) {
+            if clear || !alternatives.is_empty() {
+              return Err(AltSvcParseError::new("Alt-Svc clear must be exclusive"));
+            }
+            clear = true;
+            position = after_clear;
+          } else {
+            parse_alternative(value, &mut position, &mut alternatives)?;
+          }
+        } else {
+          if clear {
+            return Err(AltSvcParseError::new("Alt-Svc clear must be exclusive"));
+          }
+          parse_alternative(value, &mut position, &mut alternatives)?;
+        }
+        skip_ows(value.as_bytes(), &mut position);
+        if position == value.len() {
+          break;
+        }
+        if value.as_bytes()[position] != b',' {
+          return Err(AltSvcParseError::new("invalid Alt-Svc entry"));
+        }
+        position += 1;
+        skip_ows(value.as_bytes(), &mut position);
+        if position == value.len() {
+          return Err(AltSvcParseError::new("invalid Alt-Svc entry"));
+        }
+      }
+    }
+    if !seen_field || (!clear && alternatives.is_empty()) {
+      return Err(AltSvcParseError::new("invalid Alt-Svc entry"));
+    }
+    Ok(Self {
+      clear,
+      alternatives,
+    })
+  }
+
+  pub fn is_clear(&self) -> bool {
+    self.clear
+  }
+  pub fn alternatives(&self) -> &[AltSvcAlternative] {
+    &self.alternatives
+  }
+  pub fn len(&self) -> usize {
+    self.alternatives.len()
+  }
+  pub fn is_empty(&self) -> bool {
+    self.alternatives.is_empty()
+  }
+
+  pub fn header_value(&self) -> String {
+    if self.clear {
+      "clear".to_string()
+    } else {
+      self
+        .alternatives
+        .iter()
+        .map(AltSvcAlternative::header_value)
+        .collect::<Vec<_>>()
+        .join(", ")
+    }
+  }
+}
+
+impl AltSvcAlternative {
+  pub fn protocol_id(&self) -> &str {
+    &self.protocol_id
+  }
+  pub fn authority(&self) -> &str {
+    &self.authority
+  }
+  pub fn max_age(&self) -> Option<u64> {
+    self.max_age
+  }
+  pub fn persist(&self) -> Option<bool> {
+    self.persist
+  }
+  pub fn parameters(&self) -> &[AltSvcParameter] {
+    &self.parameters
+  }
+
+  fn header_value(&self) -> String {
+    let mut value = format!(
+      "{}=\"{}\"",
+      self.protocol_id,
+      escape_quoted(&self.authority)
+    );
+    if let Some(max_age) = self.max_age {
+      value.push_str(&format!("; ma={max_age}"));
+    }
+    if let Some(persist) = self.persist {
+      value.push_str(if persist {
+        "; persist=1"
+      } else {
+        "; persist=0"
+      });
+    }
+    for parameter in &self.parameters {
+      value.push_str("; ");
+      value.push_str(parameter.name());
+      if let Some(parameter_value) = parameter.value() {
+        value.push('=');
+        if is_token(parameter_value) {
+          value.push_str(parameter_value);
+        } else {
+          value.push('"');
+          value.push_str(&escape_quoted(parameter_value));
+          value.push('"');
+        }
+      }
+    }
+    value
+  }
+}
+
+impl AltSvcParameter {
+  pub fn name(&self) -> &str {
+    &self.name
+  }
+  pub fn value(&self) -> Option<&str> {
+    self.value.as_deref()
+  }
+}
+
+fn parse_alternative(
+  value: &str,
+  position: &mut usize,
+  alternatives: &mut Vec<AltSvcAlternative>,
+) -> Result<(), AltSvcParseError> {
+  let protocol_id = parse_token(value, position, "invalid Alt-Svc protocol id")?.to_string();
+  skip_ows(value.as_bytes(), position);
+  if value.as_bytes().get(*position) != Some(&b'=') {
+    return Err(AltSvcParseError::new("invalid Alt-Svc entry"));
+  }
+  *position += 1;
+  skip_ows(value.as_bytes(), position);
+  let authority = parse_quoted_string(value, position)?;
+  validate_authority(&authority)?;
+  let mut alternative = AltSvcAlternative {
+    protocol_id,
+    authority,
+    max_age: None,
+    persist: None,
+    parameters: Vec::new(),
+  };
+  let mut parameter_count = 0usize;
+  loop {
+    skip_ows(value.as_bytes(), position);
+    if matches!(value.as_bytes().get(*position), None | Some(b',')) {
+      break;
+    }
+    if value.as_bytes()[*position] != b';' {
+      return Err(AltSvcParseError::new("invalid Alt-Svc entry"));
+    }
+    *position += 1;
+    skip_ows(value.as_bytes(), position);
+    parameter_count += 1;
+    if parameter_count > MAX_ALT_SVC_PARAMETERS {
+      return Err(AltSvcParseError::new("too many Alt-Svc parameters"));
+    }
+    parse_parameter(value, position, &mut alternative)?;
+  }
+  alternatives.push(alternative);
+  Ok(())
+}
+
+fn parse_parameter(
+  value: &str,
+  position: &mut usize,
+  alternative: &mut AltSvcAlternative,
+) -> Result<(), AltSvcParseError> {
+  let name = parse_token(value, position, "invalid Alt-Svc parameter name")?.to_ascii_lowercase();
+  skip_ows(value.as_bytes(), position);
+  if value.as_bytes().get(*position) != Some(&b'=') {
+    return Err(AltSvcParseError::new("invalid Alt-Svc parameter"));
+  }
+  *position += 1;
+  skip_ows(value.as_bytes(), position);
+  let quoted_value = value.as_bytes().get(*position) == Some(&b'"');
+  let parameter_value = Some(if quoted_value {
+    parse_quoted_string(value, position)?
+  } else {
+    parse_token(value, position, "invalid Alt-Svc parameter value")?.to_string()
+  });
+  if parameter_value
+    .as_ref()
+    .is_some_and(|parameter| parameter.len() > MAX_ALT_SVC_PARAMETER_VALUE_BYTES)
+  {
+    return Err(AltSvcParseError::new(
+      "Alt-Svc parameter value is too large",
+    ));
+  }
+  match name.as_str() {
+    "ma" => {
+      if quoted_value {
+        return Err(AltSvcParseError::new("invalid Alt-Svc ma parameter"));
+      }
+      let max_age = parameter_value
+        .ok_or_else(|| AltSvcParseError::new("invalid Alt-Svc ma parameter"))?
+        .parse::<u64>()
+        .map_err(|_| AltSvcParseError::new("invalid Alt-Svc ma parameter"))?;
+      if alternative.max_age.replace(max_age).is_some() {
+        return Err(AltSvcParseError::new("duplicate Alt-Svc ma parameter"));
+      }
+    }
+    "persist" => {
+      if quoted_value {
+        return Err(AltSvcParseError::new("invalid Alt-Svc persist parameter"));
+      }
+      let persist = match parameter_value.as_deref() {
+        Some("0") => false,
+        Some("1") => true,
+        _ => return Err(AltSvcParseError::new("invalid Alt-Svc persist parameter")),
+      };
+      if alternative.persist.replace(persist).is_some() {
+        return Err(AltSvcParseError::new("duplicate Alt-Svc persist parameter"));
+      }
+    }
+    _ => {
+      if alternative
+        .parameters
+        .iter()
+        .any(|parameter| parameter.name.eq_ignore_ascii_case(&name))
+      {
+        return Err(AltSvcParseError::new("duplicate Alt-Svc parameter"));
+      }
+      alternative.parameters.push(AltSvcParameter {
+        name,
+        value: parameter_value,
+      });
+    }
+  }
+  Ok(())
+}
+
+fn validate_authority(authority: &str) -> Result<(), AltSvcParseError> {
+  let Some((host, port)) = authority.rsplit_once(':') else {
+    return Err(AltSvcParseError::new("invalid Alt-Svc authority"));
+  };
+  if port.is_empty()
+    || !port.bytes().all(|byte| byte.is_ascii_digit())
+    || port.parse::<u16>().is_err()
+  {
+    return Err(AltSvcParseError::new("invalid Alt-Svc authority"));
+  }
+  if host.is_empty() {
+    return Ok(());
+  }
+  let valid_host = if host.starts_with('[') && host.ends_with(']') {
+    host[1..host.len() - 1]
+      .bytes()
+      .all(|byte| byte.is_ascii_hexdigit() || matches!(byte, b':' | b'.'))
+  } else {
+    host
+      .bytes()
+      .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'-'))
+  };
+  if valid_host {
+    Ok(())
+  } else {
+    Err(AltSvcParseError::new("invalid Alt-Svc authority"))
+  }
+}
+
+fn parse_quoted_string(value: &str, position: &mut usize) -> Result<String, AltSvcParseError> {
+  if value.as_bytes().get(*position) != Some(&b'"') {
+    return Err(AltSvcParseError::new("invalid Alt-Svc quoted-string"));
+  }
+  *position += 1;
+  let mut parsed = String::new();
+  let mut unescaped_start = *position;
+  let mut escaped = false;
+  while let Some(&byte) = value.as_bytes().get(*position) {
+    if escaped {
+      *position += 1;
+      if !(byte == b'\t' || (0x20..=0x7e).contains(&byte)) {
+        return Err(AltSvcParseError::new("invalid Alt-Svc quoted-string"));
+      }
+      parsed.push(byte as char);
+      escaped = false;
+      unescaped_start = *position;
+    } else if byte == b'\\' {
+      parsed.push_str(&value[unescaped_start..*position]);
+      *position += 1;
+      escaped = true;
+    } else if byte == b'"' {
+      parsed.push_str(&value[unescaped_start..*position]);
+      *position += 1;
+      return Ok(parsed);
+    } else if byte == b'\t' || matches!(byte, 0x20..=0x21 | 0x23..=0x5b | 0x5d..=0x7e | 0x80..=0xff)
+    {
+      *position += 1;
+    } else {
+      return Err(AltSvcParseError::new("invalid Alt-Svc quoted-string"));
+    }
+  }
+  Err(AltSvcParseError::new("invalid Alt-Svc quoted-string"))
+}
+
+fn parse_token<'a>(
+  value: &'a str,
+  position: &mut usize,
+  message: &str,
+) -> Result<&'a str, AltSvcParseError> {
+  let start = *position;
+  while *position < value.len() && is_token_byte(value.as_bytes()[*position]) {
+    *position += 1;
+  }
+  if *position == start {
+    Err(AltSvcParseError::new(message))
+  } else {
+    Ok(&value[start..*position])
+  }
+}
+fn skip_ows(bytes: &[u8], position: &mut usize) {
+  while matches!(bytes.get(*position), Some(b' ' | b'\t')) {
+    *position += 1;
+  }
+}
+fn is_token(value: &str) -> bool {
+  !value.is_empty() && value.bytes().all(is_token_byte)
+}
+fn is_token_byte(byte: u8) -> bool {
+  matches!(byte, b'!' | b'#' | b'$' | b'%' | b'&' | b'\'' | b'*' | b'+' | b'-' | b'.' | b'^' | b'_' | b'`' | b'|' | b'~' | b'0'..=b'9' | b'A'..=b'Z' | b'a'..=b'z')
+}
+fn escape_quoted(value: &str) -> String {
+  value.replace('\\', "\\\\").replace('"', "\\\"")
+}
+
+#[cfg(test)]
+mod tests {
+  use super::AltSvc;
+
+  #[test]
+  fn parses_alternatives_and_clear() {
+    let alternatives =
+      AltSvc::parse("h3=\":443\"; ma=60; persist=1; x=token").expect("valid Alt-Svc");
+    assert_eq!("h3", alternatives.alternatives()[0].protocol_id());
+    assert_eq!(Some(60), alternatives.alternatives()[0].max_age());
+    assert!(AltSvc::parse("clear").expect("clear").is_clear());
+  }
+
+  #[test]
+  fn preserves_utf8_quoted_extension_values() {
+    let alt_svc = AltSvc::parse("h3=\":443\"; note=\"café\"").expect("valid Alt-Svc");
+    assert_eq!("h3=\":443\"; note=\"café\"", alt_svc.header_value());
+  }
+}

--- a/crates/rttp-protocol/src/lib.rs
+++ b/crates/rttp-protocol/src/lib.rs
@@ -3,6 +3,7 @@
 //! This crate is intentionally unpublished. It owns protocol syntax and framing
 //! validation only; client and server application policy remains in its callers.
 
+pub mod alt_svc;
 pub mod digest;
 pub mod forwarded;
 pub mod http1;

--- a/crates/rttp-server/src/server/response.rs
+++ b/crates/rttp-server/src/server/response.rs
@@ -1,5 +1,9 @@
 use super::*;
 
+pub use rttp_protocol::alt_svc::{
+  AltSvc as HttpAltSvc, AltSvcAlternative as HttpAltSvcAlternative,
+  AltSvcParameter as HttpAltSvcParameter, AltSvcParseError as HttpAltSvcParseError,
+};
 pub use rttp_protocol::digest::{
   Digest as HttpDigest, DigestEntry as HttpDigestEntry, DigestParseError as HttpDigestParseError,
   ReprDigest as HttpReprDigest, ReprDigestEntry as HttpReprDigestEntry,
@@ -416,6 +420,18 @@ impl HttpResponse {
     Ok(self)
   }
 
+  /// Validates and replaces `Alt-Svc` response metadata without selecting an endpoint.
+  pub fn with_alt_svc(mut self, value: impl AsRef<str>) -> Result<Self, HttpAltSvcParseError> {
+    let alt_svc = HttpAltSvc::parse(value)?;
+    self
+      .headers
+      .retain(|header| !header.name.eq_ignore_ascii_case("Alt-Svc"));
+    self
+      .headers
+      .push(HttpHeader::new("Alt-Svc", alt_svc.header_value()));
+    Ok(self)
+  }
+
   pub fn with_content_location<V: AsRef<str>>(
     mut self,
     value: V,
@@ -686,6 +702,20 @@ impl HttpResponse {
       return Ok(None);
     }
     HttpServerTiming::parse_values(values).map(Some)
+  }
+
+  /// Parses attached `Alt-Svc` metadata without changing raw headers or connections.
+  pub fn alt_svc(&self) -> Result<Option<HttpAltSvc>, HttpAltSvcParseError> {
+    let values: Vec<&str> = self
+      .headers
+      .iter()
+      .filter(|header| header.name.eq_ignore_ascii_case("Alt-Svc"))
+      .map(|header| header.value.as_str())
+      .collect();
+    if values.is_empty() {
+      return Ok(None);
+    }
+    HttpAltSvc::parse_values(values).map(Some)
   }
 
   pub fn content_location(&self) -> Result<Option<&str>, HttpContentLocationParseError> {

--- a/crates/rttp-server/src/server/server_tests.rs
+++ b/crates/rttp-server/src/server/server_tests.rs
@@ -462,3 +462,32 @@ hello\r\n\
         .header_value()
     );
   }
+
+  #[test]
+  fn alt_svc_helpers_validate_build_and_parse_response_metadata() {
+    let response = HttpResponse::ok([])
+      .with_alt_svc("h3=\":443\"; ma=3600; persist=1; region=\"us-east\"")
+      .expect("Alt-Svc should be accepted");
+    let alt_svc = response
+      .alt_svc()
+      .expect("response Alt-Svc should parse")
+      .expect("response Alt-Svc should be present");
+
+    assert_eq!("h3", alt_svc.alternatives()[0].protocol_id());
+    assert_eq!(":443", alt_svc.alternatives()[0].authority());
+    assert_eq!(Some(3600), alt_svc.alternatives()[0].max_age());
+    assert_eq!(Some(true), alt_svc.alternatives()[0].persist());
+    assert_eq!(
+      "h3=\":443\"; ma=3600; persist=1; region=us-east",
+      alt_svc.header_value()
+    );
+
+    let clear = HttpResponse::ok([])
+      .with_alt_svc("clear")
+      .expect("clear should be accepted");
+    assert!(clear
+      .alt_svc()
+      .expect("clear should parse")
+      .expect("clear should be present")
+      .is_clear());
+  }


### PR DESCRIPTION
Bounded Alt-Svc response metadata support is implemented for rttp client and server responses, with validated parsing, canonical serialization, and no automatic connection migration behavior.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1674/
work_kind: code_work
branch: hbx-1674-rttp-add-bounded-alt-svc
base: main
commit: 4cb06edd348af8ef81a9d001367caf4fc00401b4
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1674/
    url: https://plane.kahub.in/endless/browse/HBX-1674/
    close_policy: link_only
```