### PR TITLE
feat: [rttp-server] Parse bounded Cache-Control request metadata

### DIFF
--- a/crates/rttp-server/README.md
+++ b/crates/rttp-server/README.md
@@ -2,3 +2,11 @@
 
 `rttp-server` provides the blocking HTTP server implementation re-exported by
 the `rttp` compatibility facade.
+
+## Request Cache-Control metadata
+
+Handlers can call `Request::cache_control()` to obtain typed request cache
+directives. The helper combines all case-insensitive `Cache-Control` header
+fields, preserves the request for handler-defined error policy, and returns an
+error for malformed values, values larger than 64 KiB, or more than 256
+directives. It only parses metadata; it does not apply caching behavior.

--- a/crates/rttp-server/src/server/server_tests.rs
+++ b/crates/rttp-server/src/server/server_tests.rs
@@ -1,6 +1,82 @@
 use std::net::TcpStream as StdTcpStream;
 
 #[test]
+fn request_cache_control_combines_case_insensitive_header_fields() {
+  let request = Request::from_raw_frame(
+    b"GET / HTTP/1.1\r\nHost: example.test\r\nCache-Control: no-cache, max-age=60\r\ncache-control: min-fresh=30, only-if-cached\r\n\r\n",
+  )
+  .expect("request should parse");
+
+  let cache_control = request
+    .cache_control()
+    .expect("Cache-Control should parse")
+    .expect("Cache-Control should be present");
+
+  assert!(cache_control.no_cache());
+  assert_eq!(Some(60), cache_control.max_age());
+  assert_eq!(Some(30), cache_control.min_fresh());
+  assert!(cache_control.only_if_cached());
+}
+
+#[test]
+fn request_cache_control_preserves_malformed_headers_for_handler_policy() {
+  let request = Request::from_raw_frame(
+    b"GET / HTTP/1.1\r\nHost: example.test\r\nCache-Control: max-age=invalid\r\n\r\n",
+  )
+  .expect("request should retain malformed metadata");
+
+  assert!(request.cache_control().is_err());
+  assert_eq!(Some("max-age=invalid"), request.header("Cache-Control"));
+}
+
+#[test]
+fn request_cache_control_rejects_oversized_values_without_panicking() {
+  let request = Request {
+    method: "GET".to_string(),
+    target: "/".to_string(),
+    version: "HTTP/1.1".to_string(),
+    headers: vec![(
+      "Cache-Control".to_string(),
+      format!("x={}", "a".repeat(MAX_CACHE_CONTROL_VALUE_BYTES)),
+    )],
+    trailers: Vec::new(),
+    body: Vec::new(),
+    extended_connect_protocol: None,
+  };
+
+  let error = request
+    .cache_control()
+    .expect_err("oversized Cache-Control should be rejected");
+
+  assert_eq!("Cache-Control header value is too large", error.to_string());
+}
+
+#[test]
+fn request_cache_control_rejects_directive_counts_across_header_fields() {
+  let directive_field = std::iter::repeat_n("extension", MAX_CACHE_CONTROL_DIRECTIVES)
+    .collect::<Vec<_>>()
+    .join(", ");
+  let request = Request {
+    method: "GET".to_string(),
+    target: "/".to_string(),
+    version: "HTTP/1.1".to_string(),
+    headers: vec![
+      ("Cache-Control".to_string(), directive_field),
+      ("cache-control".to_string(), "another-extension".to_string()),
+    ],
+    trailers: Vec::new(),
+    body: Vec::new(),
+    extended_connect_protocol: None,
+  };
+
+  let error = request
+    .cache_control()
+    .expect_err("too many Cache-Control directives should be rejected");
+
+  assert_eq!("too many Cache-Control directives", error.to_string());
+}
+
+#[test]
 fn request_max_forwards_is_optional_bounded_and_preserves_invalid_headers() {
   let absent = Request::from_raw_frame(b"GET / HTTP/1.1\r\nHost: example.test\r\n\r\n")
     .expect("request should parse");


### PR DESCRIPTION
Added documentation and server request regression coverage for bounded `Cache-Control` metadata parsing, including multi-header aggregation and safe malformed or oversized rejection. Formatting and the full workspace test suite pass.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1692/
work_kind: code_work
branch: hbx-1692-rttp-server-parse-bounded-cache
base: main
commit: 1878b9b1bae1871fd836510a781e111c93d4ee41
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1692/
    url: https://plane.kahub.in/endless/browse/HBX-1692/
    close_policy: link_only
```