### PR TITLE
feat: [rttp] Add bounded Retry-After response metadata helpers

### DIFF
--- a/crates/rttp-client/src/response/response.rs
+++ b/crates/rttp-client/src/response/response.rs
@@ -614,6 +614,7 @@ impl RetryAfter {
     if value.len() > MAX_RETRY_AFTER_VALUE_BYTES {
       return Err(error::bad_response("Retry-After header value is too large"));
     }
+    let value = value.trim();
     if value.is_empty() {
       return Err(error::bad_response("Invalid Retry-After value"));
     }

--- a/crates/rttp-client/tests/test_response.rs
+++ b/crates/rttp-client/tests/test_response.rs
@@ -1,6 +1,6 @@
 use rttp_client::response::{
   AltSvc, ContentDisposition, ContentEncoding, ContentLocation, ContentType, Digest, LinkValues,
-  Response, ServerTiming, WwwAuthenticate,
+  Response, RetryAfter, ServerTiming, WwwAuthenticate,
 };
 use rttp_client::types::{Cookie, RoUrl};
 use std::io::Write;
@@ -1453,6 +1453,34 @@ fn test_parse_retry_after_response_metadata() {
     response
       .retry_after()
       .expect("absent retry-after should parse")
+  );
+}
+
+#[test]
+fn test_parse_retry_after_response_metadata_accepts_surrounding_http_whitespace() {
+  let raw = concat!(
+    "HTTP/1.1 503 Service Unavailable\r\n",
+    "Retry-After: \t120 \r\n",
+    "Content-Length: 4\r\n",
+    "\r\n",
+    "busy"
+  );
+  let response = Response::new(RoUrl::with("https://example.test"), raw.as_bytes().to_vec())
+    .expect("parse response with Retry-After whitespace");
+
+  assert_eq!(
+    Some(120),
+    response
+      .retry_after()
+      .expect("Retry-After metadata should parse")
+      .expect("Retry-After metadata should be present")
+      .delta_seconds()
+  );
+  assert_eq!(
+    Some(120),
+    RetryAfter::parse("\t120 ")
+      .expect("RetryAfter parser should accept HTTP whitespace")
+      .delta_seconds()
   );
 }
 


### PR DESCRIPTION
Bounded Retry-After response metadata parsing now accepts legal surrounding HTTP whitespace in the client helper, with regression coverage and successful verification.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1687/
work_kind: code_work
branch: hbx-1687-rttp-add-bounded-retry-after
base: main
commit: f2c3ff56eab91be815ebec73e0384ce6269aeea4
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1687/
    url: https://plane.kahub.in/endless/browse/HBX-1687/
    close_policy: link_only
```