### PR TITLE
feat: [rttp] Add bounded Vary response metadata helpers

### DIFF
--- a/crates/rttp-server/src/server/response.rs
+++ b/crates/rttp-server/src/server/response.rs
@@ -1436,6 +1436,7 @@ impl HttpVary {
   {
     let mut fields = Vec::new();
     let mut wildcard = false;
+    let mut field_count = 0usize;
 
     for value in values {
       if value.len() > MAX_VARY_VALUE_BYTES {
@@ -1454,11 +1455,14 @@ impl HttpVary {
         if !is_http_token(field) {
           return Err(HttpVaryParseError::new("invalid Vary field name"));
         }
+
+        field_count += 1;
+        if field_count > MAX_VARY_FIELDS {
+          return Err(HttpVaryParseError::new("too many Vary field names"));
+        }
+
         let normalized = field.to_ascii_lowercase();
         if !fields.iter().any(|known| known == &normalized) {
-          if fields.len() >= MAX_VARY_FIELDS {
-            return Err(HttpVaryParseError::new("too many Vary field names"));
-          }
           fields.push(normalized);
         }
       }

--- a/crates/rttp/tests/test_server_models.rs
+++ b/crates/rttp/tests/test_server_models.rs
@@ -724,6 +724,39 @@ fn vary_helpers_reject_malformed_values() {
 }
 
 #[test]
+fn response_vary_helper_enforces_the_field_item_limit_before_deduplicating() {
+  let value = std::iter::repeat_n("Accept-Encoding", 257)
+    .collect::<Vec<_>>()
+    .join(", ");
+
+  assert!(
+    HttpResponse::ok("body")
+      .header("Vary", value)
+      .vary()
+      .is_err(),
+    "all parsed Vary list members must count toward the bound, including duplicates"
+  );
+}
+
+#[test]
+fn response_vary_helper_combines_multiple_headers_and_deduplicates_names() {
+  let response = HttpResponse::ok("body")
+    .header("Vary", "Accept-Encoding, User-Agent")
+    .header("vArY", "accept-encoding, X-Feature");
+
+  let vary = response
+    .vary()
+    .expect("attached Vary headers should parse")
+    .expect("Vary should be present");
+
+  assert!(!vary.is_wildcard());
+  assert_eq!(
+    vec!["accept-encoding", "user-agent", "x-feature"],
+    vary.field_names()
+  );
+}
+
+#[test]
 fn response_vary_helper_declares_normalized_vary_header() {
   let response = HttpResponse::ok("body")
     .with_vary("Accept-Encoding, X-User")


### PR DESCRIPTION
Server `Vary` metadata now enforces its item bound even for duplicate field names, with coverage for multi-header normalization and deduplication.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1698/
work_kind: code_work
branch: hbx-1698-rttp-add-bounded-vary-response
base: main
commit: 6b72816398b1cc4c5588c664029fdf24933c80a2
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1698/
    url: https://plane.kahub.in/endless/browse/HBX-1698/
    close_policy: link_only
```