### PR TITLE
feat: [rttp-server] Add request body size limit policy and regression tests

### DIFF
--- a/crates/rttp-server/src/server/connection.rs
+++ b/crates/rttp-server/src/server/connection.rs
@@ -4,6 +4,7 @@ pub struct HttpServer {
   pub(crate) listener: TcpListener,
   pub(crate) read_timeout: Option<Duration>,
   pub(crate) write_timeout: Option<Duration>,
+  pub(crate) max_request_body_bytes: usize,
   pub(crate) http2_policy: Http2ServerPolicy,
 }
 
@@ -40,6 +41,7 @@ impl HttpServer {
         listener: TcpListener::from(socket),
         read_timeout: None,
         write_timeout: None,
+        max_request_body_bytes: MAX_REQUEST_BODY_BYTES,
         http2_policy: Http2ServerPolicy::default(),
       });
     }
@@ -63,6 +65,12 @@ impl HttpServer {
   /// Sets the write timeout applied to each accepted connection before writing responses.
   pub fn with_write_timeout(mut self, timeout: Option<Duration>) -> Self {
     self.write_timeout = timeout;
+    self
+  }
+
+  /// Sets the maximum number of request body bytes accepted per request.
+  pub fn with_max_request_body_bytes(mut self, max_request_body_bytes: usize) -> Self {
+    self.max_request_body_bytes = max_request_body_bytes;
     self
   }
 
@@ -128,14 +136,21 @@ impl HttpServer {
     let mut served = 0;
 
     while served < request_limit {
-      let request = match self
-        .normalize_connection_error(Request::read_next_from_with_continue(&mut reader))
-      {
+      let request = match self.normalize_connection_error(Request::read_next_from_with_continue(
+        &mut reader,
+        self.max_request_body_bytes,
+      )) {
         Ok(Some(request)) => request,
         Ok(None) => break,
         Err(err) if is_expectation_failed_error(&err) => {
           self
             .normalize_connection_error(expectation_failed_response().write_to(reader.get_mut()))?;
+          served += 1;
+          break;
+        }
+        Err(err) if is_payload_too_large_error(&err) => {
+          self
+            .normalize_connection_error(payload_too_large_response().write_to(reader.get_mut()))?;
           served += 1;
           break;
         }
@@ -219,14 +234,21 @@ impl HttpServer {
     };
     let mut reader = BufReader::new(stream);
     let request = match self.normalize_connection_error(
-      Request::read_next_from_with_continue(&mut reader).and_then(|request| {
-        request.ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "incomplete HTTP request"))
-      }),
+      Request::read_next_from_with_continue(&mut reader, self.max_request_body_bytes).and_then(
+        |request| {
+          request
+            .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "incomplete HTTP request"))
+        },
+      ),
     ) {
       Ok(request) => request,
       Err(err) if is_expectation_failed_error(&err) => {
         return self
           .normalize_connection_error(expectation_failed_response().write_to(reader.get_mut()));
+      }
+      Err(err) if is_payload_too_large_error(&err) => {
+        return self
+          .normalize_connection_error(payload_too_large_response().write_to(reader.get_mut()));
       }
       Err(err) if is_bad_request_error(&err) => {
         return self.normalize_connection_error(bad_request_response().write_to(reader.get_mut()));
@@ -274,14 +296,20 @@ impl HttpServer {
     self.configure_stream(&stream)?;
     let mut reader = BufReader::new(stream);
     let (request, body_kind) = match self.normalize_connection_error(
-      Request::read_next_head_from_with_continue(&mut reader).and_then(|request| {
-        request.ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "incomplete HTTP request"))
-      }),
+      Request::read_next_head_from_with_continue(&mut reader, self.max_request_body_bytes)
+        .and_then(|request| {
+          request
+            .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "incomplete HTTP request"))
+        }),
     ) {
       Ok(request) => request,
       Err(err) if is_expectation_failed_error(&err) => {
         return self
           .normalize_connection_error(expectation_failed_response().write_to(reader.get_mut()));
+      }
+      Err(err) if is_payload_too_large_error(&err) => {
+        return self
+          .normalize_connection_error(payload_too_large_response().write_to(reader.get_mut()));
       }
       Err(err) if is_bad_request_error(&err) => {
         return self.normalize_connection_error(bad_request_response().write_to(reader.get_mut()));
@@ -292,7 +320,12 @@ impl HttpServer {
       return self.normalize_connection_error(bad_request_response().write_to(reader.get_mut()));
     }
     let request_is_head = request.method() == "HEAD";
-    let body = RequestBodyReader::new(&mut reader, body_kind, self.read_timeout.is_some());
+    let body = RequestBodyReader::new(
+      &mut reader,
+      body_kind,
+      self.max_request_body_bytes,
+      self.read_timeout.is_some(),
+    );
     let response = handler(request, body);
     self.normalize_connection_error(response.write_to_with_default_connection_and_body(
       reader.get_mut(),
@@ -309,16 +342,21 @@ impl HttpServer {
     self.configure_stream(&stream)?;
     let mut reader = BufReader::new(stream);
     let request = match self.normalize_connection_error(
-      Request::read_next_head_from_with_continue(&mut reader).and_then(|request| {
-        request
-          .map(|(request, _)| request)
-          .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "incomplete HTTP request"))
-      }),
+      Request::read_next_head_from_with_continue(&mut reader, self.max_request_body_bytes)
+        .and_then(|request| {
+          request
+            .map(|(request, _)| request)
+            .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "incomplete HTTP request"))
+        }),
     ) {
       Ok(request) => request,
       Err(err) if is_expectation_failed_error(&err) => {
         return self
           .normalize_connection_error(expectation_failed_response().write_to(reader.get_mut()));
+      }
+      Err(err) if is_payload_too_large_error(&err) => {
+        return self
+          .normalize_connection_error(payload_too_large_response().write_to(reader.get_mut()));
       }
       Err(err) if is_bad_request_error(&err) => {
         return self.normalize_connection_error(bad_request_response().write_to(reader.get_mut()));
@@ -738,7 +776,7 @@ impl HttpServer {
             .ok_or_else(|| {
               io::Error::new(io::ErrorKind::InvalidData, "request body is too large")
             })?;
-          reject_oversized_request_body(new_len)?;
+          reject_oversized_request_body(new_len, self.max_request_body_bytes)?;
           request_stream.body.extend_from_slice(data_payload);
           if !frame.payload.is_empty() {
             write_http2_window_update(&mut stream, 0, frame.payload.len())?;

--- a/crates/rttp-server/src/server/http1.rs
+++ b/crates/rttp-server/src/server/http1.rs
@@ -11,13 +11,19 @@ pub struct RequestBodyReader<'a, R: BufRead> {
   pub(crate) chunk_remaining: usize,
   pub(crate) chunk_needs_crlf: bool,
   pub(crate) body_bytes_read: usize,
+  pub(crate) max_request_body_bytes: usize,
   pub(crate) trailers: Vec<(String, String)>,
   pub(crate) eof: bool,
   pub(crate) normalize_timeouts: bool,
 }
 
 impl<'a, R: BufRead> RequestBodyReader<'a, R> {
-  pub(crate) fn new(reader: &'a mut R, kind: RequestBodyKind, normalize_timeouts: bool) -> Self {
+  pub(crate) fn new(
+    reader: &'a mut R,
+    kind: RequestBodyKind,
+    max_request_body_bytes: usize,
+    normalize_timeouts: bool,
+  ) -> Self {
     let remaining = match kind {
       RequestBodyKind::ContentLength(length) => length,
       RequestBodyKind::Chunked => 0,
@@ -29,6 +35,7 @@ impl<'a, R: BufRead> RequestBodyReader<'a, R> {
       chunk_remaining: 0,
       chunk_needs_crlf: false,
       body_bytes_read: 0,
+      max_request_body_bytes,
       trailers: Vec::new(),
       eof: matches!(kind, RequestBodyKind::ContentLength(0)),
       normalize_timeouts,
@@ -69,22 +76,38 @@ impl<'a, R: BufRead> RequestBodyReader<'a, R> {
     }
 
     if self.chunk_needs_crlf {
-      consume_crlf(self.reader, &mut self.body_bytes_read)
-        .map_err(|err| self.normalize_error(err))?;
+      consume_crlf(
+        self.reader,
+        &mut self.body_bytes_read,
+        self.max_request_body_bytes,
+      )
+      .map_err(|err| self.normalize_error(err))?;
       self.chunk_needs_crlf = false;
     }
 
     while self.chunk_remaining == 0 {
-      let line = read_bounded_crlf_line(self.reader, &mut self.body_bytes_read)
-        .map_err(|err| self.normalize_error(err))?;
+      let line = read_bounded_crlf_line(
+        self.reader,
+        &mut self.body_bytes_read,
+        self.max_request_body_bytes,
+      )
+      .map_err(|err| self.normalize_error(err))?;
       let chunk_size = parse_chunk_size(&line)?;
       if chunk_size == 0 {
-        self.trailers = read_trailers(self.reader, &mut self.body_bytes_read)
-          .map_err(|err| self.normalize_error(err))?;
+        self.trailers = read_trailers(
+          self.reader,
+          &mut self.body_bytes_read,
+          self.max_request_body_bytes,
+        )
+        .map_err(|err| self.normalize_error(err))?;
         self.eof = true;
         return Ok(0);
       }
-      add_request_body_bytes(&mut self.body_bytes_read, chunk_size)?;
+      add_request_body_bytes(
+        &mut self.body_bytes_read,
+        chunk_size,
+        self.max_request_body_bytes,
+      )?;
       self.chunk_remaining = chunk_size;
     }
 
@@ -139,8 +162,11 @@ pub(crate) fn reject_oversized_request_head(length: usize) -> io::Result<()> {
   }
 }
 
-pub(crate) fn reject_oversized_request_body(length: usize) -> io::Result<()> {
-  if length > MAX_REQUEST_BODY_BYTES {
+pub(crate) fn reject_oversized_request_body(
+  length: usize,
+  max_request_body_bytes: usize,
+) -> io::Result<()> {
+  if length > max_request_body_bytes {
     Err(io::Error::new(
       io::ErrorKind::InvalidData,
       "request body is too large",
@@ -558,7 +584,10 @@ pub(crate) fn request_body_kind(headers: &[(String, String)]) -> io::Result<Requ
   }
 }
 
-pub(crate) fn read_chunked_request_body<R>(reader: &mut R) -> io::Result<ChunkedRequestBody>
+pub(crate) fn read_chunked_request_body<R>(
+  reader: &mut R,
+  max_request_body_bytes: usize,
+) -> io::Result<ChunkedRequestBody>
 where
   R: BufRead,
 {
@@ -566,15 +595,15 @@ where
   let mut body_bytes_read = 0;
 
   loop {
-    let line = read_bounded_crlf_line(reader, &mut body_bytes_read)?;
+    let line = read_bounded_crlf_line(reader, &mut body_bytes_read, max_request_body_bytes)?;
     let chunk_size = parse_chunk_size(&line)?;
 
     if chunk_size == 0 {
-      let trailers = read_trailers(reader, &mut body_bytes_read)?;
+      let trailers = read_trailers(reader, &mut body_bytes_read, max_request_body_bytes)?;
       return Ok(ChunkedRequestBody { body, trailers });
     }
 
-    add_request_body_bytes(&mut body_bytes_read, chunk_size)?;
+    add_request_body_bytes(&mut body_bytes_read, chunk_size, max_request_body_bytes)?;
 
     let copied = {
       let mut chunk_reader = reader.take(chunk_size as u64);
@@ -587,26 +616,31 @@ where
         "incomplete chunked request body",
       ));
     };
-    consume_crlf(reader, &mut body_bytes_read)?;
+    consume_crlf(reader, &mut body_bytes_read, max_request_body_bytes)?;
   }
 }
 
-pub(crate) fn add_request_body_bytes(total: &mut usize, length: usize) -> io::Result<()> {
+pub(crate) fn add_request_body_bytes(
+  total: &mut usize,
+  length: usize,
+  max_request_body_bytes: usize,
+) -> io::Result<()> {
   *total = total
     .checked_add(length)
     .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "request body is too large"))?;
-  reject_oversized_request_body(*total)
+  reject_oversized_request_body(*total, max_request_body_bytes)
 }
 
 pub(crate) fn read_bounded_crlf_line<R>(
   reader: &mut R,
   body_bytes_read: &mut usize,
+  max_request_body_bytes: usize,
 ) -> io::Result<Vec<u8>>
 where
   R: BufRead,
 {
   let mut line = Vec::new();
-  let remaining = MAX_REQUEST_BODY_BYTES
+  let remaining = max_request_body_bytes
     .checked_sub(*body_bytes_read)
     .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "request body is too large"))?;
   let read = {
@@ -619,7 +653,7 @@ where
       "incomplete chunked request body",
     ));
   }
-  add_request_body_bytes(body_bytes_read, read)?;
+  add_request_body_bytes(body_bytes_read, read, max_request_body_bytes)?;
   if line.ends_with(b"\r\n") {
     Ok(line)
   } else {
@@ -634,11 +668,15 @@ pub(crate) fn parse_chunk_size(line: &[u8]) -> io::Result<usize> {
   parse_protocol_chunk_size(line).map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))
 }
 
-pub(crate) fn consume_crlf<R>(reader: &mut R, body_bytes_read: &mut usize) -> io::Result<()>
+pub(crate) fn consume_crlf<R>(
+  reader: &mut R,
+  body_bytes_read: &mut usize,
+  max_request_body_bytes: usize,
+) -> io::Result<()>
 where
   R: BufRead,
 {
-  add_request_body_bytes(body_bytes_read, 2)?;
+  add_request_body_bytes(body_bytes_read, 2, max_request_body_bytes)?;
   let mut suffix = [0u8; 2];
   reader.read_exact(&mut suffix).map_err(|err| {
     if err.kind() == io::ErrorKind::UnexpectedEof {
@@ -663,6 +701,7 @@ where
 pub(crate) fn read_trailers<R>(
   reader: &mut R,
   body_bytes_read: &mut usize,
+  max_request_body_bytes: usize,
 ) -> io::Result<Vec<(String, String)>>
 where
   R: BufRead,
@@ -670,7 +709,7 @@ where
   let mut lines = Vec::new();
 
   loop {
-    let line = read_bounded_crlf_line(reader, body_bytes_read)?;
+    let line = read_bounded_crlf_line(reader, body_bytes_read, max_request_body_bytes)?;
     if line == b"\r\n" {
       return parse_trailer_lines(lines.iter().map(String::as_str));
     }
@@ -825,6 +864,14 @@ pub(crate) fn is_expectation_failed_error(err: &io::Error) -> bool {
 
 pub(crate) fn bad_request_response() -> HttpResponse {
   HttpResponse::new(400, "Bad Request").body("Bad Request")
+}
+
+pub(crate) fn is_payload_too_large_error(err: &io::Error) -> bool {
+  err.kind() == io::ErrorKind::InvalidData && err.to_string() == "request body is too large"
+}
+
+pub(crate) fn payload_too_large_response() -> HttpResponse {
+  HttpResponse::new(413, "Payload Too Large").body("Payload Too Large")
 }
 
 pub(crate) fn expectation_failed_response() -> HttpResponse {

--- a/crates/rttp-server/src/server/http2.rs
+++ b/crates/rttp-server/src/server/http2.rs
@@ -1951,7 +1951,7 @@ pub(crate) fn read_http2_response_flow_control_frame<S: Read + Write>(
           .len()
           .checked_add(data_payload.len())
           .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "request body is too large"))?;
-        reject_oversized_request_body(new_len)?;
+        reject_oversized_request_body(new_len, MAX_REQUEST_BODY_BYTES)?;
         request_stream.body.extend_from_slice(data_payload);
         if !frame.payload.is_empty() {
           write_http2_window_update(stream, 0, frame.payload.len())?;

--- a/crates/rttp-server/src/server/request.rs
+++ b/crates/rttp-server/src/server/request.rs
@@ -497,6 +497,7 @@ impl Request {
 
   pub(crate) fn read_next_from_with_continue<S>(
     reader: &mut BufReader<S>,
+    max_request_body_bytes: usize,
   ) -> io::Result<Option<Self>>
   where
     S: Read + Write,
@@ -562,11 +563,11 @@ impl Request {
               return Ok(Some(Self::from_head_and_body(head, Vec::new())));
             }
             RequestBodyKind::ContentLength(content_length) => {
-              reject_oversized_request_body(content_length)?;
+              reject_oversized_request_body(content_length, max_request_body_bytes)?;
               body_kind = Some(RequestBodyKind::ContentLength(content_length));
             }
             RequestBodyKind::Chunked => {
-              let chunked = read_chunked_request_body(reader)?;
+              let chunked = read_chunked_request_body(reader, max_request_body_bytes)?;
               return Ok(Some(Self::from_head_body_and_trailers(
                 head,
                 chunked.body,
@@ -587,11 +588,12 @@ impl Request {
 
   pub(crate) fn read_next_head_from_with_continue<S>(
     reader: &mut BufReader<S>,
+    max_request_body_bytes: usize,
   ) -> io::Result<Option<(Self, RequestBodyKind)>>
   where
     S: Read + Write,
   {
-    Self::read_next_head_and_body_kind_from_with_continue(reader)?
+    Self::read_next_head_and_body_kind_from_with_continue(reader, max_request_body_bytes)?
       .map_or(Ok(None), |(head, kind)| {
         Ok(Some((Self::from_head_and_body(head, Vec::new()), kind)))
       })
@@ -599,6 +601,7 @@ impl Request {
 
   pub(crate) fn read_next_head_and_body_kind_from_with_continue<S>(
     reader: &mut BufReader<S>,
+    max_request_body_bytes: usize,
   ) -> io::Result<Option<(RequestHead, RequestBodyKind)>>
   where
     S: Read + Write,
@@ -629,7 +632,7 @@ impl Request {
           let body_kind = request_body_kind(&head.headers)?;
           match body_kind {
             RequestBodyKind::ContentLength(content_length) => {
-              reject_oversized_request_body(content_length)?;
+              reject_oversized_request_body(content_length, max_request_body_bytes)?;
             }
             RequestBodyKind::Chunked => {}
           }
@@ -710,11 +713,11 @@ impl Request {
               return Ok(Some(Self::from_head_and_body(head, Vec::new())));
             }
             RequestBodyKind::ContentLength(content_length) => {
-              reject_oversized_request_body(content_length)?;
+              reject_oversized_request_body(content_length, MAX_REQUEST_BODY_BYTES)?;
               body_kind = Some(RequestBodyKind::ContentLength(content_length));
             }
             RequestBodyKind::Chunked => {
-              let chunked = read_chunked_request_body(reader)?;
+              let chunked = read_chunked_request_body(reader, MAX_REQUEST_BODY_BYTES)?;
               return Ok(Some(Self::from_head_body_and_trailers(
                 head,
                 chunked.body,
@@ -741,7 +744,7 @@ impl Request {
     let body_start = header_end + 4;
     let body = match request_body_kind(&head.headers)? {
       RequestBodyKind::ContentLength(content_length) => {
-        reject_oversized_request_body(content_length)?;
+        reject_oversized_request_body(content_length, MAX_REQUEST_BODY_BYTES)?;
         let body_end = checked_request_message_len(header_end, content_length)?;
 
         if raw.len() < body_end {
@@ -1986,7 +1989,8 @@ impl HttpRequest {
 
     let body = match request_body_kind(&head.headers).map_err(HttpParseError::from_io_error)? {
       RequestBodyKind::ContentLength(content_length) => {
-        reject_oversized_request_body(content_length).map_err(HttpParseError::from_io_error)?;
+        reject_oversized_request_body(content_length, MAX_REQUEST_BODY_BYTES)
+          .map_err(HttpParseError::from_io_error)?;
         if body_bytes.len() != content_length {
           return Err(HttpParseError::new(
             "request body length does not match Content-Length",
@@ -1996,8 +2000,8 @@ impl HttpRequest {
       }
       RequestBodyKind::Chunked => {
         let mut reader = Cursor::new(body_bytes);
-        let chunked =
-          read_chunked_request_body(&mut reader).map_err(HttpParseError::from_io_error)?;
+        let chunked = read_chunked_request_body(&mut reader, MAX_REQUEST_BODY_BYTES)
+          .map_err(HttpParseError::from_io_error)?;
         if reader.position() as usize != body_bytes.len() {
           return Err(HttpParseError::new(
             "request body length does not match Transfer-Encoding",

--- a/crates/rttp/tests/http2_feature.rs
+++ b/crates/rttp/tests/http2_feature.rs
@@ -2359,6 +2359,52 @@ fn prior_knowledge_server_policy_advertises_and_enforces_frame_and_metadata_boun
 }
 
 #[test]
+fn prior_knowledge_server_rejects_data_accumulation_above_configured_body_limit() {
+  let server = rttp::Http::server("127.0.0.1:0")
+    .expect("bind server")
+    .with_max_request_body_bytes(4)
+    .with_read_timeout(Some(Duration::from_secs(2)))
+    .with_write_timeout(Some(Duration::from_secs(2)));
+  let addr = server.local_addr().expect("server addr");
+  let (tx, rx) = mpsc::channel();
+
+  let handle = thread::spawn(move || {
+    server.accept_one(|request| {
+      tx.send(request.body().to_vec())
+        .expect("record unexpected handler call");
+      HttpResponse::ok("unexpected")
+    })
+  });
+
+  let mut stream = TcpStream::connect(addr).expect("connect h2 server");
+  complete_h2_server_handshake_with_settings(&mut stream, &[]);
+  write_h2_frame(
+    &mut stream,
+    H2_FRAME_HEADERS,
+    H2_FLAG_END_HEADERS,
+    1,
+    &h2_post_headers(b"/upload", addr.to_string().as_bytes()),
+  );
+  write_h2_frame(&mut stream, H2_FRAME_DATA, 0, 1, b"abc");
+  write_h2_frame(&mut stream, H2_FRAME_DATA, H2_FLAG_END_STREAM, 1, b"de");
+  stream.flush().expect("flush oversized h2 request");
+  stream
+    .shutdown(std::net::Shutdown::Write)
+    .expect("shutdown h2 request write side");
+
+  let error = handle
+    .join()
+    .expect("server thread")
+    .expect_err("oversized h2 request must fail before dispatch");
+  assert_eq!(io::ErrorKind::InvalidData, error.kind());
+  assert_eq!("request body is too large", error.to_string());
+  assert!(
+    rx.try_recv().is_err(),
+    "oversized request must not reach handler"
+  );
+}
+
+#[test]
 fn prior_knowledge_server_policy_rejects_inbound_frame_exceeding_configured_max_before_handler() {
   let server = rttp::Http::server("127.0.0.1:0")
     .expect("bind server")

--- a/crates/rttp/tests/test_server.rs
+++ b/crates/rttp/tests/test_server.rs
@@ -4537,6 +4537,111 @@ fn streaming_handler_can_reject_before_reading_request_body() {
 }
 
 #[test]
+fn server_rejects_content_length_above_configured_request_body_limit() {
+  let server = rttp::Http::server("127.0.0.1:0")
+    .expect("bind server")
+    .with_max_request_body_bytes(4);
+  let addr = server.local_addr().expect("server addr");
+  let (tx, rx) = mpsc::channel();
+
+  let handle = thread::spawn(move || {
+    server.accept_one(|_request| {
+      tx.send(()).expect("record unexpected handler call");
+      HttpResponse::ok("unexpected")
+    })
+  });
+
+  let mut stream = TcpStream::connect(addr).expect("connect server");
+  stream
+    .write_all(b"POST /upload HTTP/1.1\r\nHost: localhost\r\nContent-Length: 5\r\n\r\n")
+    .expect("write oversized request head");
+  let mut response = String::new();
+  stream.read_to_string(&mut response).expect("read response");
+
+  assert!(
+    rx.try_recv().is_err(),
+    "oversized request must not reach handler"
+  );
+  assert_eq!(
+    "HTTP/1.1 413 Payload Too Large\r\nContent-Length: 17\r\nConnection: close\r\n\r\nPayload Too Large",
+    response
+  );
+  handle
+    .join()
+    .expect("server thread")
+    .expect("serve oversized request");
+}
+
+#[test]
+fn server_rejects_chunked_body_that_accumulates_above_configured_limit() {
+  let server = rttp::Http::server("127.0.0.1:0")
+    .expect("bind server")
+    .with_max_request_body_bytes(4);
+  let addr = server.local_addr().expect("server addr");
+  let (tx, rx) = mpsc::channel();
+
+  let handle = thread::spawn(move || {
+    server.accept_one(|_request| {
+      tx.send(()).expect("record unexpected handler call");
+      HttpResponse::ok("unexpected")
+    })
+  });
+
+  let mut stream = TcpStream::connect(addr).expect("connect server");
+  stream
+    .write_all(
+      b"POST /upload HTTP/1.1\r\nHost: localhost\r\nTransfer-Encoding: chunked\r\n\r\n2\r\nab\r\n3\r\ncde\r\n0\r\n\r\n",
+    )
+    .expect("write oversized chunked request");
+  let mut response = String::new();
+  stream.read_to_string(&mut response).expect("read response");
+
+  assert!(
+    rx.try_recv().is_err(),
+    "oversized request must not reach handler"
+  );
+  assert_eq!(
+    "HTTP/1.1 413 Payload Too Large\r\nContent-Length: 17\r\nConnection: close\r\n\r\nPayload Too Large",
+    response
+  );
+  handle
+    .join()
+    .expect("server thread")
+    .expect("serve oversized request");
+}
+
+#[test]
+fn server_accepts_request_body_exactly_at_configured_limit() {
+  let server = rttp::Http::server("127.0.0.1:0")
+    .expect("bind server")
+    .with_max_request_body_bytes(4);
+  let addr = server.local_addr().expect("server addr");
+
+  let handle = thread::spawn(move || {
+    server.accept_one(|request| {
+      assert_eq!(b"body", request.body());
+      HttpResponse::ok("accepted")
+    })
+  });
+
+  let mut stream = TcpStream::connect(addr).expect("connect server");
+  stream
+    .write_all(b"POST /upload HTTP/1.1\r\nHost: localhost\r\nContent-Length: 4\r\n\r\nbody")
+    .expect("write request at limit");
+  let mut response = String::new();
+  stream.read_to_string(&mut response).expect("read response");
+
+  assert_eq!(
+    "HTTP/1.1 200 OK\r\nContent-Length: 8\r\nConnection: close\r\n\r\naccepted",
+    response
+  );
+  handle
+    .join()
+    .expect("server thread")
+    .expect("serve request at limit");
+}
+
+#[test]
 fn streaming_handler_is_not_invoked_for_transfer_encoding_with_content_length() {
   let server = rttp::Http::server("127.0.0.1:0").expect("bind server");
   let addr = server.local_addr().expect("server addr");
@@ -6080,7 +6185,7 @@ fn server_accepts_chunk_extension_without_exposing_extension_metadata() {
 }
 
 #[test]
-fn server_returns_bad_request_for_oversized_chunked_request_body() {
+fn server_returns_payload_too_large_for_oversized_chunked_request_body() {
   let server = rttp::Http::server("127.0.0.1:0").expect("bind server");
   let addr = server.local_addr().expect("server addr");
   let (tx, rx) = mpsc::channel();
@@ -6117,7 +6222,7 @@ fn server_returns_bad_request_for_oversized_chunked_request_body() {
   handle.join().expect("server thread");
   assert!(rx.try_recv().is_err());
   assert_eq!(
-    "HTTP/1.1 400 Bad Request\r\nContent-Length: 11\r\nConnection: close\r\n\r\nBad Request",
+    "HTTP/1.1 413 Payload Too Large\r\nContent-Length: 17\r\nConnection: close\r\n\r\nPayload Too Large",
     response
   );
 }
@@ -6452,7 +6557,7 @@ fn server_returns_bad_request_for_malformed_chunked_request_trailer() {
 }
 
 #[test]
-fn server_returns_bad_request_for_oversized_chunked_request_trailer() {
+fn server_returns_payload_too_large_for_oversized_chunked_request_trailer() {
   let trailer_value = "x".repeat(1024 * 1024);
   let raw = format!(
     "POST /upload HTTP/1.1\r\n\
@@ -6467,7 +6572,7 @@ fn server_returns_bad_request_for_oversized_chunked_request_trailer() {
 
   assert!(!handler_called);
   assert_eq!(
-    "HTTP/1.1 400 Bad Request\r\nContent-Length: 11\r\nConnection: close\r\n\r\nBad Request",
+    "HTTP/1.1 413 Payload Too Large\r\nContent-Length: 17\r\nConnection: close\r\n\r\nPayload Too Large",
     response
   );
 }


### PR DESCRIPTION
Added configurable request body limits to rttp-server with a preserved 1 MiB default. HTTP/1.1 oversized requests return 413, h2c DATA accumulation is bounded before allocation, and regression tests cover declared, chunked, exact-limit, and h2c cases.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1802/
work_kind: code_work
branch: hbx-1802-rttp-server-add-request-body
base: main
commit: e3472d051b82beb911beeb21c180b2a497b63298
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1802/
    url: https://plane.kahub.in/endless/browse/HBX-1802/
    close_policy: link_only
```