### PR TITLE
feat: [rttp-client] Add bounded Range and validator request helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,15 @@ available through `Response::trailers`, `Response::trailer`, and
 suffix before opening a socket. Callers can still set a manual `Range` header
 with the generic header API for cases outside those helpers.
 
+```rust
+client
+  .get()
+  .url("http://example.test/archive")
+  .range(1_024, 2_047)?
+  .if_range_etag(r#""revision-42""#)?
+  .emit()?;
+```
+
 `206 Partial Content` and `416 Range Not Satisfiable` are visible through
 `Response::is_partial_content()` and `Response::is_range_not_satisfiable()`.
 `Response::content_range()` parses `Content-Range` into `ContentRange`, using
@@ -78,6 +87,15 @@ call: `*`, a strong tag such as `"abc"`, or a weak tag such as `W/"abc"`.
 Comma-separated validator lists remain available through the generic `header`
 API. The date helpers require values that parse as HTTP-date values before a
 socket is opened.
+
+```rust
+client
+  .get()
+  .url("http://example.test/manifest")
+  .if_none_match(r#""revision-42""#)?
+  .if_modified_since("Sun, 06 Nov 1994 08:49:37 GMT")?
+  .emit()?;
+```
 
 Responses expose conditional metadata with `Response::is_not_modified()` for
 `304 Not Modified`, `Response::is_precondition_failed()` for

--- a/crates/rttp-client/README.md
+++ b/crates/rttp-client/README.md
@@ -48,6 +48,15 @@ zero suffix length before a socket is opened. They are request-header helpers;
 manual `Range` headers remain available through `header(("Range", "..."))`
 when callers need behavior outside the helper validation.
 
+```rust
+client
+  .get()
+  .url("http://example.test/archive")
+  .range(1_024, 2_047)?
+  .if_range_etag(r#""revision-42""#)?
+  .emit()?;
+```
+
 Partial-content responses are exposed through the normal `Response` API.
 `Response::is_partial_content()` identifies `206 Partial Content`, and
 `Response::content_range()` parses a `Content-Range` field such as
@@ -102,6 +111,15 @@ emission and then write the value as provided. They do not normalize date text
 or choose a validator policy for the request. `If-Range` uses its own helpers
 because it is intended to compose with range requests and permits only strong
 entity tags or HTTP-date validators.
+
+```rust
+client
+  .get()
+  .url("http://example.test/manifest")
+  .if_none_match(r#""revision-42""#)?
+  .if_modified_since("Sun, 06 Nov 1994 08:49:37 GMT")?
+  .emit()?;
+```
 
 Conditional responses are exposed through response metadata helpers.
 `Response::is_not_modified()` identifies `304 Not Modified`,

--- a/crates/rttp-client/src/client.rs
+++ b/crates/rttp-client/src/client.rs
@@ -1406,8 +1406,15 @@ fn validate_request_trailer_header(name: &str, value: &str) -> error::Result<()>
   Ok(())
 }
 
+const MAX_CONDITIONAL_VALIDATOR_VALUE_BYTES: usize = 64 * 1024;
+
 fn validate_single_etag(etag: &str) -> error::Result<&str> {
   let etag = etag.trim();
+  if etag.len() > MAX_CONDITIONAL_VALIDATOR_VALUE_BYTES {
+    return Err(error::builder_with_message(
+      "conditional entity-tag validator is too large",
+    ));
+  }
   if etag == "*" {
     return Ok(etag);
   }

--- a/crates/rttp-client/tests/test_raw_request_capture.rs
+++ b/crates/rttp-client/tests/test_raw_request_capture.rs
@@ -1181,6 +1181,32 @@ fn conditional_request_helpers_reject_obvious_malformed_inputs_before_connecting
 }
 
 #[test]
+fn conditional_etag_helpers_reject_oversized_validators_before_connecting() {
+  let oversized = format!("\"{}\"", "a".repeat(64 * 1024));
+
+  for helper in ["If-Match", "If-None-Match", "If-Range"] {
+    let request = capture_optional_request(|base_url| {
+      let mut client = client();
+      let request = client.get().url(format!("{}/asset", base_url));
+      let error = match helper {
+        "If-Match" => request.if_match(&oversized),
+        "If-None-Match" => request.if_none_match(&oversized),
+        "If-Range" => request.if_range_etag(&oversized),
+        _ => unreachable!("test helper names are exhaustive"),
+      }
+      .expect_err("oversized entity tag should be rejected");
+
+      assert!(error.is_builder());
+    });
+
+    assert!(
+      request.is_empty(),
+      "oversized {helper} helper input should not open a socket"
+    );
+  }
+}
+
+#[test]
 fn manual_conditional_headers_remain_available_as_escape_hatch() {
   let request = capture_request(|base_url| {
     client()


### PR DESCRIPTION
RTTP client validator helpers now enforce a 64 KiB entity-tag bound before network activity, with raw-request regression coverage and public range/conditional request examples.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1694/
work_kind: code_work
branch: hbx-1694-rttp-client-add-bounded-range
base: main
commit: 62402af44e72b6fd2ebda55025ec83b349eae7ec
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1694/
    url: https://plane.kahub.in/endless/browse/HBX-1694/
    close_policy: link_only
```