### PR TITLE
feat: [rttp-server] Add bounded authentication header helpers without policy behavior

### DIFF
--- a/crates/rttp-server/README.md
+++ b/crates/rttp-server/README.md
@@ -11,6 +11,26 @@ fields, preserves the request for handler-defined error policy, and returns an
 error for malformed values, values larger than 64 KiB, or more than 256
 directives. It only parses metadata; it does not apply caching behavior.
 
+## Authentication metadata
+
+`Request::authorization()` / `HttpRequest::authorization()` and
+`Request::proxy_authorization()` / `HttpRequest::proxy_authorization()` expose
+one bounded opaque credential field as `HttpAuthorization` metadata. Both
+helpers return `Ok(None)` when absent and reject malformed, oversized (over 64
+KiB), or duplicate fields while leaving the raw request headers available to
+handler code.
+
+`HttpResponse::with_www_authenticate(value)` validates and replaces attached
+`WWW-Authenticate` fields with one normalized declaration, and
+`HttpResponse::www_authenticate()` parses attached raw challenge fields without
+changing them. Invalid typed declarations are rejected before a response is
+emitted; raw headers remain intact unless a typed declaration deliberately
+replaces them.
+
+These helpers only expose metadata. RTTP does not validate credentials, select
+realms, challenge clients automatically, or enforce authentication or
+authorization decisions.
+
 ## Fetch Metadata request metadata
 
 Handlers can call `Request::sec_fetch_site()`, `sec_fetch_mode()`,

--- a/crates/rttp-server/src/server/request.rs
+++ b/crates/rttp-server/src/server/request.rs
@@ -134,28 +134,31 @@ pub struct HttpAuthorization {
 
 impl HttpAuthorization {
   pub fn parse(value: impl AsRef<str>) -> Result<Self, HttpAuthorizationParseError> {
-    let value = value.as_ref();
+    Self::parse_header(value.as_ref(), "Authorization")
+  }
+
+  fn parse_header(value: &str, header_name: &str) -> Result<Self, HttpAuthorizationParseError> {
     if value.len() > MAX_AUTHORIZATION_VALUE_BYTES {
-      return Err(HttpAuthorizationParseError::new(
-        "Authorization header value is too large",
-      ));
+      return Err(HttpAuthorizationParseError::new(format!(
+        "{header_name} header value is too large"
+      )));
     }
     let Some(separator) = value.bytes().position(|byte| byte == b' ' || byte == b'\t') else {
-      return Err(HttpAuthorizationParseError::new(
-        "Authorization header requires credentials",
-      ));
+      return Err(HttpAuthorizationParseError::new(format!(
+        "{header_name} header requires credentials"
+      )));
     };
     let scheme = &value[..separator];
     let credentials = value[separator..].trim_matches([' ', '\t']);
     if !is_http_token(scheme) {
-      return Err(HttpAuthorizationParseError::new(
-        "invalid Authorization authentication scheme",
-      ));
+      return Err(HttpAuthorizationParseError::new(format!(
+        "invalid {header_name} authentication scheme"
+      )));
     }
     if credentials.is_empty() || !credentials.bytes().all(is_header_value_byte) {
-      return Err(HttpAuthorizationParseError::new(
-        "invalid Authorization credentials",
-      ));
+      return Err(HttpAuthorizationParseError::new(format!(
+        "invalid {header_name} credentials"
+      )));
     }
     Ok(Self {
       scheme: scheme.to_string(),
@@ -353,6 +356,23 @@ impl Request {
       ));
     }
     HttpAuthorization::parse(value).map(Some)
+  }
+
+  /// Parses exactly one bounded `Proxy-Authorization` field as opaque typed
+  /// metadata. Duplicate fields are rejected to avoid ambiguous credentials.
+  pub fn proxy_authorization(
+    &self,
+  ) -> Result<Option<HttpAuthorization>, HttpAuthorizationParseError> {
+    let mut values = self.headers_named("Proxy-Authorization");
+    let Some(value) = values.next() else {
+      return Ok(None);
+    };
+    if values.next().is_some() {
+      return Err(HttpAuthorizationParseError::new(
+        "duplicate Proxy-Authorization headers",
+      ));
+    }
+    HttpAuthorization::parse_header(value, "Proxy-Authorization").map(Some)
   }
 
   /// Parses request `Cookie` pairs as bounded opaque metadata without applying
@@ -2031,6 +2051,27 @@ impl HttpRequest {
       ));
     }
     HttpAuthorization::parse(value).map(Some)
+  }
+
+  /// Parses exactly one bounded `Proxy-Authorization` field as opaque typed
+  /// metadata. Duplicate fields are rejected to avoid ambiguous credentials.
+  pub fn proxy_authorization(
+    &self,
+  ) -> Result<Option<HttpAuthorization>, HttpAuthorizationParseError> {
+    let mut values = self
+      .headers
+      .iter()
+      .filter(|header| header.name.eq_ignore_ascii_case("Proxy-Authorization"))
+      .map(|header| header.value.as_str());
+    let Some(value) = values.next() else {
+      return Ok(None);
+    };
+    if values.next().is_some() {
+      return Err(HttpAuthorizationParseError::new(
+        "duplicate Proxy-Authorization headers",
+      ));
+    }
+    HttpAuthorization::parse_header(value, "Proxy-Authorization").map(Some)
   }
 
   /// Parses request `Cookie` pairs as bounded opaque metadata without applying

--- a/crates/rttp-server/src/server/server_tests.rs
+++ b/crates/rttp-server/src/server/server_tests.rs
@@ -672,6 +672,66 @@ hello\r\n\
   }
 
   #[test]
+  fn authentication_helpers_parse_bounded_metadata_without_authentication_policy() {
+    let raw = concat!(
+      "GET / HTTP/1.1\r\n",
+      "Host: example.test\r\n",
+      "Authorization: Bearer origin-token\r\n",
+      "Proxy-Authorization: Basic cHJveHk6c2VjcmV0\r\n",
+      "\r\n"
+    );
+    let mut reader = BufReader::new(Cursor::new(raw.as_bytes()));
+    let request = Request::read_next_from(&mut reader)
+      .expect("request should parse")
+      .expect("request should be present");
+
+    assert_eq!(
+      "Bearer",
+      request
+        .authorization()
+        .expect("Authorization should parse")
+        .expect("Authorization should be present")
+        .scheme()
+    );
+    let proxy_authorization = request
+      .proxy_authorization()
+      .expect("Proxy-Authorization should parse")
+      .expect("Proxy-Authorization should be present");
+    assert_eq!("Basic", proxy_authorization.scheme());
+    assert_eq!("cHJveHk6c2VjcmV0", proxy_authorization.credentials());
+
+    let response = HttpResponse::new(401, "Unauthorized")
+      .header("WWW-Authenticate", "Broken")
+      .with_www_authenticate("Basic realm=\"private\", Bearer")
+      .expect("WWW-Authenticate should be accepted");
+    let challenges = response
+      .www_authenticate()
+      .expect("WWW-Authenticate should parse")
+      .expect("WWW-Authenticate should be present");
+    assert_eq!(2, challenges.challenges().len());
+    assert_eq!("Basic", challenges.challenges()[0].scheme());
+    assert_eq!("Bearer", challenges.challenges()[1].scheme());
+    assert!(HttpResponse::ok([])
+      .with_www_authenticate("Basic @")
+      .is_err());
+    let malformed = HttpRequest::parse(
+      concat!(
+        "GET / HTTP/1.1\r\n",
+        "Host: example.test\r\n",
+        "Proxy-Authorization: invalid\r\n",
+        "\r\n"
+      )
+      .as_bytes(),
+    )
+    .expect("request should parse");
+    assert!(malformed.proxy_authorization().is_err());
+    assert_eq!(
+      Some("invalid"),
+      malformed.header("Proxy-Authorization")
+    );
+  }
+
+  #[test]
   fn alt_svc_helpers_validate_build_and_parse_response_metadata() {
     let response = HttpResponse::ok([])
       .with_alt_svc("h3=\":443\"; ma=3600; persist=1; region=\"us-east\"")

--- a/crates/rttp/README.md
+++ b/crates/rttp/README.md
@@ -275,15 +275,27 @@ enforcement, or automatic conditional requests. Applications that build a
 cache must persist any selected request metadata and enforce their own cache
 policy around these helpers.
 
-## Bounded Authorization request metadata
+## Bounded authentication metadata
 
 `Request::authorization()` and `HttpRequest::authorization()` parse a single
 `Authorization` field into `HttpAuthorization` metadata with `scheme()` and
 `credentials()` accessors. They return `Ok(None)` when the field is absent and
 reject invalid, oversized (over 64 KiB), or duplicate fields so credentials are
-not ambiguous. Credential interpretation remains application-owned; RTTP does
-not verify schemes, store or refresh credentials, process challenges, retry,
-or forward credentials across redirects.
+not ambiguous. `Request::proxy_authorization()` and
+`HttpRequest::proxy_authorization()` expose `Proxy-Authorization` with the
+same bounded opaque representation and duplicate handling. Raw request headers
+remain available when either typed parser reports an error.
+
+`HttpResponse::with_www_authenticate(value)` validates bounded challenges from
+`rttp_protocol::www_authenticate`, replaces existing raw `WWW-Authenticate`
+fields with one normalized declaration, and rejects malformed declarations
+before emission. `HttpResponse::www_authenticate()` parses attached raw
+challenge fields while preserving them on errors.
+
+Credential interpretation remains application-owned. RTTP does not validate
+credentials, select realms, challenge clients automatically, enforce
+authentication or authorization decisions, verify schemes, store or refresh
+credentials, retry, or forward credentials across redirects.
 
 ## Bounded HTTP/1.1 Allow behavior
 
@@ -675,6 +687,7 @@ scheduling, or async accept loops.
 | Informational responses and Early Hints | `HttpResponse::early_hints` and `early_hints_with_headers` construct validated bodyless `103 Early Hints` response metadata with bounded `Link` and safe metadata headers | `101 Switching Protocols` remains a separate terminal handoff response; no automatic preload execution, cache policy, redirect/retry/replay, route generation, streaming early-write API, TLS/ALPN behavior, or status-policy behavior |
 | Cache-Control | `Request::cache_control`, `HttpRequest::cache_control`, and `HttpResponse::cache_control` parse bounded request/response directives, numeric freshness fields, quoted field-name lists, and extension directives; `HttpResponse::with_age`/`age`, `with_expires`/`expires`, and `with_retry_after_delta`/`with_retry_after_date`/`retry_after` declare and parse response `Age`, `Expires`, and `Retry-After` metadata | No cache storage, automatic revalidation, wall-clock freshness calculation, `Vary` matching, shared-cache policy enforcement, automatic conditional requests, directive-based validator evaluation, automatic sleep, retry, replay, backoff, scheduler integration, or status-code policy engine |
 | Vary | `HttpVary`, `HttpResponse::with_vary`, `HttpResponse::vary`, `Request::vary_selection`, and `HttpRequest::vary_selection` parse, declare, and select bounded `Vary` metadata with case-insensitive field-name handling | No cache storage, stored-response matching engine, cache key persistence, automatic request replay, shared-cache policy enforcement, or automatic conditional requests |
+| Authentication metadata | `Request::authorization`/`proxy_authorization` and `HttpRequest::authorization`/`proxy_authorization` expose one bounded opaque credential field, while `HttpResponse::with_www_authenticate`/`www_authenticate` declare and parse bounded `WWW-Authenticate` challenges | No credential validation, realm selection, automatic client challenge, or authentication/authorization enforcement |
 | Allow | `HttpAllowedMethods`, `HttpResponse::with_allow`, and `HttpResponse::allow` declare and parse bounded `Allow` method-list metadata | No route dispatch, automatic `405` generation, `OPTIONS` policy, fallback method selection, retry/replay, or status-code policy engine |
 | Client Hints | `HttpAcceptCh`/`HttpCriticalCh`, `HttpResponse::with_accept_ch`/`with_critical_ch`, and `accept_ch`/`critical_ch` declare and parse bounded Client Hints opt-in metadata; `Response::accept_ch` and `critical_ch` expose it to clients | No browser opt-in state, request-header generation, automatic retry, persistence, or Client Hints policy |
 | Content-Language | `HttpContentLanguages`, `HttpResponse::with_content_language`, and `HttpResponse::content_language` declare and parse bounded `Content-Language` response metadata | No automatic language negotiation, route selection, locale fallback, variant matching, cache policy, retry, replay, redirect, or status-policy behavior |

--- a/tests/http11_client_server_matrix.rs
+++ b/tests/http11_client_server_matrix.rs
@@ -549,6 +549,68 @@ fn sync_client_sec_fetch_metadata_is_observed_by_server_helpers() {
 }
 
 #[test]
+fn sync_client_and_server_exchange_bounded_authentication_metadata() {
+  let server =
+    rttp_server::server::HttpServer::bind("127.0.0.1:0").expect("bind authentication server");
+  let addr = server.local_addr().expect("authentication server addr");
+  let (observed_tx, observed_rx) = mpsc::channel();
+  let handle = thread::spawn(move || {
+    server
+      .accept_one(|request| {
+        let authorization = request
+          .authorization()
+          .expect("Authorization should parse")
+          .map(|value| (value.scheme().to_string(), value.credentials().to_string()));
+        let proxy_authorization = request
+          .proxy_authorization()
+          .expect("Proxy-Authorization should parse")
+          .map(|value| (value.scheme().to_string(), value.credentials().to_string()));
+        observed_tx
+          .send((authorization, proxy_authorization))
+          .expect("send observed authentication metadata");
+        HttpResponse::new(401, "Unauthorized")
+          .header("WWW-Authenticate", "Broken")
+          .with_www_authenticate("Basic realm=\"private\", Bearer")
+          .expect("WWW-Authenticate declaration should parse")
+      })
+      .expect("serve authentication request");
+  });
+
+  let response = client()
+    .get()
+    .url(format!("http://{addr}/matrix/authentication"))
+    .header(("Authorization", "Bearer origin-token"))
+    .header(("Proxy-Authorization", "Basic cHJveHk6c2VjcmV0"))
+    .emit()
+    .expect("authentication response should parse");
+
+  let (authorization, proxy_authorization) = observed_rx
+    .recv_timeout(Duration::from_secs(1))
+    .expect("server should observe authentication metadata");
+  assert_eq!(
+    Some(("Bearer".to_string(), "origin-token".to_string())),
+    authorization
+  );
+  assert_eq!(
+    Some(("Basic".to_string(), "cHJveHk6c2VjcmV0".to_string())),
+    proxy_authorization
+  );
+
+  let challenges = response
+    .www_authenticate()
+    .expect("WWW-Authenticate should parse")
+    .expect("WWW-Authenticate should be present");
+  assert_eq!(2, challenges.challenges().len());
+  assert_eq!("Basic", challenges.challenges()[0].scheme());
+  assert_eq!("Bearer", challenges.challenges()[1].scheme());
+  assert_eq!(
+    Some(&"Basic realm=\"private\", Bearer".to_string()),
+    response.header_value("WWW-Authenticate")
+  );
+  handle.join().expect("authentication server thread");
+}
+
+#[test]
 fn server_sec_fetch_helpers_reject_malformed_values_without_losing_raw_headers() {
   let server = rttp_server::server::HttpServer::bind("127.0.0.1:0")
     .expect("bind malformed Sec-Fetch metadata server");


### PR DESCRIPTION
Added bounded server-side Proxy-Authorization observation, documented the metadata-only authentication boundary, and covered WWW-Authenticate declaration/parsing through server and HTTP/1.1 client/server tests. Full formatting, Clippy, and all-feature test verification pass.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1789/
work_kind: code_work
branch: hbx-1789-rttp-server-add-bounded-authentication
base: main
commit: 5b6d16177d4d5b23f3745ea814ef87e483e805d3
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1789/
    url: https://plane.kahub.in/endless/browse/HBX-1789/
    close_policy: link_only
```