### PR TITLE
feat: [rttp-test-support] Add deterministic slow-body fixtures

### DIFF
--- a/crates/rttp-client/tests/test_http_basic.rs
+++ b/crates/rttp-client/tests/test_http_basic.rs
@@ -1,9 +1,11 @@
 use rttp_test_support as support;
 
 use std::collections::HashMap;
+use std::error::Error as _;
 use std::io::{self, Cursor, Read, Write};
 use std::net::TcpListener;
 use std::thread;
+use std::time::Duration;
 
 use rttp_client::types::{Auth, Para, Proxy, RoUrl};
 use rttp_client::ConnectionReader;
@@ -912,6 +914,55 @@ fn test_content_length_response_does_not_wait_for_eof() {
 
   let response = response.unwrap();
   assert_eq!("OK", response.body().string().unwrap());
+}
+
+#[test]
+fn test_client_receives_response_body_after_fixture_releases_remaining_bytes() {
+  let fixture = support::spawn_gated_response_body(b"first ", b"second");
+  let addr = fixture.addr();
+  let client = thread::spawn(move || {
+    client()
+      .get()
+      .config(Config::builder().read_timeout(1_000))
+      .url(format!("http://{}/gated-response", addr))
+      .emit()
+      .expect("response after releasing body")
+  });
+
+  fixture
+    .wait_for_partial_body(Duration::from_secs(1))
+    .expect("fixture should send the first body chunk");
+  fixture
+    .release_body()
+    .expect("release remaining body bytes");
+
+  let response = client.join().expect("client thread");
+  assert_eq!("first second", response.body().string().unwrap());
+  fixture.join().expect("gated response server");
+}
+
+#[test]
+fn test_client_times_out_after_fixture_stalls_partial_response_body() {
+  let fixture = support::spawn_gated_response_body(b"first ", b"second");
+  let response = client()
+    .get()
+    .config(Config::builder().read_timeout(100))
+    .url(format!("http://{}/gated-response", fixture.addr()))
+    .emit();
+
+  fixture
+    .wait_for_partial_body(Duration::from_secs(1))
+    .expect("fixture should send the first body chunk");
+  let error = response.expect_err("stalled body should time out");
+  assert_eq!(
+    Some(io::ErrorKind::WouldBlock),
+    error
+      .source()
+      .and_then(|source| source.downcast_ref::<io::Error>())
+      .map(io::Error::kind)
+  );
+  fixture.cancel_body().expect("cancel stalled response body");
+  fixture.join().expect("gated response server");
 }
 
 #[test]

--- a/crates/rttp-client/tests/test_http_basic.rs
+++ b/crates/rttp-client/tests/test_http_basic.rs
@@ -954,13 +954,13 @@ fn test_client_times_out_after_fixture_stalls_partial_response_body() {
     .wait_for_partial_body(Duration::from_secs(1))
     .expect("fixture should send the first body chunk");
   let error = response.expect_err("stalled body should time out");
-  assert_eq!(
-    Some(io::ErrorKind::WouldBlock),
+  assert!(matches!(
     error
       .source()
       .and_then(|source| source.downcast_ref::<io::Error>())
-      .map(io::Error::kind)
-  );
+      .map(io::Error::kind),
+    Some(io::ErrorKind::WouldBlock | io::ErrorKind::TimedOut)
+  ));
   fixture.cancel_body().expect("cancel stalled response body");
   fixture.join().expect("gated response server");
 }

--- a/crates/rttp-test-support/src/client_helpers.rs
+++ b/crates/rttp-test-support/src/client_helpers.rs
@@ -3,6 +3,7 @@
 use std::collections::HashMap;
 use std::io::{self, Read, Write};
 use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr, TcpListener, TcpStream};
+use std::sync::mpsc::{self, Receiver, RecvTimeoutError, Sender};
 use std::thread::{self, JoinHandle};
 use std::time::Duration;
 
@@ -175,6 +176,87 @@ pub fn spawn_chunked_response_server(response: impl Into<Vec<u8>>) -> (SocketAdd
     }
   });
   (addr, handle)
+}
+
+enum GatedResponseBodyControl {
+  Release,
+  Cancel,
+}
+
+pub struct GatedResponseBody {
+  addr: SocketAddr,
+  partial_body_sent: Receiver<()>,
+  control: Sender<GatedResponseBodyControl>,
+  handle: JoinHandle<()>,
+}
+
+impl GatedResponseBody {
+  pub fn addr(&self) -> SocketAddr {
+    self.addr
+  }
+
+  pub fn wait_for_partial_body(&self, timeout: Duration) -> Result<(), RecvTimeoutError> {
+    self.partial_body_sent.recv_timeout(timeout)
+  }
+
+  pub fn release_body(&self) -> Result<(), ()> {
+    self
+      .control
+      .send(GatedResponseBodyControl::Release)
+      .map_err(|_| ())
+  }
+
+  pub fn cancel_body(&self) -> Result<(), ()> {
+    self
+      .control
+      .send(GatedResponseBodyControl::Cancel)
+      .map_err(|_| ())
+  }
+
+  pub fn join(self) -> thread::Result<()> {
+    self.handle.join()
+  }
+}
+
+pub fn spawn_gated_response_body(
+  partial_body: impl Into<Vec<u8>>,
+  remaining_body: impl Into<Vec<u8>>,
+) -> GatedResponseBody {
+  let (listener, addr) = bind_local_http_listener("gated response body server");
+  let (partial_body_sent_tx, partial_body_sent) = mpsc::channel();
+  let (control, control_rx) = mpsc::channel();
+  let partial_body = partial_body.into();
+  let remaining_body = remaining_body.into();
+  let handle = thread::spawn(move || {
+    let Ok((mut stream, _)) = listener.accept() else {
+      return;
+    };
+    let _ = read_http_request(&mut stream);
+    let response_head = format!(
+      "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+      partial_body.len() + remaining_body.len()
+    );
+    if stream.write_all(response_head.as_bytes()).is_err()
+      || stream.write_all(&partial_body).is_err()
+      || stream.flush().is_err()
+    {
+      return;
+    }
+    if partial_body_sent_tx.send(()).is_err() {
+      return;
+    }
+    if matches!(control_rx.recv(), Ok(GatedResponseBodyControl::Release)) {
+      let _ = stream.write_all(&remaining_body);
+      let _ = stream.flush();
+    }
+  });
+
+  GatedResponseBody {
+    addr,
+    partial_body_sent,
+    control,
+    handle,
+  }
 }
 
 pub fn spawn_chunked_server_without_trailers() -> (SocketAddr, JoinHandle<()>) {


### PR DESCRIPTION
Added deterministic gated response-body test support and client coverage for partial delivery plus stalled-body timeout behavior. Full workspace tests and formatting checks pass.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1813/
work_kind: code_work
branch: hbx-1813-rttp-test-support-add-deterministic
base: main
commit: 4f1b7487110e823741a03d2fcb9f10e2906d54cc
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1813/
    url: https://plane.kahub.in/endless/browse/HBX-1813/
    close_policy: link_only
```