### PR TITLE
feat: [rttp-server] Add bounded Digest and Repr-Digest response declaration helpers

### DIFF
--- a/crates/rttp-server/README.md
+++ b/crates/rttp-server/README.md
@@ -32,3 +32,15 @@ when the field is absent.
 
 The helpers only declare and inspect metadata. The server does not retain
 per-client opt-ins, select hints, alter response policy, or trigger retries.
+
+## Digest response metadata
+
+`HttpResponse::with_digest(value)` and `HttpResponse::with_repr_digest(value)`
+validate bounded Structured Fields dictionaries and replace existing
+`Content-Digest` or `Repr-Digest` response fields with their normalized values.
+`HttpResponse::digest()` and `HttpResponse::repr_digest()` parse attached raw
+fields into `HttpDigest` and `HttpReprDigest` metadata, returning parser errors
+without changing those raw fields.
+
+These helpers only declare and parse metadata. They do not calculate hashes,
+verify bodies, canonicalize representations, sign values, or enforce integrity.

--- a/crates/rttp/tests/test_server_models.rs
+++ b/crates/rttp/tests/test_server_models.rs
@@ -3,9 +3,9 @@ use std::time::{Duration, UNIX_EPOCH};
 use rttp::server::{
   HttpAccept, HttpAcceptCh, HttpAcceptRanges, HttpAllowedMethods, HttpAuthorization, HttpByteRange,
   HttpByteRangeError, HttpClearSiteData, HttpConditionalMetadata, HttpContentDisposition,
-  HttpContentLanguages, HttpContentSecurityPolicy, HttpContentType, HttpCriticalCh, HttpDigest,
-  HttpEntityTag, HttpExpectations, HttpIfNoneMatch, HttpIfRange, HttpIfRangeRequestOutcome,
-  HttpLinkValues, HttpPermissionsPolicy, HttpReferrerPolicy, HttpReportingEndpoints, HttpRequest,
+  HttpContentLanguages, HttpContentSecurityPolicy, HttpContentType, HttpCriticalCh, HttpEntityTag,
+  HttpExpectations, HttpIfNoneMatch, HttpIfRange, HttpIfRangeRequestOutcome, HttpLinkValues,
+  HttpPermissionsPolicy, HttpReferrerPolicy, HttpReportingEndpoints, HttpRequest,
   HttpRequestAcceptEncodings, HttpRequestCacheControl, HttpRequestTe, HttpResponse,
   HttpResponseCacheControl, HttpResponseContentEncodings, HttpRetryAfter, HttpServerTiming,
   HttpVary,
@@ -145,8 +145,11 @@ fn response_www_authenticate_helper_validates_and_preserves_raw_headers() {
 }
 
 #[test]
-fn response_digest_helpers_format_and_preserve_recoverable_metadata_errors() {
+fn response_digest_helpers_declare_multiple_algorithms_and_replace_raw_fields() {
   let response = HttpResponse::ok("body")
+    .header("Content-Digest", "sha-256=:b2xk:")
+    .header("Content-Digest", "sha-512=:b2xk:")
+    .header("Repr-Digest", "sha-256=:b2xk:")
     .with_digest("sha-256=:YWJj:, sha-512=:ZGVm:")
     .expect("Digest should be accepted")
     .with_repr_digest("sha-256=:Z2hp:")
@@ -170,21 +173,48 @@ fn response_digest_helpers_format_and_preserve_recoverable_metadata_errors() {
       .map(|entry| entry.value())
   );
   let serialized = String::from_utf8(response.to_bytes()).expect("response should serialize");
+  assert_eq!(1, serialized.matches("\r\nContent-Digest: ").count());
+  assert_eq!(1, serialized.matches("\r\nRepr-Digest: ").count());
   assert!(serialized.contains("\r\nContent-Digest: sha-256=:YWJj:, sha-512=:ZGVm:\r\n"));
   assert!(serialized.contains("\r\nRepr-Digest: sha-256=:Z2hp:\r\n"));
+}
+
+#[test]
+fn response_digest_helpers_reject_invalid_raw_fields_without_mutating_them() {
+  for (header, value) in [
+    ("Content-Digest", "sha-256=:YWJj:, sha-256=:ZGVm:"),
+    ("Repr-Digest", "sha-256=:invalid!:"),
+  ] {
+    let raw = HttpResponse::ok("body").header(header, value);
+    let parsed = if header == "Content-Digest" {
+      raw.digest().map(|_| ())
+    } else {
+      raw.repr_digest().map(|_| ())
+    };
+    assert!(parsed.is_err());
+    assert!(String::from_utf8(raw.to_bytes())
+      .expect("response should serialize")
+      .contains(&format!("\r\n{header}: {value}\r\n")));
+  }
+
+  for header in ["Content-Digest", "Repr-Digest"] {
+    let oversized = format!("sha-256=:{}:", "A".repeat(64 * 1024));
+    let raw = HttpResponse::ok("body").header(header, &oversized);
+    let parsed = if header == "Content-Digest" {
+      raw.digest().map(|_| ())
+    } else {
+      raw.repr_digest().map(|_| ())
+    };
+    assert!(parsed.is_err());
+    assert!(String::from_utf8(raw.to_bytes())
+      .expect("response should serialize")
+      .contains(&format!("\r\n{header}: {oversized}\r\n")));
+  }
 
   assert!(HttpResponse::ok("body").with_digest("").is_err());
   assert!(HttpResponse::ok("body")
     .with_repr_digest("sha-256=:YWJj:, sha-256=:ZGVm:")
     .is_err());
-  let raw = HttpResponse::ok("body").header("Content-Digest", "sha-256=:YWJj:, sha-256=:ZGVm:");
-  assert!(raw.digest().is_err());
-  assert!(String::from_utf8(raw.to_bytes())
-    .expect("response should serialize")
-    .contains("\r\nContent-Digest: sha-256=:YWJj:, sha-256=:ZGVm:\r\n"));
-
-  let oversized = format!("sha-256=:{}:", "A".repeat(64 * 1024));
-  assert!(HttpDigest::parse(oversized).is_err());
 }
 
 #[test]


### PR DESCRIPTION
Documented and validated bounded server-side Content-Digest and Repr-Digest declaration/parsing behavior, including replacement and raw-header preservation semantics.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1791/
work_kind: code_work
branch: hbx-1791-rttp-server-add-bounded-digest
base: main
commit: 96ee6d334ffa627354ffbc500078d24af5a69980
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1791/
    url: https://plane.kahub.in/endless/browse/HBX-1791/
    close_policy: link_only
```