### PR TITLE
feat: [rttp-protocol] Add bounded Vary header parser

### DIFF
--- a/crates/rttp-protocol/src/lib.rs
+++ b/crates/rttp-protocol/src/lib.rs
@@ -22,4 +22,5 @@ pub mod range;
 pub mod server_timing;
 pub mod sunset;
 pub mod trailer;
+pub mod vary;
 pub mod www_authenticate;

--- a/crates/rttp-protocol/src/vary.rs
+++ b/crates/rttp-protocol/src/vary.rs
@@ -1,0 +1,130 @@
+use std::error::Error;
+use std::fmt;
+
+pub const MAX_VARY_VALUE_BYTES: usize = 64 * 1024;
+pub const MAX_VARY_FIELD_NAMES: usize = 256;
+
+/// Parsed, bounded `Vary` response metadata.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Vary {
+  any: bool,
+  field_names: Vec<String>,
+}
+
+impl Vary {
+  pub fn parse(value: impl AsRef<str>) -> Result<Self, VaryParseError> {
+    Self::parse_values([value.as_ref()])
+  }
+
+  pub fn parse_values<'a, I>(values: I) -> Result<Self, VaryParseError>
+  where
+    I: IntoIterator<Item = &'a str>,
+  {
+    let mut any = false;
+    let mut field_names = Vec::new();
+    let mut field_count = 0usize;
+
+    for value in values {
+      if value.len() > MAX_VARY_VALUE_BYTES {
+        return Err(VaryParseError::new("Vary header value is too large"));
+      }
+      for member in value.split(',') {
+        let field_name = member.trim();
+        if field_name == "*" {
+          if any || field_count != 0 {
+            return Err(VaryParseError::new("invalid Vary field name"));
+          }
+          any = true;
+          continue;
+        }
+        if any || !is_http_token(field_name) {
+          return Err(VaryParseError::new("invalid Vary field name"));
+        }
+        field_count += 1;
+        if field_count > MAX_VARY_FIELD_NAMES {
+          return Err(VaryParseError::new("too many Vary field names"));
+        }
+        let normalized = field_name.to_ascii_lowercase();
+        if !field_names.contains(&normalized) {
+          field_names.push(normalized);
+        }
+      }
+    }
+
+    if !any && field_names.is_empty() {
+      return Err(VaryParseError::new("invalid Vary field name"));
+    }
+    Ok(Self { any, field_names })
+  }
+
+  pub fn is_any(&self) -> bool {
+    self.any
+  }
+
+  pub fn field_names(&self) -> Vec<&str> {
+    self.field_names.iter().map(String::as_str).collect()
+  }
+
+  pub fn len(&self) -> usize {
+    self.field_names.len()
+  }
+
+  pub fn is_empty(&self) -> bool {
+    self.field_names.is_empty()
+  }
+
+  pub fn header_value(&self) -> String {
+    if self.any {
+      "*".to_owned()
+    } else {
+      self.field_names.join(", ")
+    }
+  }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct VaryParseError {
+  message: String,
+}
+
+impl VaryParseError {
+  fn new(message: impl Into<String>) -> Self {
+    Self {
+      message: message.into(),
+    }
+  }
+}
+
+impl fmt::Display for VaryParseError {
+  fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+    formatter.write_str(&self.message)
+  }
+}
+
+impl Error for VaryParseError {}
+
+fn is_http_token(value: &str) -> bool {
+  !value.is_empty() && value.bytes().all(is_http_token_byte)
+}
+
+fn is_http_token_byte(byte: u8) -> bool {
+  byte.is_ascii_alphanumeric()
+    || matches!(
+      byte,
+      b'!'
+        | b'#'
+        | b'$'
+        | b'%'
+        | b'&'
+        | b'\''
+        | b'*'
+        | b'+'
+        | b'-'
+        | b'.'
+        | b'^'
+        | b'_'
+        | b'`'
+        | b'|'
+        | b'~'
+    )
+}

--- a/crates/rttp-protocol/src/vary.rs
+++ b/crates/rttp-protocol/src/vary.rs
@@ -28,8 +28,11 @@ impl Vary {
       if value.len() > MAX_VARY_VALUE_BYTES {
         return Err(VaryParseError::new("Vary header value is too large"));
       }
+      if value.bytes().any(is_invalid_control_byte) {
+        return Err(VaryParseError::new("invalid Vary control byte"));
+      }
       for member in value.split(',') {
-        let field_name = member.trim();
+        let field_name = member.trim_matches([' ', '\t']);
         if field_name == "*" {
           if any || field_count != 0 {
             return Err(VaryParseError::new("invalid Vary field name"));
@@ -105,6 +108,10 @@ impl Error for VaryParseError {}
 
 fn is_http_token(value: &str) -> bool {
   !value.is_empty() && value.bytes().all(is_http_token_byte)
+}
+
+fn is_invalid_control_byte(byte: u8) -> bool {
+  byte != b'\t' && (byte <= 0x1f || byte == 0x7f)
 }
 
 fn is_http_token_byte(byte: u8) -> bool {

--- a/crates/rttp-protocol/src/vary.rs
+++ b/crates/rttp-protocol/src/vary.rs
@@ -34,7 +34,7 @@ impl Vary {
       for member in value.split(',') {
         let field_name = member.trim_matches([' ', '\t']);
         if field_name == "*" {
-          if any || field_count != 0 {
+          if field_count != 0 {
             return Err(VaryParseError::new("invalid Vary field name"));
           }
           any = true;

--- a/crates/rttp-protocol/tests/vary.rs
+++ b/crates/rttp-protocol/tests/vary.rs
@@ -46,6 +46,11 @@ fn vary_rejects_empty_members() {
 }
 
 #[test]
+fn vary_rejects_control_bytes() {
+  assert!(Vary::parse("\rAccept-Encoding").is_err());
+}
+
+#[test]
 fn vary_deduplicates_field_names_case_insensitively() {
   let vary = Vary::parse("Accept-Encoding, accept-encoding, ACCEPT-ENCODING")
     .expect("duplicate Vary field names are valid");

--- a/crates/rttp-protocol/tests/vary.rs
+++ b/crates/rttp-protocol/tests/vary.rs
@@ -1,0 +1,64 @@
+use rttp_protocol::vary::{Vary, MAX_VARY_FIELD_NAMES};
+
+#[test]
+fn vary_parses_wildcard() {
+  let vary = Vary::parse("*").expect("valid wildcard Vary");
+
+  assert!(vary.is_any());
+  assert_eq!(Vec::<&str>::new(), vary.field_names());
+  assert_eq!("*", vary.header_value());
+}
+
+#[test]
+fn vary_normalizes_singleton_field_names_case_insensitively() {
+  let vary = Vary::parse("Accept-Language").expect("valid Vary field name");
+
+  assert!(!vary.is_any());
+  assert_eq!(vec!["accept-language"], vary.field_names());
+  assert_eq!("accept-language", vary.header_value());
+}
+
+#[test]
+fn vary_parses_comma_lists_and_optional_whitespace() {
+  let vary = Vary::parse_values([" Accept-Encoding , Accept-Language ", "User-Agent"])
+    .expect("valid Vary field names");
+
+  assert_eq!(
+    vec!["accept-encoding", "accept-language", "user-agent"],
+    vary.field_names()
+  );
+  assert_eq!(
+    "accept-encoding, accept-language, user-agent",
+    vary.header_value()
+  );
+}
+
+#[test]
+fn vary_rejects_empty_members() {
+  for value in [
+    "",
+    "Accept-Encoding,",
+    ",Accept-Encoding",
+    "Accept-Encoding,,User-Agent",
+  ] {
+    assert!(Vary::parse(value).is_err(), "{value:?} must be rejected");
+  }
+}
+
+#[test]
+fn vary_deduplicates_field_names_case_insensitively() {
+  let vary = Vary::parse("Accept-Encoding, accept-encoding, ACCEPT-ENCODING")
+    .expect("duplicate Vary field names are valid");
+
+  assert_eq!(vec!["accept-encoding"], vary.field_names());
+  assert_eq!("accept-encoding", vary.header_value());
+}
+
+#[test]
+fn vary_rejects_field_name_list_overflow() {
+  let too_many = std::iter::repeat_n("Accept-Encoding", MAX_VARY_FIELD_NAMES + 1)
+    .collect::<Vec<_>>()
+    .join(",");
+
+  assert!(Vary::parse(too_many).is_err());
+}

--- a/crates/rttp-protocol/tests/vary.rs
+++ b/crates/rttp-protocol/tests/vary.rs
@@ -10,6 +10,24 @@ fn vary_parses_wildcard() {
 }
 
 #[test]
+fn vary_deduplicates_wildcards_across_values() {
+  let vary = Vary::parse_values(["*", "*"]).expect("duplicate wildcard Vary");
+
+  assert!(vary.is_any());
+  assert_eq!(Vec::<&str>::new(), vary.field_names());
+  assert_eq!("*", vary.header_value());
+}
+
+#[test]
+fn vary_deduplicates_wildcards_in_a_comma_list() {
+  let vary = Vary::parse("*, *").expect("duplicate wildcard Vary");
+
+  assert!(vary.is_any());
+  assert_eq!(Vec::<&str>::new(), vary.field_names());
+  assert_eq!("*", vary.header_value());
+}
+
+#[test]
 fn vary_normalizes_singleton_field_names_case_insensitively() {
   let vary = Vary::parse("Accept-Language").expect("valid Vary field name");
 


### PR DESCRIPTION
Added a bounded `Vary` response-header parser to rttp-protocol with canonical lowercase field names, wildcard support, duplicate elimination, strict empty-member and control-byte rejection, and list/value limits. Test coverage includes the requested parsing and overflow cases; workspace formatting and tests pass.

## Metadata
```yaml
version: 1
issue: default:9ea881c6-509c-45eb-970d-65565b085ca9
work_kind: code_work
branch: hbx-1814-rttp-protocol-add-bounded-vary
base: main
commit: ad92546e493cd3fa37f9913e83577261bdf11097
```