### PR TITLE
feat: [rttp-http2] Add SETTINGS_INITIAL_WINDOW_SIZE validation coverage on client and server

### DIFF
--- a/crates/rttp-client/tests/http2_prior_knowledge.rs
+++ b/crates/rttp-client/tests/http2_prior_knowledge.rs
@@ -2795,6 +2795,23 @@ fn prior_knowledge_rejects_initial_settings_with_invalid_initial_window_size() {
 }
 
 #[test]
+fn prior_knowledge_accepts_initial_settings_with_maximum_initial_window_size() {
+  let (addr, handle) = spawn_h2_prior_knowledge_peer_with_initial_window_size(2_147_483_647);
+
+  let response = HttpClient::new()
+    .get()
+    .url(format!("http://{}/maximum-initial-window-size", addr))
+    .emit_http2_prior_knowledge()
+    .expect("maximum SETTINGS_INITIAL_WINDOW_SIZE must be accepted");
+
+  assert_eq!(200, response.code());
+  assert_eq!("ok", response.body().string().unwrap());
+  handle
+    .join()
+    .expect("maximum initial window size peer thread");
+}
+
+#[test]
 fn prior_knowledge_rejects_initial_settings_ack_with_payload() {
   let payload = settings_payload(SETTING_MAX_FRAME_SIZE, 16 * 1024);
   let (addr, handle) = spawn_initial_settings_peer(FLAG_ACK, 0, &payload);
@@ -4757,6 +4774,24 @@ fn spawn_initial_settings_peer(
   (addr, handle)
 }
 
+fn spawn_h2_prior_knowledge_peer_with_initial_window_size(
+  initial_window_size: u32,
+) -> (SocketAddr, thread::JoinHandle<()>) {
+  let listener = TcpListener::bind("127.0.0.1:0").expect("bind h2 peer");
+  let addr = listener.local_addr().expect("h2 peer addr");
+
+  let handle = thread::spawn(move || {
+    let (mut stream, _) = listener.accept().expect("accept h2 client");
+    complete_h2_request_handshake_with_initial_window_size(&mut stream, initial_window_size);
+
+    write_frame(&mut stream, FRAME_SETTINGS, FLAG_ACK, 0, &[]);
+    write_frame(&mut stream, FRAME_HEADERS, FLAG_END_HEADERS, 1, &[0x88]);
+    write_frame(&mut stream, FRAME_DATA, FLAG_END_STREAM, 1, b"ok");
+  });
+
+  (addr, handle)
+}
+
 fn spawn_window_update_peer(
   stream_id: u32,
   increments: Vec<u32>,
@@ -4786,6 +4821,21 @@ fn spawn_window_update_peer(
 
 fn complete_h2_request_handshake(stream: &mut impl ReadWrite) {
   complete_h2_handshake_without_request(stream);
+
+  let request_headers = read_frame(stream);
+  assert_eq!(FRAME_HEADERS, request_headers.frame_type);
+  assert_eq!(FLAG_END_STREAM | FLAG_END_HEADERS, request_headers.flags);
+  assert_eq!(1, request_headers.stream_id);
+}
+
+fn complete_h2_request_handshake_with_initial_window_size(
+  stream: &mut impl ReadWrite,
+  initial_window_size: u32,
+) {
+  complete_h2_handshake_without_request_with_settings(
+    stream,
+    &settings_payload(SETTING_INITIAL_WINDOW_SIZE, initial_window_size),
+  );
 
   let request_headers = read_frame(stream);
   assert_eq!(FRAME_HEADERS, request_headers.frame_type);

--- a/crates/rttp/tests/http2_feature.rs
+++ b/crates/rttp/tests/http2_feature.rs
@@ -3880,6 +3880,37 @@ fn prior_knowledge_server_rejects_initial_settings_with_invalid_initial_window_s
 }
 
 #[test]
+fn prior_knowledge_server_accepts_initial_settings_with_maximum_initial_window_size() {
+  let server = rttp::Http::server("127.0.0.1:0")
+    .expect("bind server")
+    .with_read_timeout(Some(Duration::from_secs(2)))
+    .with_write_timeout(Some(Duration::from_secs(2)));
+  let addr = server.local_addr().expect("server addr");
+
+  let handle =
+    thread::spawn(move || server.accept_one(|_| HttpResponse::ok("maximum initial window size")));
+
+  let mut stream = TcpStream::connect(addr).expect("connect h2 server");
+  complete_h2_server_handshake_with_settings(
+    &mut stream,
+    &h2_setting(H2_SETTINGS_INITIAL_WINDOW_SIZE, 2_147_483_647),
+  );
+  write_h2_get_request(&mut stream, addr.to_string().as_bytes()).expect("write h2 request");
+
+  let headers = read_h2_frame(&mut stream);
+  assert_eq!(H2_FRAME_HEADERS, headers.frame_type);
+  let body = read_h2_frame(&mut stream);
+  assert_eq!(H2_FRAME_DATA, body.frame_type);
+  assert_eq!(H2_FLAG_END_STREAM, body.flags);
+  assert_eq!(b"maximum initial window size", body.payload.as_slice());
+
+  handle
+    .join()
+    .expect("server thread")
+    .expect("server result");
+}
+
+#[test]
 fn h2c_connect_protocol_settings_metadata_is_ignored_for_ordinary_requests() {
   assert_connect_protocol_settings_accepted(false);
   assert_connect_protocol_settings_accepted(true);


### PR DESCRIPTION
Added client and server h2c coverage for the maximum legal SETTINGS_INITIAL_WINDOW_SIZE while preserving rejection of oversized peer settings. Workspace tests pass with all features enabled.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1800/
work_kind: code_work
branch: hbx-1800-rttp-http2-add-settings-initial
base: main
commit: e79d9b6f16ddbf2a5ab402a193d67680beeab686
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1800/
    url: https://plane.kahub.in/endless/browse/HBX-1800/
    close_policy: link_only
```