### PR TITLE
feat: [rttp] Add bounded Prefer request metadata helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,6 +356,27 @@ the request itself.
 These helpers declare and parse metadata only. They do not enable automatic
 compression, decompression, or content negotiation.
 
+### Bounded Prefer request metadata
+
+`HttpClient::prefer()` appends a token-only request preference, and
+`prefer_with_value()` appends a token-valued preference. They emit one ordered,
+comma-separated `Prefer` field and validate preference tokens, optional values,
+duplicate names, a 64 KiB field limit, an 8 KiB individual value limit, and a
+32-preference limit before a connection is opened. `wait` is additionally
+validated as an unsigned decimal integer. Common values such as
+`respond-async`, `return=minimal`, `return=representation`, and `wait=n` are
+handled as metadata alongside unknown token extensions.
+
+On the server, `Request::prefer()` and `HttpRequest::prefer()` parse all
+received `Prefer` fields in wire order into `HttpRequestPreferences`. Each item
+exposes its original `name()` and optional `value()`; unknown extensions remain
+available. Absent metadata returns `Ok(None)`, while malformed, duplicate,
+oversized, or excessive preferences return a parse error without changing the
+raw request headers.
+
+These helpers only exchange metadata. They do not schedule asynchronous jobs,
+shape responses, choose server behavior, apply cache policy, or retry requests.
+
 ### Bounded HTTP/1.1 Vary behavior
 
 `Response::vary()` parses one or more response `Vary` header fields into

--- a/crates/rttp-client/README.md
+++ b/crates/rttp-client/README.md
@@ -333,6 +333,19 @@ connection is opened.
 These helpers declare request metadata only. They do not enable automatic
 compression, decompression, or content negotiation.
 
+## Bounded Prefer request metadata
+
+`HttpClient::prefer()` appends a token-only preference, and
+`prefer_with_value()` appends a token-valued preference. The helpers emit one
+ordered, comma-separated `Prefer` field and reject malformed tokens, duplicate
+names, values above 8 KiB, fields above 64 KiB, and more than 32 preferences
+before opening a connection. `wait` accepts only unsigned decimal integers;
+`respond-async`, `return=minimal`, `return=representation`, and unknown token
+extensions remain metadata declarations.
+
+These helpers do not schedule asynchronous work, shape responses, apply cache
+policy, retry requests, or infer server behavior from a preference.
+
 ## Bounded HTTP/1.1 Content-Disposition behavior
 
 `Response::content_disposition()` parses a singleton response

--- a/crates/rttp-client/src/client.rs
+++ b/crates/rttp-client/src/client.rs
@@ -305,6 +305,26 @@ impl HttpClient {
     self.accept_encoding_with_q("identity", qvalue)
   }
 
+  /// Append a token-only `Prefer` request metadata item.
+  ///
+  /// This records preference metadata only; it does not schedule asynchronous
+  /// work or alter response handling.
+  pub fn prefer<S: AsRef<str>>(&mut self, name: S) -> error::Result<&mut Self> {
+    self.prefer_member(name.as_ref(), None)
+  }
+
+  /// Append a token-valued `Prefer` request metadata item.
+  ///
+  /// `wait` values must be unsigned decimal integers. This records preference
+  /// metadata only; it does not apply response preference policy.
+  pub fn prefer_with_value<N: AsRef<str>, V: AsRef<str>>(
+    &mut self,
+    name: N,
+    value: V,
+  ) -> error::Result<&mut Self> {
+    self.prefer_member(name.as_ref(), Some(value.as_ref()))
+  }
+
   /// Set an `If-Range` validator with a single strong entity tag.
   ///
   /// `If-Range` only permits strong entity-tag validators. Use `header`
@@ -405,6 +425,50 @@ impl HttpClient {
       header.replace(Header::new("Accept-Encoding", value));
     } else {
       headers.push(Header::new("Accept-Encoding", member));
+    }
+    Ok(self)
+  }
+
+  fn prefer_member(&mut self, name: &str, value: Option<&str>) -> error::Result<&mut Self> {
+    let name = name.trim();
+    let value = value.map(str::trim);
+    if !is_http_token(name)
+      || value.is_some_and(|value| {
+        value.len() > MAX_PREFER_VALUE_BYTES
+          || !is_http_token(value)
+          || (name.eq_ignore_ascii_case("wait") && value.parse::<u64>().is_err())
+      })
+    {
+      return Err(error::builder_with_message("invalid Prefer preference"));
+    }
+    let member = value.map_or_else(|| name.to_string(), |value| format!("{name}={value}"));
+    if member.len() > MAX_PREFER_FIELD_BYTES {
+      return Err(error::builder_with_message(
+        "Prefer header value is too large",
+      ));
+    }
+
+    let headers = self.request.headers_mut();
+    if let Some(header) = headers
+      .iter_mut()
+      .find(|header| header.name().eq_ignore_ascii_case("Prefer"))
+    {
+      let names = parse_prefer_names(header.value())?;
+      if names.iter().any(|known| known.eq_ignore_ascii_case(name)) {
+        return Err(error::builder_with_message("duplicate Prefer preference"));
+      }
+      if names.len() >= MAX_PREFERENCES {
+        return Err(error::builder_with_message("too many Prefer preferences"));
+      }
+      let value = format!("{}, {member}", header.value());
+      if value.len() > MAX_PREFER_FIELD_BYTES {
+        return Err(error::builder_with_message(
+          "Prefer header value is too large",
+        ));
+      }
+      header.replace(Header::new("Prefer", value));
+    } else {
+      headers.push(Header::new("Prefer", member));
     }
     Ok(self)
   }
@@ -652,6 +716,52 @@ impl HttpClient {
 
 const MAX_ACCEPT_ENCODING_VALUE_BYTES: usize = 64 * 1024;
 const MAX_ACCEPT_ENCODINGS: usize = 32;
+const MAX_PREFER_FIELD_BYTES: usize = 64 * 1024;
+const MAX_PREFER_VALUE_BYTES: usize = 8 * 1024;
+const MAX_PREFERENCES: usize = 32;
+
+fn parse_prefer_names(value: &str) -> error::Result<Vec<&str>> {
+  if value.len() > MAX_PREFER_FIELD_BYTES {
+    return Err(error::builder_with_message(
+      "Prefer header value is too large",
+    ));
+  }
+  let mut names = Vec::new();
+  for member in value.split(',') {
+    let (name, preference_value) = split_prefer_member(member)?;
+    if names
+      .iter()
+      .any(|known: &&str| known.eq_ignore_ascii_case(name))
+    {
+      return Err(error::builder_with_message("duplicate Prefer preference"));
+    }
+    if names.len() >= MAX_PREFERENCES {
+      return Err(error::builder_with_message("too many Prefer preferences"));
+    }
+    let _ = preference_value;
+    names.push(name);
+  }
+  Ok(names)
+}
+
+fn split_prefer_member(member: &str) -> error::Result<(&str, Option<&str>)> {
+  let (name, value) = member
+    .trim()
+    .split_once('=')
+    .map_or((member.trim(), None), |(name, value)| {
+      (name.trim(), Some(value.trim()))
+    });
+  if !is_http_token(name)
+    || value.is_some_and(|value| {
+      value.len() > MAX_PREFER_VALUE_BYTES
+        || !is_http_token(value)
+        || (name.eq_ignore_ascii_case("wait") && value.parse::<u64>().is_err())
+    })
+  {
+    return Err(error::builder_with_message("invalid Prefer preference"));
+  }
+  Ok((name, value))
+}
 
 fn parse_accept_encoding_codings(value: &str) -> error::Result<Vec<&str>> {
   if value.len() > MAX_ACCEPT_ENCODING_VALUE_BYTES {

--- a/crates/rttp-client/src/client.rs
+++ b/crates/rttp-client/src/client.rs
@@ -593,11 +593,9 @@ impl HttpClient {
     let name = name.trim();
     let value = value.map(str::trim);
     if !is_http_token(name)
-      || value.is_some_and(|value| {
-        value.len() > MAX_PREFER_VALUE_BYTES
-          || !is_http_token(value)
-          || (name.eq_ignore_ascii_case("wait") && value.parse::<u64>().is_err())
-      })
+      || (name.eq_ignore_ascii_case("wait")
+        && !value.is_some_and(|value| value.bytes().all(|byte| byte.is_ascii_digit())))
+      || value.is_some_and(|value| value.len() > MAX_PREFER_VALUE_BYTES || !is_http_token(value))
     {
       return Err(error::builder_with_message("invalid Prefer preference"));
     }
@@ -909,6 +907,7 @@ const MAX_PREFER_FIELD_BYTES: usize = 64 * 1024;
 const MAX_PREFER_VALUE_BYTES: usize = 8 * 1024;
 const MAX_PREFERENCES: usize = 32;
 
+#[allow(clippy::too_many_arguments)]
 fn append_unique_metadata_member(
   headers: &mut Vec<Header>,
   header_name: &str,
@@ -1016,11 +1015,9 @@ fn split_prefer_member(member: &str) -> error::Result<(&str, Option<&str>)> {
       (name.trim(), Some(value.trim()))
     });
   if !is_http_token(name)
-    || value.is_some_and(|value| {
-      value.len() > MAX_PREFER_VALUE_BYTES
-        || !is_http_token(value)
-        || (name.eq_ignore_ascii_case("wait") && value.parse::<u64>().is_err())
-    })
+    || (name.eq_ignore_ascii_case("wait")
+      && !value.is_some_and(|value| value.bytes().all(|byte| byte.is_ascii_digit())))
+    || value.is_some_and(|value| value.len() > MAX_PREFER_VALUE_BYTES || !is_http_token(value))
   {
     return Err(error::builder_with_message("invalid Prefer preference"));
   }

--- a/crates/rttp-client/tests/test_raw_request_capture.rs
+++ b/crates/rttp-client/tests/test_raw_request_capture.rs
@@ -635,6 +635,20 @@ fn te_and_prefer_helpers_reject_invalid_values_before_connecting() {
 
 #[test]
 fn prefer_helpers_reject_invalid_wait_and_bound_values_before_connecting() {
+  let request = capture_optional_request(|base_url| {
+    let mut client = client();
+    assert!(client
+      .get()
+      .url(format!("{}/metadata", base_url))
+      .prefer("wait")
+      .expect_err("valueless wait preference should be rejected")
+      .is_builder());
+  });
+  assert!(
+    request.is_empty(),
+    "invalid Prefer input should not open a socket"
+  );
+
   for (name, value) in [
     ("wait", "-1"),
     ("wait", "1.5"),

--- a/crates/rttp-client/tests/test_raw_request_capture.rs
+++ b/crates/rttp-client/tests/test_raw_request_capture.rs
@@ -382,6 +382,91 @@ fn accept_language_helper_rejects_invalid_values_before_connecting() {
 }
 
 #[test]
+fn prefer_helpers_emit_ordered_preference_metadata() {
+  let request = capture_request(|base_url| {
+    client()
+      .get()
+      .url(format!("{}/metadata", base_url))
+      .prefer("respond-async")
+      .expect("respond-async should be accepted")
+      .prefer_with_value("return", "minimal")
+      .expect("return=minimal should be accepted")
+      .prefer_with_value("wait", "30")
+      .expect("wait should be accepted")
+      .prefer_with_value("example-extension", "enabled")
+      .expect("unknown extension should be accepted")
+      .emit()
+      .expect("request should succeed");
+  });
+  let request = request_text(&request);
+
+  assert_eq!(
+    Some("respond-async, return=minimal, wait=30, example-extension=enabled"),
+    header_value(&request, "Prefer")
+  );
+}
+
+#[test]
+fn prefer_helpers_reject_invalid_wait_and_preference_values_before_connecting() {
+  for (name, value) in [
+    ("wait", "-1"),
+    ("wait", "1.5"),
+    ("wait", "abc"),
+    ("return", "not a token"),
+  ] {
+    let request = capture_optional_request(|base_url| {
+      let mut client = client();
+      assert!(client
+        .get()
+        .url(format!("{}/metadata", base_url))
+        .prefer_with_value(name, value)
+        .expect_err("invalid Prefer input should be rejected")
+        .is_builder());
+    });
+    assert!(
+      request.is_empty(),
+      "invalid Prefer input should not open a socket"
+    );
+  }
+}
+
+#[test]
+fn prefer_helpers_bound_value_size_and_preference_count_before_connecting() {
+  let request = capture_optional_request(|base_url| {
+    let oversized_value = "a".repeat(8 * 1024 + 1);
+    let mut client = client();
+    assert!(client
+      .get()
+      .url(format!("{}/metadata", base_url))
+      .prefer_with_value("extension", oversized_value)
+      .expect_err("oversized preference value should be rejected")
+      .is_builder());
+  });
+  assert!(
+    request.is_empty(),
+    "oversized Prefer input should not open a socket"
+  );
+
+  let request = capture_optional_request(|base_url| {
+    let mut client = client();
+    client.get().url(format!("{}/metadata", base_url));
+    for index in 0..32 {
+      client
+        .prefer(format!("extension{index}"))
+        .expect("preference within the limit should be accepted");
+    }
+    assert!(client
+      .prefer("one-too-many")
+      .expect_err("excessive preferences should be rejected")
+      .is_builder());
+  });
+  assert!(
+    request.is_empty(),
+    "excessive Prefer input should not open a socket"
+  );
+}
+
+#[test]
 fn manual_range_header_remains_available_as_escape_hatch() {
   let request = capture_request(|base_url| {
     client()

--- a/crates/rttp-server/src/server/request.rs
+++ b/crates/rttp-server/src/server/request.rs
@@ -4,6 +4,9 @@ pub(crate) const MAX_REQUEST_HEAD_BYTES: usize = 64 * 1024;
 pub(crate) const MAX_REQUEST_BODY_BYTES: usize = 1024 * 1024;
 pub(crate) const MAX_ACCEPT_VALUE_BYTES: usize = 64 * 1024;
 pub(crate) const MAX_ACCEPT_MEDIA_RANGES: usize = 256;
+const MAX_PREFER_FIELD_BYTES: usize = 64 * 1024;
+const MAX_PREFER_VALUE_BYTES: usize = 8 * 1024;
+const MAX_PREFERENCES: usize = 32;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Request {
   pub(crate) method: String,
@@ -117,6 +120,15 @@ impl Request {
       return Ok(None);
     }
     HttpAcceptLanguages::parse_values(values).map(Some)
+  }
+
+  /// Parses received `Prefer` request metadata without applying preferences.
+  pub fn prefer(&self) -> Result<Option<HttpRequestPreferences>, HttpPreferParseError> {
+    let values: Vec<&str> = self.headers_named("Prefer").collect();
+    if values.is_empty() {
+      return Ok(None);
+    }
+    HttpRequestPreferences::parse_values(values).map(Some)
   }
 
   pub fn vary_selection(&self, vary: &HttpVary) -> HttpVarySelection {
@@ -461,6 +473,121 @@ impl Request {
       extended_connect_protocol: None,
     }
   }
+}
+
+/// A validated `Prefer` item received on an HTTP request.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct HttpPreference {
+  name: String,
+  value: Option<String>,
+}
+
+impl HttpPreference {
+  pub fn name(&self) -> &str {
+    &self.name
+  }
+
+  pub fn value(&self) -> Option<&str> {
+    self.value.as_deref()
+  }
+}
+
+/// Bounded, ordered `Prefer` request metadata.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct HttpRequestPreferences {
+  preferences: Vec<HttpPreference>,
+}
+
+impl HttpRequestPreferences {
+  pub fn parse(value: impl AsRef<str>) -> Result<Self, HttpPreferParseError> {
+    Self::parse_values([value.as_ref()])
+  }
+
+  pub fn parse_values<'a, I>(values: I) -> Result<Self, HttpPreferParseError>
+  where
+    I: IntoIterator<Item = &'a str>,
+  {
+    let mut preferences = Vec::new();
+    for value in values {
+      if value.len() > MAX_PREFER_FIELD_BYTES {
+        return Err(HttpPreferParseError::new(
+          "Prefer header value is too large",
+        ));
+      }
+      for member in value.split(',') {
+        let (name, preference_value) = parse_prefer_member(member)?;
+        if preferences
+          .iter()
+          .any(|known: &HttpPreference| known.name.eq_ignore_ascii_case(name))
+        {
+          return Err(HttpPreferParseError::new("duplicate Prefer preference"));
+        }
+        if preferences.len() >= MAX_PREFERENCES {
+          return Err(HttpPreferParseError::new("too many Prefer preferences"));
+        }
+        preferences.push(HttpPreference {
+          name: name.to_string(),
+          value: preference_value.map(ToString::to_string),
+        });
+      }
+    }
+    if preferences.is_empty() {
+      return Err(HttpPreferParseError::new("invalid Prefer preference"));
+    }
+    Ok(Self { preferences })
+  }
+
+  pub fn preferences(&self) -> &[HttpPreference] {
+    &self.preferences
+  }
+
+  pub fn len(&self) -> usize {
+    self.preferences.len()
+  }
+
+  pub fn is_empty(&self) -> bool {
+    self.preferences.is_empty()
+  }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct HttpPreferParseError {
+  message: String,
+}
+
+impl HttpPreferParseError {
+  fn new(message: impl Into<String>) -> Self {
+    Self {
+      message: message.into(),
+    }
+  }
+}
+
+impl fmt::Display for HttpPreferParseError {
+  fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+    formatter.write_str(&self.message)
+  }
+}
+
+impl Error for HttpPreferParseError {}
+
+fn parse_prefer_member(member: &str) -> Result<(&str, Option<&str>), HttpPreferParseError> {
+  let (name, value) = member
+    .trim()
+    .split_once('=')
+    .map_or((member.trim(), None), |(name, value)| {
+      (name.trim(), Some(value.trim()))
+    });
+  if !is_http_token(name)
+    || value.is_some_and(|value| {
+      value.len() > MAX_PREFER_VALUE_BYTES
+        || !is_http_token(value)
+        || (name.eq_ignore_ascii_case("wait") && value.parse::<u64>().is_err())
+    })
+  {
+    return Err(HttpPreferParseError::new("invalid Prefer preference"));
+  }
+  Ok((name, value))
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -1394,6 +1521,20 @@ impl HttpRequest {
       .filter(|header| header.name.eq_ignore_ascii_case("Accept-Language"))
       .map(|header| header.value.as_str());
     HttpAcceptLanguages::parse_optional_values(values)
+  }
+
+  /// Parses received `Prefer` request metadata without applying preferences.
+  pub fn prefer(&self) -> Result<Option<HttpRequestPreferences>, HttpPreferParseError> {
+    let values: Vec<&str> = self
+      .headers
+      .iter()
+      .filter(|header| header.name.eq_ignore_ascii_case("Prefer"))
+      .map(|header| header.value.as_str())
+      .collect();
+    if values.is_empty() {
+      return Ok(None);
+    }
+    HttpRequestPreferences::parse_values(values).map(Some)
   }
 
   pub fn vary_selection(&self, vary: &HttpVary) -> HttpVarySelection {

--- a/crates/rttp-server/src/server/request.rs
+++ b/crates/rttp-server/src/server/request.rs
@@ -870,11 +870,9 @@ fn parse_prefer_member(member: &str) -> Result<(&str, Option<&str>), HttpPreferP
       (name.trim(), Some(value.trim()))
     });
   if !is_http_token(name)
-    || value.is_some_and(|value| {
-      value.len() > MAX_PREFER_VALUE_BYTES
-        || !is_http_token(value)
-        || (name.eq_ignore_ascii_case("wait") && value.parse::<u64>().is_err())
-    })
+    || (name.eq_ignore_ascii_case("wait")
+      && !value.is_some_and(|value| value.bytes().all(|byte| byte.is_ascii_digit())))
+    || value.is_some_and(|value| value.len() > MAX_PREFER_VALUE_BYTES || !is_http_token(value))
   {
     return Err(HttpPreferParseError::new("invalid Prefer preference"));
   }

--- a/crates/rttp/tests/test_server_models.rs
+++ b/crates/rttp/tests/test_server_models.rs
@@ -66,6 +66,55 @@ fn request_accept_helper_is_optional_and_keeps_raw_invalid_headers() {
 }
 
 #[test]
+fn request_prefer_preserves_ordered_known_and_extension_metadata() {
+  let request = parse_request(concat!(
+    "GET /metadata HTTP/1.1\r\n",
+    "Host: example.test\r\n",
+    "Prefer: respond-async, return=representation\r\n",
+    "Prefer: wait=15, example-extension=enabled\r\n",
+    "\r\n"
+  ));
+
+  let preferences = request
+    .prefer()
+    .expect("Prefer should parse")
+    .expect("Prefer should be present");
+  assert_eq!(4, preferences.len());
+  assert_eq!("respond-async", preferences.preferences()[0].name());
+  assert_eq!(None, preferences.preferences()[0].value());
+  assert_eq!("return", preferences.preferences()[1].name());
+  assert_eq!(Some("representation"), preferences.preferences()[1].value());
+  assert_eq!("wait", preferences.preferences()[2].name());
+  assert_eq!(Some("15"), preferences.preferences()[2].value());
+  assert_eq!("example-extension", preferences.preferences()[3].name());
+  assert_eq!(Some("enabled"), preferences.preferences()[3].value());
+}
+
+#[test]
+fn request_prefer_rejects_malformed_wait_oversized_values_and_excessive_preferences() {
+  for value in [
+    "wait=-1",
+    "wait=1.5",
+    "wait=abc",
+    "return=bad value",
+    "respond-async,",
+  ] {
+    let request = parse_request(&format!(
+      "GET /metadata HTTP/1.1\r\nHost: example.test\r\nPrefer: {value}\r\n\r\n"
+    ));
+    assert!(request.prefer().is_err(), "Prefer should reject {value:?}");
+    assert_eq!(Some(value), request.header("Prefer"));
+  }
+
+  assert!(rttp::server::HttpRequestPreferences::parse("a".repeat(64 * 1024 + 1)).is_err());
+  let too_many = (0..33)
+    .map(|index| format!("extension{index}"))
+    .collect::<Vec<_>>()
+    .join(", ");
+  assert!(rttp::server::HttpRequestPreferences::parse(too_many).is_err());
+}
+
+#[test]
 fn request_accept_ignores_extensions_after_quality() {
   let accept = HttpAccept::parse("text/html; level=1; q=0.8; foo; bar=quoted")
     .expect("Accept extensions after quality should parse");

--- a/crates/rttp/tests/test_server_models.rs
+++ b/crates/rttp/tests/test_server_models.rs
@@ -399,6 +399,7 @@ fn request_prefer_preserves_ordered_known_and_extension_metadata() {
 #[test]
 fn request_prefer_rejects_malformed_wait_oversized_values_and_excessive_preferences() {
   for value in [
+    "wait",
     "wait=-1",
     "wait=1.5",
     "wait=abc",


### PR DESCRIPTION
Added bounded metadata-only Prefer helpers for RTTP clients and servers, including ordered parsing, extension preservation, strict wait validation, documented non-goals, and passing workspace verification.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1673/
work_kind: code_work
branch: hbx-1673-rttp-add-bounded-prefer-request
base: main
commit: a2d72a37c0cca4e5e6b1f83e963f0eafce1aff4c
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1673/
    url: https://plane.kahub.in/endless/browse/HBX-1673/
    close_policy: link_only
```