### PR TITLE
feat: [rttp-docs/tests] Add package-level API consistency checks for metadata helper exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,10 @@ rttp
 ====
 
 A small Rust HTTP workspace with public client (`rttp_client`) and server
-(`rttp-server`) crates. The `rttp` crate remains a compatibility facade for
-their established APIs, while the private, unpublished `rttp_test_support`
-crate contains shared test fixtures and local socket helpers.
+(`rttp-server`) crates, plus shared wire primitives in `rttp-protocol`. The
+`rttp` crate remains a compatibility facade for their established APIs, while
+the private, unpublished `rttp_test_support` crate contains shared test fixtures
+and local socket helpers.
 
 ## Client
 

--- a/crates/rttp-client/tests/metadata_facade.rs
+++ b/crates/rttp-client/tests/metadata_facade.rs
@@ -1,0 +1,23 @@
+use rttp_client::response::{
+  AcceptCh, AltSvc, Digest, HttpClearSiteData, Priority, ServerTiming, Trailer,
+};
+
+#[test]
+fn response_facade_exports_representative_bounded_metadata_types() {
+  let accept_ch = AcceptCh::parse("Sec-CH-UA, DPR").expect("Accept-CH should parse");
+  let clear_site_data =
+    HttpClearSiteData::parse("\"cache\"").expect("Clear-Site-Data should parse");
+  let digest = Digest::parse("sha-256=:YWJj:").expect("Digest should parse");
+  let priority = Priority::parse("u=1, i").expect("Priority should parse");
+  let server_timing = ServerTiming::parse("db;dur=53").expect("Server-Timing should parse");
+  let trailer = Trailer::parse("X-Trace").expect("Trailer should parse");
+  let alt_svc = AltSvc::parse("h3=\":443\"").expect("Alt-Svc should parse");
+
+  assert_eq!(accept_ch.client_hints(), ["Sec-CH-UA", "DPR"]);
+  assert_eq!(clear_site_data.directives().len(), 1);
+  assert_eq!(digest.entries().len(), 1);
+  assert_eq!(priority.urgency(), Some(1));
+  assert_eq!(server_timing.metrics().len(), 1);
+  assert_eq!(trailer.field_names(), ["x-trace"]);
+  assert_eq!(alt_svc.alternatives().len(), 1);
+}

--- a/crates/rttp-protocol/tests/metadata_facade.rs
+++ b/crates/rttp-protocol/tests/metadata_facade.rs
@@ -1,0 +1,18 @@
+use rttp_protocol::client_hints::{AcceptCh, CriticalCh};
+use rttp_protocol::entity_tag::{EntityTag, IfMatch};
+
+#[test]
+fn protocol_exports_representative_bounded_metadata_types() {
+  let accept_ch = AcceptCh::parse("Sec-CH-UA, DPR").expect("Accept-CH should parse");
+  let critical_ch = CriticalCh::parse("Sec-CH-UA").expect("Critical-CH should parse");
+  let entity_tag = EntityTag::parse("\"revision-42\"").expect("entity tag should parse");
+  let if_match = IfMatch::parse("\"revision-42\"").expect("If-Match should parse");
+
+  assert_eq!(accept_ch.client_hints(), ["Sec-CH-UA", "DPR"]);
+  assert_eq!(critical_ch.client_hints(), ["Sec-CH-UA"]);
+  assert_eq!(entity_tag.opaque_tag(), "revision-42");
+  assert_eq!(
+    if_match.entity_tags()[0].header_value(),
+    entity_tag.header_value()
+  );
+}

--- a/crates/rttp-protocol/tests/package_list.rs
+++ b/crates/rttp-protocol/tests/package_list.rs
@@ -1,7 +1,7 @@
 use std::process::Command;
 
 #[test]
-fn package_includes_client_test_files() {
+fn package_includes_protocol_metadata_facade_test() {
   let output = Command::new(env!("CARGO"))
     .arg("package")
     .arg("--list")
@@ -18,18 +18,15 @@ fn package_includes_client_test_files() {
 
   let package_files = String::from_utf8(output.stdout).expect("package list is utf-8");
   for expected in [
-    "tests/test_http_basic.rs",
-    "tests/test_http_async.rs",
-    "tests/test_rustls.rs",
-    "tests/test_raw_request_capture.rs",
+    "README.md",
+    "tests/package_list.rs",
     "tests/metadata_facade.rs",
   ] {
     assert!(
-      package_files.lines().any(|line| line == expected),
+      package_files.lines().any(|path| path == expected),
       "missing {expected} from package list:\n{package_files}"
     );
   }
-
   assert!(
     package_files
       .lines()

--- a/crates/rttp-server/tests/metadata_facade.rs
+++ b/crates/rttp-server/tests/metadata_facade.rs
@@ -1,0 +1,27 @@
+use rttp_server::server::{HttpAcceptCh, HttpConditionalMetadata, HttpEntityTag, HttpResponse};
+
+#[test]
+fn server_facade_exports_representative_bounded_metadata_types() {
+  let accept_ch: HttpAcceptCh = HttpAcceptCh::parse("Sec-CH-UA").expect("Accept-CH should parse");
+  let metadata = HttpConditionalMetadata::new().entity_tag(HttpEntityTag::strong("revision-42"));
+  let response = HttpResponse::ok("")
+    .with_accept_ch(["Sec-CH-UA"])
+    .expect("Accept-CH should be accepted");
+
+  assert_eq!(accept_ch.client_hints(), ["Sec-CH-UA"]);
+  assert_eq!(
+    metadata
+      .entity_tag_value()
+      .expect("entity tag should be retained")
+      .opaque_tag(),
+    "revision-42"
+  );
+  assert_eq!(
+    response
+      .accept_ch()
+      .expect("Accept-CH should parse")
+      .expect("Accept-CH should be present")
+      .client_hints(),
+    ["Sec-CH-UA"]
+  );
+}

--- a/crates/rttp-server/tests/package_list.rs
+++ b/crates/rttp-server/tests/package_list.rs
@@ -1,7 +1,7 @@
 use std::process::Command;
 
 #[test]
-fn package_includes_client_test_files() {
+fn package_includes_server_metadata_facade_test() {
   let output = Command::new(env!("CARGO"))
     .arg("package")
     .arg("--list")
@@ -18,18 +18,15 @@ fn package_includes_client_test_files() {
 
   let package_files = String::from_utf8(output.stdout).expect("package list is utf-8");
   for expected in [
-    "tests/test_http_basic.rs",
-    "tests/test_http_async.rs",
-    "tests/test_rustls.rs",
-    "tests/test_raw_request_capture.rs",
+    "README.md",
+    "tests/package_list.rs",
     "tests/metadata_facade.rs",
   ] {
     assert!(
-      package_files.lines().any(|line| line == expected),
+      package_files.lines().any(|path| path == expected),
       "missing {expected} from package list:\n{package_files}"
     );
   }
-
   assert!(
     package_files
       .lines()

--- a/crates/rttp/tests/metadata_facade.rs
+++ b/crates/rttp/tests/metadata_facade.rs
@@ -1,0 +1,35 @@
+use rttp::server::{HttpAcceptCh, HttpConditionalMetadata, HttpEntityTag};
+
+#[test]
+#[cfg(feature = "client")]
+fn compatibility_facade_exports_client_metadata_types() {
+  let accept_ch: rttp::AcceptCh =
+    rttp_client::response::AcceptCh::parse("Sec-CH-UA, DPR").expect("Accept-CH should parse");
+  let critical_ch: rttp::CriticalCh =
+    rttp_client::response::CriticalCh::parse("Sec-CH-UA").expect("Critical-CH should parse");
+  let accept_patch: rttp::AcceptPatch =
+    rttp_client::response::AcceptPatch::parse("application/json")
+      .expect("Accept-Patch should parse");
+  let accept_post: rttp::AcceptPost =
+    rttp_client::response::AcceptPost::parse("application/json").expect("Accept-Post should parse");
+
+  assert_eq!(accept_ch.client_hints(), ["Sec-CH-UA", "DPR"]);
+  assert_eq!(critical_ch.client_hints(), ["Sec-CH-UA"]);
+  assert_eq!(accept_patch.media_types().len(), 1);
+  assert_eq!(accept_post.media_types().len(), 1);
+}
+
+#[test]
+fn compatibility_facade_keeps_server_metadata_in_the_server_module() {
+  let accept_ch: HttpAcceptCh = HttpAcceptCh::parse("Sec-CH-UA").expect("Accept-CH should parse");
+  let metadata = HttpConditionalMetadata::new().entity_tag(HttpEntityTag::strong("revision-42"));
+
+  assert_eq!(accept_ch.client_hints(), ["Sec-CH-UA"]);
+  assert_eq!(
+    metadata
+      .entity_tag_value()
+      .expect("entity tag should be retained")
+      .header_value(),
+    "\"revision-42\""
+  );
+}

--- a/crates/rttp/tests/package_list.rs
+++ b/crates/rttp/tests/package_list.rs
@@ -22,10 +22,18 @@ fn package_includes_facade_test_files() {
     "tests/test_server_models.rs",
     "tests/test_client.rs",
     "tests/connect_upgrade_handoff.rs",
+    "tests/metadata_facade.rs",
   ] {
     assert!(
       package_files.lines().any(|line| line == expected),
       "missing {expected} from package list:\n{package_files}"
     );
   }
+
+  assert!(
+    package_files
+      .lines()
+      .all(|path| !path.contains("rttp-test-support")),
+    "private test-support sources leaked into the package list:\n{package_files}"
+  );
 }


### PR DESCRIPTION
Added package-level metadata facade checks across RTTP crates, ensuring bounded helper exports remain available through intended public APIs and private test support stays out of packages. README workspace boundaries now include rttp-protocol. Full workspace verification passes.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1796/
work_kind: code_work
branch: hbx-1796-rttp-docs-tests-add-package
base: main
commit: 86d8c3eb6bfafee2e3029c3f8c34d606cc62e029
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1796/
    url: https://plane.kahub.in/endless/browse/HBX-1796/
    close_policy: link_only
```