### PR TITLE
feat: [rttp-protocol] Add Accept-CH and Critical-CH parsers

### DIFF
--- a/crates/rttp-protocol/src/client_hints.rs
+++ b/crates/rttp-protocol/src/client_hints.rs
@@ -1,0 +1,168 @@
+use std::error::Error;
+use std::fmt;
+
+pub const MAX_CLIENT_HINT_VALUE_BYTES: usize = 64 * 1024;
+pub const MAX_CLIENT_HINT_NAMES: usize = 256;
+
+/// Parsed, bounded `Accept-CH` response metadata.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AcceptCh {
+  client_hints: Vec<String>,
+}
+
+/// Parsed, bounded `Critical-CH` response metadata.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CriticalCh {
+  client_hints: Vec<String>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ClientHintsParseError {
+  message: String,
+}
+
+pub type AcceptChParseError = ClientHintsParseError;
+pub type CriticalChParseError = ClientHintsParseError;
+
+impl ClientHintsParseError {
+  fn new(message: impl Into<String>) -> Self {
+    Self {
+      message: message.into(),
+    }
+  }
+}
+
+impl fmt::Display for ClientHintsParseError {
+  fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+    formatter.write_str(&self.message)
+  }
+}
+
+impl Error for ClientHintsParseError {}
+
+impl AcceptCh {
+  pub fn parse(value: impl AsRef<str>) -> Result<Self, AcceptChParseError> {
+    Self::parse_values([value.as_ref()])
+  }
+
+  pub fn parse_values<'a, I>(values: I) -> Result<Self, AcceptChParseError>
+  where
+    I: IntoIterator<Item = &'a str>,
+  {
+    Ok(Self {
+      client_hints: parse_client_hints(values, "Accept-CH")?,
+    })
+  }
+
+  pub fn client_hints(&self) -> &[String] {
+    &self.client_hints
+  }
+
+  pub fn len(&self) -> usize {
+    self.client_hints.len()
+  }
+
+  pub fn is_empty(&self) -> bool {
+    self.client_hints.is_empty()
+  }
+
+  pub fn header_value(&self) -> String {
+    self.client_hints.join(", ")
+  }
+}
+
+impl CriticalCh {
+  pub fn parse(value: impl AsRef<str>) -> Result<Self, CriticalChParseError> {
+    Self::parse_values([value.as_ref()])
+  }
+
+  pub fn parse_values<'a, I>(values: I) -> Result<Self, CriticalChParseError>
+  where
+    I: IntoIterator<Item = &'a str>,
+  {
+    Ok(Self {
+      client_hints: parse_client_hints(values, "Critical-CH")?,
+    })
+  }
+
+  pub fn client_hints(&self) -> &[String] {
+    &self.client_hints
+  }
+
+  pub fn len(&self) -> usize {
+    self.client_hints.len()
+  }
+
+  pub fn is_empty(&self) -> bool {
+    self.client_hints.is_empty()
+  }
+
+  pub fn header_value(&self) -> String {
+    self.client_hints.join(", ")
+  }
+}
+
+fn parse_client_hints<'a, I>(
+  values: I,
+  header_name: &str,
+) -> Result<Vec<String>, ClientHintsParseError>
+where
+  I: IntoIterator<Item = &'a str>,
+{
+  let mut client_hints = Vec::new();
+  for value in values {
+    if value.len() > MAX_CLIENT_HINT_VALUE_BYTES {
+      return Err(ClientHintsParseError::new(format!(
+        "{header_name} header value is too large"
+      )));
+    }
+    for member in value.split(',') {
+      let client_hint = member.trim();
+      if !is_structured_token(client_hint) {
+        return Err(ClientHintsParseError::new(format!(
+          "invalid {header_name} client hint"
+        )));
+      }
+      if client_hints.len() >= MAX_CLIENT_HINT_NAMES {
+        return Err(ClientHintsParseError::new(format!(
+          "too many {header_name} client hints"
+        )));
+      }
+      client_hints.push(client_hint.to_string());
+    }
+  }
+  if client_hints.is_empty() {
+    return Err(ClientHintsParseError::new(format!(
+      "invalid {header_name} client hint"
+    )));
+  }
+  Ok(client_hints)
+}
+
+fn is_structured_token(value: &str) -> bool {
+  let mut bytes = value.bytes();
+  matches!(bytes.next(), Some(b'*' | b'a'..=b'z' | b'A'..=b'Z'))
+    && bytes.all(|byte| {
+      byte.is_ascii_alphanumeric()
+        || matches!(
+          byte,
+          b'!'
+            | b'#'
+            | b'$'
+            | b'%'
+            | b'&'
+            | b'\''
+            | b'*'
+            | b'+'
+            | b'-'
+            | b'.'
+            | b'^'
+            | b'_'
+            | b'`'
+            | b'|'
+            | b'~'
+            | b':'
+            | b'/'
+        )
+    })
+}

--- a/crates/rttp-protocol/src/lib.rs
+++ b/crates/rttp-protocol/src/lib.rs
@@ -5,6 +5,7 @@
 
 pub mod alt_svc;
 pub mod cache_control;
+pub mod client_hints;
 pub mod cookie;
 pub mod digest;
 pub mod forwarded;

--- a/crates/rttp-protocol/tests/client_hints.rs
+++ b/crates/rttp-protocol/tests/client_hints.rs
@@ -1,0 +1,71 @@
+use rttp_protocol::client_hints::{
+  AcceptCh, CriticalCh, MAX_CLIENT_HINT_NAMES, MAX_CLIENT_HINT_VALUE_BYTES,
+};
+
+#[test]
+fn accept_ch_combines_values_and_preserves_client_hint_spelling() {
+  let accept_ch = AcceptCh::parse_values(["Sec-CH-UA, DPR", "Viewport-Width, Example/token:1"])
+    .expect("valid Accept-CH");
+
+  assert_eq!(
+    &["Sec-CH-UA", "DPR", "Viewport-Width", "Example/token:1"],
+    accept_ch.client_hints()
+  );
+  assert_eq!(
+    "Sec-CH-UA, DPR, Viewport-Width, Example/token:1",
+    accept_ch.header_value()
+  );
+}
+
+#[test]
+fn critical_ch_round_trips_comma_separated_client_hints() {
+  let critical_ch =
+    CriticalCh::parse("Sec-CH-Prefers-Color-Scheme, Downlink").expect("valid Critical-CH");
+
+  assert_eq!(
+    &["Sec-CH-Prefers-Color-Scheme", "Downlink"],
+    critical_ch.client_hints()
+  );
+  assert_eq!(
+    "Sec-CH-Prefers-Color-Scheme, Downlink",
+    critical_ch.header_value()
+  );
+  assert_eq!(
+    critical_ch,
+    CriticalCh::parse(critical_ch.header_value()).expect("serialized value is valid")
+  );
+}
+
+#[test]
+fn client_hint_headers_reject_invalid_and_empty_members() {
+  for value in [
+    "",
+    "DPR,",
+    ",DPR",
+    "DPR,,Width",
+    "DPR;Width",
+    "1DPR",
+    "DPR\r\nInjected: yes",
+  ] {
+    assert!(
+      AcceptCh::parse(value).is_err(),
+      "{value:?} must be rejected"
+    );
+    assert!(
+      CriticalCh::parse(value).is_err(),
+      "{value:?} must be rejected"
+    );
+  }
+}
+
+#[test]
+fn client_hint_headers_enforce_value_and_member_bounds() {
+  assert!(AcceptCh::parse("a".repeat(MAX_CLIENT_HINT_VALUE_BYTES + 1)).is_err());
+  assert!(CriticalCh::parse("a".repeat(MAX_CLIENT_HINT_VALUE_BYTES + 1)).is_err());
+
+  let too_many = std::iter::repeat_n("DPR", MAX_CLIENT_HINT_NAMES + 1)
+    .collect::<Vec<_>>()
+    .join(",");
+  assert!(AcceptCh::parse(&too_many).is_err());
+  assert!(CriticalCh::parse(&too_many).is_err());
+}


### PR DESCRIPTION
Adds bounded, case-preserving `Accept-CH` and `Critical-CH` parsing and serialization with regression coverage for syntax and resource limits.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1720/
work_kind: code_work
branch: hbx-1720-rttp-protocol-add-accept-ch
base: main
commit: 77cb55fc2e77559b4409342d6eb6618efc51e5e0
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1720/
    url: https://plane.kahub.in/endless/browse/HBX-1720/
    close_policy: link_only
```