### PR TITLE
feat: [rttp-protocol] Add structured Prefer and Preference-Applied header support

### DIFF
--- a/crates/rttp-client/src/response/mod.rs
+++ b/crates/rttp-client/src/response/mod.rs
@@ -20,6 +20,10 @@ pub use rttp_protocol::alt_svc::{AltSvc, AltSvcAlternative, AltSvcParameter, Alt
 pub use rttp_protocol::digest::{
   Digest, DigestEntry, DigestParseError, ReprDigest, ReprDigestEntry,
 };
+pub use rttp_protocol::prefer::{
+  PreferParseError, Preference, PreferenceApplied, PreferenceAppliedParseError, PreferenceKind,
+  PreferenceParameter,
+};
 pub use rttp_protocol::priority::{Priority, PriorityExtension, PriorityParseError};
 pub use rttp_protocol::server_timing::{
   ServerTiming, ServerTimingMetric, ServerTimingParameter, ServerTimingParseError,

--- a/crates/rttp-client/src/response/response.rs
+++ b/crates/rttp-client/src/response/response.rs
@@ -18,6 +18,7 @@ use crate::types::{Cookie, Header, RoUrl};
 use rttp_protocol::clear_site_data::ClearSiteData;
 use rttp_protocol::client_hints::{AcceptCh, CriticalCh};
 use rttp_protocol::cookie::HttpSetCookies;
+use rttp_protocol::prefer::PreferenceApplied;
 
 const MAX_CACHE_CONTROL_VALUE_BYTES: usize = 64 * 1024;
 const MAX_CACHE_CONTROL_DIRECTIVES: usize = 256;
@@ -284,6 +285,17 @@ impl Response {
       return Ok(None);
     }
     CriticalCh::parse_values(values.into_iter().map(String::as_str))
+      .map(Some)
+      .map_err(|parse_error| error::bad_response(parse_error.to_string()))
+  }
+
+  /// Parses `Preference-Applied` response metadata without applying preference semantics.
+  pub fn preference_applied(&self) -> error::Result<Option<PreferenceApplied>> {
+    let values = self.header_values("preference-applied");
+    if values.is_empty() {
+      return Ok(None);
+    }
+    PreferenceApplied::parse_values(values.into_iter().map(String::as_str))
       .map(Some)
       .map_err(|parse_error| error::bad_response(parse_error.to_string()))
   }

--- a/crates/rttp-client/tests/metadata_facade.rs
+++ b/crates/rttp-client/tests/metadata_facade.rs
@@ -1,5 +1,5 @@
 use rttp_client::response::{
-  AcceptCh, AltSvc, Digest, HttpClearSiteData, Priority, ServerTiming, Trailer,
+  AcceptCh, AltSvc, Digest, HttpClearSiteData, PreferenceApplied, Priority, ServerTiming, Trailer,
 };
 use rttp_client::{SecFetchDest, SecFetchMode, SecFetchSite, SecFetchUser};
 
@@ -29,4 +29,22 @@ fn response_facade_exports_representative_bounded_metadata_types() {
   assert_eq!(fetch_mode.header_value(), "navigate");
   assert_eq!(fetch_dest.header_value(), "document");
   assert_eq!(fetch_user.header_value(), "?1");
+}
+
+#[test]
+fn response_facade_parses_preference_applied_metadata() {
+  let response = rttp_client::response::Response::new(
+    rttp_client::types::RoUrl::with("http://example.test/"),
+    b"HTTP/1.1 200 OK\r\nPreference-Applied: return=minimal; source=cache\r\n\r\n".to_vec(),
+  )
+  .expect("response should parse");
+
+  let applied: PreferenceApplied = response
+    .preference_applied()
+    .expect("Preference-Applied should parse")
+    .expect("Preference-Applied should be present");
+
+  assert_eq!(applied.preferences()[0].name(), "return");
+  assert_eq!(applied.preferences()[0].value(), Some("minimal"));
+  assert_eq!(applied.preferences()[0].parameters()[0].name(), "source");
 }

--- a/crates/rttp-protocol/src/lib.rs
+++ b/crates/rttp-protocol/src/lib.rs
@@ -16,6 +16,7 @@ pub mod fetch_metadata;
 pub mod forwarded;
 pub mod http1;
 mod media_type;
+pub mod prefer;
 pub mod priority;
 pub mod range;
 pub mod server_timing;

--- a/crates/rttp-protocol/src/prefer.rs
+++ b/crates/rttp-protocol/src/prefer.rs
@@ -1,0 +1,460 @@
+//! Structured, policy-free parsing for RFC 7240 preference headers.
+
+use std::error::Error;
+use std::fmt;
+
+use crate::http1::is_token;
+
+pub const MAX_PREFER_VALUE_BYTES: usize = 64 * 1024;
+pub const MAX_PREFERENCES: usize = 32;
+pub const MAX_PREFERENCE_PARAMETERS: usize = 256;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum PreferenceKind {
+  Return,
+  RespondAsync,
+  Wait,
+  Handling,
+  Extension,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Preference {
+  name: String,
+  value: Option<PreferenceValue>,
+  parameters: Vec<PreferenceParameter>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct PreferenceValue {
+  value: String,
+  quoted: bool,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PreferenceParameter {
+  name: String,
+  value: Option<PreferenceValue>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Prefer {
+  preferences: Vec<Preference>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PreferenceApplied {
+  preferences: Vec<Preference>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PreferParseError {
+  message: String,
+}
+
+pub type PreferenceAppliedParseError = PreferParseError;
+
+impl PreferParseError {
+  fn new(message: impl Into<String>) -> Self {
+    Self {
+      message: message.into(),
+    }
+  }
+}
+
+impl fmt::Display for PreferParseError {
+  fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+    formatter.write_str(&self.message)
+  }
+}
+
+impl Error for PreferParseError {}
+
+impl Prefer {
+  pub fn parse(value: impl AsRef<str>) -> Result<Self, PreferParseError> {
+    Self::parse_values([value.as_ref()])
+  }
+
+  pub fn parse_values<'a, I>(values: I) -> Result<Self, PreferParseError>
+  where
+    I: IntoIterator<Item = &'a str>,
+  {
+    Ok(Self {
+      preferences: parse_values(values, "Prefer")?,
+    })
+  }
+
+  pub fn preferences(&self) -> &[Preference] {
+    &self.preferences
+  }
+
+  pub fn len(&self) -> usize {
+    self.preferences.len()
+  }
+
+  pub fn is_empty(&self) -> bool {
+    self.preferences.is_empty()
+  }
+
+  pub fn header_value(&self) -> String {
+    header_value(&self.preferences)
+  }
+}
+
+impl PreferenceApplied {
+  pub fn parse(value: impl AsRef<str>) -> Result<Self, PreferenceAppliedParseError> {
+    Self::parse_values([value.as_ref()])
+  }
+
+  pub fn parse_values<'a, I>(values: I) -> Result<Self, PreferenceAppliedParseError>
+  where
+    I: IntoIterator<Item = &'a str>,
+  {
+    Ok(Self {
+      preferences: parse_values(values, "Preference-Applied")?,
+    })
+  }
+
+  pub fn preferences(&self) -> &[Preference] {
+    &self.preferences
+  }
+
+  pub fn header_value(&self) -> String {
+    header_value(&self.preferences)
+  }
+}
+
+impl Preference {
+  pub fn kind(&self) -> PreferenceKind {
+    if self.name.eq_ignore_ascii_case("return") {
+      PreferenceKind::Return
+    } else if self.name.eq_ignore_ascii_case("respond-async") {
+      PreferenceKind::RespondAsync
+    } else if self.name.eq_ignore_ascii_case("wait") {
+      PreferenceKind::Wait
+    } else if self.name.eq_ignore_ascii_case("handling") {
+      PreferenceKind::Handling
+    } else {
+      PreferenceKind::Extension
+    }
+  }
+
+  pub fn name(&self) -> &str {
+    &self.name
+  }
+
+  pub fn value(&self) -> Option<&str> {
+    self.value.as_ref().map(|value| value.value.as_str())
+  }
+
+  pub fn parameters(&self) -> &[PreferenceParameter] {
+    &self.parameters
+  }
+
+  fn header_value(&self) -> String {
+    let mut value = self.name.clone();
+    if let Some(preference_value) = &self.value {
+      value.push('=');
+      value.push_str(&preference_value.header_value());
+    }
+    for parameter in &self.parameters {
+      value.push_str("; ");
+      value.push_str(&parameter.header_value());
+    }
+    value
+  }
+}
+
+impl PreferenceParameter {
+  pub fn name(&self) -> &str {
+    &self.name
+  }
+
+  pub fn value(&self) -> Option<&str> {
+    self.value.as_ref().map(|value| value.value.as_str())
+  }
+
+  fn header_value(&self) -> String {
+    self.value.as_ref().map_or_else(
+      || self.name.clone(),
+      |value| format!("{}={}", self.name, value.header_value()),
+    )
+  }
+}
+
+impl PreferenceValue {
+  fn header_value(&self) -> String {
+    if self.quoted {
+      format!(
+        "\"{}\"",
+        self.value.replace('\\', "\\\\").replace('"', "\\\"")
+      )
+    } else {
+      self.value.clone()
+    }
+  }
+}
+
+fn parse_values<'a, I>(values: I, header_name: &str) -> Result<Vec<Preference>, PreferParseError>
+where
+  I: IntoIterator<Item = &'a str>,
+{
+  let mut preferences = Vec::new();
+  for value in values {
+    if value.len() > MAX_PREFER_VALUE_BYTES {
+      return Err(PreferParseError::new(format!(
+        "{header_name} header value is too large"
+      )));
+    }
+    let mut position = 0;
+    skip_ows(value, &mut position);
+    if position == value.len() {
+      return Err(invalid(header_name));
+    }
+    loop {
+      let preference = parse_preference(value, &mut position, header_name)?;
+      if preferences
+        .iter()
+        .any(|known: &Preference| known.name.eq_ignore_ascii_case(&preference.name))
+      {
+        return Err(PreferParseError::new(format!(
+          "duplicate {header_name} preference"
+        )));
+      }
+      if preferences.len() >= MAX_PREFERENCES {
+        return Err(PreferParseError::new(format!(
+          "too many {header_name} preferences"
+        )));
+      }
+      preferences.push(preference);
+      skip_ows(value, &mut position);
+      if position == value.len() {
+        break;
+      }
+      if take_byte(value, &mut position) != Some(b',') {
+        return Err(invalid(header_name));
+      }
+      skip_ows(value, &mut position);
+      if position == value.len() {
+        return Err(invalid(header_name));
+      }
+    }
+  }
+  if preferences.is_empty() {
+    Err(invalid(header_name))
+  } else {
+    Ok(preferences)
+  }
+}
+
+fn parse_preference(
+  value: &str,
+  position: &mut usize,
+  header_name: &str,
+) -> Result<Preference, PreferParseError> {
+  let name = parse_token(value, position, header_name)?;
+  skip_ows(value, position);
+  let preference_value = if take_if(value, position, b'=') {
+    skip_ows(value, position);
+    Some(parse_value(value, position, header_name)?)
+  } else {
+    None
+  };
+  validate_known(
+    &name,
+    preference_value.as_ref().map(|value| value.value.as_str()),
+    header_name,
+  )?;
+  let mut parameters = Vec::new();
+  loop {
+    skip_ows(value, position);
+    if !take_if(value, position, b';') {
+      break;
+    }
+    skip_ows(value, position);
+    let parameter_name = parse_token(value, position, header_name)?;
+    skip_ows(value, position);
+    let parameter_value = if take_if(value, position, b'=') {
+      skip_ows(value, position);
+      Some(parse_value(value, position, header_name)?)
+    } else {
+      None
+    };
+    if parameters
+      .iter()
+      .any(|parameter: &PreferenceParameter| parameter.name.eq_ignore_ascii_case(&parameter_name))
+    {
+      return Err(PreferParseError::new(format!(
+        "duplicate {header_name} preference parameter"
+      )));
+    }
+    if parameters.len() >= MAX_PREFERENCE_PARAMETERS {
+      return Err(PreferParseError::new(format!(
+        "too many {header_name} preference parameters"
+      )));
+    }
+    parameters.push(PreferenceParameter {
+      name: parameter_name,
+      value: parameter_value,
+    });
+  }
+  Ok(Preference {
+    name,
+    value: preference_value,
+    parameters,
+  })
+}
+
+fn validate_known(
+  name: &str,
+  value: Option<&str>,
+  header_name: &str,
+) -> Result<(), PreferParseError> {
+  let valid = if name.eq_ignore_ascii_case("return") {
+    matches!(value, Some("minimal" | "representation"))
+  } else if name.eq_ignore_ascii_case("respond-async") {
+    value.is_none()
+  } else if name.eq_ignore_ascii_case("wait") {
+    value.is_some_and(|value| !value.is_empty() && value.bytes().all(|byte| byte.is_ascii_digit()))
+  } else if name.eq_ignore_ascii_case("handling") {
+    matches!(value, Some("lenient" | "strict"))
+  } else {
+    true
+  };
+  if valid {
+    Ok(())
+  } else {
+    Err(invalid(header_name))
+  }
+}
+
+fn parse_token(
+  value: &str,
+  position: &mut usize,
+  header_name: &str,
+) -> Result<String, PreferParseError> {
+  let start = *position;
+  while value
+    .as_bytes()
+    .get(*position)
+    .is_some_and(|byte| crate::http1::is_token_byte(*byte))
+  {
+    *position += 1;
+  }
+  let token = &value[start..*position];
+  if is_token(token) {
+    Ok(token.to_string())
+  } else {
+    Err(invalid(header_name))
+  }
+}
+
+fn parse_value(
+  value: &str,
+  position: &mut usize,
+  header_name: &str,
+) -> Result<PreferenceValue, PreferParseError> {
+  if take_if(value, position, b'\"') {
+    let mut parsed = Vec::new();
+    loop {
+      let Some(byte) = take_byte(value, position) else {
+        return Err(invalid(header_name));
+      };
+      match byte {
+        b'\"' => break,
+        b'\\' => {
+          let Some(escaped) = take_byte(value, position) else {
+            return Err(invalid(header_name));
+          };
+          if escaped.is_ascii_control() {
+            return Err(invalid(header_name));
+          }
+          parsed.push(escaped);
+        }
+        byte if byte == b'\t' || (0x20..=0x7e).contains(&byte) || byte >= 0x80 => parsed.push(byte),
+        _ => return Err(invalid(header_name)),
+      }
+    }
+    Ok(PreferenceValue {
+      value: String::from_utf8(parsed).map_err(|_| invalid(header_name))?,
+      quoted: true,
+    })
+  } else {
+    Ok(PreferenceValue {
+      value: parse_token(value, position, header_name)?,
+      quoted: false,
+    })
+  }
+}
+
+fn header_value(preferences: &[Preference]) -> String {
+  preferences
+    .iter()
+    .map(Preference::header_value)
+    .collect::<Vec<_>>()
+    .join(", ")
+}
+
+fn invalid(header_name: &str) -> PreferParseError {
+  PreferParseError::new(format!("invalid {header_name} preference"))
+}
+
+fn skip_ows(value: &str, position: &mut usize) {
+  while value
+    .as_bytes()
+    .get(*position)
+    .is_some_and(|byte| matches!(*byte, b' ' | b'\t'))
+  {
+    *position += 1;
+  }
+}
+
+fn take_if(value: &str, position: &mut usize, expected: u8) -> bool {
+  if value.as_bytes().get(*position) == Some(&expected) {
+    *position += 1;
+    true
+  } else {
+    false
+  }
+}
+
+fn take_byte(value: &str, position: &mut usize) -> Option<u8> {
+  let byte = *value.as_bytes().get(*position)?;
+  *position += 1;
+  Some(byte)
+}
+
+#[cfg(test)]
+mod tests {
+  use super::{Prefer, PreferenceApplied};
+
+  #[test]
+  fn parses_and_formats_multiple_preferences_with_parameters() {
+    let prefer =
+      Prefer::parse("return=minimal, wait=10; source=client, vendor=\"a b\"; trace=enabled")
+        .expect("Prefer should parse");
+    assert_eq!(prefer.preferences().len(), 3);
+    assert_eq!(
+      prefer.preferences()[2].parameters()[0].value(),
+      Some("enabled")
+    );
+    assert_eq!(
+      prefer.header_value(),
+      "return=minimal, wait=10; source=client, vendor=\"a b\"; trace=enabled"
+    );
+  }
+
+  #[test]
+  fn rejects_malformed_preferences() {
+    for value in [
+      "return=other",
+      "respond-async=value",
+      "wait=1.5",
+      "extension=\"unterminated",
+      "extension; =value",
+    ] {
+      assert!(Prefer::parse(value).is_err(), "{value} should be rejected");
+    }
+    assert!(PreferenceApplied::parse("handling=relaxed").is_err());
+  }
+}

--- a/crates/rttp-protocol/tests/metadata_facade.rs
+++ b/crates/rttp-protocol/tests/metadata_facade.rs
@@ -1,6 +1,7 @@
 use rttp_protocol::client_hints::{AcceptCh, CriticalCh};
 use rttp_protocol::entity_tag::{EntityTag, IfMatch};
 use rttp_protocol::fetch_metadata::{SecFetchDest, SecFetchMode, SecFetchSite, SecFetchUser};
+use rttp_protocol::prefer::{Prefer, PreferenceApplied, PreferenceKind};
 
 #[test]
 fn protocol_exports_representative_bounded_metadata_types() {
@@ -24,4 +25,30 @@ fn protocol_exports_representative_bounded_metadata_types() {
   assert_eq!(fetch_mode.header_value(), "navigate");
   assert_eq!(fetch_dest.header_value(), "document");
   assert_eq!(fetch_user.header_value(), "?1");
+}
+
+#[test]
+fn protocol_exports_structured_preference_metadata() {
+  let prefer = Prefer::parse(
+    "return=representation, wait=10; priority=high, example=\"quoted value\"; mode=fast",
+  )
+  .expect("Prefer should parse");
+  let applied = PreferenceApplied::parse("respond-async; accepted=true")
+    .expect("Preference-Applied should parse");
+
+  assert_eq!(prefer.preferences().len(), 3);
+  assert_eq!(prefer.preferences()[0].kind(), PreferenceKind::Return);
+  assert_eq!(prefer.preferences()[1].parameters()[0].name(), "priority");
+  assert_eq!(
+    prefer.header_value(),
+    "return=representation, wait=10; priority=high, example=\"quoted value\"; mode=fast"
+  );
+  assert_eq!(
+    applied.preferences()[0].kind(),
+    PreferenceKind::RespondAsync
+  );
+  assert_eq!(
+    applied.preferences()[0].parameters()[0].value(),
+    Some("true")
+  );
 }

--- a/crates/rttp-server/src/server/request.rs
+++ b/crates/rttp-server/src/server/request.rs
@@ -9,6 +9,11 @@ pub use rttp_protocol::forwarded::{
   Forwarded as HttpForwarded, ForwardedElement as HttpForwardedElement,
   ForwardedParameter as HttpForwardedParameter, ForwardedParseError as HttpForwardedParseError,
 };
+pub use rttp_protocol::prefer::{
+  Prefer as HttpRequestPreferences, PreferParseError as HttpPreferParseError,
+  Preference as HttpPreference, PreferenceKind as HttpPreferenceKind,
+  PreferenceParameter as HttpPreferenceParameter,
+};
 pub use rttp_protocol::trailer::{
   Trailer as HttpTrailer, TrailerParseError as HttpTrailerParseError,
 };
@@ -116,9 +121,6 @@ impl fmt::Display for HttpExpectParseError {
 impl Error for HttpExpectParseError {}
 
 pub(crate) const MAX_AUTHORIZATION_VALUE_BYTES: usize = 64 * 1024;
-const MAX_PREFER_FIELD_BYTES: usize = 64 * 1024;
-const MAX_PREFER_VALUE_BYTES: usize = 8 * 1024;
-const MAX_PREFERENCES: usize = 32;
 
 /// Typed, bounded `Authorization` request metadata.
 ///
@@ -948,117 +950,14 @@ pub struct HttpMaxForwardsParseError {
   message: String,
 }
 
-/// A validated `Prefer` item received on an HTTP request.
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct HttpPreference {
-  name: String,
-  value: Option<String>,
-}
-
-impl HttpPreference {
-  pub fn name(&self) -> &str {
-    &self.name
-  }
-
-  pub fn value(&self) -> Option<&str> {
-    self.value.as_deref()
-  }
-}
-
-/// Bounded `Prefer` request metadata.
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct HttpRequestPreferences {
-  preferences: Vec<HttpPreference>,
-}
-
-impl HttpRequestPreferences {
-  pub fn parse(value: impl AsRef<str>) -> Result<Self, HttpPreferParseError> {
-    parse_prefer_values([value.as_ref()])?
-      .ok_or_else(|| HttpPreferParseError::new("invalid Prefer preference"))
-  }
-
-  pub fn preferences(&self) -> &[HttpPreference] {
-    &self.preferences
-  }
-
-  pub fn len(&self) -> usize {
-    self.preferences.len()
-  }
-
-  pub fn is_empty(&self) -> bool {
-    self.preferences.is_empty()
-  }
-}
-
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct HttpPreferParseError {
-  message: String,
-}
-
-impl HttpPreferParseError {
-  fn new(message: impl Into<String>) -> Self {
-    Self {
-      message: message.into(),
-    }
-  }
-}
-
-impl fmt::Display for HttpPreferParseError {
-  fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-    formatter.write_str(&self.message)
-  }
-}
-
-impl Error for HttpPreferParseError {}
-
 fn parse_prefer_values<'a>(
   values: impl IntoIterator<Item = &'a str>,
 ) -> Result<Option<HttpRequestPreferences>, HttpPreferParseError> {
-  let mut preferences = Vec::new();
-  for value in values {
-    if value.len() > MAX_PREFER_FIELD_BYTES {
-      return Err(HttpPreferParseError::new(
-        "Prefer header value is too large",
-      ));
-    }
-    for member in value.split(',') {
-      let (name, preference_value) = parse_prefer_member(member)?;
-      if preferences
-        .iter()
-        .any(|known: &HttpPreference| known.name.eq_ignore_ascii_case(name))
-      {
-        return Err(HttpPreferParseError::new("duplicate Prefer preference"));
-      }
-      if preferences.len() >= MAX_PREFERENCES {
-        return Err(HttpPreferParseError::new("too many Prefer preferences"));
-      }
-      preferences.push(HttpPreference {
-        name: name.to_string(),
-        value: preference_value.map(ToString::to_string),
-      });
-    }
+  let values: Vec<&str> = values.into_iter().collect();
+  if values.is_empty() {
+    return Ok(None);
   }
-  if preferences.is_empty() {
-    return Err(HttpPreferParseError::new("invalid Prefer preference"));
-  }
-  Ok(Some(HttpRequestPreferences { preferences }))
-}
-
-fn parse_prefer_member(member: &str) -> Result<(&str, Option<&str>), HttpPreferParseError> {
-  let (name, value) = member
-    .trim()
-    .split_once('=')
-    .map_or((member.trim(), None), |(name, value)| {
-      (name.trim(), Some(value.trim()))
-    });
-  if !is_http_token(name)
-    || (name.eq_ignore_ascii_case("wait")
-      && !value.is_some_and(|value| value.bytes().all(|byte| byte.is_ascii_digit())))
-    || value.is_some_and(|value| value.len() > MAX_PREFER_VALUE_BYTES || !is_http_token(value))
-  {
-    return Err(HttpPreferParseError::new("invalid Prefer preference"));
-  }
-  Ok((name, value))
+  HttpRequestPreferences::parse_values(values).map(Some)
 }
 impl HttpMaxForwardsParseError {
   fn new(message: impl Into<String>) -> Self {

--- a/crates/rttp-server/tests/metadata_facade.rs
+++ b/crates/rttp-server/tests/metadata_facade.rs
@@ -1,6 +1,6 @@
 use rttp_server::server::{
-  HttpAcceptCh, HttpConditionalMetadata, HttpEntityTag, HttpResponse, SecFetchDest, SecFetchMode,
-  SecFetchSite, SecFetchUser,
+  HttpAcceptCh, HttpConditionalMetadata, HttpEntityTag, HttpPreferenceKind, HttpRequest,
+  HttpResponse, SecFetchDest, SecFetchMode, SecFetchSite, SecFetchUser,
 };
 
 #[test]
@@ -35,4 +35,20 @@ fn server_facade_exports_representative_bounded_metadata_types() {
   assert_eq!(fetch_mode.header_value(), "navigate");
   assert_eq!(fetch_dest.header_value(), "document");
   assert_eq!(fetch_user.header_value(), "?1");
+}
+
+#[test]
+fn request_facade_parses_structured_prefer_metadata() {
+  let request = HttpRequest::parse(
+    b"GET / HTTP/1.1\r\nHost: example.test\r\nPrefer: handling=strict, vendor=enabled; trace=\"a b\"\r\n\r\n",
+  )
+  .expect("request should parse");
+
+  let prefer = request
+    .prefer()
+    .expect("Prefer should parse")
+    .expect("Prefer should be present");
+
+  assert_eq!(prefer.preferences()[0].kind(), HttpPreferenceKind::Handling);
+  assert_eq!(prefer.preferences()[1].parameters()[0].value(), Some("a b"));
 }

--- a/crates/rttp/tests/test_server_models.rs
+++ b/crates/rttp/tests/test_server_models.rs
@@ -483,7 +483,7 @@ fn request_te_and_prefer_reject_invalid_or_duplicate_metadata() {
     assert!(request.te().is_err(), "TE should reject {value:?}");
     assert_eq!(Some(value), request.header("TE"));
   }
-  for value in ["return=bad value", "respond-async; wait=1"] {
+  for value in ["return=bad value", "respond-async; wait=bad value"] {
     let request = parse_request(&format!(
       "GET /metadata HTTP/1.1\r\nHost: example.test\r\nPrefer: {value}\r\n\r\n"
     ));


### PR DESCRIPTION
Added structured RFC 7240 Prefer and Preference-Applied parsing/formatting with protocol, client response, and server request facades. Extension parameters are preserved, malformed values are rejected, and the full workspace test suite passes.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1797/
work_kind: code_work
branch: hbx-1797-rttp-protocol-add-structured-prefer
base: main
commit: c60b7fdcd1e599e57fd42bec2eb57adaed940042
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1797/
    url: https://plane.kahub.in/endless/browse/HBX-1797/
    close_policy: link_only
```