### PR TITLE
feat: [rttp] Add bounded Trailer header metadata support

### DIFF
--- a/crates/rttp-client/src/client.rs
+++ b/crates/rttp-client/src/client.rs
@@ -9,6 +9,7 @@ use crate::{error, Config, H2cClientPolicy};
 use futures::io::AsyncRead;
 use rttp_protocol::forwarded::{Forwarded, MAX_FORWARDED_VALUE_BYTES};
 use rttp_protocol::priority::Priority;
+use rttp_protocol::trailer::Trailer;
 use std::io;
 
 #[derive(Debug)]
@@ -237,6 +238,22 @@ impl HttpClient {
       }
     }
     Ok(self)
+  }
+
+  /// Declare bounded `Trailer` field-name metadata without enabling streaming
+  /// request trailers or adding `TE` capability metadata.
+  pub fn trailer_header<I, S>(&mut self, field_names: I) -> error::Result<&mut Self>
+  where
+    I: IntoIterator<Item = S>,
+    S: AsRef<str>,
+  {
+    let fields: Vec<String> = field_names
+      .into_iter()
+      .map(|field_name| field_name.as_ref().to_string())
+      .collect();
+    let trailer = Trailer::parse_values(fields.iter().map(String::as_str))
+      .map_err(|error| error::builder_with_message(error.to_string()))?;
+    Ok(self.header(Header::new("Trailer", trailer.header_value())))
   }
 
   /// Add request cookie

--- a/crates/rttp-client/src/response/mod.rs
+++ b/crates/rttp-client/src/response/mod.rs
@@ -13,6 +13,7 @@ pub use rttp_protocol::priority::{Priority, PriorityExtension, PriorityParseErro
 pub use rttp_protocol::server_timing::{
   ServerTiming, ServerTimingMetric, ServerTimingParameter, ServerTimingParseError,
 };
+pub use rttp_protocol::trailer::{Trailer, TrailerParseError};
 pub use rttp_protocol::www_authenticate::{
   WwwAuthenticate, WwwAuthenticateChallenge, WwwAuthenticateParameter, WwwAuthenticateParseError,
 };

--- a/crates/rttp-client/src/response/response.rs
+++ b/crates/rttp-client/src/response/response.rs
@@ -12,6 +12,7 @@ use crate::response::Digest;
 use crate::response::Priority;
 use crate::response::ReprDigest;
 use crate::response::ServerTiming;
+use crate::response::Trailer;
 use crate::response::WwwAuthenticate;
 use crate::types::{Cookie, Header, RoUrl};
 
@@ -371,6 +372,18 @@ impl Response {
       return Ok(None);
     }
     Vary::parse_values(values.into_iter().map(String::as_str)).map(Some)
+  }
+
+  /// Parses announced trailer field names without waiting for or exposing a
+  /// trailer block.
+  pub fn trailer_header(&self) -> error::Result<Option<Trailer>> {
+    let values = self.header_values("trailer");
+    if values.is_empty() {
+      return Ok(None);
+    }
+    Trailer::parse_values(values.into_iter().map(String::as_str))
+      .map(Some)
+      .map_err(|error| error::bad_response(error.to_string()))
   }
 
   /// Parses `Link` response metadata without enabling preload, redirects,

--- a/crates/rttp-client/tests/test_raw_request_capture.rs
+++ b/crates/rttp-client/tests/test_raw_request_capture.rs
@@ -560,6 +560,43 @@ fn te_helpers_reject_invalid_members_before_connecting() {
 }
 
 #[test]
+fn trailer_header_helper_declares_validated_fields_without_enabling_trailer_streaming() {
+  let request = capture_request(|base_url| {
+    client()
+      .post()
+      .url(format!("{}/upload", base_url))
+      .trailer_header(["X-Checksum", "x-signature", "X-Checksum"])
+      .expect("Trailer field names should be accepted")
+      .emit()
+      .expect("request should succeed");
+  });
+  let request = request_text(&request);
+  assert_eq!(
+    Some("x-checksum, x-signature"),
+    header_value(&request, "Trailer")
+  );
+  assert_eq!(None, header_value(&request, "TE"));
+
+  for field in [
+    "Content-Length",
+    "TE",
+    "bad field",
+    "X-Good\r\nInjected: yes",
+  ] {
+    let mut client = client();
+    let error = client
+      .post()
+      .url("http://example.test/upload")
+      .trailer_header([field])
+      .expect_err("invalid Trailer field name should be rejected");
+    assert!(
+      error.is_builder(),
+      "{field:?} should be rejected before connecting"
+    );
+  }
+}
+
+#[test]
 fn priority_helper_emits_bounded_known_and_extension_metadata() {
   let request = capture_request(|base_url| {
     client()

--- a/crates/rttp-client/tests/test_response.rs
+++ b/crates/rttp-client/tests/test_response.rs
@@ -1876,6 +1876,35 @@ fn test_parse_vary_response_helper_normalizes_and_deduplicates_field_names() {
 }
 
 #[test]
+fn test_parse_trailer_header_metadata_keeps_te_capability_separate() {
+  let response = Response::new(
+    RoUrl::with("http://example.test/"),
+    concat!(
+      "HTTP/1.1 200 OK\r\n",
+      "TE: trailers\r\n",
+      "Trailer: X-Checksum, x-signature\r\n",
+      "Trailer: X-Checksum\r\n",
+      "Content-Length: 0\r\n\r\n"
+    )
+    .as_bytes()
+    .to_vec(),
+  )
+  .expect("response should parse");
+  let trailer = response
+    .trailer_header()
+    .expect("Trailer metadata should parse")
+    .expect("Trailer metadata should be present");
+  assert_eq!(vec!["x-checksum", "x-signature"], trailer.field_names());
+
+  let invalid = Response::new(
+    RoUrl::with("http://example.test/"),
+    b"HTTP/1.1 200 OK\r\nTrailer: Content-Length\r\nContent-Length: 0\r\n\r\n".to_vec(),
+  )
+  .expect("response framing should parse");
+  assert!(invalid.trailer_header().is_err());
+}
+
+#[test]
 fn test_parse_vary_response_helper_supports_wildcard_and_absent_header() {
   let s = concat!(
     "HTTP/1.1 200 OK\r\n",

--- a/crates/rttp-protocol/src/lib.rs
+++ b/crates/rttp-protocol/src/lib.rs
@@ -9,4 +9,5 @@ pub mod forwarded;
 pub mod http1;
 pub mod priority;
 pub mod server_timing;
+pub mod trailer;
 pub mod www_authenticate;

--- a/crates/rttp-protocol/src/trailer.rs
+++ b/crates/rttp-protocol/src/trailer.rs
@@ -1,0 +1,142 @@
+use std::error::Error;
+use std::fmt;
+
+pub const MAX_TRAILER_VALUE_BYTES: usize = 64 * 1024;
+pub const MAX_TRAILER_FIELD_NAMES: usize = 32;
+
+/// Bounded field names declared by an HTTP `Trailer` header.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Trailer {
+  field_names: Vec<String>,
+}
+
+impl Trailer {
+  pub fn parse(value: impl AsRef<str>) -> Result<Self, TrailerParseError> {
+    Self::parse_values([value.as_ref()])
+  }
+
+  pub fn parse_values<'a, I>(values: I) -> Result<Self, TrailerParseError>
+  where
+    I: IntoIterator<Item = &'a str>,
+  {
+    let mut field_names = Vec::new();
+    let mut field_count = 0usize;
+
+    for value in values {
+      if value.len() > MAX_TRAILER_VALUE_BYTES {
+        return Err(TrailerParseError::new("Trailer header value is too large"));
+      }
+      for field_name in value.split(',') {
+        let field_name = field_name.trim();
+        if !is_http_token(field_name) {
+          return Err(TrailerParseError::new("invalid Trailer field name"));
+        }
+        if is_forbidden_trailer_field_name(field_name) {
+          return Err(TrailerParseError::new("forbidden Trailer field name"));
+        }
+        field_count += 1;
+        if field_count > MAX_TRAILER_FIELD_NAMES {
+          return Err(TrailerParseError::new("too many Trailer field names"));
+        }
+        let normalized = field_name.to_ascii_lowercase();
+        if !field_names.contains(&normalized) {
+          field_names.push(normalized);
+        }
+      }
+    }
+
+    if field_names.is_empty() {
+      return Err(TrailerParseError::new("invalid Trailer field name"));
+    }
+    Ok(Self { field_names })
+  }
+
+  pub fn field_names(&self) -> Vec<&str> {
+    self.field_names.iter().map(String::as_str).collect()
+  }
+
+  pub fn len(&self) -> usize {
+    self.field_names.len()
+  }
+
+  pub fn is_empty(&self) -> bool {
+    self.field_names.is_empty()
+  }
+
+  pub fn header_value(&self) -> String {
+    self.field_names.join(", ")
+  }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TrailerParseError {
+  message: String,
+}
+
+impl TrailerParseError {
+  fn new(message: impl Into<String>) -> Self {
+    Self {
+      message: message.into(),
+    }
+  }
+}
+
+impl fmt::Display for TrailerParseError {
+  fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+    formatter.write_str(&self.message)
+  }
+}
+
+impl Error for TrailerParseError {}
+
+pub fn is_forbidden_trailer_field_name(name: &str) -> bool {
+  matches!(
+    name.to_ascii_lowercase().as_str(),
+    "authorization"
+      | "cache-control"
+      | "connection"
+      | "content-encoding"
+      | "content-length"
+      | "content-range"
+      | "content-type"
+      | "cookie"
+      | "host"
+      | "keep-alive"
+      | "max-forwards"
+      | "proxy-authenticate"
+      | "proxy-authorization"
+      | "proxy-connection"
+      | "set-cookie"
+      | "te"
+      | "trailer"
+      | "transfer-encoding"
+      | "upgrade"
+      | "www-authenticate"
+  )
+}
+
+fn is_http_token(value: &str) -> bool {
+  !value.is_empty() && value.bytes().all(is_http_token_byte)
+}
+
+fn is_http_token_byte(byte: u8) -> bool {
+  byte.is_ascii_alphanumeric()
+    || matches!(
+      byte,
+      b'!'
+        | b'#'
+        | b'$'
+        | b'%'
+        | b'&'
+        | b'\''
+        | b'*'
+        | b'+'
+        | b'-'
+        | b'.'
+        | b'^'
+        | b'_'
+        | b'`'
+        | b'|'
+        | b'~'
+    )
+}

--- a/crates/rttp-server/src/server/request.rs
+++ b/crates/rttp-server/src/server/request.rs
@@ -4,6 +4,9 @@ pub use rttp_protocol::forwarded::{
   Forwarded as HttpForwarded, ForwardedElement as HttpForwardedElement,
   ForwardedParameter as HttpForwardedParameter, ForwardedParseError as HttpForwardedParseError,
 };
+pub use rttp_protocol::trailer::{
+  Trailer as HttpTrailer, TrailerParseError as HttpTrailerParseError,
+};
 
 pub(crate) const MAX_REQUEST_HEAD_BYTES: usize = 64 * 1024;
 pub(crate) const MAX_REQUEST_BODY_BYTES: usize = 1024 * 1024;
@@ -333,6 +336,16 @@ impl Request {
       return Ok(None);
     }
     HttpRequestTe::parse_values(values).map(Some)
+  }
+
+  /// Parses announced trailer field names without waiting for or exposing a
+  /// trailer block.
+  pub fn trailer_header(&self) -> Result<Option<HttpTrailer>, HttpTrailerParseError> {
+    let values: Vec<&str> = self.headers_named("Trailer").collect();
+    if values.is_empty() {
+      return Ok(None);
+    }
+    HttpTrailer::parse_values(values).map(Some)
   }
 
   pub fn accept(&self) -> Result<Option<HttpAccept>, HttpAcceptParseError> {
@@ -1845,6 +1858,21 @@ impl HttpRequest {
       return Ok(None);
     }
     HttpRequestTe::parse_values(values).map(Some)
+  }
+
+  /// Parses announced trailer field names without waiting for or exposing a
+  /// trailer block.
+  pub fn trailer_header(&self) -> Result<Option<HttpTrailer>, HttpTrailerParseError> {
+    let values: Vec<&str> = self
+      .headers
+      .iter()
+      .filter(|header| header.name.eq_ignore_ascii_case("Trailer"))
+      .map(|header| header.value.as_str())
+      .collect();
+    if values.is_empty() {
+      return Ok(None);
+    }
+    HttpTrailer::parse_values(values).map(Some)
   }
 
   pub fn accept(&self) -> Result<Option<HttpAccept>, HttpAcceptParseError> {

--- a/crates/rttp/tests/test_server_models.rs
+++ b/crates/rttp/tests/test_server_models.rs
@@ -318,6 +318,43 @@ fn request_te_and_prefer_reject_invalid_or_duplicate_metadata() {
 }
 
 #[test]
+fn request_trailer_header_parses_bounded_field_names_separately_from_te_trailers() {
+  let request = parse_request(concat!(
+    "POST /upload HTTP/1.1\r\n",
+    "Host: example.test\r\n",
+    "TE: trailers\r\n",
+    "Trailer: X-Checksum, x-signature\r\n",
+    "Trailer: X-Checksum\r\n",
+    "\r\n"
+  ));
+
+  let trailer = request
+    .trailer_header()
+    .expect("Trailer header should parse")
+    .expect("Trailer header should be present");
+  assert_eq!(vec!["x-checksum", "x-signature"], trailer.field_names());
+  assert!(request
+    .te()
+    .expect("TE should parse")
+    .expect("TE should be present")
+    .codings()[0]
+    .is_trailers());
+}
+
+#[test]
+fn request_trailer_header_rejects_forbidden_and_invalid_field_names() {
+  for value in ["Content-Length", "TE", "bad field"] {
+    let request = parse_request(&format!(
+      "POST /upload HTTP/1.1\r\nHost: example.test\r\nTrailer: {value}\r\n\r\n"
+    ));
+    assert!(
+      request.trailer_header().is_err(),
+      "{value:?} must be rejected"
+    );
+  }
+}
+
+#[test]
 fn parses_request_accept_media_ranges_in_field_order() {
   let request = parse_request(concat!(
     "GET /resource HTTP/1.1\r\n",


### PR DESCRIPTION
Bounded `Trailer` header metadata is available across the client and server request surfaces, with protocol-safe field-name validation and interoperability coverage for `TE: trailers`.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1696/
work_kind: code_work
branch: hbx-1696-rttp-add-bounded-trailer-header
base: main
commit: 6f2d8bf66e7fd40a8fbdb36d4df0f199914ac279
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1696/
    url: https://plane.kahub.in/endless/browse/HBX-1696/
    close_policy: link_only
```