### PR TITLE
feat: [rttp-server] Add Accept-Patch and Accept-Post response helpers

### DIFF
--- a/crates/rttp-server/src/server/response.rs
+++ b/crates/rttp-server/src/server/response.rs
@@ -42,6 +42,10 @@ pub(crate) const MAX_CONTENT_DISPOSITION_VALUE_BYTES: usize = 64 * 1024;
 pub(crate) const MAX_CONTENT_DISPOSITION_PARAMETERS: usize = 32;
 pub(crate) const MAX_CONTENT_TYPE_VALUE_BYTES: usize = 64 * 1024;
 pub(crate) const MAX_CONTENT_TYPE_PARAMETERS: usize = 32;
+pub(crate) const MAX_ACCEPT_PATCH_VALUE_BYTES: usize = 64 * 1024;
+pub(crate) const MAX_ACCEPT_PATCH_MEDIA_TYPES: usize = 32;
+pub(crate) const MAX_ACCEPT_POST_VALUE_BYTES: usize = 64 * 1024;
+pub(crate) const MAX_ACCEPT_POST_MEDIA_TYPES: usize = 32;
 pub(crate) const MAX_ACCEPT_RANGES_VALUE_BYTES: usize = 64 * 1024;
 pub(crate) const MAX_ACCEPT_RANGES_UNITS: usize = 32;
 pub(crate) const MAX_RETRY_AFTER_VALUE_BYTES: usize = 64 * 1024;
@@ -722,6 +726,39 @@ impl HttpResponse {
     Ok(self)
   }
 
+  pub fn with_accept_patch<I, M>(
+    mut self,
+    media_types: I,
+  ) -> Result<Self, HttpAcceptPatchParseError>
+  where
+    I: IntoIterator<Item = M>,
+    M: AsRef<str>,
+  {
+    let accept_patch = HttpAcceptPatch::from_media_types(media_types)?;
+    self
+      .headers
+      .retain(|header| !header.name.eq_ignore_ascii_case("Accept-Patch"));
+    self
+      .headers
+      .push(HttpHeader::new("Accept-Patch", accept_patch.header_value()));
+    Ok(self)
+  }
+
+  pub fn with_accept_post<I, M>(mut self, media_types: I) -> Result<Self, HttpAcceptPostParseError>
+  where
+    I: IntoIterator<Item = M>,
+    M: AsRef<str>,
+  {
+    let accept_post = HttpAcceptPost::from_media_types(media_types)?;
+    self
+      .headers
+      .retain(|header| !header.name.eq_ignore_ascii_case("Accept-Post"));
+    self
+      .headers
+      .push(HttpHeader::new("Accept-Post", accept_post.header_value()));
+    Ok(self)
+  }
+
   pub fn with_inline_content_disposition(self) -> Result<Self, HttpContentDispositionParseError> {
     self.with_content_disposition(HttpContentDisposition::inline())
   }
@@ -1010,6 +1047,32 @@ impl HttpResponse {
       return Ok(None);
     };
     HttpContentType::parse(value).map(Some)
+  }
+
+  pub fn accept_patch(&self) -> Result<Option<HttpAcceptPatch>, HttpAcceptPatchParseError> {
+    let values: Vec<&str> = self
+      .headers
+      .iter()
+      .filter(|header| header.name.eq_ignore_ascii_case("Accept-Patch"))
+      .map(|header| header.value.as_str())
+      .collect();
+    if values.is_empty() {
+      return Ok(None);
+    }
+    HttpAcceptPatch::parse_values(values).map(Some)
+  }
+
+  pub fn accept_post(&self) -> Result<Option<HttpAcceptPost>, HttpAcceptPostParseError> {
+    let values: Vec<&str> = self
+      .headers
+      .iter()
+      .filter(|header| header.name.eq_ignore_ascii_case("Accept-Post"))
+      .map(|header| header.value.as_str())
+      .collect();
+    if values.is_empty() {
+      return Ok(None);
+    }
+    HttpAcceptPost::parse_values(values).map(Some)
   }
 
   pub fn accept_ranges(&self) -> Result<Option<HttpAcceptRanges>, HttpAcceptRangesParseError> {
@@ -2889,6 +2952,249 @@ impl fmt::Display for HttpContentTypeParseError {
 }
 
 impl Error for HttpContentTypeParseError {}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct HttpAcceptedMediaTypes {
+  media_types: Vec<HttpContentType>,
+}
+
+impl HttpAcceptedMediaTypes {
+  fn parse_values<'a, I>(
+    values: I,
+    header_name: &str,
+    max_value_bytes: usize,
+    max_media_types: usize,
+  ) -> Result<Self, String>
+  where
+    I: IntoIterator<Item = &'a str>,
+  {
+    let mut media_types = Vec::new();
+    for value in values {
+      if value.len() > max_value_bytes {
+        return Err(format!("{header_name} header value is too large"));
+      }
+      for member in split_accept_capability_members(value)? {
+        if media_types.len() >= max_media_types {
+          return Err(format!("too many {header_name} media types"));
+        }
+        media_types.push(
+          HttpContentType::parse(member)
+            .map_err(|_| format!("invalid {header_name} media type"))?,
+        );
+      }
+    }
+    if media_types.is_empty() {
+      return Err(format!("invalid {header_name} media type"));
+    }
+    Ok(Self { media_types })
+  }
+
+  fn from_media_types<I, M>(
+    media_types: I,
+    header_name: &str,
+    max_value_bytes: usize,
+    max_media_types: usize,
+  ) -> Result<Self, String>
+  where
+    I: IntoIterator<Item = M>,
+    M: AsRef<str>,
+  {
+    let mut value = String::new();
+    for (index, media_type) in media_types.into_iter().enumerate() {
+      if index > 0 {
+        value.push_str(", ");
+      }
+      value.push_str(media_type.as_ref());
+      if value.len() > max_value_bytes {
+        return Err(format!("{header_name} header value is too large"));
+      }
+    }
+    Self::parse_values(
+      [value.as_str()],
+      header_name,
+      max_value_bytes,
+      max_media_types,
+    )
+  }
+
+  fn media_types(&self) -> &[HttpContentType] {
+    &self.media_types
+  }
+
+  fn header_value(&self) -> String {
+    self
+      .media_types
+      .iter()
+      .map(HttpContentType::header_value)
+      .collect::<Vec<_>>()
+      .join(", ")
+  }
+}
+
+fn split_accept_capability_members(value: &str) -> Result<Vec<&str>, String> {
+  let mut members = Vec::new();
+  let mut start = 0usize;
+  let mut quoted = false;
+  let mut escaped = false;
+  for (index, byte) in value.bytes().enumerate() {
+    if escaped {
+      escaped = false;
+      continue;
+    }
+    match byte {
+      b'\\' if quoted => escaped = true,
+      b'"' => quoted = !quoted,
+      b',' if !quoted => {
+        let member = value[start..index].trim();
+        if member.is_empty() {
+          return Err("empty media type".to_string());
+        }
+        members.push(member);
+        start = index + 1;
+      }
+      _ => {}
+    }
+  }
+  if quoted || escaped {
+    return Err("unterminated media type parameter".to_string());
+  }
+  let member = value[start..].trim();
+  if member.is_empty() {
+    return Err("empty media type".to_string());
+  }
+  members.push(member);
+  Ok(members)
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct HttpAcceptPatch(HttpAcceptedMediaTypes);
+
+impl HttpAcceptPatch {
+  pub fn parse(value: impl AsRef<str>) -> Result<Self, HttpAcceptPatchParseError> {
+    Self::parse_values([value.as_ref()])
+  }
+
+  pub fn parse_values<'a, I>(values: I) -> Result<Self, HttpAcceptPatchParseError>
+  where
+    I: IntoIterator<Item = &'a str>,
+  {
+    HttpAcceptedMediaTypes::parse_values(
+      values,
+      "Accept-Patch",
+      MAX_ACCEPT_PATCH_VALUE_BYTES,
+      MAX_ACCEPT_PATCH_MEDIA_TYPES,
+    )
+    .map(Self)
+    .map_err(HttpAcceptPatchParseError::new)
+  }
+
+  pub fn from_media_types<I, M>(media_types: I) -> Result<Self, HttpAcceptPatchParseError>
+  where
+    I: IntoIterator<Item = M>,
+    M: AsRef<str>,
+  {
+    HttpAcceptedMediaTypes::from_media_types(
+      media_types,
+      "Accept-Patch",
+      MAX_ACCEPT_PATCH_VALUE_BYTES,
+      MAX_ACCEPT_PATCH_MEDIA_TYPES,
+    )
+    .map(Self)
+    .map_err(HttpAcceptPatchParseError::new)
+  }
+
+  pub fn media_types(&self) -> &[HttpContentType] {
+    self.0.media_types()
+  }
+
+  pub fn header_value(&self) -> String {
+    self.0.header_value()
+  }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct HttpAcceptPatchParseError {
+  message: String,
+}
+
+impl HttpAcceptPatchParseError {
+  fn new(message: String) -> Self {
+    Self { message }
+  }
+}
+
+impl fmt::Display for HttpAcceptPatchParseError {
+  fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+    formatter.write_str(&self.message)
+  }
+}
+
+impl Error for HttpAcceptPatchParseError {}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct HttpAcceptPost(HttpAcceptedMediaTypes);
+
+impl HttpAcceptPost {
+  pub fn parse(value: impl AsRef<str>) -> Result<Self, HttpAcceptPostParseError> {
+    Self::parse_values([value.as_ref()])
+  }
+
+  pub fn parse_values<'a, I>(values: I) -> Result<Self, HttpAcceptPostParseError>
+  where
+    I: IntoIterator<Item = &'a str>,
+  {
+    HttpAcceptedMediaTypes::parse_values(
+      values,
+      "Accept-Post",
+      MAX_ACCEPT_POST_VALUE_BYTES,
+      MAX_ACCEPT_POST_MEDIA_TYPES,
+    )
+    .map(Self)
+    .map_err(HttpAcceptPostParseError::new)
+  }
+
+  pub fn from_media_types<I, M>(media_types: I) -> Result<Self, HttpAcceptPostParseError>
+  where
+    I: IntoIterator<Item = M>,
+    M: AsRef<str>,
+  {
+    HttpAcceptedMediaTypes::from_media_types(
+      media_types,
+      "Accept-Post",
+      MAX_ACCEPT_POST_VALUE_BYTES,
+      MAX_ACCEPT_POST_MEDIA_TYPES,
+    )
+    .map(Self)
+    .map_err(HttpAcceptPostParseError::new)
+  }
+
+  pub fn media_types(&self) -> &[HttpContentType] {
+    self.0.media_types()
+  }
+
+  pub fn header_value(&self) -> String {
+    self.0.header_value()
+  }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct HttpAcceptPostParseError {
+  message: String,
+}
+
+impl HttpAcceptPostParseError {
+  fn new(message: String) -> Self {
+    Self { message }
+  }
+}
+
+impl fmt::Display for HttpAcceptPostParseError {
+  fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+    formatter.write_str(&self.message)
+  }
+}
+
+impl Error for HttpAcceptPostParseError {}
 
 pub(crate) fn parse_content_type_media_type(
   value: &str,

--- a/crates/rttp/tests/http11_compliance_matrix.rs
+++ b/crates/rttp/tests/http11_compliance_matrix.rs
@@ -869,6 +869,97 @@ fn server_response_with_allow_coexists_with_cache_and_retry_metadata_helpers() {
 }
 
 #[test]
+fn server_response_accept_patch_and_accept_post_helpers_declare_and_parse_media_types() {
+  let response = HttpResponse::ok("OK")
+    .with_accept_patch([
+      "application/json; charset=utf-8",
+      "application/merge-patch+json",
+    ])
+    .expect("Accept-Patch declaration should parse")
+    .with_accept_post(["application/json", "text/plain; profile=summary"])
+    .expect("Accept-Post declaration should parse");
+  let serialized = String::from_utf8(response.to_bytes()).expect("response is UTF-8");
+
+  assert_eq!(
+    Some("application/json; charset=utf-8, application/merge-patch+json"),
+    header_value(&serialized, "Accept-Patch")
+  );
+  assert_eq!(
+    Some("application/json, text/plain; profile=summary"),
+    header_value(&serialized, "Accept-Post")
+  );
+
+  let accept_patch = response
+    .accept_patch()
+    .expect("Accept-Patch should parse")
+    .expect("Accept-Patch should be present");
+  assert_eq!(
+    vec!["application/json", "application/merge-patch+json"],
+    accept_patch
+      .media_types()
+      .iter()
+      .map(|media_type| media_type.media_type())
+      .collect::<Vec<_>>()
+  );
+  assert_eq!(
+    Some("utf-8"),
+    accept_patch.media_types()[0].parameter("charset")
+  );
+
+  let accept_post = response
+    .accept_post()
+    .expect("Accept-Post should parse")
+    .expect("Accept-Post should be present");
+  assert_eq!(
+    vec!["application/json", "text/plain"],
+    accept_post
+      .media_types()
+      .iter()
+      .map(|media_type| media_type.media_type())
+      .collect::<Vec<_>>()
+  );
+  assert_eq!(
+    Some("summary"),
+    accept_post.media_types()[1].parameter("profile")
+  );
+}
+
+#[test]
+fn server_response_accept_patch_and_accept_post_helpers_reject_invalid_raw_metadata() {
+  for (header, value) in [
+    ("Accept-Patch", "application/json,"),
+    ("Accept-Post", "application/json; profile=\"unterminated"),
+  ] {
+    let response = HttpResponse::ok("OK").header(header, value);
+
+    if header == "Accept-Patch" {
+      assert!(
+        response.accept_patch().is_err(),
+        "{header} should reject {value:?}"
+      );
+      assert!(
+        HttpResponse::ok("OK").with_accept_patch([value]).is_err(),
+        "{header} declaration should reject {value:?}"
+      );
+    } else {
+      assert!(
+        response.accept_post().is_err(),
+        "{header} should reject {value:?}"
+      );
+      assert!(
+        HttpResponse::ok("OK").with_accept_post([value]).is_err(),
+        "{header} declaration should reject {value:?}"
+      );
+    }
+
+    assert_eq!(
+      Some(value),
+      header_value(&String::from_utf8(response.to_bytes()).unwrap(), header)
+    );
+  }
+}
+
+#[test]
 fn server_allow_helpers_reject_shared_invalid_matrix() {
   for case in fixtures::allow::invalid_cases() {
     assert!(


### PR DESCRIPTION
Implemented validated server-side Accept-Patch and Accept-Post response metadata helpers with parsing and regression coverage.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1718/
work_kind: code_work
branch: hbx-1718-rttp-server-add-accept-patch
base: main
commit: ed3891e1a53d62ede14fdb65b06bee709aa90f3b
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1718/
    url: https://plane.kahub.in/endless/browse/HBX-1718/
    close_policy: link_only
```