### PR TITLE
feat: [rttp-http2] Add h2c client/server roundtrip coverage for trailers and metadata preservation

### DIFF
--- a/tests/http2_client_server_roundtrip.rs
+++ b/tests/http2_client_server_roundtrip.rs
@@ -50,3 +50,95 @@ fn bounded_h2c_prior_knowledge_round_trip_reaches_the_server() {
   );
   handle.join().expect("h2c server thread");
 }
+
+#[test]
+fn h2c_prior_knowledge_round_trip_preserves_metadata_and_response_trailers() {
+  let server = HttpServer::bind("127.0.0.1:0")
+    .expect("bind h2c server")
+    .with_read_timeout(Some(Duration::from_secs(2)))
+    .with_write_timeout(Some(Duration::from_secs(2)));
+  let addr = server.local_addr().expect("h2c server address");
+
+  let handle = thread::spawn(move || {
+    server
+      .accept_one(|request| {
+        assert_eq!("HTTP/2", request.version());
+        assert_eq!(Some("client-context"), request.header("x-request-context"));
+        let priority = request
+          .priority()
+          .expect("parse request Priority")
+          .expect("request Priority is present");
+        assert_eq!(Some(1), priority.urgency());
+        assert!(priority.incremental());
+        assert_eq!(Some("token"), priority.extensions()[0].value());
+
+        HttpResponse::ok("h2c metadata")
+          .header("X-Response-Context", "server-context")
+          .with_priority("u=3, i=?0, x=response")
+          .expect("build response Priority")
+          .with_server_timing("db;dur=53.2;desc=\"primary database\";region=us-east")
+          .expect("build response Server-Timing")
+          .trailer("X-Response-Trace", "trailer-context")
+      })
+      .expect("serve h2c metadata request");
+  });
+
+  let mut client = HttpClient::new();
+  let response = client
+    .get()
+    .url(format!("http://{addr}/workspace/h2c-metadata"))
+    .header(("X-Request-Context", "client-context"))
+    .priority("u=1, i, x=token")
+    .expect("configure request Priority")
+    .emit_http2_prior_knowledge()
+    .expect("receive h2c metadata response");
+
+  assert_eq!("HTTP/2", response.version());
+  assert_eq!(
+    Some(&"server-context".to_string()),
+    response.header_value("x-response-context")
+  );
+  assert_eq!(
+    Some(&"u=3, i=?0, x=response".to_string()),
+    response.header_value("priority")
+  );
+  assert_eq!(
+    Some(&"db; dur=53.2; desc=\"primary database\"; region=us-east".to_string()),
+    response.header_value("server-timing")
+  );
+  assert_eq!(
+    Some(&"trailer-context".to_string()),
+    response.trailer_value("x-response-trace")
+  );
+  assert_eq!(
+    vec![("x-response-trace", "trailer-context")],
+    response
+      .trailers()
+      .iter()
+      .map(|trailer| (trailer.name().as_str(), trailer.value().as_str()))
+      .collect::<Vec<_>>()
+  );
+
+  let priority = response
+    .priority()
+    .expect("parse response Priority")
+    .expect("response Priority is present");
+  assert_eq!(Some(3), priority.urgency());
+  assert!(!priority.incremental());
+  assert_eq!(Some("response"), priority.extensions()[0].value());
+
+  let timing = response
+    .server_timing()
+    .expect("parse response Server-Timing")
+    .expect("response Server-Timing is present");
+  assert_eq!(1, timing.len());
+  assert_eq!("db", timing.metrics()[0].name());
+  assert_eq!(Some(53.2), timing.metrics()[0].duration());
+  assert_eq!(Some("primary database"), timing.metrics()[0].description());
+
+  assert_eq!(
+    "h2c metadata",
+    response.body().string().expect("h2c response body")
+  );
+  handle.join().expect("h2c server thread");
+}


### PR DESCRIPTION
Added and validated h2c prior-knowledge client/server roundtrip coverage for ordinary metadata, Priority and Server-Timing helpers, and response trailers.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1795/
work_kind: code_work
branch: hbx-1795-rttp-http2-add-h2c-client-retry-default-4626e08d-abd3-4ed1-9ce1-2bc33a225011-attempt-3
base: main
commit: adbbc9c529b762eb6b61e4760219978c68e969de
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1795/
    url: https://plane.kahub.in/endless/browse/HBX-1795/
    close_policy: link_only
```