### PR TITLE
feat: [rttp-protocol] Add Accept-Patch and Accept-Post media-list parsers

### DIFF
--- a/crates/rttp-protocol/src/accept_patch.rs
+++ b/crates/rttp-protocol/src/accept_patch.rs
@@ -1,0 +1,67 @@
+use std::error::Error;
+use std::fmt;
+
+pub use crate::media_type::{MediaType, MediaTypeParameter};
+
+pub const MAX_ACCEPT_PATCH_VALUE_BYTES: usize = 64 * 1024;
+pub const MAX_ACCEPT_PATCH_MEDIA_TYPES: usize = 256;
+
+/// Parsed, bounded `Accept-Patch` response metadata.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AcceptPatch {
+  media_types: Vec<MediaType>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AcceptPatchParseError {
+  message: String,
+}
+
+impl fmt::Display for AcceptPatchParseError {
+  fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+    formatter.write_str(&self.message)
+  }
+}
+
+impl Error for AcceptPatchParseError {}
+
+impl AcceptPatch {
+  pub fn parse(value: impl AsRef<str>) -> Result<Self, AcceptPatchParseError> {
+    Self::parse_values([value.as_ref()])
+  }
+
+  pub fn parse_values<'a, I>(values: I) -> Result<Self, AcceptPatchParseError>
+  where
+    I: IntoIterator<Item = &'a str>,
+  {
+    crate::media_type::parse_values(
+      values,
+      "Accept-Patch",
+      MAX_ACCEPT_PATCH_VALUE_BYTES,
+      MAX_ACCEPT_PATCH_MEDIA_TYPES,
+    )
+    .map(|media_types| Self { media_types })
+    .map_err(|message| AcceptPatchParseError { message })
+  }
+
+  pub fn media_types(&self) -> &[MediaType] {
+    &self.media_types
+  }
+
+  pub fn len(&self) -> usize {
+    self.media_types.len()
+  }
+
+  pub fn is_empty(&self) -> bool {
+    self.media_types.is_empty()
+  }
+
+  pub fn header_value(&self) -> String {
+    self
+      .media_types
+      .iter()
+      .map(MediaType::header_value)
+      .collect::<Vec<_>>()
+      .join(", ")
+  }
+}

--- a/crates/rttp-protocol/src/accept_post.rs
+++ b/crates/rttp-protocol/src/accept_post.rs
@@ -1,0 +1,67 @@
+use std::error::Error;
+use std::fmt;
+
+pub use crate::media_type::{MediaType, MediaTypeParameter};
+
+pub const MAX_ACCEPT_POST_VALUE_BYTES: usize = 64 * 1024;
+pub const MAX_ACCEPT_POST_MEDIA_TYPES: usize = 256;
+
+/// Parsed, bounded `Accept-Post` response metadata.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AcceptPost {
+  media_types: Vec<MediaType>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AcceptPostParseError {
+  message: String,
+}
+
+impl fmt::Display for AcceptPostParseError {
+  fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+    formatter.write_str(&self.message)
+  }
+}
+
+impl Error for AcceptPostParseError {}
+
+impl AcceptPost {
+  pub fn parse(value: impl AsRef<str>) -> Result<Self, AcceptPostParseError> {
+    Self::parse_values([value.as_ref()])
+  }
+
+  pub fn parse_values<'a, I>(values: I) -> Result<Self, AcceptPostParseError>
+  where
+    I: IntoIterator<Item = &'a str>,
+  {
+    crate::media_type::parse_values(
+      values,
+      "Accept-Post",
+      MAX_ACCEPT_POST_VALUE_BYTES,
+      MAX_ACCEPT_POST_MEDIA_TYPES,
+    )
+    .map(|media_types| Self { media_types })
+    .map_err(|message| AcceptPostParseError { message })
+  }
+
+  pub fn media_types(&self) -> &[MediaType] {
+    &self.media_types
+  }
+
+  pub fn len(&self) -> usize {
+    self.media_types.len()
+  }
+
+  pub fn is_empty(&self) -> bool {
+    self.media_types.is_empty()
+  }
+
+  pub fn header_value(&self) -> String {
+    self
+      .media_types
+      .iter()
+      .map(MediaType::header_value)
+      .collect::<Vec<_>>()
+      .join(", ")
+  }
+}

--- a/crates/rttp-protocol/src/lib.rs
+++ b/crates/rttp-protocol/src/lib.rs
@@ -3,12 +3,15 @@
 //! This crate is intentionally unpublished. It owns protocol syntax and framing
 //! validation only; client and server application policy remains in its callers.
 
+pub mod accept_patch;
+pub mod accept_post;
 pub mod alt_svc;
 pub mod cache_control;
 pub mod cookie;
 pub mod digest;
 pub mod forwarded;
 pub mod http1;
+mod media_type;
 pub mod priority;
 pub mod range;
 pub mod server_timing;

--- a/crates/rttp-protocol/src/media_type.rs
+++ b/crates/rttp-protocol/src/media_type.rs
@@ -1,0 +1,279 @@
+use std::fmt::Write;
+
+pub(crate) const MAX_MEDIA_TYPE_PARAMETERS: usize = 256;
+
+/// A media type and its optional parameters.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct MediaType {
+  type_: String,
+  subtype: String,
+  parameters: Vec<MediaTypeParameter>,
+}
+
+/// One parameter from a parsed media type.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct MediaTypeParameter {
+  name: String,
+  value: String,
+}
+
+impl MediaType {
+  pub fn type_(&self) -> &str {
+    &self.type_
+  }
+
+  pub fn subtype(&self) -> &str {
+    &self.subtype
+  }
+
+  pub fn parameters(&self) -> &[MediaTypeParameter] {
+    &self.parameters
+  }
+
+  pub(crate) fn header_value(&self) -> String {
+    let mut value = format!("{}/{}", self.type_, self.subtype);
+    for parameter in &self.parameters {
+      value.push_str("; ");
+      value.push_str(parameter.name());
+      value.push('=');
+      if is_token(parameter.value()) {
+        value.push_str(parameter.value());
+      } else {
+        value.push('"');
+        value.push_str(&escape_quoted(parameter.value()));
+        value.push('"');
+      }
+    }
+    value
+  }
+}
+
+impl MediaTypeParameter {
+  pub fn name(&self) -> &str {
+    &self.name
+  }
+
+  pub fn value(&self) -> &str {
+    &self.value
+  }
+}
+
+pub(crate) fn parse_values<'a, I>(
+  values: I,
+  header_name: &str,
+  maximum_value_bytes: usize,
+  maximum_media_types: usize,
+) -> Result<Vec<MediaType>, String>
+where
+  I: IntoIterator<Item = &'a str>,
+{
+  let mut media_types = Vec::new();
+  for value in values {
+    if value.len() > maximum_value_bytes {
+      return Err(format!("{header_name} header value is too large"));
+    }
+    if value.bytes().any(is_invalid_control_byte) {
+      return Err(format!("invalid {header_name} header value"));
+    }
+    parse_field(value, header_name, maximum_media_types, &mut media_types)?;
+  }
+  if media_types.is_empty() {
+    return Err(format!("invalid {header_name} media type"));
+  }
+  Ok(media_types)
+}
+
+fn parse_field(
+  value: &str,
+  header_name: &str,
+  maximum_media_types: usize,
+  media_types: &mut Vec<MediaType>,
+) -> Result<(), String> {
+  let bytes = value.as_bytes();
+  let mut position = 0;
+  skip_ows(bytes, &mut position);
+  if position == bytes.len() {
+    return Err(format!("invalid {header_name} media type"));
+  }
+
+  loop {
+    if media_types.len() >= maximum_media_types {
+      return Err(format!("too many {header_name} media types"));
+    }
+    media_types.push(parse_media_type(value, &mut position, header_name)?);
+    skip_ows(bytes, &mut position);
+    if position == bytes.len() {
+      return Ok(());
+    }
+    if bytes[position] != b',' {
+      return Err(format!("invalid {header_name} media type"));
+    }
+    position += 1;
+    skip_ows(bytes, &mut position);
+    if position == bytes.len() || bytes[position] == b',' {
+      return Err(format!("invalid {header_name} media type"));
+    }
+  }
+}
+
+fn parse_media_type(
+  value: &str,
+  position: &mut usize,
+  header_name: &str,
+) -> Result<MediaType, String> {
+  let type_ = parse_token(value, position, header_name)?.to_string();
+  if value.as_bytes().get(*position) != Some(&b'/') {
+    return Err(format!("invalid {header_name} media type"));
+  }
+  *position += 1;
+  let subtype = parse_token(value, position, header_name)?.to_string();
+  let mut parameters = Vec::new();
+
+  loop {
+    skip_ows(value.as_bytes(), position);
+    if value.as_bytes().get(*position) != Some(&b';') {
+      break;
+    }
+    if parameters.len() >= MAX_MEDIA_TYPE_PARAMETERS {
+      return Err(format!("too many {header_name} media type parameters"));
+    }
+    *position += 1;
+    skip_ows(value.as_bytes(), position);
+    let name = parse_token(value, position, header_name)?.to_string();
+    skip_ows(value.as_bytes(), position);
+    if value.as_bytes().get(*position) != Some(&b'=') {
+      return Err(format!("invalid {header_name} media type parameter"));
+    }
+    *position += 1;
+    skip_ows(value.as_bytes(), position);
+    let parameter_value = if value.as_bytes().get(*position) == Some(&b'"') {
+      parse_quoted_string(value, position, header_name)?
+    } else {
+      parse_token(value, position, header_name)?.to_string()
+    };
+    parameters.push(MediaTypeParameter {
+      name,
+      value: parameter_value,
+    });
+  }
+
+  Ok(MediaType {
+    type_,
+    subtype,
+    parameters,
+  })
+}
+
+fn parse_token<'a>(
+  value: &'a str,
+  position: &mut usize,
+  header_name: &str,
+) -> Result<&'a str, String> {
+  let start = *position;
+  while value
+    .as_bytes()
+    .get(*position)
+    .is_some_and(|byte| is_token_byte(*byte))
+  {
+    *position += 1;
+  }
+  if start == *position {
+    Err(format!("invalid {header_name} media type"))
+  } else {
+    Ok(&value[start..*position])
+  }
+}
+
+fn parse_quoted_string(
+  value: &str,
+  position: &mut usize,
+  header_name: &str,
+) -> Result<String, String> {
+  *position += 1;
+  let mut parsed = Vec::new();
+  while let Some(&byte) = value.as_bytes().get(*position) {
+    *position += 1;
+    match byte {
+      b'"' => {
+        return String::from_utf8(parsed)
+          .map_err(|_| format!("invalid {header_name} media type parameter"));
+      }
+      b'\\' => {
+        let Some(&escaped) = value.as_bytes().get(*position) else {
+          return Err(format!("invalid {header_name} media type parameter"));
+        };
+        if !is_quoted_pair_byte(escaped) {
+          return Err(format!("invalid {header_name} media type parameter"));
+        }
+        *position += 1;
+        parsed.push(escaped);
+      }
+      _ if is_quoted_text_byte(byte) => parsed.push(byte),
+      _ => return Err(format!("invalid {header_name} media type parameter")),
+    }
+  }
+  Err(format!("invalid {header_name} media type parameter"))
+}
+
+fn skip_ows(bytes: &[u8], position: &mut usize) {
+  while bytes
+    .get(*position)
+    .is_some_and(|byte| matches!(*byte, b' ' | b'\t'))
+  {
+    *position += 1;
+  }
+}
+
+fn is_invalid_control_byte(byte: u8) -> bool {
+  byte != b'\t' && (byte <= 0x1f || byte == 0x7f)
+}
+
+fn is_token(value: &str) -> bool {
+  !value.is_empty() && value.bytes().all(is_token_byte)
+}
+
+fn is_token_byte(byte: u8) -> bool {
+  byte.is_ascii_alphanumeric()
+    || matches!(
+      byte,
+      b'!'
+        | b'#'
+        | b'$'
+        | b'%'
+        | b'&'
+        | b'\''
+        | b'*'
+        | b'+'
+        | b'-'
+        | b'.'
+        | b'^'
+        | b'_'
+        | b'`'
+        | b'|'
+        | b'~'
+    )
+}
+
+fn is_quoted_text_byte(byte: u8) -> bool {
+  byte == b'\t'
+    || byte == b' '
+    || (0x21..=0x7e).contains(&byte) && byte != b'"' && byte != b'\\'
+    || byte >= 0x80
+}
+
+fn is_quoted_pair_byte(byte: u8) -> bool {
+  byte == b'\t' || byte == b' ' || (0x21..=0x7e).contains(&byte) || byte >= 0x80
+}
+
+fn escape_quoted(value: &str) -> String {
+  let mut escaped = String::with_capacity(value.len());
+  for character in value.chars() {
+    if matches!(character, '"' | '\\') {
+      escaped.push('\\');
+    }
+    escaped
+      .write_char(character)
+      .expect("writing to String cannot fail");
+  }
+  escaped
+}

--- a/crates/rttp-protocol/tests/accept_capabilities.rs
+++ b/crates/rttp-protocol/tests/accept_capabilities.rs
@@ -1,0 +1,84 @@
+use rttp_protocol::accept_patch::{
+  AcceptPatch, MAX_ACCEPT_PATCH_MEDIA_TYPES, MAX_ACCEPT_PATCH_VALUE_BYTES,
+};
+use rttp_protocol::accept_post::{
+  AcceptPost, MAX_ACCEPT_POST_MEDIA_TYPES, MAX_ACCEPT_POST_VALUE_BYTES,
+};
+
+#[test]
+fn accept_patch_parses_media_types_with_parameters_and_preserves_order() {
+  let accept_patch = AcceptPatch::parse_values([
+    "application/merge-patch+json; charset=utf-8",
+    "application/json; profile=\"https://example.test/profile, v1\"",
+  ])
+  .expect("Accept-Patch should parse");
+
+  assert_eq!(accept_patch.len(), 2);
+  assert_eq!(accept_patch.media_types()[0].type_(), "application");
+  assert_eq!(accept_patch.media_types()[0].subtype(), "merge-patch+json");
+  assert_eq!(
+    accept_patch.media_types()[0].parameters()[0].name(),
+    "charset"
+  );
+  assert_eq!(
+    accept_patch.media_types()[0].parameters()[0].value(),
+    "utf-8"
+  );
+  assert_eq!(
+    accept_patch.media_types()[1].parameters()[0].value(),
+    "https://example.test/profile, v1"
+  );
+  assert_eq!(
+    accept_patch.header_value(),
+    "application/merge-patch+json; charset=utf-8, application/json; profile=\"https://example.test/profile, v1\""
+  );
+}
+
+#[test]
+fn accept_post_parses_media_types_with_parameters_and_preserves_order() {
+  let accept_post = AcceptPost::parse("application/json; charset=utf-8, text/plain")
+    .expect("Accept-Post should parse");
+
+  assert_eq!(accept_post.len(), 2);
+  assert_eq!(accept_post.media_types()[0].subtype(), "json");
+  assert_eq!(accept_post.media_types()[1].type_(), "text");
+  assert_eq!(
+    accept_post.header_value(),
+    "application/json; charset=utf-8, text/plain"
+  );
+}
+
+#[test]
+fn accept_capability_headers_reject_invalid_media_types_and_empty_members() {
+  for value in [
+    "application",
+    "/json",
+    "application/",
+    "application/json; charset",
+    "application/json,, text/plain",
+    ",application/json",
+    "application/json,",
+  ] {
+    assert!(AcceptPatch::parse(value).is_err(), "{value:?} should fail");
+    assert!(AcceptPost::parse(value).is_err(), "{value:?} should fail");
+  }
+}
+
+#[test]
+fn accept_capability_headers_enforce_value_and_list_limits() {
+  assert!(AcceptPatch::parse("x".repeat(MAX_ACCEPT_PATCH_VALUE_BYTES + 1)).is_err());
+  assert!(AcceptPost::parse("x".repeat(MAX_ACCEPT_POST_VALUE_BYTES + 1)).is_err());
+
+  assert!(AcceptPatch::parse(
+    std::iter::repeat_n("application/json", MAX_ACCEPT_PATCH_MEDIA_TYPES + 1)
+      .collect::<Vec<_>>()
+      .join(","),
+  )
+  .is_err());
+  assert!(AcceptPost::parse(
+    std::iter::repeat_n("application/json", MAX_ACCEPT_POST_MEDIA_TYPES + 1)
+      .collect::<Vec<_>>()
+      .join(","),
+  )
+  .is_err());
+}


### PR DESCRIPTION
Added bounded Accept-Patch and Accept-Post media-list parser/serializer support with regression tests for ordering, parameters, invalid input, and limits. Protocol tests pass.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1716/
work_kind: code_work
branch: hbx-1716-rttp-protocol-add-accept-patch
base: main
commit: 0ecbc30a7ef1a975fe0d2fd10a10431dc09c3cef
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1716/
    url: https://plane.kahub.in/endless/browse/HBX-1716/
    close_policy: link_only
```