### PR TITLE
feat: [rttp-protocol] Add bounded RateLimit response header parsers

### DIFF
--- a/crates/rttp-protocol/Cargo.toml
+++ b/crates/rttp-protocol/Cargo.toml
@@ -22,3 +22,4 @@ path = "src/lib.rs"
 [dependencies]
 base64 = "0.22"
 httpdate = "1.0"
+sfv = "0.15.0"

--- a/crates/rttp-protocol/src/lib.rs
+++ b/crates/rttp-protocol/src/lib.rs
@@ -19,6 +19,7 @@ mod media_type;
 pub mod prefer;
 pub mod priority;
 pub mod range;
+pub mod rate_limit;
 pub mod server_timing;
 pub mod sunset;
 pub mod trailer;

--- a/crates/rttp-protocol/src/rate_limit.rs
+++ b/crates/rttp-protocol/src/rate_limit.rs
@@ -6,12 +6,93 @@
 use std::error::Error;
 use std::fmt;
 
+use sfv::{BareItem, List, ListEntry, Parser};
+
 pub const MAX_RATE_LIMIT_VALUE_BYTES: usize = 64 * 1024;
 pub const MAX_RATE_LIMIT_LIMIT_VALUE_BYTES: usize = MAX_RATE_LIMIT_VALUE_BYTES;
 pub const MAX_RATE_LIMIT_REMAINING_VALUE_BYTES: usize = MAX_RATE_LIMIT_VALUE_BYTES;
 pub const MAX_RATE_LIMIT_RESET_VALUE_BYTES: usize = MAX_RATE_LIMIT_VALUE_BYTES;
 
-macro_rules! rate_limit_value {
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct RateLimitLimit(Vec<RateLimitLimitItem>);
+
+impl RateLimitLimit {
+  pub fn new(items: impl IntoIterator<Item = RateLimitLimitItem>) -> Self {
+    Self(items.into_iter().collect())
+  }
+
+  pub fn parse(value: impl AsRef<str>) -> Result<Self, RateLimitParseError> {
+    Self::parse_values([value.as_ref()])
+  }
+
+  pub fn parse_values<'a, I>(values: I) -> Result<Self, RateLimitParseError>
+  where
+    I: IntoIterator<Item = &'a str>,
+  {
+    let values = collect_list_values(values, "RateLimit-Limit", MAX_RATE_LIMIT_LIMIT_VALUE_BYTES)?;
+    let values = Parser::new(trim_ows(&values))
+      .parse::<List>()
+      .map_err(|_| invalid_value("RateLimit-Limit"))?;
+    if values.is_empty() {
+      return Err(invalid_value("RateLimit-Limit"));
+    }
+    let items = values
+      .into_iter()
+      .map(parse_limit_item)
+      .collect::<Result<_, _>>()?;
+    Ok(Self(items))
+  }
+
+  pub fn items(&self) -> &[RateLimitLimitItem] {
+    &self.0
+  }
+
+  pub fn header_value(&self) -> String {
+    self
+      .0
+      .iter()
+      .map(RateLimitLimitItem::header_value)
+      .collect::<Vec<_>>()
+      .join(", ")
+  }
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub struct RateLimitLimitItem {
+  value: u64,
+  window: Option<u64>,
+}
+
+impl RateLimitLimitItem {
+  pub const fn new(value: u64) -> Self {
+    Self {
+      value,
+      window: None,
+    }
+  }
+
+  pub const fn with_window(mut self, window: u64) -> Self {
+    self.window = Some(window);
+    self
+  }
+
+  pub const fn value(self) -> u64 {
+    self.value
+  }
+
+  pub const fn window(self) -> Option<u64> {
+    self.window
+  }
+
+  fn header_value(&self) -> String {
+    match self.window {
+      Some(window) => format!("{};w={window}", self.value),
+      None => self.value.to_string(),
+    }
+  }
+}
+
+macro_rules! rate_limit_singleton_value {
   ($doc:literal, $name:ident, $header_name:literal, $max_value_bytes:ident) => {
     #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
     #[doc = $doc]
@@ -44,19 +125,13 @@ macro_rules! rate_limit_value {
   };
 }
 
-rate_limit_value!(
-  "The limit declared by the `RateLimit-Limit` response header.",
-  RateLimitLimit,
-  "RateLimit-Limit",
-  MAX_RATE_LIMIT_LIMIT_VALUE_BYTES
-);
-rate_limit_value!(
+rate_limit_singleton_value!(
   "The remaining quota declared by the `RateLimit-Remaining` response header.",
   RateLimitRemaining,
   "RateLimit-Remaining",
   MAX_RATE_LIMIT_REMAINING_VALUE_BYTES
 );
-rate_limit_value!(
+rate_limit_singleton_value!(
   "The seconds until reset declared by the `RateLimit-Reset` response header.",
   RateLimitReset,
   "RateLimit-Reset",
@@ -109,7 +184,57 @@ where
   if value.is_empty() || value.bytes().any(|byte| !byte.is_ascii_digit()) {
     return Err(invalid_value(header_name));
   }
-  value.parse().map_err(|_| invalid_value(header_name))
+  parse_structured_integer(value, header_name)
+}
+
+fn collect_list_values<'a, I>(
+  values: I,
+  header_name: &str,
+  max_value_bytes: usize,
+) -> Result<String, RateLimitParseError>
+where
+  I: IntoIterator<Item = &'a str>,
+{
+  let mut values = values.into_iter();
+  let value = values.next().ok_or_else(|| invalid_value(header_name))?;
+  validate_bounded_value(value, header_name, max_value_bytes)?;
+  let mut combined = value.to_owned();
+  for value in values {
+    validate_bounded_value(value, header_name, max_value_bytes)?;
+    combined.push(',');
+    combined.push_str(value);
+  }
+  Ok(combined)
+}
+
+fn parse_limit_item(value: ListEntry) -> Result<RateLimitLimitItem, RateLimitParseError> {
+  let ListEntry::Item(item) = value else {
+    return Err(invalid_value("RateLimit-Limit"));
+  };
+  let value = parse_structured_bare_integer(item.bare_item, "RateLimit-Limit")?;
+  let window = item
+    .params
+    .get("w")
+    .map(|value| parse_structured_bare_integer(value.clone(), "RateLimit-Limit"))
+    .transpose()?;
+  Ok(RateLimitLimitItem { value, window })
+}
+
+fn parse_structured_integer(value: &str, header_name: &str) -> Result<u64, RateLimitParseError> {
+  let value = Parser::new(trim_ows(value))
+    .parse::<sfv::Item>()
+    .map_err(|_| invalid_value(header_name))?;
+  parse_structured_bare_integer(value.bare_item, header_name)
+}
+
+fn parse_structured_bare_integer(
+  value: BareItem,
+  header_name: &str,
+) -> Result<u64, RateLimitParseError> {
+  let BareItem::Integer(value) = value else {
+    return Err(invalid_value(header_name));
+  };
+  u64::try_from(value).map_err(|_| invalid_value(header_name))
 }
 
 fn validate_bounded_value(

--- a/crates/rttp-protocol/src/rate_limit.rs
+++ b/crates/rttp-protocol/src/rate_limit.rs
@@ -1,0 +1,134 @@
+//! Bounded, policy-free `RateLimit-*` response metadata parsing.
+//!
+//! This module validates the standardized response field values only. Callers
+//! decide whether and how to apply rate-limit behavior.
+
+use std::error::Error;
+use std::fmt;
+
+pub const MAX_RATE_LIMIT_VALUE_BYTES: usize = 64 * 1024;
+pub const MAX_RATE_LIMIT_LIMIT_VALUE_BYTES: usize = MAX_RATE_LIMIT_VALUE_BYTES;
+pub const MAX_RATE_LIMIT_REMAINING_VALUE_BYTES: usize = MAX_RATE_LIMIT_VALUE_BYTES;
+pub const MAX_RATE_LIMIT_RESET_VALUE_BYTES: usize = MAX_RATE_LIMIT_VALUE_BYTES;
+
+macro_rules! rate_limit_value {
+  ($doc:literal, $name:ident, $header_name:literal, $max_value_bytes:ident) => {
+    #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+    #[doc = $doc]
+    pub struct $name(u64);
+
+    impl $name {
+      pub const fn new(value: u64) -> Self {
+        Self(value)
+      }
+
+      pub fn parse(value: impl AsRef<str>) -> Result<Self, RateLimitParseError> {
+        Self::parse_values([value.as_ref()])
+      }
+
+      pub fn parse_values<'a, I>(values: I) -> Result<Self, RateLimitParseError>
+      where
+        I: IntoIterator<Item = &'a str>,
+      {
+        parse_singleton(values, $header_name, $max_value_bytes).map(Self)
+      }
+
+      pub const fn value(self) -> u64 {
+        self.0
+      }
+
+      pub fn header_value(self) -> String {
+        self.0.to_string()
+      }
+    }
+  };
+}
+
+rate_limit_value!(
+  "The limit declared by the `RateLimit-Limit` response header.",
+  RateLimitLimit,
+  "RateLimit-Limit",
+  MAX_RATE_LIMIT_LIMIT_VALUE_BYTES
+);
+rate_limit_value!(
+  "The remaining quota declared by the `RateLimit-Remaining` response header.",
+  RateLimitRemaining,
+  "RateLimit-Remaining",
+  MAX_RATE_LIMIT_REMAINING_VALUE_BYTES
+);
+rate_limit_value!(
+  "The seconds until reset declared by the `RateLimit-Reset` response header.",
+  RateLimitReset,
+  "RateLimit-Reset",
+  MAX_RATE_LIMIT_RESET_VALUE_BYTES
+);
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RateLimitParseError {
+  message: String,
+}
+
+pub type RateLimitLimitParseError = RateLimitParseError;
+pub type RateLimitRemainingParseError = RateLimitParseError;
+pub type RateLimitResetParseError = RateLimitParseError;
+
+impl RateLimitParseError {
+  fn new(message: impl Into<String>) -> Self {
+    Self {
+      message: message.into(),
+    }
+  }
+}
+
+impl fmt::Display for RateLimitParseError {
+  fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+    formatter.write_str(&self.message)
+  }
+}
+
+impl Error for RateLimitParseError {}
+
+fn parse_singleton<'a, I>(
+  values: I,
+  header_name: &str,
+  max_value_bytes: usize,
+) -> Result<u64, RateLimitParseError>
+where
+  I: IntoIterator<Item = &'a str>,
+{
+  let mut values = values.into_iter();
+  let value = values.next().ok_or_else(|| invalid_value(header_name))?;
+  validate_bounded_value(value, header_name, max_value_bytes)?;
+  if let Some(duplicate) = values.next() {
+    validate_bounded_value(duplicate, header_name, max_value_bytes)?;
+    return Err(RateLimitParseError::new(format!(
+      "duplicate {header_name} header fields"
+    )));
+  }
+  let value = trim_ows(value);
+  if value.is_empty() || value.bytes().any(|byte| !byte.is_ascii_digit()) {
+    return Err(invalid_value(header_name));
+  }
+  value.parse().map_err(|_| invalid_value(header_name))
+}
+
+fn validate_bounded_value(
+  value: &str,
+  header_name: &str,
+  max_value_bytes: usize,
+) -> Result<(), RateLimitParseError> {
+  if value.len() > max_value_bytes {
+    return Err(RateLimitParseError::new(format!(
+      "{header_name} header value is too large"
+    )));
+  }
+  Ok(())
+}
+
+fn invalid_value(header_name: &str) -> RateLimitParseError {
+  RateLimitParseError::new(format!("invalid {header_name} header value"))
+}
+
+fn trim_ows(value: &str) -> &str {
+  value.trim_matches([' ', '\t'])
+}

--- a/crates/rttp-protocol/tests/rate_limit.rs
+++ b/crates/rttp-protocol/tests/rate_limit.rs
@@ -1,6 +1,7 @@
 use rttp_protocol::rate_limit::{
-  RateLimitLimit, RateLimitLimitParseError, RateLimitRemaining, RateLimitRemainingParseError,
-  RateLimitReset, RateLimitResetParseError, MAX_RATE_LIMIT_VALUE_BYTES,
+  RateLimitLimit, RateLimitLimitItem, RateLimitLimitParseError, RateLimitRemaining,
+  RateLimitRemainingParseError, RateLimitReset, RateLimitResetParseError,
+  MAX_RATE_LIMIT_VALUE_BYTES,
 };
 
 #[test]
@@ -11,15 +12,22 @@ fn rate_limit_exposes_per_header_parse_error_aliases() {
 }
 
 #[test]
-fn rate_limit_parses_singleton_response_values() {
-  let limit = RateLimitLimit::parse("100").expect("RateLimit-Limit should parse");
+fn rate_limit_parses_response_values() {
+  let limit =
+    RateLimitLimit::parse("100, 50;w=3600").expect("RateLimit-Limit structured list should parse");
   let remaining = RateLimitRemaining::parse("42").expect("RateLimit-Remaining should parse");
   let reset = RateLimitReset::parse("60").expect("RateLimit-Reset should parse");
 
-  assert_eq!(limit.value(), 100);
+  assert_eq!(
+    limit.items(),
+    &[
+      RateLimitLimitItem::new(100),
+      RateLimitLimitItem::new(50).with_window(3600),
+    ]
+  );
   assert_eq!(remaining.value(), 42);
   assert_eq!(reset.value(), 60);
-  assert_eq!(limit.header_value(), "100");
+  assert_eq!(limit.header_value(), "100, 50;w=3600");
   assert_eq!(remaining.header_value(), "42");
   assert_eq!(reset.header_value(), "60");
 }
@@ -27,8 +35,8 @@ fn rate_limit_parses_singleton_response_values() {
 #[test]
 fn rate_limit_trims_optional_whitespace() {
   assert_eq!(
-    RateLimitLimit::parse(" \t100\t ").expect("whitespace is allowed"),
-    RateLimitLimit::new(100)
+    RateLimitLimit::parse(" \t100;w=60\t ").expect("whitespace is allowed"),
+    RateLimitLimit::new([RateLimitLimitItem::new(100).with_window(60)])
   );
   assert_eq!(
     RateLimitRemaining::parse(" 42 ").expect("whitespace is allowed"),
@@ -48,7 +56,7 @@ fn rate_limit_rejects_malformed_numeric_values() {
     "+1",
     "1.5",
     "one",
-    "18446744073709551616",
+    "1000000000000000",
     "1\r\nX: y",
   ] {
     assert!(
@@ -67,30 +75,37 @@ fn rate_limit_rejects_malformed_numeric_values() {
 }
 
 #[test]
-fn rate_limit_rejects_duplicate_and_list_values() {
-  assert!(RateLimitLimit::parse("100, 50").is_err());
+fn rate_limit_rejects_invalid_list_and_duplicate_values() {
+  assert!(RateLimitLimit::parse("100, (50)").is_err());
   assert!(RateLimitRemaining::parse("42, 21").is_err());
   assert!(RateLimitReset::parse("60, 30").is_err());
 
-  assert!(RateLimitLimit::parse_values(["100", "50"]).is_err());
+  assert_eq!(
+    RateLimitLimit::parse_values(["100", "50;w=3600"])
+      .expect("multiple header fields form one structured list"),
+    RateLimitLimit::new([
+      RateLimitLimitItem::new(100),
+      RateLimitLimitItem::new(50).with_window(3600),
+    ])
+  );
   assert!(RateLimitRemaining::parse_values(["42", "21"]).is_err());
   assert!(RateLimitReset::parse_values(["60", "30"]).is_err());
 }
 
 #[test]
-fn rate_limit_stops_after_the_first_duplicate_field() {
-  let mut values = ["100", "50", "must not be inspected"].into_iter();
+fn rate_limit_combines_all_list_fields() {
+  let mut values = ["100", "50"].into_iter();
   let mut calls = 0;
 
-  assert!(RateLimitLimit::parse_values(std::iter::from_fn(|| {
-    calls += 1;
-    assert!(
-      calls <= 2,
-      "parser must not inspect fields after a duplicate"
-    );
-    values.next()
-  }))
-  .is_err());
+  assert_eq!(
+    RateLimitLimit::parse_values(std::iter::from_fn(|| {
+      calls += 1;
+      assert!(calls <= 3, "parser must inspect every list field");
+      values.next()
+    }))
+    .expect("multiple fields form one structured list"),
+    RateLimitLimit::new([RateLimitLimitItem::new(100), RateLimitLimitItem::new(50),])
+  );
 }
 
 #[test]

--- a/crates/rttp-protocol/tests/rate_limit.rs
+++ b/crates/rttp-protocol/tests/rate_limit.rs
@@ -1,0 +1,108 @@
+use rttp_protocol::rate_limit::{
+  RateLimitLimit, RateLimitLimitParseError, RateLimitRemaining, RateLimitRemainingParseError,
+  RateLimitReset, RateLimitResetParseError, MAX_RATE_LIMIT_VALUE_BYTES,
+};
+
+#[test]
+fn rate_limit_exposes_per_header_parse_error_aliases() {
+  let _: Result<RateLimitLimit, RateLimitLimitParseError> = RateLimitLimit::parse("100");
+  let _: Result<RateLimitRemaining, RateLimitRemainingParseError> = RateLimitRemaining::parse("42");
+  let _: Result<RateLimitReset, RateLimitResetParseError> = RateLimitReset::parse("60");
+}
+
+#[test]
+fn rate_limit_parses_singleton_response_values() {
+  let limit = RateLimitLimit::parse("100").expect("RateLimit-Limit should parse");
+  let remaining = RateLimitRemaining::parse("42").expect("RateLimit-Remaining should parse");
+  let reset = RateLimitReset::parse("60").expect("RateLimit-Reset should parse");
+
+  assert_eq!(limit.value(), 100);
+  assert_eq!(remaining.value(), 42);
+  assert_eq!(reset.value(), 60);
+  assert_eq!(limit.header_value(), "100");
+  assert_eq!(remaining.header_value(), "42");
+  assert_eq!(reset.header_value(), "60");
+}
+
+#[test]
+fn rate_limit_trims_optional_whitespace() {
+  assert_eq!(
+    RateLimitLimit::parse(" \t100\t ").expect("whitespace is allowed"),
+    RateLimitLimit::new(100)
+  );
+  assert_eq!(
+    RateLimitRemaining::parse(" 42 ").expect("whitespace is allowed"),
+    RateLimitRemaining::new(42)
+  );
+  assert_eq!(
+    RateLimitReset::parse("\t60 ").expect("whitespace is allowed"),
+    RateLimitReset::new(60)
+  );
+}
+
+#[test]
+fn rate_limit_rejects_malformed_numeric_values() {
+  for value in [
+    "",
+    "-1",
+    "+1",
+    "1.5",
+    "one",
+    "18446744073709551616",
+    "1\r\nX: y",
+  ] {
+    assert!(
+      RateLimitLimit::parse(value).is_err(),
+      "{value:?} must be rejected"
+    );
+    assert!(
+      RateLimitRemaining::parse(value).is_err(),
+      "{value:?} must be rejected"
+    );
+    assert!(
+      RateLimitReset::parse(value).is_err(),
+      "{value:?} must be rejected"
+    );
+  }
+}
+
+#[test]
+fn rate_limit_rejects_duplicate_and_list_values() {
+  assert!(RateLimitLimit::parse("100, 50").is_err());
+  assert!(RateLimitRemaining::parse("42, 21").is_err());
+  assert!(RateLimitReset::parse("60, 30").is_err());
+
+  assert!(RateLimitLimit::parse_values(["100", "50"]).is_err());
+  assert!(RateLimitRemaining::parse_values(["42", "21"]).is_err());
+  assert!(RateLimitReset::parse_values(["60", "30"]).is_err());
+}
+
+#[test]
+fn rate_limit_stops_after_the_first_duplicate_field() {
+  let mut values = ["100", "50", "must not be inspected"].into_iter();
+  let mut calls = 0;
+
+  assert!(RateLimitLimit::parse_values(std::iter::from_fn(|| {
+    calls += 1;
+    assert!(
+      calls <= 2,
+      "parser must not inspect fields after a duplicate"
+    );
+    values.next()
+  }))
+  .is_err());
+}
+
+#[test]
+fn rate_limit_enforces_value_bounds_for_every_field() {
+  let oversized = "1".repeat(MAX_RATE_LIMIT_VALUE_BYTES + 1);
+
+  assert!(RateLimitLimit::parse(&oversized).is_err());
+  assert!(RateLimitRemaining::parse(&oversized).is_err());
+  assert!(RateLimitReset::parse(&oversized).is_err());
+
+  assert!(
+    RateLimitLimit::parse_values(["100", oversized.as_str()]).is_err(),
+    "an oversized duplicate must not bypass validation"
+  );
+}


### PR DESCRIPTION
Added bounded, allocation-conscious protocol parsers for RateLimit-Limit, RateLimit-Remaining, and RateLimit-Reset, including typed values and compatible per-header parse errors. Workspace tests, formatting, and Clippy pass.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1808/
work_kind: code_work
branch: hbx-1808-rttp-protocol-add-bounded-ratelimit
base: main
commit: 2a07a031c41494873cad6b72abdd54e5223d38de
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1808/
    url: https://plane.kahub.in/endless/browse/HBX-1808/
    close_policy: link_only
```