### PR TITLE
feat: [rttp-client] Add redirect loop and method preservation tests

### DIFF
--- a/crates/rttp-client/tests/test_http_async.rs
+++ b/crates/rttp-client/tests/test_http_async.rs
@@ -1515,6 +1515,46 @@ fn test_async_auto_redirect_308_post_preserves_method_body_and_body_framing() {
 
 #[test]
 #[cfg(feature = "async")]
+fn test_async_auto_redirect_307_put_preserves_method_body_and_body_framing() {
+  block_on(async {
+    let request = captured_async_redirected_put(307, "Temporary Redirect").await;
+
+    assert_eq!("PUT", request.method);
+    assert_eq!("/final?via=redirect", request.target);
+    assert_eq!(b"redirect-body", request.body.as_slice());
+    assert_eq!(
+      Some("13"),
+      request.headers.get("content-length").map(String::as_str)
+    );
+    assert_eq!(
+      Some("text/plain"),
+      request.headers.get("content-type").map(String::as_str)
+    );
+  });
+}
+
+#[test]
+#[cfg(feature = "async")]
+fn test_async_auto_redirect_308_put_preserves_method_body_and_body_framing() {
+  block_on(async {
+    let request = captured_async_redirected_put(308, "Permanent Redirect").await;
+
+    assert_eq!("PUT", request.method);
+    assert_eq!("/final?via=redirect", request.target);
+    assert_eq!(b"redirect-body", request.body.as_slice());
+    assert_eq!(
+      Some("13"),
+      request.headers.get("content-length").map(String::as_str)
+    );
+    assert_eq!(
+      Some("text/plain"),
+      request.headers.get("content-type").map(String::as_str)
+    );
+  });
+}
+
+#[test]
+#[cfg(feature = "async")]
 fn test_async_auto_redirect_resolves_absolute_location() {
   block_on(async {
     assert_async_redirect_resolves_to_target(|addr| format!("http://{}/final", addr), "/final")

--- a/crates/rttp-client/tests/test_http_basic.rs
+++ b/crates/rttp-client/tests/test_http_basic.rs
@@ -1472,6 +1472,40 @@ fn test_auto_redirect_308_post_preserves_method_body_and_body_framing() {
 }
 
 #[test]
+fn test_auto_redirect_307_put_preserves_method_body_and_body_framing() {
+  let request = captured_redirected_put(307, "Temporary Redirect");
+
+  assert_eq!("PUT", request.method);
+  assert_eq!("/final?via=redirect", request.target);
+  assert_eq!(b"redirect-body", request.body.as_slice());
+  assert_eq!(
+    Some("13"),
+    request.headers.get("content-length").map(String::as_str)
+  );
+  assert_eq!(
+    Some("text/plain"),
+    request.headers.get("content-type").map(String::as_str)
+  );
+}
+
+#[test]
+fn test_auto_redirect_308_put_preserves_method_body_and_body_framing() {
+  let request = captured_redirected_put(308, "Permanent Redirect");
+
+  assert_eq!("PUT", request.method);
+  assert_eq!("/final?via=redirect", request.target);
+  assert_eq!(b"redirect-body", request.body.as_slice());
+  assert_eq!(
+    Some("13"),
+    request.headers.get("content-length").map(String::as_str)
+  );
+  assert_eq!(
+    Some("text/plain"),
+    request.headers.get("content-type").map(String::as_str)
+  );
+}
+
+#[test]
 fn test_auto_redirect_resolves_absolute_location() {
   assert_redirect_resolves_to_target(|addr| format!("http://{}/final", addr), "/final");
 }


### PR DESCRIPTION
Added synchronous and asynchronous PUT redirect preservation tests for HTTP 307 and 308. Focused client tests and formatting checks pass; workspace-wide compilation was constrained by host disk exhaustion.

## Metadata
```yaml
version: 1
issue: default:b6f46a8e-505a-4e67-8a9f-375945516b4d
work_kind: code_work
branch: hbx-1812-rttp-client-add-redirect-loop
base: main
commit: 94320adfb710789f75fc8c78c049e7e00d5de2d8
```