### PR TITLE
feat: [rttp-client] Expose Accept-Patch and Accept-Post response helpers

### DIFF
--- a/crates/rttp-client/src/response/response.rs
+++ b/crates/rttp-client/src/response/response.rs
@@ -23,6 +23,7 @@ const MAX_ALLOW_VALUE_BYTES: usize = 64 * 1024;
 const MAX_ALLOW_METHODS: usize = 256;
 const MAX_ACCEPT_RANGES_VALUE_BYTES: usize = 64 * 1024;
 const MAX_ACCEPT_RANGE_UNITS: usize = 256;
+const MAX_ACCEPT_MEDIA_TYPES: usize = 256;
 const MAX_RETRY_AFTER_VALUE_BYTES: usize = 64 * 1024;
 const MAX_CONTENT_TYPE_VALUE_BYTES: usize = 64 * 1024;
 const MAX_CONTENT_TYPE_PARAMETERS: usize = 256;
@@ -239,6 +240,26 @@ impl Response {
       return Ok(None);
     }
     AcceptRanges::parse_values(values.into_iter().map(String::as_str)).map(Some)
+  }
+
+  /// Parses `Accept-Patch` media-type metadata without selecting a request
+  /// method or sending a follow-up request.
+  pub fn accept_patch(&self) -> error::Result<Option<AcceptPatch>> {
+    let values = self.header_values("accept-patch");
+    if values.is_empty() {
+      return Ok(None);
+    }
+    AcceptPatch::parse_values(values.into_iter().map(String::as_str)).map(Some)
+  }
+
+  /// Parses `Accept-Post` media-type metadata without choosing an upload or
+  /// sending a follow-up request.
+  pub fn accept_post(&self) -> error::Result<Option<AcceptPost>> {
+    let values = self.header_values("accept-post");
+    if values.is_empty() {
+      return Ok(None);
+    }
+    AcceptPost::parse_values(values.into_iter().map(String::as_str)).map(Some)
   }
 
   pub fn content_range(&self) -> Option<ContentRange> {
@@ -567,6 +588,82 @@ pub struct AcceptRanges {
   units: Vec<String>,
 }
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AcceptPatch {
+  media_types: Vec<ContentType>,
+}
+
+impl AcceptPatch {
+  pub fn parse(value: impl AsRef<str>) -> error::Result<Self> {
+    Self::parse_values([value.as_ref()])
+  }
+
+  fn parse_values<'a, I>(values: I) -> error::Result<Self>
+  where
+    I: IntoIterator<Item = &'a str>,
+  {
+    Ok(Self {
+      media_types: parse_accepted_media_types(values, "Accept-Patch")?,
+    })
+  }
+
+  pub fn media_types(&self) -> &[ContentType] {
+    &self.media_types
+  }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AcceptPost {
+  media_types: Vec<ContentType>,
+}
+
+impl AcceptPost {
+  pub fn parse(value: impl AsRef<str>) -> error::Result<Self> {
+    Self::parse_values([value.as_ref()])
+  }
+
+  fn parse_values<'a, I>(values: I) -> error::Result<Self>
+  where
+    I: IntoIterator<Item = &'a str>,
+  {
+    Ok(Self {
+      media_types: parse_accepted_media_types(values, "Accept-Post")?,
+    })
+  }
+
+  pub fn media_types(&self) -> &[ContentType] {
+    &self.media_types
+  }
+}
+
+fn parse_accepted_media_types<'a, I>(values: I, header: &str) -> error::Result<Vec<ContentType>>
+where
+  I: IntoIterator<Item = &'a str>,
+{
+  let mut media_types = Vec::new();
+
+  for value in values {
+    if value.len() > MAX_CONTENT_TYPE_VALUE_BYTES {
+      return Err(error::bad_response(format!(
+        "{header} header value is too large"
+      )));
+    }
+    for member in split_accepted_media_type_members(value)? {
+      if media_types.len() >= MAX_ACCEPT_MEDIA_TYPES {
+        return Err(error::bad_response(format!(
+          "Too many {header} media types"
+        )));
+      }
+      media_types.push(ContentType::parse(member)?);
+    }
+  }
+
+  if media_types.is_empty() {
+    return Err(error::bad_response(format!("Invalid {header} media type")));
+  }
+  Ok(media_types)
+}
+
 impl AcceptRanges {
   pub fn parse(value: impl AsRef<str>) -> error::Result<Self> {
     Self::parse_values([value.as_ref()])
@@ -892,6 +989,52 @@ fn split_content_type_members(value: &str) -> error::Result<Vec<String>> {
   }
   push_content_type_member(&mut members, &current)?;
   Ok(members)
+}
+
+fn split_accepted_media_type_members(value: &str) -> error::Result<Vec<String>> {
+  let mut members = Vec::new();
+  let mut current = String::new();
+  let mut in_quote = false;
+  let mut escaped = false;
+
+  for ch in value.chars() {
+    if escaped {
+      current.push(ch);
+      escaped = false;
+      continue;
+    }
+
+    match ch {
+      '\\' if in_quote => {
+        current.push(ch);
+        escaped = true;
+      }
+      '"' => {
+        current.push(ch);
+        in_quote = !in_quote;
+      }
+      ',' if !in_quote => {
+        push_accepted_media_type_member(&mut members, &current)?;
+        current.clear();
+      }
+      _ => current.push(ch),
+    }
+  }
+
+  if in_quote || escaped {
+    return Err(error::bad_response("Invalid accepted media type"));
+  }
+  push_accepted_media_type_member(&mut members, &current)?;
+  Ok(members)
+}
+
+fn push_accepted_media_type_member(members: &mut Vec<String>, current: &str) -> error::Result<()> {
+  let member = current.trim();
+  if member.is_empty() {
+    return Err(error::bad_response("Invalid accepted media type"));
+  }
+  members.push(member.to_string());
+  Ok(())
 }
 
 fn push_content_type_member(members: &mut Vec<String>, member: &str) -> error::Result<()> {

--- a/crates/rttp-client/tests/test_response.rs
+++ b/crates/rttp-client/tests/test_response.rs
@@ -1832,6 +1832,120 @@ fn test_parse_accept_ranges_rejects_duplicate_oversized_and_too_many_values() {
 }
 
 #[test]
+fn test_parse_accept_patch_response_helper_preserves_media_types_across_header_fields() {
+  let raw = concat!(
+    "HTTP/1.1 200 OK\r\n",
+    "Accept-Patch: application/json; charset=utf-8, application/merge-patch+json\r\n",
+    "accept-patch: application/example; profile=\"https://example.test/schema,v1\"\r\n",
+    "Content-Length: 0\r\n",
+    "\r\n"
+  );
+  let response = Response::new(RoUrl::with("https://example.test"), raw.as_bytes().to_vec())
+    .expect("parse response with Accept-Patch headers");
+  let accept_patch = response
+    .accept_patch()
+    .expect("valid Accept-Patch should parse")
+    .expect("Accept-Patch header should be present");
+
+  assert_eq!(
+    vec![
+      "application/json",
+      "application/merge-patch+json",
+      "application/example",
+    ],
+    accept_patch
+      .media_types()
+      .iter()
+      .map(|media_type| media_type.essence())
+      .collect::<Vec<_>>()
+  );
+  assert_eq!(
+    Some("https://example.test/schema,v1"),
+    accept_patch.media_types()[2].parameter("profile")
+  );
+  assert_eq!(
+    vec![
+      &"application/json; charset=utf-8, application/merge-patch+json".to_string(),
+      &"application/example; profile=\"https://example.test/schema,v1\"".to_string(),
+    ],
+    response.header_values("Accept-Patch")
+  );
+}
+
+#[test]
+fn test_parse_accept_post_response_helper_preserves_parameters_across_header_fields() {
+  let raw = concat!(
+    "HTTP/1.1 201 Created\r\n",
+    "Accept-Post: text/plain; charset=utf-8\r\n",
+    "accept-post: application/json; profile=\"https://example.test/v1\"\r\n",
+    "Content-Length: 0\r\n",
+    "\r\n"
+  );
+  let response = Response::new(RoUrl::with("https://example.test"), raw.as_bytes().to_vec())
+    .expect("parse response with Accept-Post headers");
+  let accept_post = response
+    .accept_post()
+    .expect("valid Accept-Post should parse")
+    .expect("Accept-Post header should be present");
+
+  assert_eq!(
+    vec!["text/plain", "application/json"],
+    accept_post
+      .media_types()
+      .iter()
+      .map(|media_type| media_type.essence())
+      .collect::<Vec<_>>()
+  );
+  assert_eq!(
+    Some("utf-8"),
+    accept_post.media_types()[0].parameter("charset")
+  );
+  assert_eq!(
+    Some("https://example.test/v1"),
+    accept_post.media_types()[1].parameter("profile")
+  );
+}
+
+#[test]
+fn test_accept_patch_and_accept_post_helpers_preserve_malformed_headers() {
+  for (header, value) in [
+    ("Accept-Patch", "application/json,"),
+    ("Accept-Post", "application/json; charset=\"unterminated"),
+  ] {
+    let raw = format!("HTTP/1.1 200 OK\r\n{header}: {value}\r\nContent-Length: 0\r\n\r\n");
+    let response = Response::new(RoUrl::with("https://example.test"), raw.into_bytes())
+      .expect("raw response remains usable");
+
+    if header == "Accept-Patch" {
+      assert!(response.accept_patch().is_err());
+    } else {
+      assert!(response.accept_post().is_err());
+    }
+    assert_eq!(Some(&value.to_string()), response.header_value(header));
+  }
+}
+
+#[test]
+fn test_accept_patch_and_accept_post_helpers_return_none_when_absent() {
+  let raw = concat!("HTTP/1.1 200 OK\r\n", "Content-Length: 0\r\n", "\r\n");
+  let response = Response::new(RoUrl::with("https://example.test"), raw.as_bytes().to_vec())
+    .expect("parse response without accept metadata");
+
+  assert_eq!(
+    None,
+    response
+      .accept_patch()
+      .expect("absent Accept-Patch should parse")
+  );
+  assert_eq!(
+    None,
+    response
+      .accept_post()
+      .expect("absent Accept-Post should parse")
+  );
+}
+
+#[test]
 fn test_parse_age_rejects_invalid_helper_values_without_rejecting_response() {
   let invalid_values = [
     "",

--- a/crates/rttp/src/lib.rs
+++ b/crates/rttp/src/lib.rs
@@ -4,6 +4,9 @@ pub struct Http {}
 
 pub use rttp_server::server;
 
+#[cfg(feature = "client")]
+pub use rttp_client::response::{AcceptPatch, AcceptPost};
+
 impl Http {
   #[cfg(feature = "client")]
   pub fn client() -> rttp_client::HttpClient {

--- a/crates/rttp/tests/test_client.rs
+++ b/crates/rttp/tests/test_client.rs
@@ -21,6 +21,32 @@ fn test_client_http() {
 }
 
 #[test]
+#[cfg(any(feature = "all", feature = "client"))]
+fn compatibility_facade_reexports_accept_response_metadata() {
+  let raw = concat!(
+    "HTTP/1.1 200 OK\r\n",
+    "Accept-Patch: application/json\r\n",
+    "Accept-Post: text/plain\r\n",
+    "Content-Length: 0\r\n",
+    "\r\n"
+  );
+  let response = rttp_client::response::Response::new(
+    rttp_client::types::RoUrl::with("https://example.test"),
+    raw.as_bytes().to_vec(),
+  )
+  .expect("response should parse");
+
+  let _: rttp::AcceptPatch = response
+    .accept_patch()
+    .expect("Accept-Patch should parse")
+    .expect("Accept-Patch should be present");
+  let _: rttp::AcceptPost = response
+    .accept_post()
+    .expect("Accept-Post should parse")
+    .expect("Accept-Post should be present");
+}
+
+#[test]
 #[cfg(any(
   feature = "all",
   feature = "client",


### PR DESCRIPTION
Added bounded `Accept-Patch` and `Accept-Post` response helpers with facade exposure and coverage for multiple headers, parameters, malformed values, and absent headers.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1717/
work_kind: code_work
branch: hbx-1717-rttp-client-expose-accept-patch
base: main
commit: 2cb3f2262000fdb65406b7953bd5afef4093acf7
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1717/
    url: https://plane.kahub.in/endless/browse/HBX-1717/
    close_policy: link_only
```