### PR TITLE
feat: [rttp-client] Add redirect policy tests for method and body preservation boundaries

### DIFF
--- a/crates/rttp-client/tests/test_http_async.rs
+++ b/crates/rttp-client/tests/test_http_async.rs
@@ -1214,6 +1214,23 @@ fn test_async_auto_redirect() {
   });
 }
 
+#[test]
+#[cfg(feature = "async")]
+fn test_async_redirect_is_not_followed_by_default() {
+  let (addr, _handle) = support::spawn_redirect_server();
+  block_on(async {
+    let response = client()
+      .get()
+      .url(format!("http://{}/", addr))
+      .rasync()
+      .await
+      .expect("default redirect policy should return the redirect response");
+
+    assert_eq!(302, response.code());
+    assert!(response.is_redirect());
+  });
+}
+
 #[cfg(feature = "async")]
 async fn assert_async_redirect_resolves_to_target<F>(location: F, expected_target: &str)
 where

--- a/crates/rttp-client/tests/test_http_basic.rs
+++ b/crates/rttp-client/tests/test_http_basic.rs
@@ -1215,6 +1215,19 @@ fn test_auto_redirect() {
   assert!(response.ok());
 }
 
+#[test]
+fn test_redirect_is_not_followed_by_default() {
+  let (addr, _handle) = support::spawn_redirect_server();
+  let response = client()
+    .get()
+    .url(format!("http://{}/", addr))
+    .emit()
+    .expect("default redirect policy should return the redirect response");
+
+  assert_eq!(302, response.code());
+  assert!(response.is_redirect());
+}
+
 fn assert_redirect_resolves_to_target<F>(location: F, expected_target: &str)
 where
   F: FnOnce(std::net::SocketAddr) -> String + Send + 'static,


### PR DESCRIPTION
Added sync and async regression coverage proving redirects are not followed by default. The existing opt-in redirect suite continues to cover redirect status method/body semantics, loop detection, and redirect limits.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1801/
work_kind: code_work
branch: hbx-1801-rttp-client-add-redirect-policy
base: main
commit: 597ea5c56e13d3fe5774a3cba0b01b5dd6f2947d
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1801/
    url: https://plane.kahub.in/endless/browse/HBX-1801/
    close_policy: link_only
```