### PR TITLE
feat: [rttp-http1] Enforce folded header rejection and obs-text preservation tests

### DIFF
--- a/crates/rttp-client/src/connection/connection_reader.rs
+++ b/crates/rttp-client/src/connection/connection_reader.rs
@@ -9,7 +9,7 @@ use url::Url;
 
 use crate::error;
 use crate::response::{InformationalResponse, Response};
-use crate::types::{Header, IntoHeader, RoUrl};
+use crate::types::{Header, RoUrl};
 
 const HEADER_END: &[u8] = b"\r\n\r\n";
 const CRLF: &[u8] = b"\r\n";
@@ -357,20 +357,25 @@ pub(crate) fn response_connection_reusable(
 }
 
 pub(crate) fn response_headers(header: &[u8]) -> error::Result<Vec<Header>> {
-  validate_response_header_lines(header)?;
-  let header = String::from_utf8(header.to_vec()).map_err(error::response)?;
-  Ok(
-    header
-      .lines()
-      .skip(1)
-      .filter(|line| !line.is_empty())
-      .flat_map(|line| line.into_headers())
-      .collect(),
-  )
+  let (_, header_lines) = split_response_head_lines(header)?;
+  let mut headers = Vec::new();
+  for line in header_lines.into_iter().filter(|line| !line.is_empty()) {
+    let Some(colon) = line.iter().position(|byte| *byte == b':') else {
+      return Err(error::bad_response("Invalid response header"));
+    };
+    if matches!(line.first(), Some(b' ' | b'\t')) {
+      return Err(error::bad_response("Invalid response header"));
+    }
+    let (name, value) = line.split_at(colon);
+    let value = &value[1..];
+    let name = std::str::from_utf8(name).map_err(error::response)?;
+    headers.push(Header::new(name, decode_http1_text(value)));
+  }
+  Ok(headers)
 }
 
 pub(crate) fn response_connection_should_close(header: &[u8]) -> error::Result<bool> {
-  let header = String::from_utf8(header.to_vec()).map_err(error::response)?;
+  let header = decode_http1_text(header);
   let version = header
     .lines()
     .next()
@@ -543,11 +548,13 @@ pub(crate) fn parse_informational_response(header: &[u8]) -> error::Result<Infor
     if line.is_empty() {
       continue;
     }
-    let line = std::str::from_utf8(line).map_err(error::response)?;
-    let (name, value) = line
-      .split_once(':')
-      .ok_or_else(|| error::bad_response("Invalid informational response header"))?;
-    if !is_http_token(name) || !value.bytes().all(is_header_value_byte) {
+    let Some(colon) = line.iter().position(|byte| *byte == b':') else {
+      return Err(error::bad_response("Invalid informational response header"));
+    };
+    let (name, value) = line.split_at(colon);
+    let value = &value[1..];
+    let name = std::str::from_utf8(name).map_err(error::response)?;
+    if !is_http_token(name) || !value.iter().copied().all(is_header_value_byte) {
       return Err(error::bad_response("Invalid informational response header"));
     }
     if name.eq_ignore_ascii_case("Content-Length") || name.eq_ignore_ascii_case("Transfer-Encoding")
@@ -556,7 +563,7 @@ pub(crate) fn parse_informational_response(header: &[u8]) -> error::Result<Infor
         "Informational response must not declare body framing",
       ));
     }
-    headers.push(Header::new(name, value));
+    headers.push(Header::new(name, decode_http1_text(value)));
   }
 
   Ok(InformationalResponse::new(
@@ -605,6 +612,29 @@ fn has_only_crlf_line_breaks(bytes: &[u8]) -> bool {
     }
   }
   true
+}
+
+fn decode_http1_text(bytes: &[u8]) -> String {
+  let mut text = String::new();
+  let mut remaining = bytes;
+  while !remaining.is_empty() {
+    match std::str::from_utf8(remaining) {
+      Ok(valid) => {
+        text.push_str(valid);
+        break;
+      }
+      Err(error) => {
+        let valid_up_to = error.valid_up_to();
+        text.push_str(std::str::from_utf8(&remaining[..valid_up_to]).expect("valid UTF-8 prefix"));
+        let invalid_len = error.error_len().unwrap_or(remaining.len() - valid_up_to);
+        for byte in &remaining[valid_up_to..valid_up_to + invalid_len] {
+          text.push(*byte as char);
+        }
+        remaining = &remaining[valid_up_to + invalid_len..];
+      }
+    }
+  }
+  text
 }
 
 fn parse_response_status_line(status_line: &[u8]) -> error::Result<(&str, u16, &str)> {

--- a/crates/rttp-client/src/connection/connection_reader.rs
+++ b/crates/rttp-client/src/connection/connection_reader.rs
@@ -369,7 +369,7 @@ pub(crate) fn response_headers(header: &[u8]) -> error::Result<Vec<Header>> {
     let (name, value) = line.split_at(colon);
     let value = &value[1..];
     let name = std::str::from_utf8(name).map_err(error::response)?;
-    headers.push(Header::new(name, decode_http1_text(value)));
+    headers.push(Header::from_http1(name, decode_http1_text(value)));
   }
   Ok(headers)
 }
@@ -563,7 +563,7 @@ pub(crate) fn parse_informational_response(header: &[u8]) -> error::Result<Infor
         "Informational response must not declare body framing",
       ));
     }
-    headers.push(Header::new(name, decode_http1_text(value)));
+    headers.push(Header::from_http1(name, decode_http1_text(value)));
   }
 
   Ok(InformationalResponse::new(
@@ -615,26 +615,7 @@ fn has_only_crlf_line_breaks(bytes: &[u8]) -> bool {
 }
 
 fn decode_http1_text(bytes: &[u8]) -> String {
-  let mut text = String::new();
-  let mut remaining = bytes;
-  while !remaining.is_empty() {
-    match std::str::from_utf8(remaining) {
-      Ok(valid) => {
-        text.push_str(valid);
-        break;
-      }
-      Err(error) => {
-        let valid_up_to = error.valid_up_to();
-        text.push_str(std::str::from_utf8(&remaining[..valid_up_to]).expect("valid UTF-8 prefix"));
-        let invalid_len = error.error_len().unwrap_or(remaining.len() - valid_up_to);
-        for byte in &remaining[valid_up_to..valid_up_to + invalid_len] {
-          text.push(*byte as char);
-        }
-        remaining = &remaining[valid_up_to + invalid_len..];
-      }
-    }
-  }
-  text
+  bytes.iter().map(|byte| *byte as char).collect()
 }
 
 fn parse_response_status_line(status_line: &[u8]) -> error::Result<(&str, u16, &str)> {

--- a/crates/rttp-client/src/response/raw_response.rs
+++ b/crates/rttp-client/src/response/raw_response.rs
@@ -219,7 +219,7 @@ impl Parser {
       };
       let (name, value) = line.split_at(colon);
       let value = &value[1..];
-      headers.push(Header::new(
+      headers.push(Header::from_http1(
         decode_http1_text(name),
         decode_http1_text(value),
       ));
@@ -268,26 +268,7 @@ fn has_only_crlf_line_breaks(bytes: &[u8]) -> bool {
 }
 
 fn decode_http1_text(bytes: &[u8]) -> String {
-  let mut text = String::new();
-  let mut remaining = bytes;
-  while !remaining.is_empty() {
-    match std::str::from_utf8(remaining) {
-      Ok(valid) => {
-        text.push_str(valid);
-        break;
-      }
-      Err(error) => {
-        let valid_up_to = error.valid_up_to();
-        text.push_str(std::str::from_utf8(&remaining[..valid_up_to]).expect("valid UTF-8 prefix"));
-        let invalid_len = error.error_len().unwrap_or(remaining.len() - valid_up_to);
-        for byte in &remaining[valid_up_to..valid_up_to + invalid_len] {
-          text.push(*byte as char);
-        }
-        remaining = &remaining[valid_up_to + invalid_len..];
-      }
-    }
-  }
-  text
+  bytes.iter().map(|byte| *byte as char).collect()
 }
 
 fn response_status_has_no_body(status_code: u32) -> bool {

--- a/crates/rttp-client/src/response/raw_response.rs
+++ b/crates/rttp-client/src/response/raw_response.rs
@@ -3,12 +3,11 @@ use std::io::Read;
 
 use crate::error;
 use crate::response::ResponseBody;
-use crate::types::{Cookie, Header, IntoHeader, RoUrl, ToUrl};
+use crate::types::{Cookie, Header, RoUrl, ToUrl};
 use url::Url;
 
 static CR: u8 = b'\r';
 static LF: u8 = b'\n';
-static CRLF: &str = "\r\n";
 
 #[derive(Clone)]
 pub struct RawResponse {
@@ -163,21 +162,15 @@ impl Parser {
         && self.binary.get(i + 2) == Some(&CR)
         && self.binary.get(i + 3) == Some(&LF)
       {
-        position = i + 3;
+        position = i;
         break;
       }
-      //      if self.binary[i] == CR && self.binary[i + 1] == LF && self.binary[i + 2] == CR && self.binary[i + 3] == LF {
-      //        position = i + 3;
-      //        break;
-      //      }
     }
     if position == 0 {
       return Err(error::bad_response("No http response"));
     }
-    let (header_b, body_b): (&[u8], &[u8]) = self.binary.split_at(position);
-
-    let header = String::from_utf8(header_b.to_vec()).map_err(error::response)?;
-    let body = body_b[1..].to_owned();
+    let header = &self.binary[..position];
+    let body = self.binary[position + 4..].to_owned();
 
     self.parse_header(response, header)?;
     self.parse_body(response, body)?;
@@ -186,11 +179,17 @@ impl Parser {
     Ok(())
   }
 
-  fn parse_header(&self, response: &mut RawResponse, text: String) -> error::Result<()> {
-    let parts: Vec<&str> = text.split(CRLF).collect();
-    let status_line = parts
-      .first()
+  fn parse_header(&self, response: &mut RawResponse, text: &[u8]) -> error::Result<()> {
+    if !has_only_crlf_line_breaks(text) {
+      return Err(error::bad_response("Invalid response header"));
+    }
+    let mut lines = text
+      .split(|byte| *byte == LF)
+      .map(|line| line.strip_suffix(&[CR]).unwrap_or(line));
+    let status_line = lines
+      .next()
       .ok_or(error::bad_response("Response not have status line"))?;
+    let status_line = std::str::from_utf8(status_line).map_err(error::response)?;
     let status_parts: Vec<&str> = status_line.splitn(3, " ").collect();
 
     let http_version = status_parts
@@ -210,24 +209,21 @@ impl Parser {
       .code(status_code)
       .reason(reason);
 
-    for header_line in parts
-      .iter()
-      .skip(1)
-      .map(|part| part.trim_end_matches('\r'))
-      .filter(|part| !part.is_empty())
-    {
-      if !header_line.contains(':') {
+    let mut headers = Vec::new();
+    for line in lines.filter(|line| !line.is_empty()) {
+      if matches!(line.first(), Some(b' ' | b'\t')) {
         return Err(error::bad_response("Invalid response header"));
       }
+      let Some(colon) = line.iter().position(|byte| *byte == b':') else {
+        return Err(error::bad_response("Invalid response header"));
+      };
+      let (name, value) = line.split_at(colon);
+      let value = &value[1..];
+      headers.push(Header::new(
+        decode_http1_text(name),
+        decode_http1_text(value),
+      ));
     }
-
-    let headers = parts
-      .iter()
-      .enumerate()
-      .filter(|(ix, _)| *ix > 0)
-      .filter(|(_, v)| !v.is_empty())
-      .flat_map(|(_, v)| v.into_headers())
-      .collect::<Vec<Header>>();
 
     let cookies: Vec<Cookie> = headers
       .iter()
@@ -262,6 +258,36 @@ impl Parser {
     response.body(body);
     Ok(())
   }
+}
+
+fn has_only_crlf_line_breaks(bytes: &[u8]) -> bool {
+  bytes
+    .iter()
+    .enumerate()
+    .all(|(index, byte)| *byte != LF || (index > 0 && bytes.get(index - 1) == Some(&CR)))
+}
+
+fn decode_http1_text(bytes: &[u8]) -> String {
+  let mut text = String::new();
+  let mut remaining = bytes;
+  while !remaining.is_empty() {
+    match std::str::from_utf8(remaining) {
+      Ok(valid) => {
+        text.push_str(valid);
+        break;
+      }
+      Err(error) => {
+        let valid_up_to = error.valid_up_to();
+        text.push_str(std::str::from_utf8(&remaining[..valid_up_to]).expect("valid UTF-8 prefix"));
+        let invalid_len = error.error_len().unwrap_or(remaining.len() - valid_up_to);
+        for byte in &remaining[valid_up_to..valid_up_to + invalid_len] {
+          text.push(*byte as char);
+        }
+        remaining = &remaining[valid_up_to + invalid_len..];
+      }
+    }
+  }
+  text
 }
 
 fn response_status_has_no_body(status_code: u32) -> bool {

--- a/crates/rttp-client/src/response/raw_response.rs
+++ b/crates/rttp-client/src/response/raw_response.rs
@@ -261,10 +261,14 @@ impl Parser {
 }
 
 fn has_only_crlf_line_breaks(bytes: &[u8]) -> bool {
-  bytes
-    .iter()
-    .enumerate()
-    .all(|(index, byte)| *byte != LF || (index > 0 && bytes.get(index - 1) == Some(&CR)))
+  for (index, byte) in bytes.iter().enumerate() {
+    match *byte {
+      b'\r' if bytes.get(index + 1) != Some(&LF) => return false,
+      b'\n' if index == 0 || bytes.get(index - 1) != Some(&CR) => return false,
+      _ => {}
+    }
+  }
+  true
 }
 
 fn decode_http1_text(bytes: &[u8]) -> String {

--- a/crates/rttp-client/src/types/header.rs
+++ b/crates/rttp-client/src/types/header.rs
@@ -19,6 +19,13 @@ impl Header {
     }
   }
 
+  pub(crate) fn from_http1<N: AsRef<str>, V: AsRef<str>>(name: N, value: V) -> Self {
+    Self {
+      name: name.as_ref().trim_matches([' ', '\t']).into(),
+      value: value.as_ref().trim_matches([' ', '\t']).into(),
+    }
+  }
+
   pub(crate) fn replace(&mut self, header: Header) -> &mut Self {
     self.name = header.name().clone();
     self.value = header.value().clone();

--- a/crates/rttp-client/tests/test_response.rs
+++ b/crates/rttp-client/tests/test_response.rs
@@ -194,14 +194,26 @@ fn test_parse_response_rejects_folded_and_bare_lf_headers() {
 
 #[test]
 fn test_parse_response_preserves_obs_text_header_values_as_latin1_code_points() {
-  let raw = b"HTTP/1.1 200 OK\r\nX-Obs: \x80\xff\r\nContent-Length: 0\r\n\r\n";
+  let raw = b"HTTP/1.1 200 OK\r\nX-Obs: \x80\xc3\xa9\xff\r\nContent-Length: 0\r\n\r\n";
   let response = Response::new(RoUrl::with("https://example.test"), raw.to_vec())
     .expect("obs-text response header should parse");
 
   // Header values are exposed as `String`, so each accepted raw obs-text byte is
   // represented by the matching Latin-1 code point rather than returned as bytes.
   assert_eq!(
-    Some(&"\u{0080}\u{00ff}".to_string()),
+    Some(&"\u{0080}\u{00c3}\u{00a9}\u{00ff}".to_string()),
+    response.header_value("X-Obs")
+  );
+}
+
+#[test]
+fn test_parse_response_preserves_non_ows_obs_text_header_value_edges() {
+  let raw = b"HTTP/1.1 200 OK\r\nX-Obs: \xa0value\xa0\r\nContent-Length: 0\r\n\r\n";
+  let response = Response::new(RoUrl::with("https://example.test"), raw.to_vec())
+    .expect("obs-text response header should parse");
+
+  assert_eq!(
+    Some(&"\u{00a0}value\u{00a0}".to_string()),
     response.header_value("X-Obs")
   );
 }
@@ -692,7 +704,7 @@ fn test_www_authenticate_response_helper_parses_bounded_challenges() {
 }
 
 #[test]
-fn test_www_authenticate_preserves_utf8_quoted_parameter_values() {
+fn test_www_authenticate_preserves_quoted_parameter_wire_bytes() {
   let raw = concat!(
     "HTTP/1.1 401 Unauthorized\r\n",
     "WWW-Authenticate: Digest realm=\"caf\u{e9}\"\r\n",
@@ -707,7 +719,7 @@ fn test_www_authenticate_preserves_utf8_quoted_parameter_values() {
     .expect("WWW-Authenticate should be present");
 
   assert_eq!(
-    Some("caf\u{e9}"),
+    Some("caf\u{00c3}\u{00a9}"),
     challenges.challenges()[0].parameter("realm")
   );
 }

--- a/crates/rttp-client/tests/test_response.rs
+++ b/crates/rttp-client/tests/test_response.rs
@@ -180,6 +180,33 @@ fn test_parse_response_preserves_duplicate_headers_with_case_insensitive_lookup(
 }
 
 #[test]
+fn test_parse_response_rejects_folded_and_bare_lf_headers() {
+  for raw in [
+    b"HTTP/1.1 200 OK\r\nX-Test: first\r\n second\r\nContent-Length: 0\r\n\r\n".as_slice(),
+    b"HTTP/1.1 200 OK\r\nX-Test: first\r\n\tsecond\r\nContent-Length: 0\r\n\r\n".as_slice(),
+    b"HTTP/1.1 200 OK\r\nX-Test: first\nsecond\r\nContent-Length: 0\r\n\r\n".as_slice(),
+  ] {
+    let error = Response::new(RoUrl::with("https://example.test"), raw.to_vec())
+      .expect_err("folded and bare-LF response headers must be rejected");
+    assert!(error.to_string().contains("Invalid response header"));
+  }
+}
+
+#[test]
+fn test_parse_response_preserves_obs_text_header_values_as_latin1_code_points() {
+  let raw = b"HTTP/1.1 200 OK\r\nX-Obs: \x80\xff\r\nContent-Length: 0\r\n\r\n";
+  let response = Response::new(RoUrl::with("https://example.test"), raw.to_vec())
+    .expect("obs-text response header should parse");
+
+  // Header values are exposed as `String`, so each accepted raw obs-text byte is
+  // represented by the matching Latin-1 code point rather than returned as bytes.
+  assert_eq!(
+    Some(&"\u{0080}\u{00ff}".to_string()),
+    response.header_value("X-Obs")
+  );
+}
+
+#[test]
 fn test_parse_reporting_endpoints_response_metadata() {
   let raw = concat!(
     "HTTP/1.1 200 OK\r\n",

--- a/crates/rttp-client/tests/test_response.rs
+++ b/crates/rttp-client/tests/test_response.rs
@@ -180,14 +180,15 @@ fn test_parse_response_preserves_duplicate_headers_with_case_insensitive_lookup(
 }
 
 #[test]
-fn test_parse_response_rejects_folded_and_bare_lf_headers() {
+fn test_parse_response_rejects_folded_and_invalid_line_break_headers() {
   for raw in [
     b"HTTP/1.1 200 OK\r\nX-Test: first\r\n second\r\nContent-Length: 0\r\n\r\n".as_slice(),
     b"HTTP/1.1 200 OK\r\nX-Test: first\r\n\tsecond\r\nContent-Length: 0\r\n\r\n".as_slice(),
     b"HTTP/1.1 200 OK\r\nX-Test: first\nsecond\r\nContent-Length: 0\r\n\r\n".as_slice(),
+    b"HTTP/1.1 200 OK\r\nX-Test: first\rsecond\r\nContent-Length: 0\r\n\r\n".as_slice(),
   ] {
     let error = Response::new(RoUrl::with("https://example.test"), raw.to_vec())
-      .expect_err("folded and bare-LF response headers must be rejected");
+      .expect_err("folded and invalid response header line breaks must be rejected");
     assert!(error.to_string().contains("Invalid response header"));
   }
 }
@@ -437,8 +438,6 @@ fn test_parse_content_type_rejects_invalid_helper_values_without_rejecting_respo
     "text/plain; char set=utf-8",
     "text/plain; charset=utf 8",
     "text/plain; charset=\"unterminated",
-    "text/plain; charset=\"bad\\\r\"",
-    "text/plain; charset=\"bad\rvalue\"",
   ];
 
   for value in invalid_values {
@@ -998,8 +997,6 @@ fn test_parse_content_disposition_rejects_invalid_helper_values_without_rejectin
     "attachment; file name=report.txt",
     "attachment; filename=report txt",
     "attachment; filename=\"unterminated",
-    "attachment; filename=\"bad\\\r\"",
-    "attachment; filename=\"bad\rname\"",
     "attachment; filename*=UTF-8''bad%ZZname",
   ];
 

--- a/crates/rttp-server/src/server/http1.rs
+++ b/crates/rttp-server/src/server/http1.rs
@@ -232,26 +232,7 @@ pub(crate) fn parse_request_head(raw: &[u8]) -> io::Result<RequestHead> {
 }
 
 fn decode_http1_text(bytes: &[u8]) -> String {
-  let mut text = String::new();
-  let mut remaining = bytes;
-  while !remaining.is_empty() {
-    match std::str::from_utf8(remaining) {
-      Ok(valid) => {
-        text.push_str(valid);
-        break;
-      }
-      Err(error) => {
-        let valid_up_to = error.valid_up_to();
-        text.push_str(std::str::from_utf8(&remaining[..valid_up_to]).expect("valid UTF-8 prefix"));
-        let invalid_len = error.error_len().unwrap_or(remaining.len() - valid_up_to);
-        for byte in &remaining[valid_up_to..valid_up_to + invalid_len] {
-          text.push(*byte as char);
-        }
-        remaining = &remaining[valid_up_to + invalid_len..];
-      }
-    }
-  }
-  text
+  bytes.iter().map(|byte| *byte as char).collect()
 }
 
 pub(crate) fn validate_request_line(method: &str, target: &str, version: &str) -> io::Result<()> {
@@ -451,7 +432,10 @@ pub(crate) fn parse_header_lines_with_error<'a>(
         invalid_line_error,
       ));
     }
-    headers.push((name.trim().to_string(), value.trim().to_string()));
+    headers.push((
+      name.trim_matches([' ', '\t']).to_string(),
+      value.trim_matches([' ', '\t']).to_string(),
+    ));
   }
 
   Ok(headers)

--- a/crates/rttp-server/src/server/http1.rs
+++ b/crates/rttp-server/src/server/http1.rs
@@ -195,8 +195,7 @@ pub(crate) struct ChunkedRequestBody {
 }
 
 pub(crate) fn parse_request_head(raw: &[u8]) -> io::Result<RequestHead> {
-  let text = std::str::from_utf8(raw)
-    .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "request head is not UTF-8"))?;
+  let text = decode_http1_text(raw);
   let mut lines = text.split("\r\n");
   let request_line = lines
     .next()
@@ -230,6 +229,29 @@ pub(crate) fn parse_request_head(raw: &[u8]) -> io::Result<RequestHead> {
     version: version.to_string(),
     headers,
   })
+}
+
+fn decode_http1_text(bytes: &[u8]) -> String {
+  let mut text = String::new();
+  let mut remaining = bytes;
+  while !remaining.is_empty() {
+    match std::str::from_utf8(remaining) {
+      Ok(valid) => {
+        text.push_str(valid);
+        break;
+      }
+      Err(error) => {
+        let valid_up_to = error.valid_up_to();
+        text.push_str(std::str::from_utf8(&remaining[..valid_up_to]).expect("valid UTF-8 prefix"));
+        let invalid_len = error.error_len().unwrap_or(remaining.len() - valid_up_to);
+        for byte in &remaining[valid_up_to..valid_up_to + invalid_len] {
+          text.push(*byte as char);
+        }
+        remaining = &remaining[valid_up_to + invalid_len..];
+      }
+    }
+  }
+  text
 }
 
 pub(crate) fn validate_request_line(method: &str, target: &str, version: &str) -> io::Result<()> {

--- a/crates/rttp-server/src/server/server_tests.rs
+++ b/crates/rttp-server/src/server/server_tests.rs
@@ -19,6 +19,32 @@ fn request_cache_control_combines_case_insensitive_header_fields() {
 }
 
 #[test]
+fn request_raw_parser_rejects_folded_and_bare_lf_headers() {
+  for raw in [
+    b"GET / HTTP/1.1\r\nHost: example.test\r\nX-Test: first\r\n second\r\n\r\n".as_slice(),
+    b"GET / HTTP/1.1\r\nHost: example.test\r\nX-Test: first\r\n\tsecond\r\n\r\n".as_slice(),
+    b"GET / HTTP/1.1\r\nHost: example.test\r\nX-Test: first\nsecond\r\n\r\n".as_slice(),
+  ] {
+    let error = Request::from_raw_frame(raw)
+      .expect_err("folded and bare-LF request headers must be rejected");
+    assert_eq!(std::io::ErrorKind::InvalidData, error.kind());
+    assert_eq!("invalid request header", error.to_string());
+  }
+}
+
+#[test]
+fn request_raw_parser_preserves_obs_text_header_values_as_latin1_code_points() {
+  let request = Request::from_raw_frame(
+    b"GET / HTTP/1.1\r\nHost: example.test\r\nX-Obs: \x80\xff\r\n\r\n",
+  )
+  .expect("obs-text request header should parse");
+
+  // Request headers use `String`, so raw obs-text bytes cross the API boundary
+  // as their corresponding Latin-1 code points.
+  assert_eq!(Some("\u{0080}\u{00ff}"), request.header("X-Obs"));
+}
+
+#[test]
 fn request_cache_control_preserves_malformed_headers_for_handler_policy() {
   let request = Request::from_raw_frame(
     b"GET / HTTP/1.1\r\nHost: example.test\r\nCache-Control: max-age=invalid\r\n\r\n",

--- a/crates/rttp-server/src/server/server_tests.rs
+++ b/crates/rttp-server/src/server/server_tests.rs
@@ -35,13 +35,23 @@ fn request_raw_parser_rejects_folded_and_bare_lf_headers() {
 #[test]
 fn request_raw_parser_preserves_obs_text_header_values_as_latin1_code_points() {
   let request = Request::from_raw_frame(
-    b"GET / HTTP/1.1\r\nHost: example.test\r\nX-Obs: \x80\xff\r\n\r\n",
+    b"GET / HTTP/1.1\r\nHost: example.test\r\nX-Obs: \x80\xc3\xa9\xff\r\n\r\n",
   )
   .expect("obs-text request header should parse");
 
   // Request headers use `String`, so raw obs-text bytes cross the API boundary
   // as their corresponding Latin-1 code points.
-  assert_eq!(Some("\u{0080}\u{00ff}"), request.header("X-Obs"));
+  assert_eq!(Some("\u{0080}\u{00c3}\u{00a9}\u{00ff}"), request.header("X-Obs"));
+}
+
+#[test]
+fn request_raw_parser_preserves_non_ows_obs_text_header_value_edges() {
+  let request = Request::from_raw_frame(
+    b"GET / HTTP/1.1\r\nHost: example.test\r\nX-Obs: \xa0value\xa0\r\n\r\n",
+  )
+  .expect("obs-text request header should parse");
+
+  assert_eq!(Some("\u{00a0}value\u{00a0}"), request.header("X-Obs"));
 }
 
 #[test]

--- a/crates/rttp-server/src/server/server_tests.rs
+++ b/crates/rttp-server/src/server/server_tests.rs
@@ -24,12 +24,26 @@ fn request_raw_parser_rejects_folded_and_bare_lf_headers() {
     b"GET / HTTP/1.1\r\nHost: example.test\r\nX-Test: first\r\n second\r\n\r\n".as_slice(),
     b"GET / HTTP/1.1\r\nHost: example.test\r\nX-Test: first\r\n\tsecond\r\n\r\n".as_slice(),
     b"GET / HTTP/1.1\r\nHost: example.test\r\nX-Test: first\nsecond\r\n\r\n".as_slice(),
+    b"GET / HTTP/1.1\r\nHost: example.test\r\nX-Test: first\rsecond\r\n\r\n".as_slice(),
   ] {
     let error = Request::from_raw_frame(raw)
       .expect_err("folded and bare-LF request headers must be rejected");
     assert_eq!(std::io::ErrorKind::InvalidData, error.kind());
     assert_eq!("invalid request header", error.to_string());
   }
+}
+
+#[test]
+fn request_raw_parser_preserves_duplicate_ordinary_headers_in_wire_order() {
+  let request = Request::from_raw_frame(
+    b"GET / HTTP/1.1\r\nHost: example.test\r\nX-Test: first\r\nx-test: second\r\n\r\n",
+  )
+  .expect("duplicate ordinary request headers should parse");
+
+  assert_eq!(
+    vec!["first", "second"],
+    request.headers_named("X-Test").collect::<Vec<_>>()
+  );
 }
 
 #[test]


### PR DESCRIPTION
HTTP/1 parsers now reject obs-fold and bare-LF header lines while preserving legal obs-text at the String API boundary.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1799/
work_kind: code_work
branch: hbx-1799-rttp-http1-enforce-folded-header
base: main
commit: 06ca5a016a22693056fe7b4fec76b37211434d26
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1799/
    url: https://plane.kahub.in/endless/browse/HBX-1799/
    close_policy: link_only
```