### PR TITLE
feat: [rttp-protocol] Add bounded entity-tag parsers for conditional requests

### DIFF
--- a/crates/rttp-protocol/src/entity_tag.rs
+++ b/crates/rttp-protocol/src/entity_tag.rs
@@ -1,0 +1,320 @@
+//! Bounded parsing for HTTP entity tags and conditional entity-tag headers.
+
+use std::collections::HashSet;
+use std::error::Error;
+use std::fmt;
+
+pub const MAX_ENTITY_TAG_VALUE_BYTES: usize = 64 * 1024;
+pub const MAX_IF_MATCH_VALUE_BYTES: usize = 64 * 1024;
+pub const MAX_IF_NONE_MATCH_VALUE_BYTES: usize = 64 * 1024;
+pub const MAX_CONDITIONAL_ENTITY_TAGS: usize = 256;
+
+/// A parsed HTTP entity tag.
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct EntityTag {
+  opaque_tag: String,
+  weak: bool,
+}
+
+/// Parsed, bounded `If-Match` request metadata.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct IfMatch {
+  value: ConditionalEntityTags,
+}
+
+/// Parsed, bounded `If-None-Match` request metadata.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct IfNoneMatch {
+  value: ConditionalEntityTags,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum ConditionalEntityTags {
+  Wildcard,
+  Tags(Vec<EntityTag>),
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct EntityTagParseError {
+  message: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ConditionalEntityTagParseError {
+  message: String,
+}
+
+pub type IfMatchParseError = ConditionalEntityTagParseError;
+pub type IfNoneMatchParseError = ConditionalEntityTagParseError;
+
+impl EntityTagParseError {
+  fn new(message: impl Into<String>) -> Self {
+    Self {
+      message: message.into(),
+    }
+  }
+}
+
+impl ConditionalEntityTagParseError {
+  fn new(message: impl Into<String>) -> Self {
+    Self {
+      message: message.into(),
+    }
+  }
+}
+
+impl fmt::Display for EntityTagParseError {
+  fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+    formatter.write_str(&self.message)
+  }
+}
+
+impl fmt::Display for ConditionalEntityTagParseError {
+  fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+    formatter.write_str(&self.message)
+  }
+}
+
+impl Error for EntityTagParseError {}
+impl Error for ConditionalEntityTagParseError {}
+
+impl EntityTag {
+  pub fn parse(value: impl AsRef<str>) -> Result<Self, EntityTagParseError> {
+    let value = value.as_ref();
+    validate_length(value, MAX_ENTITY_TAG_VALUE_BYTES, "entity tag")
+      .map_err(EntityTagParseError::new)?;
+    parse_entity_tag(trim_ows(value)).map_err(EntityTagParseError::new)
+  }
+
+  pub fn opaque_tag(&self) -> &str {
+    &self.opaque_tag
+  }
+
+  pub fn is_weak(&self) -> bool {
+    self.weak
+  }
+
+  pub fn header_value(&self) -> String {
+    if self.weak {
+      format!("W/\"{}\"", self.opaque_tag)
+    } else {
+      format!("\"{}\"", self.opaque_tag)
+    }
+  }
+}
+
+impl IfMatch {
+  pub fn parse(value: impl AsRef<str>) -> Result<Self, IfMatchParseError> {
+    Self::parse_values([value.as_ref()])
+  }
+
+  pub fn parse_values<'a, I>(values: I) -> Result<Self, IfMatchParseError>
+  where
+    I: IntoIterator<Item = &'a str>,
+  {
+    Ok(Self {
+      value: parse_conditional_values(values, "If-Match", MAX_IF_MATCH_VALUE_BYTES)?,
+    })
+  }
+
+  pub fn is_wildcard(&self) -> bool {
+    matches!(self.value, ConditionalEntityTags::Wildcard)
+  }
+
+  pub fn entity_tags(&self) -> &[EntityTag] {
+    self.value.entity_tags()
+  }
+
+  pub fn header_value(&self) -> String {
+    self.value.header_value()
+  }
+}
+
+impl IfNoneMatch {
+  pub fn parse(value: impl AsRef<str>) -> Result<Self, IfNoneMatchParseError> {
+    Self::parse_values([value.as_ref()])
+  }
+
+  pub fn parse_values<'a, I>(values: I) -> Result<Self, IfNoneMatchParseError>
+  where
+    I: IntoIterator<Item = &'a str>,
+  {
+    Ok(Self {
+      value: parse_conditional_values(values, "If-None-Match", MAX_IF_NONE_MATCH_VALUE_BYTES)?,
+    })
+  }
+
+  pub fn is_wildcard(&self) -> bool {
+    matches!(self.value, ConditionalEntityTags::Wildcard)
+  }
+
+  pub fn entity_tags(&self) -> &[EntityTag] {
+    self.value.entity_tags()
+  }
+
+  pub fn header_value(&self) -> String {
+    self.value.header_value()
+  }
+}
+
+impl ConditionalEntityTags {
+  fn entity_tags(&self) -> &[EntityTag] {
+    match self {
+      Self::Wildcard => &[],
+      Self::Tags(entity_tags) => entity_tags,
+    }
+  }
+
+  fn header_value(&self) -> String {
+    match self {
+      Self::Wildcard => "*".to_string(),
+      Self::Tags(entity_tags) => entity_tags
+        .iter()
+        .map(EntityTag::header_value)
+        .collect::<Vec<_>>()
+        .join(", "),
+    }
+  }
+}
+
+fn parse_conditional_values<'a, I>(
+  values: I,
+  header_name: &str,
+  maximum_length: usize,
+) -> Result<ConditionalEntityTags, ConditionalEntityTagParseError>
+where
+  I: IntoIterator<Item = &'a str>,
+{
+  let mut entity_tags = Vec::new();
+  let mut seen = HashSet::new();
+  let mut wildcard = false;
+  let mut saw_value = false;
+
+  for value in values {
+    validate_length(value, maximum_length, header_name)
+      .map_err(ConditionalEntityTagParseError::new)?;
+    let bytes = value.as_bytes();
+    let mut position = 0;
+    skip_ows(bytes, &mut position);
+    if position == bytes.len() {
+      return Err(ConditionalEntityTagParseError::new(format!(
+        "invalid {header_name} entity tag"
+      )));
+    }
+
+    loop {
+      saw_value = true;
+      if bytes.get(position) == Some(&b'*') {
+        position += 1;
+        skip_ows(bytes, &mut position);
+        if wildcard || !entity_tags.is_empty() || position != bytes.len() {
+          return Err(ConditionalEntityTagParseError::new(format!(
+            "invalid {header_name} wildcard"
+          )));
+        }
+        wildcard = true;
+        break;
+      }
+      if wildcard || entity_tags.len() >= MAX_CONDITIONAL_ENTITY_TAGS {
+        return Err(ConditionalEntityTagParseError::new(format!(
+          "too many {header_name} entity tags"
+        )));
+      }
+
+      let start = position;
+      let entity_tag = parse_entity_tag_at(value, &mut position).map_err(|_| {
+        ConditionalEntityTagParseError::new(format!("invalid {header_name} entity tag"))
+      })?;
+      if !seen.insert(entity_tag.clone()) {
+        return Err(ConditionalEntityTagParseError::new(format!(
+          "duplicate {header_name} entity tag"
+        )));
+      }
+      entity_tags.push(entity_tag);
+      debug_assert!(position > start);
+      skip_ows(bytes, &mut position);
+      if position == bytes.len() {
+        break;
+      }
+      if bytes[position] != b',' {
+        return Err(ConditionalEntityTagParseError::new(format!(
+          "invalid {header_name} entity tag"
+        )));
+      }
+      position += 1;
+      skip_ows(bytes, &mut position);
+      if position == bytes.len() {
+        return Err(ConditionalEntityTagParseError::new(format!(
+          "invalid {header_name} entity tag"
+        )));
+      }
+    }
+  }
+
+  if !saw_value {
+    return Err(ConditionalEntityTagParseError::new(format!(
+      "invalid {header_name} entity tag"
+    )));
+  }
+  if wildcard {
+    Ok(ConditionalEntityTags::Wildcard)
+  } else {
+    Ok(ConditionalEntityTags::Tags(entity_tags))
+  }
+}
+
+fn parse_entity_tag(value: &str) -> Result<EntityTag, String> {
+  let mut position = 0;
+  let entity_tag = parse_entity_tag_at(value, &mut position)?;
+  if position != value.len() {
+    return Err("invalid entity tag".to_string());
+  }
+  Ok(entity_tag)
+}
+
+fn parse_entity_tag_at(value: &str, position: &mut usize) -> Result<EntityTag, String> {
+  let bytes = value.as_bytes();
+  let weak = if bytes.get(*position..*position + 2) == Some(b"W/") {
+    *position += 2;
+    true
+  } else {
+    false
+  };
+  if bytes.get(*position) != Some(&b'"') {
+    return Err("invalid entity tag".to_string());
+  }
+  *position += 1;
+  let start = *position;
+  while let Some(&byte) = bytes.get(*position) {
+    match byte {
+      b'"' => {
+        let opaque_tag = value[start..*position].to_string();
+        *position += 1;
+        return Ok(EntityTag { opaque_tag, weak });
+      }
+      0x21 | 0x23..=0x7e | 0x80..=0xff => *position += 1,
+      _ => return Err("invalid entity tag".to_string()),
+    }
+  }
+  Err("invalid entity tag".to_string())
+}
+
+fn validate_length(value: &str, maximum_length: usize, name: &str) -> Result<(), String> {
+  if value.len() > maximum_length {
+    return Err(format!("{name} header value is too large"));
+  }
+  Ok(())
+}
+
+fn trim_ows(value: &str) -> &str {
+  value.trim_matches([' ', '\t'])
+}
+
+fn skip_ows(bytes: &[u8], position: &mut usize) {
+  while bytes
+    .get(*position)
+    .is_some_and(|byte| matches!(*byte, b' ' | b'\t'))
+  {
+    *position += 1;
+  }
+}

--- a/crates/rttp-protocol/src/lib.rs
+++ b/crates/rttp-protocol/src/lib.rs
@@ -11,6 +11,7 @@ pub mod clear_site_data;
 pub mod client_hints;
 pub mod cookie;
 pub mod digest;
+pub mod entity_tag;
 pub mod forwarded;
 pub mod http1;
 mod media_type;

--- a/crates/rttp-protocol/tests/entity_tag.rs
+++ b/crates/rttp-protocol/tests/entity_tag.rs
@@ -1,0 +1,63 @@
+use rttp_protocol::entity_tag::{
+  EntityTag, IfMatch, IfNoneMatch, MAX_CONDITIONAL_ENTITY_TAGS, MAX_ENTITY_TAG_VALUE_BYTES,
+};
+
+#[test]
+fn entity_tags_parse_strong_and_weak_forms_and_serialize_canonically() {
+  let strong = EntityTag::parse("\"abc\"").expect("strong entity tag");
+  assert_eq!("abc", strong.opaque_tag());
+  assert!(!strong.is_weak());
+  assert_eq!("\"abc\"", strong.header_value());
+
+  let weak = EntityTag::parse("W/\"abc\"").expect("weak entity tag");
+  assert_eq!("abc", weak.opaque_tag());
+  assert!(weak.is_weak());
+  assert_eq!("W/\"abc\"", weak.header_value());
+}
+
+#[test]
+fn conditional_entity_tag_lists_parse_values_and_serialize_canonically() {
+  let if_match =
+    IfMatch::parse_values([" \"one\" , W/\"two\" ", "\"three\""]).expect("If-Match list");
+  assert!(!if_match.is_wildcard());
+  assert_eq!(3, if_match.entity_tags().len());
+  assert_eq!("\"one\", W/\"two\", \"three\"", if_match.header_value());
+
+  let if_none_match = IfNoneMatch::parse("*").expect("If-None-Match wildcard");
+  assert!(if_none_match.is_wildcard());
+  assert!(if_none_match.entity_tags().is_empty());
+  assert_eq!("*", if_none_match.header_value());
+}
+
+#[test]
+fn conditional_entity_tags_reject_malformed_ambiguous_and_unbounded_inputs() {
+  for value in ["abc", "W/abc", "w/\"abc\"", "\"abc", "\"a b\"", "\"a\n\""] {
+    assert!(
+      EntityTag::parse(value).is_err(),
+      "{value:?} must be rejected"
+    );
+  }
+
+  for value in [
+    "",
+    ",\"one\"",
+    "\"one\",",
+    "\"one\",,\"two\"",
+    "*, \"one\"",
+    "\"one\", \"one\"",
+  ] {
+    assert!(IfMatch::parse(value).is_err(), "{value:?} must be rejected");
+    assert!(
+      IfNoneMatch::parse(value).is_err(),
+      "{value:?} must be rejected"
+    );
+  }
+
+  assert!(EntityTag::parse(format!("\"{}\"", "a".repeat(MAX_ENTITY_TAG_VALUE_BYTES))).is_err());
+
+  let too_many = std::iter::repeat_n("\"tag\"", MAX_CONDITIONAL_ENTITY_TAGS + 1)
+    .collect::<Vec<_>>()
+    .join(",");
+  assert!(IfMatch::parse(&too_many).is_err());
+  assert!(IfNoneMatch::parse(&too_many).is_err());
+}


### PR DESCRIPTION
Added bounded entity-tag parsing and canonical conditional-header serialization for `If-Match` and `If-None-Match`, with malformed and unbounded inputs rejected. Formatting, Clippy, focused protocol tests, and all-feature workspace tests pass.

## Metadata
```yaml
version: 1
issue: default:81578723-b2e9-4aaa-89fc-2e3d77b6169f
work_kind: code_work
branch: hbx-1731-rttp-protocol-add-bounded-entity
base: main
commit: ca5f84cdb3b6e4979606441a4beee8363a66d642
```