### PR TITLE
feat: [rttp] Add Clear-Site-Data response metadata helpers

### DIFF
--- a/crates/rttp-client/src/response/mod.rs
+++ b/crates/rttp-client/src/response/mod.rs
@@ -2,6 +2,10 @@
 
 pub use self::response::*;
 
+pub use rttp_protocol::clear_site_data::{
+  ClearSiteData as HttpClearSiteData, ClearSiteDataDirective as HttpClearSiteDataDirective,
+  ClearSiteDataParseError as HttpClearSiteDataParseError,
+};
 pub use rttp_protocol::cookie::{
   HttpCookieParseError, HttpSetCookie, HttpSetCookieAttribute, HttpSetCookies,
 };

--- a/crates/rttp-client/src/response/response.rs
+++ b/crates/rttp-client/src/response/response.rs
@@ -15,6 +15,7 @@ use crate::response::ServerTiming;
 use crate::response::Trailer;
 use crate::response::WwwAuthenticate;
 use crate::types::{Cookie, Header, RoUrl};
+use rttp_protocol::clear_site_data::ClearSiteData;
 use rttp_protocol::cookie::HttpSetCookies;
 
 const MAX_CACHE_CONTROL_VALUE_BYTES: usize = 64 * 1024;
@@ -365,6 +366,17 @@ impl Response {
       return Ok(None);
     }
     CacheControl::parse_values(values.into_iter().map(String::as_str)).map(Some)
+  }
+
+  /// Parses `Clear-Site-Data` response metadata without clearing any client state.
+  pub fn clear_site_data(&self) -> error::Result<Option<ClearSiteData>> {
+    let values = self.header_values("clear-site-data");
+    if values.is_empty() {
+      return Ok(None);
+    }
+    ClearSiteData::parse_values(values.into_iter().map(String::as_str))
+      .map(Some)
+      .map_err(|parse_error| error::bad_response(parse_error.to_string()))
   }
 
   pub fn vary(&self) -> error::Result<Option<Vary>> {

--- a/crates/rttp-client/tests/test_response.rs
+++ b/crates/rttp-client/tests/test_response.rs
@@ -1,6 +1,7 @@
 use rttp_client::response::{
   AltSvc, ContentDisposition, ContentEncoding, ContentLocation, ContentType, Digest,
-  HttpSetCookies, LinkValues, Response, RetryAfter, ServerTiming, WwwAuthenticate,
+  HttpClearSiteData, HttpSetCookies, LinkValues, Response, RetryAfter, ServerTiming,
+  WwwAuthenticate,
 };
 use rttp_client::types::{Cookie, RoUrl};
 use std::io::Write;
@@ -23,6 +24,67 @@ fn test_parse_cookie_name_can_match_attribute_name() {
   assert_eq!("Path", path.name());
   assert_eq!("value", path.value());
   assert!(path.http_only());
+}
+
+#[test]
+fn clear_site_data_metadata_parses_quoted_directives_and_wildcard_without_clearing_state() {
+  let response = Response::new(
+    RoUrl::with("https://example.test"),
+    concat!(
+      "HTTP/1.1 200 OK\r\n",
+      "Clear-Site-Data: \"cache\", \"cookies\"\r\n",
+      "Clear-Site-Data: \"storage\", \"executionContexts\"\r\n",
+      "Content-Length: 0\r\n\r\n"
+    )
+    .as_bytes()
+    .to_vec(),
+  )
+  .expect("response should parse");
+  let metadata = response
+    .clear_site_data()
+    .expect("Clear-Site-Data should parse")
+    .expect("Clear-Site-Data should be present");
+  assert_eq!(
+    vec!["cache", "cookies", "storage", "executionContexts"],
+    metadata
+      .directives()
+      .iter()
+      .map(|directive| directive.as_str())
+      .collect::<Vec<_>>()
+  );
+  assert!(metadata.clears_cache());
+  assert!(metadata.clears_cookies());
+  assert!(metadata.clears_storage());
+  assert!(metadata.clears_execution_contexts());
+
+  let wildcard = HttpClearSiteData::parse("\"*\"").expect("wildcard should parse");
+  assert!(wildcard.is_wildcard());
+  assert!(wildcard.clears_cache());
+  assert!(wildcard.clears_cookies());
+  assert!(wildcard.clears_storage());
+  assert!(wildcard.clears_execution_contexts());
+}
+
+#[test]
+fn clear_site_data_metadata_rejects_invalid_duplicate_and_unbounded_values() {
+  for value in [
+    "cache",
+    "\"unknown\"",
+    "\"cache\", \"cache\"",
+    "\"unterminated",
+  ] {
+    assert!(
+      HttpClearSiteData::parse(value).is_err(),
+      "should reject {value:?}"
+    );
+  }
+  assert!(HttpClearSiteData::parse(format!("\"{}\"", "x".repeat(64 * 1024))).is_err());
+  assert!(HttpClearSiteData::parse(
+    std::iter::repeat_n("\"cache\"", 257)
+      .collect::<Vec<_>>()
+      .join(","),
+  )
+  .is_err());
 }
 
 #[test]

--- a/crates/rttp-protocol/src/clear_site_data.rs
+++ b/crates/rttp-protocol/src/clear_site_data.rs
@@ -1,0 +1,254 @@
+//! Bounded, policy-free `Clear-Site-Data` response metadata parsing.
+//!
+//! This module only parses directives. Callers decide whether and how to clear
+//! any state; parsing never clears caches, cookies, storage, or execution contexts.
+
+use std::collections::HashSet;
+use std::error::Error;
+use std::fmt;
+
+pub const MAX_CLEAR_SITE_DATA_VALUE_BYTES: usize = 64 * 1024;
+pub const MAX_CLEAR_SITE_DATA_DIRECTIVES: usize = 256;
+
+/// A directive declared by the `Clear-Site-Data` response header.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum ClearSiteDataDirective {
+  Cache,
+  Cookies,
+  Storage,
+  ExecutionContexts,
+  Wildcard,
+}
+
+impl ClearSiteDataDirective {
+  pub fn as_str(self) -> &'static str {
+    match self {
+      Self::Cache => "cache",
+      Self::Cookies => "cookies",
+      Self::Storage => "storage",
+      Self::ExecutionContexts => "executionContexts",
+      Self::Wildcard => "*",
+    }
+  }
+}
+
+/// Parsed, bounded `Clear-Site-Data` response metadata.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ClearSiteData {
+  directives: Vec<ClearSiteDataDirective>,
+}
+
+impl ClearSiteData {
+  pub fn parse(value: impl AsRef<str>) -> Result<Self, ClearSiteDataParseError> {
+    Self::parse_values([value.as_ref()])
+  }
+
+  pub fn parse_values<'a, I>(values: I) -> Result<Self, ClearSiteDataParseError>
+  where
+    I: IntoIterator<Item = &'a str>,
+  {
+    let mut directives = Vec::new();
+    let mut seen = HashSet::new();
+    for value in values {
+      validate_field(value)?;
+      parse_field(value, &mut directives, &mut seen)?;
+    }
+    if directives.is_empty() {
+      return Err(ClearSiteDataParseError::new(
+        "invalid Clear-Site-Data directive",
+      ));
+    }
+    Ok(Self { directives })
+  }
+
+  pub fn directives(&self) -> &[ClearSiteDataDirective] {
+    &self.directives
+  }
+
+  pub fn is_wildcard(&self) -> bool {
+    self.directives.contains(&ClearSiteDataDirective::Wildcard)
+  }
+
+  pub fn clears_cache(&self) -> bool {
+    self.is_wildcard() || self.directives.contains(&ClearSiteDataDirective::Cache)
+  }
+
+  pub fn clears_cookies(&self) -> bool {
+    self.is_wildcard() || self.directives.contains(&ClearSiteDataDirective::Cookies)
+  }
+
+  pub fn clears_storage(&self) -> bool {
+    self.is_wildcard() || self.directives.contains(&ClearSiteDataDirective::Storage)
+  }
+
+  pub fn clears_execution_contexts(&self) -> bool {
+    self.is_wildcard()
+      || self
+        .directives
+        .contains(&ClearSiteDataDirective::ExecutionContexts)
+  }
+
+  pub fn header_value(&self) -> String {
+    self
+      .directives
+      .iter()
+      .map(|directive| format!("\"{}\"", directive.as_str()))
+      .collect::<Vec<_>>()
+      .join(", ")
+  }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ClearSiteDataParseError {
+  message: String,
+}
+
+impl ClearSiteDataParseError {
+  fn new(message: impl Into<String>) -> Self {
+    Self {
+      message: message.into(),
+    }
+  }
+}
+
+impl fmt::Display for ClearSiteDataParseError {
+  fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+    formatter.write_str(&self.message)
+  }
+}
+
+impl Error for ClearSiteDataParseError {}
+
+fn validate_field(value: &str) -> Result<(), ClearSiteDataParseError> {
+  if value.len() > MAX_CLEAR_SITE_DATA_VALUE_BYTES {
+    return Err(ClearSiteDataParseError::new(
+      "Clear-Site-Data header value is too large",
+    ));
+  }
+  if value.bytes().any(is_invalid_control_byte) {
+    return Err(ClearSiteDataParseError::new(
+      "invalid Clear-Site-Data control byte",
+    ));
+  }
+  Ok(())
+}
+
+fn parse_field(
+  value: &str,
+  directives: &mut Vec<ClearSiteDataDirective>,
+  seen: &mut HashSet<ClearSiteDataDirective>,
+) -> Result<(), ClearSiteDataParseError> {
+  let bytes = value.as_bytes();
+  let mut position = 0usize;
+  skip_ows(bytes, &mut position);
+  if position == bytes.len() {
+    return Err(ClearSiteDataParseError::new(
+      "invalid Clear-Site-Data directive",
+    ));
+  }
+
+  loop {
+    if directives.len() >= MAX_CLEAR_SITE_DATA_DIRECTIVES {
+      return Err(ClearSiteDataParseError::new(
+        "too many Clear-Site-Data directives",
+      ));
+    }
+    let directive = parse_quoted_directive(value, &mut position)?;
+    if !seen.insert(directive) {
+      return Err(ClearSiteDataParseError::new(
+        "duplicate Clear-Site-Data directive",
+      ));
+    }
+    directives.push(directive);
+    skip_ows(bytes, &mut position);
+    if position == bytes.len() {
+      return Ok(());
+    }
+    if bytes[position] != b',' {
+      return Err(ClearSiteDataParseError::new(
+        "invalid Clear-Site-Data directive",
+      ));
+    }
+    position += 1;
+    skip_ows(bytes, &mut position);
+    if position == bytes.len() {
+      return Err(ClearSiteDataParseError::new(
+        "invalid Clear-Site-Data directive",
+      ));
+    }
+  }
+}
+
+fn parse_quoted_directive(
+  value: &str,
+  position: &mut usize,
+) -> Result<ClearSiteDataDirective, ClearSiteDataParseError> {
+  if value.as_bytes().get(*position) != Some(&b'"') {
+    return Err(ClearSiteDataParseError::new(
+      "Clear-Site-Data directives must be quoted strings",
+    ));
+  }
+  *position += 1;
+  let start = *position;
+  while let Some(&byte) = value.as_bytes().get(*position) {
+    match byte {
+      b'"' => {
+        let directive = match &value[start..*position] {
+          "cache" => ClearSiteDataDirective::Cache,
+          "cookies" => ClearSiteDataDirective::Cookies,
+          "storage" => ClearSiteDataDirective::Storage,
+          "executionContexts" => ClearSiteDataDirective::ExecutionContexts,
+          "*" => ClearSiteDataDirective::Wildcard,
+          _ => {
+            return Err(ClearSiteDataParseError::new(
+              "invalid Clear-Site-Data directive",
+            ))
+          }
+        };
+        *position += 1;
+        return Ok(directive);
+      }
+      b'\\' | 0x00..=0x1f | 0x7f..=0xff => {
+        return Err(ClearSiteDataParseError::new(
+          "malformed Clear-Site-Data quoted-string",
+        ))
+      }
+      _ => *position += 1,
+    }
+  }
+  Err(ClearSiteDataParseError::new(
+    "malformed Clear-Site-Data quoted-string",
+  ))
+}
+
+fn skip_ows(bytes: &[u8], position: &mut usize) {
+  while bytes
+    .get(*position)
+    .is_some_and(|byte| matches!(*byte, b' ' | b'\t'))
+  {
+    *position += 1;
+  }
+}
+
+fn is_invalid_control_byte(byte: u8) -> bool {
+  byte != b'\t' && (byte <= 0x1f || byte == 0x7f)
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn parses_known_directives_and_canonicalizes_header_values() {
+    let metadata =
+      ClearSiteData::parse("\"cache\", \"executionContexts\"").expect("directives should parse");
+    assert_eq!(
+      vec![
+        ClearSiteDataDirective::Cache,
+        ClearSiteDataDirective::ExecutionContexts,
+      ],
+      metadata.directives()
+    );
+    assert_eq!("\"cache\", \"executionContexts\"", metadata.header_value());
+  }
+}

--- a/crates/rttp-protocol/src/lib.rs
+++ b/crates/rttp-protocol/src/lib.rs
@@ -5,6 +5,7 @@
 
 pub mod alt_svc;
 pub mod cache_control;
+pub mod clear_site_data;
 pub mod cookie;
 pub mod digest;
 pub mod forwarded;

--- a/crates/rttp-server/src/server/response.rs
+++ b/crates/rttp-server/src/server/response.rs
@@ -4,6 +4,10 @@ pub use rttp_protocol::alt_svc::{
   AltSvc as HttpAltSvc, AltSvcAlternative as HttpAltSvcAlternative,
   AltSvcParameter as HttpAltSvcParameter, AltSvcParseError as HttpAltSvcParseError,
 };
+pub use rttp_protocol::clear_site_data::{
+  ClearSiteData as HttpClearSiteData, ClearSiteDataDirective as HttpClearSiteDataDirective,
+  ClearSiteDataParseError as HttpClearSiteDataParseError,
+};
 pub use rttp_protocol::digest::{
   Digest as HttpDigest, DigestEntry as HttpDigestEntry, DigestParseError as HttpDigestParseError,
   ReprDigest as HttpReprDigest, ReprDigestEntry as HttpReprDigestEntry,
@@ -676,6 +680,22 @@ impl HttpResponse {
     Ok(self)
   }
 
+  /// Validates and replaces `Clear-Site-Data` metadata without clearing server state.
+  pub fn with_clear_site_data(
+    mut self,
+    value: impl AsRef<str>,
+  ) -> Result<Self, HttpClearSiteDataParseError> {
+    let clear_site_data = HttpClearSiteData::parse(value)?;
+    self
+      .headers
+      .retain(|header| !header.name.eq_ignore_ascii_case("Clear-Site-Data"));
+    self.headers.push(HttpHeader::new(
+      "Clear-Site-Data",
+      clear_site_data.header_value(),
+    ));
+    Ok(self)
+  }
+
   pub fn with_content_location<V: AsRef<str>>(
     mut self,
     value: V,
@@ -975,6 +995,20 @@ impl HttpResponse {
       return Ok(None);
     }
     HttpAltSvc::parse_values(values).map(Some)
+  }
+
+  /// Parses attached `Clear-Site-Data` metadata without changing server state.
+  pub fn clear_site_data(&self) -> Result<Option<HttpClearSiteData>, HttpClearSiteDataParseError> {
+    let values: Vec<&str> = self
+      .headers
+      .iter()
+      .filter(|header| header.name.eq_ignore_ascii_case("Clear-Site-Data"))
+      .map(|header| header.value.as_str())
+      .collect();
+    if values.is_empty() {
+      return Ok(None);
+    }
+    HttpClearSiteData::parse_values(values).map(Some)
   }
 
   pub fn content_location(&self) -> Result<Option<&str>, HttpContentLocationParseError> {

--- a/crates/rttp/tests/test_server_models.rs
+++ b/crates/rttp/tests/test_server_models.rs
@@ -2,12 +2,41 @@ use std::time::{Duration, UNIX_EPOCH};
 
 use rttp::server::{
   HttpAccept, HttpAcceptRanges, HttpAllowedMethods, HttpAuthorization, HttpByteRange,
-  HttpByteRangeError, HttpConditionalMetadata, HttpContentDisposition, HttpContentLanguages,
-  HttpContentType, HttpDigest, HttpEntityTag, HttpExpectations, HttpIfNoneMatch, HttpIfRange,
-  HttpIfRangeRequestOutcome, HttpLinkValues, HttpRequest, HttpRequestAcceptEncodings,
-  HttpRequestCacheControl, HttpRequestTe, HttpResponse, HttpResponseCacheControl,
-  HttpResponseContentEncodings, HttpRetryAfter, HttpServerTiming, HttpVary,
+  HttpByteRangeError, HttpClearSiteData, HttpConditionalMetadata, HttpContentDisposition,
+  HttpContentLanguages, HttpContentType, HttpDigest, HttpEntityTag, HttpExpectations,
+  HttpIfNoneMatch, HttpIfRange, HttpIfRangeRequestOutcome, HttpLinkValues, HttpRequest,
+  HttpRequestAcceptEncodings, HttpRequestCacheControl, HttpRequestTe, HttpResponse,
+  HttpResponseCacheControl, HttpResponseContentEncodings, HttpRetryAfter, HttpServerTiming,
+  HttpVary,
 };
+
+#[test]
+fn response_clear_site_data_builder_and_parser_preserve_metadata_only_directives() {
+  let response = HttpResponse::ok("body")
+    .header("Clear-Site-Data", "\"cache\"")
+    .with_clear_site_data("\"cookies\", \"executionContexts\"")
+    .expect("Clear-Site-Data should be accepted");
+  let metadata = response
+    .clear_site_data()
+    .expect("Clear-Site-Data should parse")
+    .expect("Clear-Site-Data should be present");
+  assert_eq!(
+    vec!["cookies", "executionContexts"],
+    metadata
+      .directives()
+      .iter()
+      .map(|directive| directive.as_str())
+      .collect::<Vec<_>>()
+  );
+  assert!(String::from_utf8(response.to_bytes())
+    .expect("response should serialize")
+    .contains("\r\nClear-Site-Data: \"cookies\", \"executionContexts\"\r\n"));
+
+  assert!(HttpResponse::ok("body")
+    .with_clear_site_data("cache")
+    .is_err());
+  assert!(HttpClearSiteData::parse("\"cache\", \"cache\"").is_err());
+}
 
 #[test]
 fn response_www_authenticate_helper_validates_and_preserves_raw_headers() {


### PR DESCRIPTION
Added bounded Clear-Site-Data parsing and server response helpers without introducing any state-clearing behavior. Full workspace verification passes.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1725/
work_kind: code_work
branch: hbx-1725-rttp-add-clear-site-data
base: main
commit: 289e8e9f02a1f29c41e0a1c1fe8100a28ddd2bcb
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1725/
    url: https://plane.kahub.in/endless/browse/HBX-1725/
    close_policy: link_only
```