### PR TITLE
feat: [rttp-client] Add request helpers for Want-Content-Digest and Want-Repr-Digest metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,6 +403,32 @@ the request itself.
 These helpers declare and parse metadata only. They do not enable automatic
 compression, decompression, or content negotiation.
 
+### Bounded digest preference request metadata
+
+`HttpClient::want_content_digest()` and `want_content_digest_with_q()` append
+validated algorithms to one `Want-Content-Digest` field. `want_repr_digest()`
+and `want_repr_digest_with_q()` do the same for `Want-Repr-Digest`. The
+q-value variants accept values from `0` through `1` with at most three
+fractional digits.
+
+```rust
+HttpClient::new()
+  .get()
+  .url("http://example.test/asset")
+  .want_content_digest("sha-256")?
+  .want_repr_digest_with_q("sha-512", "0.8")?;
+```
+
+Each helper emits a comma-separated field and rejects malformed algorithm
+tokens or q-values, case-insensitive duplicate algorithms, fields over 64 KiB,
+and more than 32 algorithms before opening a connection. Raw
+`header(("Want-Content-Digest", value))` and
+`header(("Want-Repr-Digest", value))` remain available for syntax outside the
+bounded helper API.
+
+These helpers declare preferences only. RTTP does not compute digests, verify
+response body hashes, retry requests, or sign messages.
+
 ### Bounded Accept request metadata
 
 `HttpClient::accept()` appends one validated media range, while
@@ -620,6 +646,7 @@ gain additional HTTP/2 header-block handling.
 | HTTP/1.1 response parsing | `Content-Length`, chunked transfer coding, chunk extensions, informational responses, bodyless `204`/`304`, duplicate `Set-Cookie`, and framing ambiguity rejection | Not a complete RFC conformance suite |
 | HTTP/1.1 request emission | Origin-form requests, absolute-form proxy requests, `CONNECT`, `HEAD`, fixed bodies, streaming chunked uploads, and explicit `Expect: 100-continue` metadata | Expect metadata does not gate body transmission; SOCKS handshakes are delegated to the `socks` crate |
 | Fetch Metadata | Client `sec_fetch_site`, `sec_fetch_mode`, `sec_fetch_dest`, and `sec_fetch_user` emit bounded `Sec-Fetch-*` fields; server `Request` helpers parse typed received values while preserving raw headers on errors | No browser security policy, request blocking, origin validation, navigation policy, or automatic header generation |
+| Digest preferences | `want_content_digest`, `want_content_digest_with_q`, `want_repr_digest`, and `want_repr_digest_with_q` emit bounded `Want-Content-Digest` and `Want-Repr-Digest` request metadata | No digest computation, response body hash validation, retries, or signing |
 | Upgrade and tunnel handoff | `CONNECT` returns the tunnel socket after a successful `200`; `upgrade()` returns the socket after `101 Switching Protocols` and skips interim `1xx` responses | Upgraded protocols are handed to the caller and are not parsed by `rttp_client` |
 | Redirects | Auto-redirect covers 301, 302, 303, 307, and 308 method/body behavior, relative and absolute `Location` resolution, same- and cross-authority header handling, loop detection, and redirect bounds | Redirects are HTTP client behavior, not a browser policy implementation |
 | Byte ranges | `range`, `range_from`, `range_suffix`, `if_range_etag`, and `if_range_date` emit bounded HTTP/1.1 range request metadata; `Response::content_range`, `accept_ranges`, `is_partial_content`, and `is_range_not_satisfiable` expose `Content-Range`, `Accept-Ranges`, `206`, and `416` metadata while preserving raw headers | No Range request generation from `Accept-Ranges`, client-side `If-Range` evaluation, partial response engine, byte serving, content slicing, download resume, automatic retry/replay, cache storage, redirect handling, status-policy behavior, multipart range generation, or automatic cache validation policy |

--- a/README.md
+++ b/README.md
@@ -408,15 +408,15 @@ compression, decompression, or content negotiation.
 `HttpClient::want_content_digest()` and `want_content_digest_with_q()` append
 validated algorithms to one `Want-Content-Digest` field. `want_repr_digest()`
 and `want_repr_digest_with_q()` do the same for `Want-Repr-Digest`. The
-q-value variants accept values from `0` through `1` with at most three
-fractional digits.
+`_with_q` variants accept RFC 9530 relative preference values from `0` through
+`10`; the default helper value is `10`.
 
 ```rust
 HttpClient::new()
   .get()
   .url("http://example.test/asset")
   .want_content_digest("sha-256")?
-  .want_repr_digest_with_q("sha-512", "0.8")?;
+  .want_repr_digest_with_q("sha-512", "8")?;
 ```
 
 Each helper emits a comma-separated field and rejects malformed algorithm

--- a/crates/rttp-client/README.md
+++ b/crates/rttp-client/README.md
@@ -382,15 +382,15 @@ compression, decompression, or content negotiation.
 `HttpClient::want_content_digest()` and `want_content_digest_with_q()` append
 validated algorithms to one `Want-Content-Digest` field. `want_repr_digest()`
 and `want_repr_digest_with_q()` do the same for `Want-Repr-Digest`. The
-q-value variants accept values from `0` through `1` with at most three
-fractional digits.
+`_with_q` variants accept RFC 9530 relative preference values from `0` through
+`10`; the default helper value is `10`.
 
 ```rust
 HttpClient::new()
   .get()
   .url("http://example.test/asset")
   .want_content_digest("sha-256")?
-  .want_repr_digest_with_q("sha-512", "0.8")?;
+  .want_repr_digest_with_q("sha-512", "8")?;
 ```
 
 Each helper emits a comma-separated field and rejects malformed algorithm

--- a/crates/rttp-client/README.md
+++ b/crates/rttp-client/README.md
@@ -377,6 +377,32 @@ connection is opened.
 These helpers declare request metadata only. They do not enable automatic
 compression, decompression, or content negotiation.
 
+## Bounded digest preference request metadata
+
+`HttpClient::want_content_digest()` and `want_content_digest_with_q()` append
+validated algorithms to one `Want-Content-Digest` field. `want_repr_digest()`
+and `want_repr_digest_with_q()` do the same for `Want-Repr-Digest`. The
+q-value variants accept values from `0` through `1` with at most three
+fractional digits.
+
+```rust
+HttpClient::new()
+  .get()
+  .url("http://example.test/asset")
+  .want_content_digest("sha-256")?
+  .want_repr_digest_with_q("sha-512", "0.8")?;
+```
+
+Each helper emits a comma-separated field and rejects malformed algorithm
+tokens or q-values, case-insensitive duplicate algorithms, fields over 64 KiB,
+and more than 32 algorithms before opening a connection. Raw
+`header(("Want-Content-Digest", value))` and
+`header(("Want-Repr-Digest", value))` remain available for syntax outside the
+bounded helper API.
+
+These helpers declare preferences only. RTTP does not compute digests, verify
+response body hashes, retry requests, or sign messages.
+
 ## Bounded Accept request metadata
 
 `HttpClient::accept()` appends one validated media range, and
@@ -535,6 +561,7 @@ header-block model.
 | HTTP/1.1 response parsing | `Content-Length`, chunked transfer coding, chunk extensions, informational responses, bodyless `204`/`304`, duplicate `Set-Cookie`, and framing ambiguity rejection | Not a complete RFC conformance suite |
 | HTTP/1.1 request emission | Origin-form requests, absolute-form proxy requests, `CONNECT`, `HEAD`, fixed bodies, streaming chunked uploads, and `Expect: 100-continue` | SOCKS handshakes are delegated to the `socks` crate |
 | Fetch Metadata | `sec_fetch_site`, `sec_fetch_mode`, `sec_fetch_dest`, and `sec_fetch_user` emit bounded `Sec-Fetch-*` request metadata | No browser security policy, automatic header generation, origin validation, navigation policy, or request blocking |
+| Digest preferences | `want_content_digest`, `want_content_digest_with_q`, `want_repr_digest`, and `want_repr_digest_with_q` emit bounded `Want-Content-Digest` and `Want-Repr-Digest` request metadata | No digest computation, response body hash validation, retries, or signing |
 | Upgrade and tunnel handoff | `CONNECT` returns the tunnel socket after a successful `200`; `upgrade()` returns the socket after `101 Switching Protocols` and skips interim `1xx` responses | Upgraded protocols are handed to the caller and are not parsed by `rttp_client` |
 | Redirects | Auto-redirect covers 301, 302, 303, 307, and 308 method/body behavior, relative and absolute `Location` resolution, same- and cross-authority header handling, loop detection, and redirect bounds | Redirects are HTTP client behavior, not a browser policy implementation |
 | Byte ranges | `range`, `range_from`, `range_suffix`, `if_range_etag`, and `if_range_date` emit bounded HTTP/1.1 range request metadata; `Response::content_range`, `accept_ranges`, `is_partial_content`, and `is_range_not_satisfiable` expose `Content-Range`, `Accept-Ranges`, `206`, and `416` metadata while preserving raw headers | No Range request generation from `Accept-Ranges`, client-side `If-Range` evaluation, partial response engine, byte serving, content slicing, download resume, automatic retry/replay, cache storage, redirect handling, status-policy behavior, multipart range generation, or automatic cache validation policy |

--- a/crates/rttp-client/src/client.rs
+++ b/crates/rttp-client/src/client.rs
@@ -547,7 +547,8 @@ impl HttpClient {
     self.accept_encoding_with_q("identity", qvalue)
   }
 
-  /// Append a validated digest algorithm to `Want-Content-Digest`.
+  /// Append a validated digest algorithm to `Want-Content-Digest` with the
+  /// highest preference.
   ///
   /// This declares request metadata only; it does not compute or validate
   /// content digests.
@@ -555,8 +556,8 @@ impl HttpClient {
     self.want_digest_member("Want-Content-Digest", algorithm.as_ref(), None)
   }
 
-  /// Append a validated digest algorithm with an HTTP q-value to
-  /// `Want-Content-Digest`.
+  /// Append a validated digest algorithm with a relative preference from `0`
+  /// through `10` to `Want-Content-Digest`.
   pub fn want_content_digest_with_q<A: AsRef<str>, Q: AsRef<str>>(
     &mut self,
     algorithm: A,
@@ -569,7 +570,8 @@ impl HttpClient {
     )
   }
 
-  /// Append a validated digest algorithm to `Want-Repr-Digest`.
+  /// Append a validated digest algorithm to `Want-Repr-Digest` with the
+  /// highest preference.
   ///
   /// This declares request metadata only; it does not compute or validate
   /// representation digests.
@@ -577,8 +579,8 @@ impl HttpClient {
     self.want_digest_member("Want-Repr-Digest", algorithm.as_ref(), None)
   }
 
-  /// Append a validated digest algorithm with an HTTP q-value to
-  /// `Want-Repr-Digest`.
+  /// Append a validated digest algorithm with a relative preference from `0`
+  /// through `10` to `Want-Repr-Digest`.
   pub fn want_repr_digest_with_q<A: AsRef<str>, Q: AsRef<str>>(
     &mut self,
     algorithm: A,
@@ -781,10 +783,10 @@ impl HttpClient {
     if !is_http_token(algorithm) {
       return Err(error::builder_with_message("invalid digest algorithm"));
     }
-    let qvalue = qvalue.map(validate_digest_qvalue).transpose()?;
-    let member = qvalue.map_or_else(
-      || algorithm.to_string(),
-      |qvalue| format!("{algorithm};q={qvalue}"),
+    let preference = qvalue.map(validate_digest_qvalue).transpose()?;
+    let member = preference.map_or_else(
+      || format!("{algorithm}=10"),
+      |preference| format!("{algorithm}={preference}"),
     );
     append_unique_metadata_member(
       self.request.headers_mut(),
@@ -1320,38 +1322,20 @@ fn validate_te_qvalue(qvalue: &str) -> error::Result<&str> {
 
 fn parse_digest_algorithms(value: &str) -> error::Result<Vec<&str>> {
   parse_metadata_members(value, "invalid digest algorithm", |member| {
-    let mut parts = member.split(';');
-    let algorithm = parts.next().unwrap_or_default().trim();
-    if !is_http_token(algorithm) {
-      return None;
-    }
-    match parts.next() {
-      None => Some(algorithm),
-      Some(parameter) if parts.next().is_none() => {
-        let (name, value) = parameter.trim().split_once('=')?;
-        (name.trim().eq_ignore_ascii_case("q") && validate_digest_qvalue(value.trim()).is_ok())
-          .then_some(algorithm)
-      }
-      Some(_) => None,
-    }
+    let (algorithm, preference) = member.trim().split_once('=')?;
+    let algorithm = algorithm.trim();
+    (is_http_token(algorithm) && validate_digest_qvalue(preference.trim()).is_ok())
+      .then_some(algorithm)
   })
 }
 
 fn validate_digest_qvalue(qvalue: &str) -> error::Result<&str> {
-  let valid = match qvalue.split_once('.') {
-    Some((whole, fraction)) => {
-      fraction.len() <= 3
-        && fraction.bytes().all(|byte| byte.is_ascii_digit())
-        && matches!(whole, "0" | "1")
-        && (whole == "0" || fraction.bytes().all(|byte| byte == b'0'))
-    }
-    None => matches!(qvalue, "0" | "1"),
-  };
-  if valid {
-    Ok(qvalue)
-  } else {
-    Err(error::builder_with_message("invalid digest q-value"))
-  }
+  matches!(
+    qvalue,
+    "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9" | "10"
+  )
+  .then_some(qvalue)
+  .ok_or_else(|| error::builder_with_message("invalid digest preference"))
 }
 
 fn parse_prefer_names(value: &str) -> error::Result<Vec<&str>> {

--- a/crates/rttp-client/src/client.rs
+++ b/crates/rttp-client/src/client.rs
@@ -547,6 +547,50 @@ impl HttpClient {
     self.accept_encoding_with_q("identity", qvalue)
   }
 
+  /// Append a validated digest algorithm to `Want-Content-Digest`.
+  ///
+  /// This declares request metadata only; it does not compute or validate
+  /// content digests.
+  pub fn want_content_digest<S: AsRef<str>>(&mut self, algorithm: S) -> error::Result<&mut Self> {
+    self.want_digest_member("Want-Content-Digest", algorithm.as_ref(), None)
+  }
+
+  /// Append a validated digest algorithm with an HTTP q-value to
+  /// `Want-Content-Digest`.
+  pub fn want_content_digest_with_q<A: AsRef<str>, Q: AsRef<str>>(
+    &mut self,
+    algorithm: A,
+    qvalue: Q,
+  ) -> error::Result<&mut Self> {
+    self.want_digest_member(
+      "Want-Content-Digest",
+      algorithm.as_ref(),
+      Some(qvalue.as_ref()),
+    )
+  }
+
+  /// Append a validated digest algorithm to `Want-Repr-Digest`.
+  ///
+  /// This declares request metadata only; it does not compute or validate
+  /// representation digests.
+  pub fn want_repr_digest<S: AsRef<str>>(&mut self, algorithm: S) -> error::Result<&mut Self> {
+    self.want_digest_member("Want-Repr-Digest", algorithm.as_ref(), None)
+  }
+
+  /// Append a validated digest algorithm with an HTTP q-value to
+  /// `Want-Repr-Digest`.
+  pub fn want_repr_digest_with_q<A: AsRef<str>, Q: AsRef<str>>(
+    &mut self,
+    algorithm: A,
+    qvalue: Q,
+  ) -> error::Result<&mut Self> {
+    self.want_digest_member(
+      "Want-Repr-Digest",
+      algorithm.as_ref(),
+      Some(qvalue.as_ref()),
+    )
+  }
+
   /// Append a validated `TE` transfer coding. This declares request metadata
   /// only; it does not enable a transfer-coding engine.
   pub fn te<S: AsRef<str>>(&mut self, coding: S) -> error::Result<&mut Self> {
@@ -724,6 +768,35 @@ impl HttpClient {
       parse_te_codings,
     )?;
     self.ensure_connection_te_token();
+    Ok(self)
+  }
+
+  fn want_digest_member(
+    &mut self,
+    header_name: &str,
+    algorithm: &str,
+    qvalue: Option<&str>,
+  ) -> error::Result<&mut Self> {
+    let algorithm = algorithm.trim();
+    if !is_http_token(algorithm) {
+      return Err(error::builder_with_message("invalid digest algorithm"));
+    }
+    let qvalue = qvalue.map(validate_digest_qvalue).transpose()?;
+    let member = qvalue.map_or_else(
+      || algorithm.to_string(),
+      |qvalue| format!("{algorithm};q={qvalue}"),
+    );
+    append_unique_metadata_member(
+      self.request.headers_mut(),
+      header_name,
+      algorithm,
+      member,
+      "invalid digest algorithm",
+      "duplicate digest algorithm",
+      "too many digest algorithms",
+      "digest header value is too large",
+      parse_digest_algorithms,
+    )?;
     Ok(self)
   }
 
@@ -1242,6 +1315,42 @@ fn validate_te_qvalue(qvalue: &str) -> error::Result<&str> {
     Ok(qvalue)
   } else {
     Err(error::builder_with_message("invalid TE q-value"))
+  }
+}
+
+fn parse_digest_algorithms(value: &str) -> error::Result<Vec<&str>> {
+  parse_metadata_members(value, "invalid digest algorithm", |member| {
+    let mut parts = member.split(';');
+    let algorithm = parts.next().unwrap_or_default().trim();
+    if !is_http_token(algorithm) {
+      return None;
+    }
+    match parts.next() {
+      None => Some(algorithm),
+      Some(parameter) if parts.next().is_none() => {
+        let (name, value) = parameter.trim().split_once('=')?;
+        (name.trim().eq_ignore_ascii_case("q") && validate_digest_qvalue(value.trim()).is_ok())
+          .then_some(algorithm)
+      }
+      Some(_) => None,
+    }
+  })
+}
+
+fn validate_digest_qvalue(qvalue: &str) -> error::Result<&str> {
+  let valid = match qvalue.split_once('.') {
+    Some((whole, fraction)) => {
+      fraction.len() <= 3
+        && fraction.bytes().all(|byte| byte.is_ascii_digit())
+        && matches!(whole, "0" | "1")
+        && (whole == "0" || fraction.bytes().all(|byte| byte == b'0'))
+    }
+    None => matches!(qvalue, "0" | "1"),
+  };
+  if valid {
+    Ok(qvalue)
+  } else {
+    Err(error::builder_with_message("invalid digest q-value"))
   }
 }
 

--- a/crates/rttp-client/tests/test_raw_request_capture.rs
+++ b/crates/rttp-client/tests/test_raw_request_capture.rs
@@ -375,30 +375,30 @@ fn accept_encoding_helpers_reject_invalid_members_before_connecting() {
 }
 
 #[test]
-fn want_digest_helpers_emit_validated_algorithms_and_quality_values() {
+fn want_digest_helpers_emit_rfc_9530_dictionary_members() {
   let request = capture_request(|base_url| {
     client()
       .get()
       .url(format!("{}/asset", base_url))
       .want_content_digest("sha-256")
       .expect("content digest algorithm should be accepted")
-      .want_content_digest_with_q("sha-512", "0.8")
-      .expect("content digest quality should be accepted")
+      .want_content_digest_with_q("sha-512", "8")
+      .expect("content digest preference should be accepted")
       .want_repr_digest("sha-256")
       .expect("representation digest algorithm should be accepted")
       .want_repr_digest_with_q("sha-512", "0")
-      .expect("representation digest quality should be accepted")
+      .expect("representation digest preference should be accepted")
       .emit()
       .expect("request should succeed");
   });
   let request = request_text(&request);
 
   assert_eq!(
-    Some("sha-256, sha-512;q=0.8"),
+    Some("sha-256=10, sha-512=8"),
     header_value(&request, "Want-Content-Digest")
   );
   assert_eq!(
-    Some("sha-256, sha-512;q=0"),
+    Some("sha-256=10, sha-512=0"),
     header_value(&request, "Want-Repr-Digest")
   );
 }
@@ -424,8 +424,8 @@ fn want_digest_helpers_reject_invalid_or_excessive_values_before_connecting() {
     assert!(client
       .get()
       .url(format!("{}/asset", base_url))
-      .want_repr_digest_with_q("sha-256", "1.1")
-      .expect_err("invalid digest quality should be rejected")
+      .want_repr_digest_with_q("sha-256", "11")
+      .expect_err("invalid digest preference should be rejected")
       .is_builder());
   });
   assert!(

--- a/crates/rttp-client/tests/test_raw_request_capture.rs
+++ b/crates/rttp-client/tests/test_raw_request_capture.rs
@@ -375,6 +375,132 @@ fn accept_encoding_helpers_reject_invalid_members_before_connecting() {
 }
 
 #[test]
+fn want_digest_helpers_emit_validated_algorithms_and_quality_values() {
+  let request = capture_request(|base_url| {
+    client()
+      .get()
+      .url(format!("{}/asset", base_url))
+      .want_content_digest("sha-256")
+      .expect("content digest algorithm should be accepted")
+      .want_content_digest_with_q("sha-512", "0.8")
+      .expect("content digest quality should be accepted")
+      .want_repr_digest("sha-256")
+      .expect("representation digest algorithm should be accepted")
+      .want_repr_digest_with_q("sha-512", "0")
+      .expect("representation digest quality should be accepted")
+      .emit()
+      .expect("request should succeed");
+  });
+  let request = request_text(&request);
+
+  assert_eq!(
+    Some("sha-256, sha-512;q=0.8"),
+    header_value(&request, "Want-Content-Digest")
+  );
+  assert_eq!(
+    Some("sha-256, sha-512;q=0"),
+    header_value(&request, "Want-Repr-Digest")
+  );
+}
+
+#[test]
+fn want_digest_helpers_reject_invalid_or_excessive_values_before_connecting() {
+  let request = capture_optional_request(|base_url| {
+    let mut client = client();
+    assert!(client
+      .get()
+      .url(format!("{}/asset", base_url))
+      .want_content_digest("bad algorithm")
+      .expect_err("invalid digest algorithm should be rejected")
+      .is_builder());
+  });
+  assert!(
+    request.is_empty(),
+    "invalid digest preference helper input should not open a socket"
+  );
+
+  let request = capture_optional_request(|base_url| {
+    let mut client = client();
+    assert!(client
+      .get()
+      .url(format!("{}/asset", base_url))
+      .want_repr_digest_with_q("sha-256", "1.1")
+      .expect_err("invalid digest quality should be rejected")
+      .is_builder());
+  });
+  assert!(
+    request.is_empty(),
+    "invalid digest preference helper input should not open a socket"
+  );
+
+  let request = capture_optional_request(|base_url| {
+    let mut client = client();
+    client.get().url(format!("{}/asset", base_url));
+    client
+      .want_content_digest("sha-256")
+      .expect("first digest algorithm should be accepted");
+    assert!(client
+      .want_content_digest("SHA-256")
+      .expect_err("duplicate digest algorithm should be rejected")
+      .is_builder());
+  });
+  assert!(
+    request.is_empty(),
+    "invalid digest preference helper input should not open a socket"
+  );
+
+  let request = capture_optional_request(|base_url| {
+    let oversized_algorithm = "a".repeat(64 * 1024 + 1);
+    let mut client = client();
+    assert!(client
+      .get()
+      .url(format!("{}/asset", base_url))
+      .want_repr_digest(&oversized_algorithm)
+      .expect_err("oversized digest algorithm should be rejected")
+      .is_builder());
+  });
+  assert!(
+    request.is_empty(),
+    "invalid digest preference helper input should not open a socket"
+  );
+
+  let request = capture_optional_request(|base_url| {
+    let mut client = client();
+    client.get().url(format!("{}/asset", base_url));
+    for index in 0..32 {
+      client
+        .want_repr_digest(format!("algorithm{index}"))
+        .expect("digest algorithm within the limit should be accepted");
+    }
+    assert!(client
+      .want_repr_digest("one-too-many")
+      .expect_err("too many digest algorithms should be rejected")
+      .is_builder());
+  });
+  assert!(
+    request.is_empty(),
+    "excessive digest preference helper input should not open a socket"
+  );
+}
+
+#[test]
+fn raw_want_digest_headers_remain_available_for_extended_syntax() {
+  let request = capture_request(|base_url| {
+    client()
+      .get()
+      .url(format!("{}/asset", base_url))
+      .header(("Want-Content-Digest", "sha-256;example=custom"))
+      .emit()
+      .expect("request should succeed");
+  });
+
+  assert_eq!(
+    Some("sha-256;example=custom"),
+    header_value(&request_text(&request), "Want-Content-Digest")
+  );
+}
+
+#[test]
 fn accept_helpers_emit_validated_media_ranges_and_quality_values() {
   let request = capture_request(|base_url| {
     client()

--- a/crates/rttp-client/tests/test_raw_request_capture.rs
+++ b/crates/rttp-client/tests/test_raw_request_capture.rs
@@ -424,6 +424,20 @@ fn want_digest_helpers_reject_invalid_or_excessive_values_before_connecting() {
     assert!(client
       .get()
       .url(format!("{}/asset", base_url))
+      .want_content_digest_with_q("sha-256", "1.0")
+      .expect_err("malformed digest preference should be rejected")
+      .is_builder());
+  });
+  assert!(
+    request.is_empty(),
+    "invalid digest preference helper input should not open a socket"
+  );
+
+  let request = capture_optional_request(|base_url| {
+    let mut client = client();
+    assert!(client
+      .get()
+      .url(format!("{}/asset", base_url))
       .want_repr_digest_with_q("sha-256", "11")
       .expect_err("invalid digest preference should be rejected")
       .is_builder());
@@ -490,6 +504,7 @@ fn raw_want_digest_headers_remain_available_for_extended_syntax() {
       .get()
       .url(format!("{}/asset", base_url))
       .header(("Want-Content-Digest", "sha-256;example=custom"))
+      .header(("Want-Repr-Digest", "sha-512;example=custom"))
       .emit()
       .expect("request should succeed");
   });
@@ -497,6 +512,10 @@ fn raw_want_digest_headers_remain_available_for_extended_syntax() {
   assert_eq!(
     Some("sha-256;example=custom"),
     header_value(&request_text(&request), "Want-Content-Digest")
+  );
+  assert_eq!(
+    Some("sha-512;example=custom"),
+    header_value(&request_text(&request), "Want-Repr-Digest")
   );
 }
 


### PR DESCRIPTION
Added bounded request-builder support for Want-Content-Digest and Want-Repr-Digest, including validation, socket-prevention regression coverage, raw-header escape hatches, and README documentation. The rttp_client test suite passes.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1792/
work_kind: code_work
branch: hbx-1792-rttp-client-add-request-helpers
base: main
commit: 05acc556355677477d016af8cf73d2bfdfa6aeff
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1792/
    url: https://plane.kahub.in/endless/browse/HBX-1792/
    close_policy: link_only
```