### PR TITLE
feat: [rttp] Add bounded Cookie and Set-Cookie metadata helpers

### DIFF
--- a/crates/rttp-client/src/response/mod.rs
+++ b/crates/rttp-client/src/response/mod.rs
@@ -2,6 +2,10 @@
 
 pub use self::response::*;
 
+pub use rttp_protocol::cookie::{
+  HttpCookieParseError, HttpSetCookie, HttpSetCookieAttribute, HttpSetCookies,
+};
+
 mod raw_response;
 mod response;
 

--- a/crates/rttp-client/src/response/response.rs
+++ b/crates/rttp-client/src/response/response.rs
@@ -14,6 +14,7 @@ use crate::response::ReprDigest;
 use crate::response::ServerTiming;
 use crate::response::WwwAuthenticate;
 use crate::types::{Cookie, Header, RoUrl};
+use rttp_protocol::cookie::HttpSetCookies;
 
 const MAX_CACHE_CONTROL_VALUE_BYTES: usize = 64 * 1024;
 const MAX_CACHE_CONTROL_DIRECTIVES: usize = 256;
@@ -381,6 +382,18 @@ impl Response {
       return Ok(None);
     }
     LinkValues::parse_values(values.into_iter().map(String::as_str)).map(Some)
+  }
+
+  /// Parses response `Set-Cookie` fields as bounded opaque metadata without
+  /// creating a cookie jar or applying storage and matching policy.
+  pub fn set_cookies(&self) -> error::Result<Option<HttpSetCookies>> {
+    let values = self.header_values("set-cookie");
+    if values.is_empty() {
+      return Ok(None);
+    }
+    HttpSetCookies::parse_values(values.into_iter().map(String::as_str))
+      .map(Some)
+      .map_err(|parse_error| error::bad_response(parse_error.to_string()))
   }
 
   pub fn headers(&self) -> &Vec<Header> {

--- a/crates/rttp-client/tests/test_response.rs
+++ b/crates/rttp-client/tests/test_response.rs
@@ -1,6 +1,6 @@
 use rttp_client::response::{
-  AltSvc, ContentDisposition, ContentEncoding, ContentLocation, ContentType, Digest, LinkValues,
-  Response, ServerTiming, WwwAuthenticate,
+  AltSvc, ContentDisposition, ContentEncoding, ContentLocation, ContentType, Digest,
+  HttpSetCookies, LinkValues, Response, ServerTiming, WwwAuthenticate,
 };
 use rttp_client::types::{Cookie, RoUrl};
 use std::io::Write;
@@ -115,6 +115,40 @@ fn test_parse_response_preserves_duplicate_headers_with_case_insensitive_lookup(
       .cookie("theme")
       .map(|cookie| cookie.value().as_str())
   );
+}
+
+#[test]
+fn set_cookie_metadata_is_bounded_and_preserves_unknown_attributes() {
+  let raw = concat!(
+    "HTTP/1.1 200 OK\r\n",
+    "Set-Cookie: session=abc; Path=/; Priority=high; Partitioned\r\n",
+    "SET-COOKIE: theme=dark; SameSite=Lax\r\n",
+    "Content-Length: 0\r\n",
+    "\r\n"
+  );
+  let response = Response::new(RoUrl::with("https://example.test"), raw.as_bytes().to_vec())
+    .expect("response should parse");
+  let cookies = response
+    .set_cookies()
+    .expect("Set-Cookie metadata should parse")
+    .expect("Set-Cookie headers should be present");
+  assert_eq!(2, cookies.cookies().len());
+  assert_eq!("session", cookies.cookies()[0].name());
+  assert_eq!("abc", cookies.cookies()[0].value());
+  assert_eq!(
+    vec![
+      ("Path", Some("/")),
+      ("Priority", Some("high")),
+      ("Partitioned", None),
+    ],
+    cookies.cookies()[0]
+      .attributes()
+      .iter()
+      .map(|attribute| (attribute.name(), attribute.value()))
+      .collect::<Vec<_>>()
+  );
+
+  assert!(HttpSetCookies::parse("session=abc\x01").is_err());
 }
 
 #[test]

--- a/crates/rttp-protocol/src/cookie.rs
+++ b/crates/rttp-protocol/src/cookie.rs
@@ -1,0 +1,262 @@
+//! Bounded, policy-free cookie metadata parsing.
+//!
+//! This module intentionally keeps cookie values and attributes opaque. It
+//! does not implement a cookie jar, domain/path matching, expiry, or any other
+//! storage and sending policy.
+
+use std::error::Error;
+use std::fmt;
+
+/// Maximum number of parsed request cookies or response `Set-Cookie` fields.
+pub const MAX_COOKIE_COUNT: usize = 256;
+/// Maximum number of attributes retained for one `Set-Cookie` field.
+pub const MAX_SET_COOKIE_ATTRIBUTES: usize = 64;
+/// Maximum byte length of an individual cookie or attribute value.
+pub const MAX_COOKIE_VALUE_BYTES: usize = 4 * 1024;
+const MAX_COOKIE_FIELD_BYTES: usize = 64 * 1024;
+
+/// One name/value pair from a request `Cookie` field.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct HttpCookiePair {
+  name: String,
+  value: String,
+}
+
+impl HttpCookiePair {
+  pub fn name(&self) -> &str {
+    &self.name
+  }
+
+  pub fn value(&self) -> &str {
+    &self.value
+  }
+}
+
+/// Parsed request `Cookie` metadata.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct HttpCookies {
+  pairs: Vec<HttpCookiePair>,
+}
+
+impl HttpCookies {
+  pub fn parse(value: impl AsRef<str>) -> Result<Self, HttpCookieParseError> {
+    Self::parse_values([value.as_ref()])
+  }
+
+  pub fn parse_values<'a, I>(values: I) -> Result<Self, HttpCookieParseError>
+  where
+    I: IntoIterator<Item = &'a str>,
+  {
+    let mut pairs = Vec::new();
+    for value in values {
+      validate_field(value)?;
+      for member in value.split(';') {
+        let pair = parse_pair(member)?;
+        if pairs.len() >= MAX_COOKIE_COUNT {
+          return Err(HttpCookieParseError::new("too many cookies"));
+        }
+        pairs.push(pair);
+      }
+    }
+    if pairs.is_empty() {
+      return Err(HttpCookieParseError::new("invalid Cookie header value"));
+    }
+    Ok(Self { pairs })
+  }
+
+  pub fn pairs(&self) -> &[HttpCookiePair] {
+    &self.pairs
+  }
+}
+
+/// One attribute from a response `Set-Cookie` field.
+///
+/// Attributes are intentionally unclassified so extension attributes are
+/// retained alongside standardized ones.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct HttpSetCookieAttribute {
+  name: String,
+  value: Option<String>,
+}
+
+impl HttpSetCookieAttribute {
+  pub fn name(&self) -> &str {
+    &self.name
+  }
+
+  pub fn value(&self) -> Option<&str> {
+    self.value.as_deref()
+  }
+}
+
+/// One bounded response `Set-Cookie` field.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct HttpSetCookie {
+  name: String,
+  value: String,
+  attributes: Vec<HttpSetCookieAttribute>,
+}
+
+impl HttpSetCookie {
+  pub fn parse(value: impl AsRef<str>) -> Result<Self, HttpCookieParseError> {
+    let value = value.as_ref();
+    validate_field(value)?;
+    let mut members = value.split(';');
+    let pair = parse_pair(members.next().unwrap_or_default())?;
+    let mut attributes = Vec::new();
+    for member in members {
+      let member = member.trim_matches([' ', '\t']);
+      if member.is_empty() {
+        return Err(HttpCookieParseError::new("invalid Set-Cookie attribute"));
+      }
+      if attributes.len() >= MAX_SET_COOKIE_ATTRIBUTES {
+        return Err(HttpCookieParseError::new("too many Set-Cookie attributes"));
+      }
+      let (name, value) = match member.split_once('=') {
+        Some((name, value)) => {
+          let value = value.trim_matches([' ', '\t']);
+          validate_value(value)?;
+          (name.trim_matches([' ', '\t']), Some(value.to_owned()))
+        }
+        None => (member, None),
+      };
+      if name.is_empty() {
+        return Err(HttpCookieParseError::new("invalid Set-Cookie attribute"));
+      }
+      attributes.push(HttpSetCookieAttribute {
+        name: name.to_owned(),
+        value,
+      });
+    }
+    Ok(Self {
+      name: pair.name,
+      value: pair.value,
+      attributes,
+    })
+  }
+
+  pub fn name(&self) -> &str {
+    &self.name
+  }
+
+  pub fn value(&self) -> &str {
+    &self.value
+  }
+
+  pub fn attributes(&self) -> &[HttpSetCookieAttribute] {
+    &self.attributes
+  }
+}
+
+/// Parsed response `Set-Cookie` metadata.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct HttpSetCookies {
+  cookies: Vec<HttpSetCookie>,
+}
+
+impl HttpSetCookies {
+  pub fn parse(value: impl AsRef<str>) -> Result<Self, HttpCookieParseError> {
+    Self::parse_values([value.as_ref()])
+  }
+
+  pub fn parse_values<'a, I>(values: I) -> Result<Self, HttpCookieParseError>
+  where
+    I: IntoIterator<Item = &'a str>,
+  {
+    let mut cookies = Vec::new();
+    for value in values {
+      if cookies.len() >= MAX_COOKIE_COUNT {
+        return Err(HttpCookieParseError::new("too many Set-Cookie fields"));
+      }
+      cookies.push(HttpSetCookie::parse(value)?);
+    }
+    if cookies.is_empty() {
+      return Err(HttpCookieParseError::new("invalid Set-Cookie header value"));
+    }
+    Ok(Self { cookies })
+  }
+
+  pub fn cookies(&self) -> &[HttpSetCookie] {
+    &self.cookies
+  }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct HttpCookieParseError {
+  message: String,
+}
+
+impl HttpCookieParseError {
+  fn new(message: impl Into<String>) -> Self {
+    Self {
+      message: message.into(),
+    }
+  }
+}
+
+impl fmt::Display for HttpCookieParseError {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    f.write_str(&self.message)
+  }
+}
+
+impl Error for HttpCookieParseError {}
+
+fn parse_pair(value: &str) -> Result<HttpCookiePair, HttpCookieParseError> {
+  let value = value.trim_matches([' ', '\t']);
+  let Some((name, value)) = value.split_once('=') else {
+    return Err(HttpCookieParseError::new("invalid cookie pair"));
+  };
+  let name = name.trim_matches([' ', '\t']);
+  let value = value.trim_matches([' ', '\t']);
+  if name.is_empty() {
+    return Err(HttpCookieParseError::new("invalid cookie name"));
+  }
+  validate_value(value)?;
+  Ok(HttpCookiePair {
+    name: name.to_owned(),
+    value: value.to_owned(),
+  })
+}
+
+fn validate_field(value: &str) -> Result<(), HttpCookieParseError> {
+  if value.len() > MAX_COOKIE_FIELD_BYTES {
+    return Err(HttpCookieParseError::new(
+      "cookie header value is too large",
+    ));
+  }
+  if value.bytes().any(|byte| byte.is_ascii_control()) {
+    return Err(HttpCookieParseError::new(
+      "cookie header contains a control byte",
+    ));
+  }
+  Ok(())
+}
+
+fn validate_value(value: &str) -> Result<(), HttpCookieParseError> {
+  if value.len() > MAX_COOKIE_VALUE_BYTES {
+    return Err(HttpCookieParseError::new("cookie value is too large"));
+  }
+  Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn cookie_metadata_rejects_values_and_collections_above_its_bounds() {
+    let oversized_value = format!("session={}", "a".repeat(MAX_COOKIE_VALUE_BYTES + 1));
+    assert!(HttpCookies::parse(&oversized_value).is_err());
+    assert!(HttpSetCookie::parse(&oversized_value).is_err());
+
+    let pairs = std::iter::repeat("name=value")
+      .take(MAX_COOKIE_COUNT + 1)
+      .collect::<Vec<_>>()
+      .join(";");
+    assert!(HttpCookies::parse(&pairs).is_err());
+
+    let fields = std::iter::repeat("name=value").take(MAX_COOKIE_COUNT + 1);
+    assert!(HttpSetCookies::parse_values(fields).is_err());
+  }
+}

--- a/crates/rttp-protocol/src/cookie.rs
+++ b/crates/rttp-protocol/src/cookie.rs
@@ -4,6 +4,7 @@
 //! does not implement a cookie jar, domain/path matching, expiry, or any other
 //! storage and sending policy.
 
+use crate::http1::is_token;
 use std::error::Error;
 use std::fmt;
 
@@ -209,7 +210,7 @@ fn parse_pair(value: &str) -> Result<HttpCookiePair, HttpCookieParseError> {
   };
   let name = name.trim_matches([' ', '\t']);
   let value = value.trim_matches([' ', '\t']);
-  if name.is_empty() {
+  if !is_token(name) {
     return Err(HttpCookieParseError::new("invalid cookie name"));
   }
   validate_value(value)?;
@@ -258,5 +259,11 @@ mod tests {
 
     let fields = std::iter::repeat("name=value").take(MAX_COOKIE_COUNT + 1);
     assert!(HttpSetCookies::parse_values(fields).is_err());
+  }
+
+  #[test]
+  fn cookie_metadata_rejects_non_token_names() {
+    assert!(HttpCookies::parse("bad name=value").is_err());
+    assert!(HttpSetCookie::parse("bad name=value").is_err());
   }
 }

--- a/crates/rttp-protocol/src/lib.rs
+++ b/crates/rttp-protocol/src/lib.rs
@@ -4,6 +4,7 @@
 //! validation only; client and server application policy remains in its callers.
 
 pub mod alt_svc;
+pub mod cookie;
 pub mod digest;
 pub mod forwarded;
 pub mod http1;

--- a/crates/rttp-server/src/server/request.rs
+++ b/crates/rttp-server/src/server/request.rs
@@ -1,5 +1,6 @@
 use super::*;
 
+pub use rttp_protocol::cookie::{HttpCookiePair, HttpCookieParseError, HttpCookies};
 pub use rttp_protocol::forwarded::{
   Forwarded as HttpForwarded, ForwardedElement as HttpForwardedElement,
   ForwardedParameter as HttpForwardedParameter, ForwardedParseError as HttpForwardedParseError,
@@ -288,6 +289,16 @@ impl Request {
       ));
     }
     HttpAuthorization::parse(value).map(Some)
+  }
+
+  /// Parses request `Cookie` pairs as bounded opaque metadata without applying
+  /// cookie storage, matching, or authorization policy.
+  pub fn cookies(&self) -> Result<Option<HttpCookies>, HttpCookieParseError> {
+    let values: Vec<&str> = self.headers_named("Cookie").collect();
+    if values.is_empty() {
+      return Ok(None);
+    }
+    HttpCookies::parse_values(values).map(Some)
   }
 
   /// Parses received `Max-Forwards` request metadata without automatically
@@ -1773,6 +1784,21 @@ impl HttpRequest {
       ));
     }
     HttpAuthorization::parse(value).map(Some)
+  }
+
+  /// Parses request `Cookie` pairs as bounded opaque metadata without applying
+  /// cookie storage, matching, or authorization policy.
+  pub fn cookies(&self) -> Result<Option<HttpCookies>, HttpCookieParseError> {
+    let values: Vec<&str> = self
+      .headers
+      .iter()
+      .filter(|header| header.name.eq_ignore_ascii_case("Cookie"))
+      .map(|header| header.value.as_str())
+      .collect();
+    if values.is_empty() {
+      return Ok(None);
+    }
+    HttpCookies::parse_values(values).map(Some)
   }
 
   /// Parses received `Max-Forwards` request metadata without automatically

--- a/crates/rttp-server/src/server/server_tests.rs
+++ b/crates/rttp-server/src/server/server_tests.rs
@@ -40,6 +40,28 @@ fn request_max_forwards_is_optional_bounded_and_preserves_invalid_headers() {
   assert_eq!(Some("1"), duplicate.header("Max-Forwards"));
 }
 
+#[test]
+fn request_cookies_are_bounded_and_preserve_pairs() {
+  let request = Request::from_raw_frame(
+    b"GET / HTTP/1.1\r\nHost: example.test\r\nCookie: session=abc; theme=dark\r\nCookie: flag=\r\n\r\n",
+  )
+  .expect("request should parse");
+  let cookies = request
+    .cookies()
+    .expect("cookie metadata should parse")
+    .expect("Cookie header should be present");
+  assert_eq!(
+    vec![("session", "abc"), ("theme", "dark"), ("flag", "")],
+    cookies
+      .pairs()
+      .iter()
+      .map(|pair| (pair.name(), pair.value()))
+      .collect::<Vec<_>>()
+  );
+
+  assert!(HttpCookies::parse("session=abc\x01").is_err());
+}
+
   #[test]
   fn http2_huffman_decode_table_resolves_symbols_without_linear_scan() {
     let table = http2_huffman_decode_table();


### PR DESCRIPTION
Bounded Cookie and Set-Cookie metadata helpers are available on server requests and client responses, with safe limits, control-byte rejection, unknown-attribute preservation, and passing workspace verification.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1697/
work_kind: code_work
branch: hbx-1697-rttp-add-bounded-cookie-and
base: main
commit: 2803ee044f307e73c8a0ff0ed916c8084d37640a
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1697/
    url: https://plane.kahub.in/endless/browse/HBX-1697/
    close_policy: link_only
```