### PR TITLE
feat: [rttp-client] Expose bounded Cache-Control request helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,21 @@ parameters per value.
 This shares Early Hints' bounded metadata posture, but it does not preload,
 schedule fetches, redirect, apply cache policy, or generate routes.
 
+### Bounded Cache-Control request metadata
+
+`HttpClient::cache_control_no_cache()`, `cache_control_no_store()`, and
+`cache_control_max_age(seconds)` append common request directives to one
+`Cache-Control` field. `cache_control_extension(name)` and
+`cache_control_extension_with_value(name, value)` append valueless and
+token-valued extension directives. The helpers reject malformed tokens,
+duplicate directives, oversized values, and more than 256 directives before a
+connection is opened.
+
+These methods only declare request metadata: they do not create a cache,
+compute freshness, or automatically revalidate. Raw
+`header(("Cache-Control", value))` remains available for quoted-string
+extension values or other syntax outside this bounded API.
+
 ### Bounded HTTP/1.1 Cache-Control behavior
 
 `Response::cache_control()` parses one or more response `Cache-Control` header

--- a/crates/rttp-client/README.md
+++ b/crates/rttp-client/README.md
@@ -145,6 +145,21 @@ metadata does not trigger automatic preload execution, cache policy, redirect,
 retry, replay, route generation, streaming early-write behavior, TLS/ALPN
 behavior, or status-policy behavior.
 
+## Bounded Cache-Control request metadata
+
+`HttpClient::cache_control_no_cache()`, `cache_control_no_store()`, and
+`cache_control_max_age(seconds)` append common request directives to one
+`Cache-Control` field. `cache_control_extension(name)` and
+`cache_control_extension_with_value(name, value)` append valueless and
+token-valued extension directives. The helpers reject malformed tokens,
+duplicate directives, oversized values, and more than 256 directives before a
+connection is opened.
+
+The helpers only declare request metadata: they do not create a cache, compute
+freshness, or automatically revalidate. Raw `header(("Cache-Control", value))`
+remains available for quoted-string extension values or other syntax outside
+this bounded API.
+
 ## Bounded HTTP/1.1 Cache-Control behavior
 
 `Response::cache_control()` parses one or more response `Cache-Control` header

--- a/crates/rttp-client/src/client.rs
+++ b/crates/rttp-client/src/client.rs
@@ -337,6 +337,45 @@ impl HttpClient {
     self.accept_with_q("text/plain", qvalue)
   }
 
+  /// Append `no-cache` to bounded `Cache-Control` request metadata.
+  ///
+  /// This declares request metadata only; it does not enable cache storage or
+  /// automatic revalidation.
+  pub fn cache_control_no_cache(&mut self) -> error::Result<&mut Self> {
+    self.cache_control_member("no-cache", None)
+  }
+
+  /// Append `no-store` to bounded `Cache-Control` request metadata.
+  ///
+  /// This declares request metadata only; it does not enable cache storage or
+  /// automatic revalidation.
+  pub fn cache_control_no_store(&mut self) -> error::Result<&mut Self> {
+    self.cache_control_member("no-store", None)
+  }
+
+  /// Append `max-age=<seconds>` to bounded `Cache-Control` request metadata.
+  pub fn cache_control_max_age(&mut self, seconds: u64) -> error::Result<&mut Self> {
+    let value = seconds.to_string();
+    self.cache_control_member("max-age", Some(&value))
+  }
+
+  /// Append a valueless Cache-Control extension directive.
+  pub fn cache_control_extension<N: AsRef<str>>(&mut self, name: N) -> error::Result<&mut Self> {
+    self.cache_control_member(name.as_ref(), None)
+  }
+
+  /// Append a token-valued Cache-Control extension directive.
+  ///
+  /// Both the extension name and value must be HTTP tokens. Use [`Self::header`]
+  /// directly for extension values that require quoted-string syntax.
+  pub fn cache_control_extension_with_value<N: AsRef<str>, V: AsRef<str>>(
+    &mut self,
+    name: N,
+    value: V,
+  ) -> error::Result<&mut Self> {
+    self.cache_control_member(name.as_ref(), Some(value.as_ref()))
+  }
+
   /// Set bounded HTTP `Priority` request metadata.
   ///
   /// This validates RFC 9218 urgency, incremental, and extension parameters
@@ -750,6 +789,52 @@ impl HttpClient {
       header.replace(Header::new("Accept", value));
     } else {
       headers.push(Header::new("Accept", member));
+    }
+    Ok(self)
+  }
+
+  fn cache_control_member(&mut self, name: &str, value: Option<&str>) -> error::Result<&mut Self> {
+    let name = name.trim();
+    if !is_http_token(name) || value.is_some_and(|value| !is_http_token(value)) {
+      return Err(error::builder_with_message(
+        "invalid Cache-Control directive",
+      ));
+    }
+    let member = value.map_or_else(|| name.to_string(), |value| format!("{name}={value}"));
+    if member.len() > MAX_CACHE_CONTROL_VALUE_BYTES {
+      return Err(error::builder_with_message(
+        "Cache-Control header value is too large",
+      ));
+    }
+
+    let headers = self.request.headers_mut();
+    if let Some(header) = headers
+      .iter_mut()
+      .find(|header| header.name().eq_ignore_ascii_case("Cache-Control"))
+    {
+      let directives = parse_cache_control_directive_names(header.value())?;
+      if directives
+        .iter()
+        .any(|known| known.eq_ignore_ascii_case(name))
+      {
+        return Err(error::builder_with_message(
+          "duplicate Cache-Control directive",
+        ));
+      }
+      if directives.len() >= MAX_CACHE_CONTROL_DIRECTIVES {
+        return Err(error::builder_with_message(
+          "too many Cache-Control directives",
+        ));
+      }
+      let value = format!("{}, {member}", header.value());
+      if value.len() > MAX_CACHE_CONTROL_VALUE_BYTES {
+        return Err(error::builder_with_message(
+          "Cache-Control header value is too large",
+        ));
+      }
+      header.replace(Header::new("Cache-Control", value));
+    } else {
+      headers.push(Header::new("Cache-Control", member));
     }
     Ok(self)
   }
@@ -1174,6 +1259,45 @@ fn parse_metadata_members<'a>(
 
 const MAX_ACCEPT_VALUE_BYTES: usize = 64 * 1024;
 const MAX_ACCEPT_MEDIA_RANGES: usize = 32;
+const MAX_CACHE_CONTROL_VALUE_BYTES: usize = 64 * 1024;
+const MAX_CACHE_CONTROL_DIRECTIVES: usize = 256;
+
+fn parse_cache_control_directive_names(value: &str) -> error::Result<Vec<&str>> {
+  if value.len() > MAX_CACHE_CONTROL_VALUE_BYTES {
+    return Err(error::builder_with_message(
+      "Cache-Control header value is too large",
+    ));
+  }
+  let mut names = Vec::new();
+  for directive in value.split(',') {
+    let (name, directive_value) = directive
+      .trim()
+      .split_once('=')
+      .map_or((directive.trim(), None), |(name, value)| {
+        (name.trim(), Some(value.trim()))
+      });
+    if !is_http_token(name) || directive_value.is_some_and(|value| !is_http_token(value)) {
+      return Err(error::builder_with_message(
+        "invalid Cache-Control directive",
+      ));
+    }
+    if names
+      .iter()
+      .any(|known: &&str| known.eq_ignore_ascii_case(name))
+    {
+      return Err(error::builder_with_message(
+        "duplicate Cache-Control directive",
+      ));
+    }
+    if names.len() >= MAX_CACHE_CONTROL_DIRECTIVES {
+      return Err(error::builder_with_message(
+        "too many Cache-Control directives",
+      ));
+    }
+    names.push(name);
+  }
+  Ok(names)
+}
 
 fn parse_accept_media_ranges(value: &str) -> error::Result<usize> {
   if value.len() > MAX_ACCEPT_VALUE_BYTES {

--- a/crates/rttp-client/src/client.rs
+++ b/crates/rttp-client/src/client.rs
@@ -361,7 +361,7 @@ impl HttpClient {
 
   /// Append a valueless Cache-Control extension directive.
   pub fn cache_control_extension<N: AsRef<str>>(&mut self, name: N) -> error::Result<&mut Self> {
-    self.cache_control_member(name.as_ref(), None)
+    self.cache_control_extension_member(name.as_ref(), None)
   }
 
   /// Append a token-valued Cache-Control extension directive.
@@ -373,7 +373,7 @@ impl HttpClient {
     name: N,
     value: V,
   ) -> error::Result<&mut Self> {
-    self.cache_control_member(name.as_ref(), Some(value.as_ref()))
+    self.cache_control_extension_member(name.as_ref(), Some(value.as_ref()))
   }
 
   /// Set bounded HTTP `Priority` request metadata.
@@ -837,6 +837,22 @@ impl HttpClient {
       headers.push(Header::new("Cache-Control", member));
     }
     Ok(self)
+  }
+
+  fn cache_control_extension_member(
+    &mut self,
+    name: &str,
+    value: Option<&str>,
+  ) -> error::Result<&mut Self> {
+    if ["no-cache", "no-store", "max-age"]
+      .iter()
+      .any(|directive| directive.eq_ignore_ascii_case(name.trim()))
+    {
+      return Err(error::builder_with_message(
+        "Cache-Control directive must use a dedicated helper",
+      ));
+    }
+    self.cache_control_member(name, value)
   }
 
   /// Add request para

--- a/crates/rttp-client/tests/test_raw_request_capture.rs
+++ b/crates/rttp-client/tests/test_raw_request_capture.rs
@@ -463,6 +463,34 @@ fn cache_control_helpers_reject_invalid_or_excessive_values_before_connecting() 
     request.is_empty(),
     "excessive Cache-Control directives should not open a socket"
   );
+
+  let request = capture_optional_request(|base_url| {
+    let mut client = client();
+    let error = client
+      .get()
+      .url(format!("{}/document", base_url))
+      .cache_control_extension("max-age")
+      .expect_err("dedicated Cache-Control directives should not be extensions");
+    assert!(error.is_builder());
+  });
+  assert!(
+    request.is_empty(),
+    "reserved Cache-Control directive names should not open a socket"
+  );
+
+  let request = capture_optional_request(|base_url| {
+    let mut client = client();
+    let error = client
+      .get()
+      .url(format!("{}/document", base_url))
+      .cache_control_extension_with_value("no-store", "1")
+      .expect_err("dedicated Cache-Control directives should not be extensions");
+    assert!(error.is_builder());
+  });
+  assert!(
+    request.is_empty(),
+    "reserved Cache-Control directive names should not open a socket"
+  );
 }
 
 #[test]

--- a/crates/rttp-client/tests/test_raw_request_capture.rs
+++ b/crates/rttp-client/tests/test_raw_request_capture.rs
@@ -398,6 +398,74 @@ fn accept_helpers_emit_validated_media_ranges_and_quality_values() {
 }
 
 #[test]
+fn cache_control_helpers_emit_bounded_request_directives() {
+  let request = capture_request(|base_url| {
+    client()
+      .get()
+      .url(format!("{}/document", base_url))
+      .cache_control_no_cache()
+      .expect("no-cache should be accepted")
+      .cache_control_no_store()
+      .expect("no-store should be accepted")
+      .cache_control_max_age(60)
+      .expect("max-age should be accepted")
+      .cache_control_extension_with_value("community", "private")
+      .expect("extension should be accepted")
+      .cache_control_extension("immutable")
+      .expect("valueless extension should be accepted")
+      .emit()
+      .expect("request should succeed");
+  });
+  let request = request_text(&request);
+
+  assert_eq!(
+    Some("no-cache, no-store, max-age=60, community=private, immutable"),
+    header_value(&request, "Cache-Control")
+  );
+}
+
+#[test]
+fn cache_control_helpers_reject_invalid_or_excessive_values_before_connecting() {
+  for (name, value) in [
+    ("bad name", "value".to_string()),
+    ("community", "bad\r\nvalue".to_string()),
+    ("community", "a".repeat(64 * 1024 + 1)),
+  ] {
+    let request = capture_optional_request(|base_url| {
+      let mut client = client();
+      let error = client
+        .get()
+        .url(format!("{}/document", base_url))
+        .cache_control_extension_with_value(name, value)
+        .expect_err("invalid Cache-Control extension should be rejected");
+      assert!(error.is_builder());
+    });
+    assert!(
+      request.is_empty(),
+      "invalid Cache-Control metadata should not open a socket"
+    );
+  }
+
+  let request = capture_optional_request(|base_url| {
+    let mut client = client();
+    client.get().url(format!("{}/document", base_url));
+    for index in 0..256 {
+      client
+        .cache_control_extension(format!("extension-{index}"))
+        .expect("bounded Cache-Control directive should be accepted");
+    }
+    let error = client
+      .cache_control_extension("overflow")
+      .expect_err("too many Cache-Control directives should be rejected");
+    assert!(error.is_builder());
+  });
+  assert!(
+    request.is_empty(),
+    "excessive Cache-Control directives should not open a socket"
+  );
+}
+
+#[test]
 fn accept_helpers_reject_invalid_values_before_connecting() {
   for value in [
     "text",


### PR DESCRIPTION
Expose bounded Cache-Control request helpers for common directives and token-valued extensions, with validation, documentation, and raw request-capture coverage.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1691/
work_kind: code_work
branch: hbx-1691-rttp-client-expose-bounded-cache
base: main
commit: afce458eb11f1d513d913438f668365e931d1668
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1691/
    url: https://plane.kahub.in/endless/browse/HBX-1691/
    close_policy: link_only
```