### PR TITLE
feat: [rttp-client/server] Add RFC 8594 Sunset response metadata helpers

### DIFF
--- a/crates/rttp-client/src/response/response.rs
+++ b/crates/rttp-client/src/response/response.rs
@@ -18,6 +18,7 @@ use crate::types::{Cookie, Header, RoUrl};
 use rttp_protocol::clear_site_data::ClearSiteData;
 use rttp_protocol::client_hints::{AcceptCh, CriticalCh};
 use rttp_protocol::cookie::HttpSetCookies;
+use rttp_protocol::sunset::parse_sunset_values;
 
 const MAX_CACHE_CONTROL_VALUE_BYTES: usize = 64 * 1024;
 const MAX_CACHE_CONTROL_DIRECTIVES: usize = 256;
@@ -219,6 +220,15 @@ impl Response {
           .map_err(|_| error::bad_response("Invalid Expires HTTP-date"))
       })
       .unwrap_or(Ok(None))
+  }
+
+  pub fn sunset_value(&self) -> Option<&String> {
+    self.header_value("sunset")
+  }
+
+  pub fn sunset(&self) -> error::Result<Option<SystemTime>> {
+    parse_sunset_values(self.header_values("sunset").into_iter().map(String::as_str))
+      .map_err(|err| error::bad_response(err.to_string()))
   }
 
   pub fn retry_after(&self) -> error::Result<Option<RetryAfter>> {

--- a/crates/rttp-client/tests/test_response.rs
+++ b/crates/rttp-client/tests/test_response.rs
@@ -1529,6 +1529,47 @@ fn test_parse_age_and_expires_response_metadata() {
 }
 
 #[test]
+fn test_parse_sunset_response_metadata_and_preserves_raw_value() {
+  let response = Response::new(
+    RoUrl::with("https://example.test"),
+    concat!(
+      "HTTP/1.1 200 OK\r\n",
+      "Sunset: Sun, 06 Nov 1994 08:49:37 GMT\r\n",
+      "Content-Length: 0\r\n\r\n"
+    )
+    .as_bytes()
+    .to_vec(),
+  )
+  .expect("response should parse");
+
+  assert_eq!(
+    Some(UNIX_EPOCH + Duration::from_secs(784_111_777)),
+    response.sunset().expect("Sunset should parse")
+  );
+  assert_eq!(
+    Some(&"Sun, 06 Nov 1994 08:49:37 GMT".to_string()),
+    response.sunset_value()
+  );
+}
+
+#[test]
+fn test_parse_sunset_rejects_invalid_and_duplicate_values_without_rejecting_response() {
+  for header in [
+    "Sunset: not a date\r\n",
+    "Sunset: Sun, 06 Nov 1994 08:49:37 GMT\r\nSunset: Sun, 06 Nov 1994 08:49:38 GMT\r\n",
+  ] {
+    let raw = format!("HTTP/1.1 200 OK\r\n{header}Content-Length: 0\r\n\r\n");
+    let response = Response::new(RoUrl::with("https://example.test"), raw.into_bytes())
+      .expect("response should remain usable");
+
+    assert!(
+      response.sunset().is_err(),
+      "Sunset helper should reject {header:?}"
+    );
+  }
+}
+
+#[test]
 fn test_parse_retry_after_response_metadata() {
   let s = concat!(
     "HTTP/1.1 503 Service Unavailable\r\n",

--- a/crates/rttp-protocol/Cargo.toml
+++ b/crates/rttp-protocol/Cargo.toml
@@ -21,3 +21,4 @@ path = "src/lib.rs"
 
 [dependencies]
 base64 = "0.22"
+httpdate = "1.0"

--- a/crates/rttp-protocol/src/lib.rs
+++ b/crates/rttp-protocol/src/lib.rs
@@ -19,5 +19,6 @@ mod media_type;
 pub mod priority;
 pub mod range;
 pub mod server_timing;
+pub mod sunset;
 pub mod trailer;
 pub mod www_authenticate;

--- a/crates/rttp-protocol/src/sunset.rs
+++ b/crates/rttp-protocol/src/sunset.rs
@@ -1,0 +1,47 @@
+//! RFC 8594 `Sunset` response metadata parsing.
+
+use std::error::Error;
+use std::fmt;
+use std::time::SystemTime;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SunsetParseError {
+  message: String,
+}
+
+impl SunsetParseError {
+  fn new(message: impl Into<String>) -> Self {
+    Self {
+      message: message.into(),
+    }
+  }
+}
+
+impl fmt::Display for SunsetParseError {
+  fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+    formatter.write_str(&self.message)
+  }
+}
+
+impl Error for SunsetParseError {}
+
+/// Parses RFC 8594 `Sunset` response metadata as an HTTP-date.
+pub fn parse_sunset(value: impl AsRef<str>) -> Result<SystemTime, SunsetParseError> {
+  httpdate::parse_http_date(value.as_ref())
+    .map_err(|_| SunsetParseError::new("invalid Sunset HTTP-date"))
+}
+
+/// Parses an optional single RFC 8594 `Sunset` response field.
+pub fn parse_sunset_values<'a, I>(values: I) -> Result<Option<SystemTime>, SunsetParseError>
+where
+  I: IntoIterator<Item = &'a str>,
+{
+  let mut values = values.into_iter();
+  let Some(value) = values.next() else {
+    return Ok(None);
+  };
+  if values.next().is_some() {
+    return Err(SunsetParseError::new("multiple Sunset headers"));
+  }
+  parse_sunset(value).map(Some)
+}

--- a/crates/rttp-protocol/tests/sunset.rs
+++ b/crates/rttp-protocol/tests/sunset.rs
@@ -1,0 +1,15 @@
+use rttp_protocol::sunset::parse_sunset;
+use std::time::{Duration, UNIX_EPOCH};
+
+#[test]
+fn parses_imf_fixdate_sunset_values() {
+  assert_eq!(
+    UNIX_EPOCH + Duration::from_secs(784_111_777),
+    parse_sunset("Sun, 06 Nov 1994 08:49:37 GMT").expect("Sunset should parse")
+  );
+}
+
+#[test]
+fn rejects_invalid_sunset_values() {
+  assert!(parse_sunset("not a date").is_err());
+}

--- a/crates/rttp-server/src/server/response.rs
+++ b/crates/rttp-server/src/server/response.rs
@@ -1020,6 +1020,9 @@ impl HttpResponse {
   }
 
   pub fn with_sunset(mut self, http_date: SystemTime) -> Self {
+    self
+      .headers
+      .retain(|header| !header.name.eq_ignore_ascii_case("Sunset"));
     self.headers.push(HttpHeader::new(
       "Sunset",
       httpdate::fmt_http_date(http_date),

--- a/crates/rttp-server/src/server/response.rs
+++ b/crates/rttp-server/src/server/response.rs
@@ -25,6 +25,7 @@ pub use rttp_protocol::server_timing::{
   ServerTimingParameter as HttpServerTimingParameter,
   ServerTimingParseError as HttpServerTimingParseError,
 };
+pub use rttp_protocol::sunset::SunsetParseError as HttpSunsetParseError;
 pub use rttp_protocol::www_authenticate::{
   WwwAuthenticate as HttpWwwAuthenticate, WwwAuthenticateChallenge as HttpWwwAuthenticateChallenge,
   WwwAuthenticateParameter as HttpWwwAuthenticateParameter,
@@ -1018,6 +1019,14 @@ impl HttpResponse {
     self
   }
 
+  pub fn with_sunset(mut self, http_date: SystemTime) -> Self {
+    self.headers.push(HttpHeader::new(
+      "Sunset",
+      httpdate::fmt_http_date(http_date),
+    ));
+    self
+  }
+
   pub fn with_retry_after_delta(mut self, delta_seconds: u64) -> Self {
     self
       .headers
@@ -1414,6 +1423,16 @@ impl HttpResponse {
     httpdate::parse_http_date(value)
       .map(Some)
       .map_err(|_| HttpExpiresParseError::new("invalid Expires HTTP-date"))
+  }
+
+  pub fn sunset(&self) -> Result<Option<SystemTime>, HttpSunsetParseError> {
+    rttp_protocol::sunset::parse_sunset_values(
+      self
+        .headers
+        .iter()
+        .filter(|header| header.name.eq_ignore_ascii_case("Sunset"))
+        .map(|header| header.value.as_str()),
+    )
   }
 
   pub fn retry_after(&self) -> Result<Option<HttpRetryAfter>, HttpRetryAfterParseError> {

--- a/crates/rttp/tests/metadata_facade.rs
+++ b/crates/rttp/tests/metadata_facade.rs
@@ -1,4 +1,7 @@
-use rttp::server::{HttpAcceptCh, HttpConditionalMetadata, HttpEntityTag};
+use rttp::server::{
+  HttpAcceptCh, HttpConditionalMetadata, HttpEntityTag, HttpResponse, HttpSunsetParseError,
+};
+use std::time::{Duration, UNIX_EPOCH};
 
 #[test]
 #[cfg(feature = "client")]
@@ -34,5 +37,17 @@ fn compatibility_facade_keeps_server_metadata_in_the_server_module() {
       .expect("entity tag should be retained")
       .header_value(),
     "\"revision-42\""
+  );
+}
+
+#[test]
+fn compatibility_facade_exposes_sunset_response_metadata() {
+  let sunset = UNIX_EPOCH + Duration::from_secs(784_111_777);
+  let response = HttpResponse::ok("").with_sunset(sunset);
+  let _: Result<Option<std::time::SystemTime>, HttpSunsetParseError> = response.sunset();
+
+  assert_eq!(
+    Some(sunset),
+    response.sunset().expect("Sunset should parse")
   );
 }

--- a/crates/rttp/tests/test_server_models.rs
+++ b/crates/rttp/tests/test_server_models.rs
@@ -1947,6 +1947,35 @@ fn response_age_and_expires_helpers_declare_metadata_headers() {
 }
 
 #[test]
+fn response_sunset_helper_declares_and_parses_metadata() {
+  let sunset = UNIX_EPOCH + Duration::from_secs(784_111_777);
+  let response = HttpResponse::ok("body").with_sunset(sunset);
+
+  let serialized = String::from_utf8(response.to_bytes()).expect("response is UTF-8");
+
+  assert!(serialized.contains("\r\nSunset: Sun, 06 Nov 1994 08:49:37 GMT\r\n"));
+  assert_eq!(
+    Some(sunset),
+    response.sunset().expect("Sunset should parse")
+  );
+}
+
+#[test]
+fn response_sunset_helper_rejects_invalid_and_duplicate_raw_values() {
+  for response in [
+    HttpResponse::ok("body").header("Sunset", "not a date"),
+    HttpResponse::ok("body")
+      .header("Sunset", "Sun, 06 Nov 1994 08:49:37 GMT")
+      .header("Sunset", "Sun, 06 Nov 1994 08:49:38 GMT"),
+  ] {
+    assert!(
+      response.sunset().is_err(),
+      "Sunset helper should reject invalid metadata"
+    );
+  }
+}
+
+#[test]
 fn response_age_and_expires_helpers_parse_raw_metadata_headers() {
   let response = HttpResponse::ok("body")
     .header("Age", "0")

--- a/crates/rttp/tests/test_server_models.rs
+++ b/crates/rttp/tests/test_server_models.rs
@@ -1961,6 +1961,24 @@ fn response_sunset_helper_declares_and_parses_metadata() {
 }
 
 #[test]
+fn response_sunset_helper_replaces_existing_metadata() {
+  let initial_sunset = UNIX_EPOCH + Duration::from_secs(784_111_777);
+  let sunset = initial_sunset + Duration::from_secs(1);
+  let response = HttpResponse::ok("body")
+    .header("Sunset", httpdate::fmt_http_date(initial_sunset))
+    .with_sunset(initial_sunset)
+    .with_sunset(sunset);
+
+  let serialized = String::from_utf8(response.to_bytes()).expect("response is UTF-8");
+
+  assert_eq!(1, serialized.matches("\r\nSunset: ").count());
+  assert_eq!(
+    Some(sunset),
+    response.sunset().expect("Sunset should parse")
+  );
+}
+
+#[test]
 fn response_sunset_helper_rejects_invalid_and_duplicate_raw_values() {
   for response in [
     HttpResponse::ok("body").header("Sunset", "not a date"),

--- a/tests/http11_client_server_matrix.rs
+++ b/tests/http11_client_server_matrix.rs
@@ -1568,6 +1568,35 @@ fn sync_client_parses_shared_expires_response_matrix() {
 }
 
 #[test]
+fn sync_client_reads_sunset_emitted_by_server() {
+  let sunset = UNIX_EPOCH + Duration::from_secs(784_111_777);
+  let server =
+    rttp_server::server::HttpServer::bind("127.0.0.1:0").expect("bind Sunset response server");
+  let addr = server.local_addr().expect("Sunset response server addr");
+  let handle = thread::spawn(move || {
+    server
+      .accept_one(|_| HttpResponse::ok("OK").with_sunset(sunset))
+      .expect("serve Sunset response request");
+  });
+
+  let response = client()
+    .get()
+    .url(format!("http://{addr}/matrix/sunset"))
+    .emit()
+    .expect("Sunset response should parse");
+
+  assert_eq!(
+    Some(sunset),
+    response.sunset().expect("Sunset should parse")
+  );
+  assert_eq!(
+    Some(&"Sun, 06 Nov 1994 08:49:37 GMT".to_string()),
+    response.sunset_value()
+  );
+  handle.join().expect("Sunset response server thread");
+}
+
+#[test]
 fn sync_client_parses_shared_retry_after_response_matrix() {
   for case in fixtures::retry_after::retry_after_cases() {
     let raw_response = retry_after_response(&[case.value], false);


### PR DESCRIPTION
Implemented RFC 8594 Sunset response metadata parsing and client/server helpers, including typed access, raw fallback, duplicate rejection, and HTTP/1.1 round-trip coverage. Full workspace tests pass.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1798/
work_kind: code_work
branch: hbx-1798-rttp-client-server-add-rfc
base: main
commit: ecf0534ffe141cdf9be8e1a65a1f6cb60a1c5e78
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1798/
    url: https://plane.kahub.in/endless/browse/HBX-1798/
    close_policy: link_only
```