### PR TITLE
feat: [rttp] Add Reporting-Endpoints response metadata helpers

### DIFF
--- a/crates/rttp-client/src/response/response.rs
+++ b/crates/rttp-client/src/response/response.rs
@@ -40,6 +40,8 @@ const MAX_LINK_VALUE_BYTES: usize = 64 * 1024;
 const MAX_LINK_VALUES: usize = 256;
 const MAX_LINK_PARAMETERS: usize = 256;
 const MAX_LINK_PARAMETER_VALUE_BYTES: usize = 64 * 1024;
+const MAX_REPORTING_ENDPOINTS_VALUE_BYTES: usize = 64 * 1024;
+const MAX_REPORTING_ENDPOINTS: usize = 256;
 
 #[derive(Clone)]
 pub struct Response {
@@ -284,6 +286,15 @@ impl Response {
       return Ok(None);
     }
     ContentLanguage::parse_values(values.into_iter().map(String::as_str)).map(Some)
+  }
+
+  /// Parses bounded `Reporting-Endpoints` response metadata without sending reports.
+  pub fn reporting_endpoints(&self) -> error::Result<Option<ReportingEndpoints>> {
+    let values = self.header_values("reporting-endpoints");
+    if values.is_empty() {
+      return Ok(None);
+    }
+    ReportingEndpoints::parse_values(values.into_iter().map(String::as_str)).map(Some)
   }
 
   pub fn content_encoding(&self) -> error::Result<Option<ContentEncoding>> {
@@ -1505,6 +1516,160 @@ fn is_content_disposition_language_byte(byte: u8) -> bool {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ContentLanguage {
   tags: Vec<String>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ReportingEndpoints {
+  endpoints: Vec<(String, String)>,
+}
+
+impl ReportingEndpoints {
+  pub fn parse(value: impl AsRef<str>) -> error::Result<Self> {
+    Self::parse_values([value.as_ref()])
+  }
+
+  fn parse_values<'a, I>(values: I) -> error::Result<Self>
+  where
+    I: IntoIterator<Item = &'a str>,
+  {
+    let mut endpoints = Vec::new();
+    for value in values {
+      if value.len() > MAX_REPORTING_ENDPOINTS_VALUE_BYTES {
+        return Err(error::bad_response(
+          "Reporting-Endpoints header value is too large",
+        ));
+      }
+      parse_reporting_endpoints_value(value, &mut endpoints)?;
+    }
+    if endpoints.is_empty() {
+      return Err(error::bad_response(
+        "Invalid Reporting-Endpoints dictionary",
+      ));
+    }
+    Ok(Self { endpoints })
+  }
+
+  pub fn endpoints(&self) -> Vec<(&str, &str)> {
+    self
+      .endpoints
+      .iter()
+      .map(|(name, url)| (name.as_str(), url.as_str()))
+      .collect()
+  }
+
+  pub fn endpoint(&self, name: impl AsRef<str>) -> Option<&str> {
+    self
+      .endpoints
+      .iter()
+      .find(|(known, _)| known == name.as_ref())
+      .map(|(_, url)| url.as_str())
+  }
+}
+
+fn parse_reporting_endpoints_value(
+  value: &str,
+  endpoints: &mut Vec<(String, String)>,
+) -> error::Result<()> {
+  let bytes = value.as_bytes();
+  let mut position = 0;
+  while position < bytes.len() {
+    while position < bytes.len() && bytes[position].is_ascii_whitespace() {
+      position += 1;
+    }
+    let name_start = position;
+    while position < bytes.len()
+      && is_reporting_endpoint_key_byte(bytes[position], position == name_start)
+    {
+      position += 1;
+    }
+    if position == name_start {
+      return Err(error::bad_response(
+        "Invalid Reporting-Endpoints endpoint name",
+      ));
+    }
+    let name = &value[name_start..position];
+    if position >= bytes.len() || bytes[position] != b'=' {
+      return Err(error::bad_response(
+        "Invalid Reporting-Endpoints dictionary",
+      ));
+    }
+    position += 1;
+    if position >= bytes.len() || bytes[position] != b'\"' {
+      return Err(error::bad_response(
+        "Reporting-Endpoints URL must be a quoted string",
+      ));
+    }
+    position += 1;
+    let mut url = String::new();
+    loop {
+      let Some(&byte) = bytes.get(position) else {
+        return Err(error::bad_response(
+          "Malformed Reporting-Endpoints quoted string",
+        ));
+      };
+      position += 1;
+      match byte {
+        b'\"' => break,
+        b'\\' => {
+          let Some(&escaped) = bytes.get(position) else {
+            return Err(error::bad_response(
+              "Malformed Reporting-Endpoints quoted string",
+            ));
+          };
+          if !matches!(escaped, b'\"' | b'\\') {
+            return Err(error::bad_response(
+              "Malformed Reporting-Endpoints quoted string",
+            ));
+          }
+          position += 1;
+          url.push(escaped as char);
+        }
+        0..=31 | 127..=u8::MAX => {
+          return Err(error::bad_response(
+            "Malformed Reporting-Endpoints quoted string",
+          ))
+        }
+        _ => url.push(byte as char),
+      }
+    }
+    if endpoints.iter().any(|(known, _)| known == name) {
+      return Err(error::bad_response(
+        "Duplicate Reporting-Endpoints endpoint name",
+      ));
+    }
+    if endpoints.len() >= MAX_REPORTING_ENDPOINTS {
+      return Err(error::bad_response(
+        "Too many Reporting-Endpoints endpoints",
+      ));
+    }
+    endpoints.push((name.to_string(), url));
+    while position < bytes.len() && bytes[position].is_ascii_whitespace() {
+      position += 1;
+    }
+    if position == bytes.len() {
+      break;
+    }
+    if bytes[position] != b',' {
+      return Err(error::bad_response(
+        "Invalid Reporting-Endpoints dictionary",
+      ));
+    }
+    position += 1;
+    if position == bytes.len() {
+      return Err(error::bad_response(
+        "Invalid Reporting-Endpoints dictionary",
+      ));
+    }
+  }
+  Ok(())
+}
+
+fn is_reporting_endpoint_key_byte(byte: u8, first: bool) -> bool {
+  if first {
+    byte.is_ascii_lowercase() || byte == b'*'
+  } else {
+    byte.is_ascii_lowercase() || byte.is_ascii_digit() || matches!(byte, b'_' | b'-' | b'.' | b'*')
+  }
 }
 
 impl ContentLanguage {

--- a/crates/rttp-client/tests/test_response.rs
+++ b/crates/rttp-client/tests/test_response.rs
@@ -118,6 +118,40 @@ fn test_parse_response_preserves_duplicate_headers_with_case_insensitive_lookup(
 }
 
 #[test]
+fn test_parse_reporting_endpoints_response_metadata() {
+  let raw = concat!(
+    "HTTP/1.1 200 OK\r\n",
+    "Reporting-Endpoints: default=\"https://reports.example/default\"\r\n",
+    "Reporting-Endpoints: csp=\"https://reports.example/csp\"\r\n",
+    "Content-Length: 0\r\n\r\n"
+  );
+  let response = Response::new(RoUrl::with("https://example.test"), raw.as_bytes().to_vec())
+    .expect("response should parse");
+  let endpoints = response
+    .reporting_endpoints()
+    .expect("Reporting-Endpoints metadata should parse")
+    .expect("Reporting-Endpoints should be present");
+  assert_eq!(
+    vec![
+      ("default", "https://reports.example/default"),
+      ("csp", "https://reports.example/csp"),
+    ],
+    endpoints.endpoints()
+  );
+  assert_eq!(
+    Some("https://reports.example/csp"),
+    endpoints.endpoint("csp")
+  );
+
+  let invalid = Response::new(
+    RoUrl::with("https://example.test"),
+    b"HTTP/1.1 200 OK\r\nReporting-Endpoints: Default=\"https://reports.example/default\"\r\nContent-Length: 0\r\n\r\n".to_vec(),
+  )
+  .expect("raw response should remain inspectable");
+  assert!(invalid.reporting_endpoints().is_err());
+}
+
+#[test]
 fn set_cookie_metadata_is_bounded_and_preserves_unknown_attributes() {
   let raw = concat!(
     "HTTP/1.1 200 OK\r\n",

--- a/crates/rttp-server/src/server/response.rs
+++ b/crates/rttp-server/src/server/response.rs
@@ -50,6 +50,8 @@ pub(crate) const MAX_LINK_VALUE_BYTES: usize = 64 * 1024;
 pub(crate) const MAX_LINK_VALUES: usize = 256;
 pub(crate) const MAX_LINK_PARAMETERS: usize = 256;
 pub(crate) const MAX_LINK_PARAMETER_VALUE_BYTES: usize = 64 * 1024;
+pub(crate) const MAX_REPORTING_ENDPOINTS_VALUE_BYTES: usize = 64 * 1024;
+pub(crate) const MAX_REPORTING_ENDPOINTS: usize = 32;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct HttpResponse {
@@ -578,6 +580,27 @@ impl HttpResponse {
     Ok(self)
   }
 
+  /// Validates and replaces `Reporting-Endpoints` response metadata.
+  pub fn with_reporting_endpoints<I, N, U>(
+    mut self,
+    endpoints: I,
+  ) -> Result<Self, HttpReportingEndpointsParseError>
+  where
+    I: IntoIterator<Item = (N, U)>,
+    N: AsRef<str>,
+    U: AsRef<str>,
+  {
+    let endpoints = HttpReportingEndpoints::from_endpoints(endpoints)?;
+    self
+      .headers
+      .retain(|header| !header.name.eq_ignore_ascii_case("Reporting-Endpoints"));
+    self.headers.push(HttpHeader::new(
+      "Reporting-Endpoints",
+      endpoints.header_value(),
+    ));
+    Ok(self)
+  }
+
   pub fn with_content_encoding<I, C>(
     mut self,
     codings: I,
@@ -879,6 +902,22 @@ impl HttpResponse {
       return Ok(None);
     }
     HttpContentLanguages::parse_values(values).map(Some)
+  }
+
+  /// Parses bounded `Reporting-Endpoints` response metadata without scheduling reports.
+  pub fn reporting_endpoints(
+    &self,
+  ) -> Result<Option<HttpReportingEndpoints>, HttpReportingEndpointsParseError> {
+    let values: Vec<&str> = self
+      .headers
+      .iter()
+      .filter(|header| header.name.eq_ignore_ascii_case("Reporting-Endpoints"))
+      .map(|header| header.value.as_str())
+      .collect();
+    if values.is_empty() {
+      return Ok(None);
+    }
+    HttpReportingEndpoints::parse_values(values).map(Some)
   }
 
   pub fn content_encoding(
@@ -1800,6 +1839,211 @@ impl fmt::Display for HttpContentLanguageParseError {
 }
 
 impl Error for HttpContentLanguageParseError {}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct HttpReportingEndpoints {
+  endpoints: Vec<(String, String)>,
+}
+
+impl HttpReportingEndpoints {
+  pub fn parse(value: impl AsRef<str>) -> Result<Self, HttpReportingEndpointsParseError> {
+    Self::parse_values([value.as_ref()])
+  }
+
+  pub fn parse_values<'a, I>(values: I) -> Result<Self, HttpReportingEndpointsParseError>
+  where
+    I: IntoIterator<Item = &'a str>,
+  {
+    let mut endpoints = Vec::new();
+    for value in values {
+      if value.len() > MAX_REPORTING_ENDPOINTS_VALUE_BYTES {
+        return Err(HttpReportingEndpointsParseError::new(
+          "Reporting-Endpoints header value is too large",
+        ));
+      }
+      parse_reporting_endpoints_value(value, &mut endpoints)?;
+    }
+    if endpoints.is_empty() {
+      return Err(HttpReportingEndpointsParseError::new(
+        "invalid Reporting-Endpoints dictionary",
+      ));
+    }
+    Ok(Self { endpoints })
+  }
+
+  pub fn from_endpoints<I, N, U>(endpoints: I) -> Result<Self, HttpReportingEndpointsParseError>
+  where
+    I: IntoIterator<Item = (N, U)>,
+    N: AsRef<str>,
+    U: AsRef<str>,
+  {
+    let value = endpoints
+      .into_iter()
+      .map(|(name, url)| {
+        format!(
+          "{}=\"{}\"",
+          name.as_ref(),
+          escape_reporting_endpoint_url(url.as_ref())
+        )
+      })
+      .collect::<Vec<_>>()
+      .join(", ");
+    Self::parse(value)
+  }
+
+  pub fn endpoints(&self) -> Vec<(&str, &str)> {
+    self
+      .endpoints
+      .iter()
+      .map(|(name, url)| (name.as_str(), url.as_str()))
+      .collect()
+  }
+
+  pub fn endpoint(&self, name: impl AsRef<str>) -> Option<&str> {
+    self
+      .endpoints
+      .iter()
+      .find(|(known, _)| known == name.as_ref())
+      .map(|(_, url)| url.as_str())
+  }
+
+  pub fn header_value(&self) -> String {
+    self
+      .endpoints
+      .iter()
+      .map(|(name, url)| format!("{name}=\"{}\"", escape_reporting_endpoint_url(url)))
+      .collect::<Vec<_>>()
+      .join(", ")
+  }
+}
+
+fn parse_reporting_endpoints_value(
+  value: &str,
+  endpoints: &mut Vec<(String, String)>,
+) -> Result<(), HttpReportingEndpointsParseError> {
+  let bytes = value.as_bytes();
+  let mut position = 0;
+  while position < bytes.len() {
+    while position < bytes.len() && bytes[position].is_ascii_whitespace() {
+      position += 1;
+    }
+    let name_start = position;
+    while position < bytes.len()
+      && is_reporting_endpoint_key_byte(bytes[position], position == name_start)
+    {
+      position += 1;
+    }
+    if position == name_start {
+      return Err(HttpReportingEndpointsParseError::new(
+        "invalid Reporting-Endpoints endpoint name",
+      ));
+    }
+    let name = &value[name_start..position];
+    if position >= bytes.len() || bytes[position] != b'=' {
+      return Err(HttpReportingEndpointsParseError::new(
+        "invalid Reporting-Endpoints dictionary",
+      ));
+    }
+    position += 1;
+    if position >= bytes.len() || bytes[position] != b'\"' {
+      return Err(HttpReportingEndpointsParseError::new(
+        "Reporting-Endpoints URL must be a quoted string",
+      ));
+    }
+    position += 1;
+    let mut url = String::new();
+    loop {
+      let Some(&byte) = bytes.get(position) else {
+        return Err(HttpReportingEndpointsParseError::new(
+          "malformed Reporting-Endpoints quoted string",
+        ));
+      };
+      position += 1;
+      match byte {
+        b'\"' => break,
+        b'\\' => {
+          let Some(&escaped) = bytes.get(position) else {
+            return Err(HttpReportingEndpointsParseError::new(
+              "malformed Reporting-Endpoints quoted string",
+            ));
+          };
+          if !matches!(escaped, b'\"' | b'\\') {
+            return Err(HttpReportingEndpointsParseError::new(
+              "malformed Reporting-Endpoints quoted string",
+            ));
+          }
+          position += 1;
+          url.push(escaped as char);
+        }
+        0..=31 | 127..=u8::MAX => {
+          return Err(HttpReportingEndpointsParseError::new(
+            "malformed Reporting-Endpoints quoted string",
+          ))
+        }
+        _ => url.push(byte as char),
+      }
+    }
+    if endpoints.iter().any(|(known, _)| known == name) {
+      return Err(HttpReportingEndpointsParseError::new(
+        "duplicate Reporting-Endpoints endpoint name",
+      ));
+    }
+    if endpoints.len() >= MAX_REPORTING_ENDPOINTS {
+      return Err(HttpReportingEndpointsParseError::new(
+        "too many Reporting-Endpoints endpoints",
+      ));
+    }
+    endpoints.push((name.to_string(), url));
+    while position < bytes.len() && bytes[position].is_ascii_whitespace() {
+      position += 1;
+    }
+    if position == bytes.len() {
+      break;
+    }
+    if bytes[position] != b',' {
+      return Err(HttpReportingEndpointsParseError::new(
+        "invalid Reporting-Endpoints dictionary",
+      ));
+    }
+    position += 1;
+    if position == bytes.len() {
+      return Err(HttpReportingEndpointsParseError::new(
+        "invalid Reporting-Endpoints dictionary",
+      ));
+    }
+  }
+  Ok(())
+}
+
+fn is_reporting_endpoint_key_byte(byte: u8, first: bool) -> bool {
+  if first {
+    byte.is_ascii_lowercase() || byte == b'*'
+  } else {
+    byte.is_ascii_lowercase() || byte.is_ascii_digit() || matches!(byte, b'_' | b'-' | b'.' | b'*')
+  }
+}
+
+fn escape_reporting_endpoint_url(url: &str) -> String {
+  url.replace('\\', "\\\\").replace('\"', "\\\"")
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct HttpReportingEndpointsParseError {
+  pub(crate) message: String,
+}
+impl HttpReportingEndpointsParseError {
+  pub(crate) fn new(message: impl AsRef<str>) -> Self {
+    Self {
+      message: message.as_ref().to_string(),
+    }
+  }
+}
+impl fmt::Display for HttpReportingEndpointsParseError {
+  fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+    formatter.write_str(&self.message)
+  }
+}
+impl Error for HttpReportingEndpointsParseError {}
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct HttpResponseContentEncodings {

--- a/crates/rttp/tests/test_server_models.rs
+++ b/crates/rttp/tests/test_server_models.rs
@@ -4,9 +4,10 @@ use rttp::server::{
   HttpAccept, HttpAcceptRanges, HttpAllowedMethods, HttpAuthorization, HttpByteRange,
   HttpByteRangeError, HttpConditionalMetadata, HttpContentDisposition, HttpContentLanguages,
   HttpContentType, HttpDigest, HttpEntityTag, HttpExpectations, HttpIfNoneMatch, HttpIfRange,
-  HttpIfRangeRequestOutcome, HttpLinkValues, HttpRequest, HttpRequestAcceptEncodings,
-  HttpRequestCacheControl, HttpRequestTe, HttpResponse, HttpResponseCacheControl,
-  HttpResponseContentEncodings, HttpRetryAfter, HttpServerTiming, HttpVary,
+  HttpIfRangeRequestOutcome, HttpLinkValues, HttpReportingEndpoints, HttpRequest,
+  HttpRequestAcceptEncodings, HttpRequestCacheControl, HttpRequestTe, HttpResponse,
+  HttpResponseCacheControl, HttpResponseContentEncodings, HttpRetryAfter, HttpServerTiming,
+  HttpVary,
 };
 
 #[test]
@@ -732,6 +733,18 @@ fn request_accept_language_helper_rejects_invalid_wire_values() {
       "Accept-Language helper should reject {value:?}"
     );
   }
+
+  assert!(
+    HttpReportingEndpoints::parse(format!("default=\"{}\"", "x".repeat(64 * 1024))).is_err(),
+    "should reject oversized Reporting-Endpoints fields"
+  );
+  assert!(
+    HttpReportingEndpoints::from_endpoints(
+      (0..33).map(|index| (format!("endpoint{index}"), "https://reports.example/")),
+    )
+    .is_err(),
+    "should reject excessive Reporting-Endpoints entries"
+  );
 }
 
 #[test]
@@ -1060,6 +1073,55 @@ fn raw_content_language_headers_are_preserved_without_helper_validation() {
     response.content_language().is_err(),
     "typed Content-Language parser should reject malformed raw values"
   );
+}
+
+#[test]
+fn reporting_endpoints_helpers_parse_and_build_bounded_metadata() {
+  let endpoints = HttpReportingEndpoints::parse(
+    "default=\"https://reports.example/default\", csp=\"https://reports.example/csp\"",
+  )
+  .expect("valid Reporting-Endpoints header should parse");
+  assert_eq!(
+    vec![
+      ("default", "https://reports.example/default"),
+      ("csp", "https://reports.example/csp"),
+    ],
+    endpoints.endpoints()
+  );
+  assert_eq!(
+    Some("https://reports.example/csp"),
+    endpoints.endpoint("csp")
+  );
+
+  let response = HttpResponse::ok("body")
+    .header(
+      "Reporting-Endpoints",
+      "default=\"https://reports.example/default\"",
+    )
+    .with_reporting_endpoints([("csp", "https://reports.example/csp")])
+    .expect("valid Reporting-Endpoints values should be accepted");
+  let serialized = String::from_utf8(response.to_bytes()).expect("response is UTF-8");
+  assert_eq!(1, serialized.matches("\r\nReporting-Endpoints: ").count());
+  assert!(serialized.contains("csp=\"https://reports.example/csp\""));
+  let parsed = response
+    .reporting_endpoints()
+    .expect("Reporting-Endpoints header should parse")
+    .expect("Reporting-Endpoints should be present");
+  assert_eq!(
+    vec![("csp", "https://reports.example/csp")],
+    parsed.endpoints()
+  );
+
+  for value in [
+    "default=https://reports.example/default",
+    "Default=\"https://reports.example/default\"",
+    "default=\"https://reports.example/default\", default=\"https://reports.example/other\"",
+  ] {
+    assert!(
+      HttpReportingEndpoints::parse(value).is_err(),
+      "should reject {value:?}"
+    );
+  }
 }
 
 #[test]


### PR DESCRIPTION
RTTP now provides bounded `Reporting-Endpoints` response metadata parsing on clients and validated declaration/parsing on servers, without adding reporting delivery behavior.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1726/
work_kind: code_work
branch: hbx-1726-rttp-add-reporting-endpoints-response
base: main
commit: 72032eeed80cb07c163b7f6b93e92fca621d47b1
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1726/
    url: https://plane.kahub.in/endless/browse/HBX-1726/
    close_policy: link_only
```