### PR TITLE
feat: [rttp-client] Add bounded Max-Forwards request helpers

### DIFF
--- a/crates/rttp-client/README.md
+++ b/crates/rttp-client/README.md
@@ -27,6 +27,17 @@ HTTP/1.x chunked responses are decoded, and response trailers are exposed
 through `Response::trailers`, `Response::trailer`, and
 `Response::trailer_value` for both blocking and async request APIs.
 
+## Bounded Max-Forwards diagnostics
+
+`HttpClient::max_forwards(value)` sets a `Max-Forwards` request header for
+application-selected `TRACE` or `OPTIONS` diagnostics. The helper accepts only
+up to ten ASCII decimal digits that fit in the `u32` range (`0` through
+`4294967295`) and rejects negative, fractional, empty, oversized, and
+overflowing values before a socket is opened. It only validates and emits the
+header: RTTP does not select a diagnostic policy, route through proxies,
+decrement the value, or retry the request. Callers needing an unusual value can
+retain full raw-header control with `header(("Max-Forwards", "..."))`.
+
 ## Bounded HTTP/1.1 byte ranges
 
 `HttpClient` includes helpers for the single-range `bytes` forms RTTP keeps

--- a/crates/rttp-client/src/client.rs
+++ b/crates/rttp-client/src/client.rs
@@ -284,6 +284,17 @@ impl HttpClient {
     Ok(self.header(("Range", format!("bytes=-{}", suffix).as_str())))
   }
 
+  /// Set a bounded `Max-Forwards` request header for TRACE or OPTIONS diagnostics.
+  ///
+  /// The value must be at most ten ASCII decimal digits and fit in the `u32`
+  /// range (`0` through `4294967295`). This only emits the header; it does not
+  /// route through proxies, decrement the value, retry requests, or select a
+  /// TRACE or OPTIONS policy. Use `header` directly for unusual values.
+  pub fn max_forwards<S: AsRef<str>>(&mut self, value: S) -> error::Result<&mut Self> {
+    let value = validate_max_forwards(value.as_ref())?;
+    Ok(self.header(Header::new("Max-Forwards", value)))
+  }
+
   /// Append a validated `Accept-Encoding` coding with the default quality of
   /// `1`. This declares request metadata only; it does not enable compression
   /// or decompression.
@@ -699,6 +710,22 @@ fn bounded_forwarded_header_value(forwarded: Forwarded) -> error::Result<String>
   Ok(value)
 }
 
+fn validate_max_forwards(value: &str) -> error::Result<&str> {
+  if value.is_empty()
+    || value.len() > MAX_MAX_FORWARDS_VALUE_BYTES
+    || !value.bytes().all(|byte| byte.is_ascii_digit())
+  {
+    return Err(error::builder_with_message(
+      "Max-Forwards must be a non-empty decimal u32",
+    ));
+  }
+  value.parse::<u32>().map_err(|_| {
+    error::builder_with_message("Max-Forwards must be a decimal value no greater than u32::MAX")
+  })?;
+  Ok(value)
+}
+
+const MAX_MAX_FORWARDS_VALUE_BYTES: usize = 10;
 const MAX_ACCEPT_ENCODING_VALUE_BYTES: usize = 64 * 1024;
 const MAX_ACCEPT_ENCODINGS: usize = 32;
 

--- a/crates/rttp-client/tests/test_raw_request_capture.rs
+++ b/crates/rttp-client/tests/test_raw_request_capture.rs
@@ -518,6 +518,91 @@ fn manual_range_header_remains_available_as_escape_hatch() {
 }
 
 #[test]
+fn max_forwards_helper_emits_bounded_trace_and_options_headers() {
+  let trace = capture_request(|base_url| {
+    client()
+      .trace()
+      .url(format!("{}/diagnostics", base_url))
+      .max_forwards("0")
+      .expect("zero Max-Forwards should be accepted")
+      .emit()
+      .expect("TRACE request should succeed");
+  });
+  let trace = request_text(&trace);
+  assert!(trace.starts_with("TRACE /diagnostics HTTP/1.1\r\n"));
+  assert_eq!(Some("0"), header_value(&trace, "Max-Forwards"));
+
+  let options = capture_request(|base_url| {
+    client()
+      .options()
+      .url(format!("{}/diagnostics", base_url))
+      .max_forwards("4294967295")
+      .expect("u32::MAX Max-Forwards should be accepted")
+      .emit()
+      .expect("OPTIONS request should succeed");
+  });
+  let options = request_text(&options);
+  assert!(options.starts_with("OPTIONS /diagnostics HTTP/1.1\r\n"));
+  assert_eq!(Some("4294967295"), header_value(&options, "Max-Forwards"));
+}
+
+#[test]
+fn max_forwards_helper_rejects_invalid_values_before_connecting() {
+  for value in ["-1", "1.5", "", "4294967296", "99999999999"] {
+    let request = capture_optional_request(|base_url| {
+      let mut client = client();
+      let error = client
+        .trace()
+        .url(format!("{}/diagnostics", base_url))
+        .max_forwards(value)
+        .expect_err("invalid Max-Forwards should be rejected");
+
+      assert!(error.is_builder());
+    });
+
+    assert!(
+      request.is_empty(),
+      "invalid Max-Forwards helper input should not open a socket"
+    );
+  }
+
+  let oversized = "0".repeat(64 * 1024 + 1);
+  let request = capture_optional_request(|base_url| {
+    let mut client = client();
+    let error = client
+      .options()
+      .url(format!("{}/diagnostics", base_url))
+      .max_forwards(oversized.as_str())
+      .expect_err("oversized Max-Forwards should be rejected");
+
+    assert!(error.is_builder());
+  });
+
+  assert!(
+    request.is_empty(),
+    "oversized Max-Forwards helper input should not open a socket"
+  );
+}
+
+#[test]
+fn manual_max_forwards_header_remains_available_as_escape_hatch() {
+  let request = capture_request(|base_url| {
+    client()
+      .trace()
+      .url(format!("{}/diagnostics", base_url))
+      .header(("Max-Forwards", "unusual-value"))
+      .emit()
+      .expect("manual Max-Forwards header should succeed");
+  });
+  let request = request_text(&request);
+
+  assert_eq!(
+    Some("unusual-value"),
+    header_value(&request, "Max-Forwards")
+  );
+}
+
+#[test]
 fn conditional_request_helpers_emit_validator_headers() {
   let request = capture_request(|base_url| {
     client()


### PR DESCRIPTION
Bounded Max-Forwards diagnostics are implemented with pre-connection validation, raw-header escape-hatch preservation, documentation, and request-capture coverage.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1670/
work_kind: code_work
branch: hbx-1670-rttp-client-add-bounded-max
base: main
commit: 7a0061fda9b90af6c5e877eabc5603c2c19d01ec
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1670/
    url: https://plane.kahub.in/endless/browse/HBX-1670/
    close_policy: link_only
```