### PR TITLE
feat: [rttp-http2] Add GOAWAY and RST_STREAM diagnostic coverage

### DIFF
--- a/crates/rttp-client/src/http2.rs
+++ b/crates/rttp-client/src/http2.rs
@@ -1114,11 +1114,7 @@ fn read_until_send_window_available(
       }
       (FRAME_RST_STREAM, id) if id == stream_id => {
         let error_code = rst_stream_error_code(&frame)?;
-        return Err(error::bad_response(format!(
-          "HTTP/2 stream received RST_STREAM error code {} ({})",
-          error_code,
-          http2_error_code_name(error_code),
-        )));
+        return Err(response_stream_reset_error(error_code, false));
       }
       (FRAME_RST_STREAM, _) => {
         rst_stream_error_code(&frame)?;
@@ -1487,6 +1483,7 @@ fn read_single_stream_response_with_first_frame(
   let mut pending_header_block = None;
   let mut final_response_started = false;
   let mut response_body_started = false;
+  let mut goaway_received = false;
   let mut hpack = HpackDecoder::new(local_settings.header_table_size);
   let mut connection_receive_window = ReceiveWindow::new();
   let mut stream_receive_window = ReceiveWindow::new();
@@ -1500,6 +1497,12 @@ fn read_single_stream_response_with_first_frame(
         Ok(frame) => frame,
         Err(err) if pending_header_block.is_some() && is_unexpected_eof(&err) => {
           return Err(error::bad_response("incomplete HTTP/2 header block"));
+        }
+        Err(err) if is_unexpected_eof(&err) => {
+          return Err(response_connection_abort_error(
+            response_body_started,
+            goaway_received,
+          ));
         }
         Err(err) => return Err(err),
       },
@@ -1611,11 +1614,10 @@ fn read_single_stream_response_with_first_frame(
       }
       (FRAME_RST_STREAM, id) if id == stream_id => {
         let error_code = rst_stream_error_code(&frame)?;
-        return Err(error::bad_response(format!(
-          "HTTP/2 stream received RST_STREAM error code {} ({})",
+        return Err(response_stream_reset_error(
           error_code,
-          http2_error_code_name(error_code),
-        )));
+          response_body_started,
+        ));
       }
       (FRAME_RST_STREAM, _) => {
         rst_stream_error_code(&frame)?;
@@ -1636,6 +1638,7 @@ fn read_single_stream_response_with_first_frame(
             http2_error_code_name(goaway.error_code),
           )));
         }
+        goaway_received = true;
       }
       (_, id) if id == stream_id => {}
       (FRAME_CONTINUATION, _) => {
@@ -1802,6 +1805,37 @@ fn rst_stream_error_code(frame: &Frame) -> error::Result<u32> {
     frame.payload[2],
     frame.payload[3],
   ]))
+}
+
+fn response_stream_reset_error(error_code: u32, response_body_started: bool) -> error::Error {
+  let phase = if response_body_started {
+    "during response body"
+  } else {
+    "before response body"
+  };
+  error::bad_response(format!(
+    "HTTP/2 stream reset {}: RST_STREAM error code {} ({})",
+    phase,
+    error_code,
+    http2_error_code_name(error_code),
+  ))
+}
+
+fn response_connection_abort_error(
+  response_body_started: bool,
+  goaway_received: bool,
+) -> error::Error {
+  let phase = if response_body_started {
+    "during response body"
+  } else {
+    "before response body"
+  };
+  let shutdown = if goaway_received {
+    "after GOAWAY without RST_STREAM"
+  } else {
+    "without GOAWAY or RST_STREAM"
+  };
+  error::bad_response(format!("HTTP/2 connection aborted {} {}", phase, shutdown,))
 }
 
 fn http2_error_code_name(error_code: u32) -> &'static str {

--- a/crates/rttp-client/src/http2.rs
+++ b/crates/rttp-client/src/http2.rs
@@ -1483,7 +1483,7 @@ fn read_single_stream_response_with_first_frame(
   let mut pending_header_block = None;
   let mut final_response_started = false;
   let mut response_body_started = false;
-  let mut goaway_received = false;
+  let mut goaway = None;
   let mut hpack = HpackDecoder::new(local_settings.header_table_size);
   let mut connection_receive_window = ReceiveWindow::new();
   let mut stream_receive_window = ReceiveWindow::new();
@@ -1501,7 +1501,7 @@ fn read_single_stream_response_with_first_frame(
         Err(err) if is_unexpected_eof(&err) => {
           return Err(response_connection_abort_error(
             response_body_started,
-            goaway_received,
+            goaway.as_ref(),
           ));
         }
         Err(err) => return Err(err),
@@ -1629,16 +1629,16 @@ fn read_single_stream_response_with_first_frame(
         return Err(error::bad_response("invalid HTTP/2 PING frame"));
       }
       (FRAME_GOAWAY, _) => {
-        let goaway = goaway_metadata(&frame)?;
-        if goaway.last_stream_id < stream_id {
+        let received_goaway = goaway_metadata(&frame)?;
+        if received_goaway.last_stream_id < stream_id {
           return Err(error::bad_response(format!(
             "HTTP/2 connection received GOAWAY last stream ID {} with error code {} ({})",
-            goaway.last_stream_id,
-            goaway.error_code,
-            http2_error_code_name(goaway.error_code),
+            received_goaway.last_stream_id,
+            received_goaway.error_code,
+            http2_error_code_name(received_goaway.error_code),
           )));
         }
-        goaway_received = true;
+        goaway = Some(received_goaway);
       }
       (_, id) if id == stream_id => {}
       (FRAME_CONTINUATION, _) => {
@@ -1823,17 +1823,21 @@ fn response_stream_reset_error(error_code: u32, response_body_started: bool) -> 
 
 fn response_connection_abort_error(
   response_body_started: bool,
-  goaway_received: bool,
+  goaway: Option<&GoawayMetadata>,
 ) -> error::Error {
   let phase = if response_body_started {
     "during response body"
   } else {
     "before response body"
   };
-  let shutdown = if goaway_received {
-    "after GOAWAY without RST_STREAM"
+  let shutdown = if let Some(goaway) = goaway {
+    format!(
+      "after GOAWAY error code {} ({}) without RST_STREAM",
+      goaway.error_code,
+      http2_error_code_name(goaway.error_code),
+    )
   } else {
-    "without GOAWAY or RST_STREAM"
+    "without GOAWAY or RST_STREAM".to_string()
   };
   error::bad_response(format!("HTTP/2 connection aborted {} {}", phase, shutdown,))
 }

--- a/crates/rttp-client/tests/http2_prior_knowledge.rs
+++ b/crates/rttp-client/tests/http2_prior_knowledge.rs
@@ -3973,6 +3973,123 @@ fn prior_knowledge_get_reports_stream_reset_and_goaway() {
 }
 
 #[test]
+fn prior_knowledge_get_reports_stream_reset_during_response_body() {
+  let listener = TcpListener::bind("127.0.0.1:0").expect("bind h2 peer");
+  let addr = listener.local_addr().expect("h2 peer addr");
+
+  let handle = thread::spawn(move || {
+    let (mut stream, _) = listener.accept().expect("accept h2 client");
+    complete_h2_request_handshake(&mut stream);
+
+    write_frame(&mut stream, FRAME_HEADERS, FLAG_END_HEADERS, 1, &[0x88]);
+    write_frame(&mut stream, FRAME_DATA, 0, 1, b"partial body");
+    write_frame(&mut stream, FRAME_RST_STREAM, 0, 1, &[0, 0, 0, 8]);
+  });
+
+  let error = HttpClient::new()
+    .get()
+    .url(format!("http://{}/reset-during-body", addr))
+    .emit_http2_prior_knowledge()
+    .expect_err("stream reset during response body must fail the response");
+
+  assert!(
+    error
+      .to_string()
+      .contains("HTTP/2 stream reset during response body: RST_STREAM error code 8 (CANCEL)"),
+    "unexpected error: {error}"
+  );
+  handle.join().expect("reset peer thread");
+}
+
+#[test]
+fn prior_knowledge_get_reports_connection_abort_after_graceful_goaway() {
+  let listener = TcpListener::bind("127.0.0.1:0").expect("bind h2 peer");
+  let addr = listener.local_addr().expect("h2 peer addr");
+
+  let handle = thread::spawn(move || {
+    let (mut stream, _) = listener.accept().expect("accept h2 client");
+    complete_h2_request_handshake(&mut stream);
+
+    write_frame(&mut stream, FRAME_HEADERS, FLAG_END_HEADERS, 1, &[0x88]);
+    write_frame(&mut stream, FRAME_DATA, 0, 1, b"partial body");
+    write_frame(&mut stream, FRAME_GOAWAY, 0, 0, &[0, 0, 0, 1, 0, 0, 0, 0]);
+  });
+
+  let error = HttpClient::new()
+    .get()
+    .url(format!("http://{}/abort-after-goaway", addr))
+    .emit_http2_prior_knowledge()
+    .expect_err("connection abort after graceful GOAWAY must fail the response");
+
+  assert!(
+    error
+      .to_string()
+      .contains("HTTP/2 connection aborted during response body after GOAWAY without RST_STREAM"),
+    "unexpected error: {error}"
+  );
+  handle.join().expect("graceful GOAWAY peer thread");
+}
+
+#[test]
+fn prior_knowledge_get_reports_connection_abort_during_response_body() {
+  let listener = TcpListener::bind("127.0.0.1:0").expect("bind h2 peer");
+  let addr = listener.local_addr().expect("h2 peer addr");
+
+  let handle = thread::spawn(move || {
+    let (mut stream, _) = listener.accept().expect("accept h2 client");
+    complete_h2_request_handshake(&mut stream);
+
+    write_frame(&mut stream, FRAME_HEADERS, FLAG_END_HEADERS, 1, &[0x88]);
+    write_frame(&mut stream, FRAME_DATA, 0, 1, b"partial body");
+  });
+
+  let error = HttpClient::new()
+    .get()
+    .url(format!("http://{}/abort-during-body", addr))
+    .emit_http2_prior_knowledge()
+    .expect_err("connection abort during response body must fail the response");
+
+  assert!(
+    error
+      .to_string()
+      .contains("HTTP/2 connection aborted during response body without GOAWAY or RST_STREAM"),
+    "unexpected error: {error}"
+  );
+  handle.join().expect("aborting peer thread");
+}
+
+#[test]
+fn prior_knowledge_get_continues_after_reset_of_unaffected_stream() {
+  let listener = TcpListener::bind("127.0.0.1:0").expect("bind h2 peer");
+  let addr = listener.local_addr().expect("h2 peer addr");
+
+  let handle = thread::spawn(move || {
+    let (mut stream, _) = listener.accept().expect("accept h2 client");
+    complete_h2_request_handshake(&mut stream);
+
+    write_frame(&mut stream, FRAME_RST_STREAM, 0, 3, &[0, 0, 0, 8]);
+    write_frame(&mut stream, FRAME_HEADERS, FLAG_END_HEADERS, 1, &[0x88]);
+    write_frame(
+      &mut stream,
+      FRAME_DATA,
+      FLAG_END_STREAM,
+      1,
+      b"unaffected response",
+    );
+  });
+
+  let response = HttpClient::new()
+    .get()
+    .url(format!("http://{}/unaffected-stream", addr))
+    .emit_http2_prior_knowledge()
+    .expect("unaffected stream response");
+
+  assert_eq!(200, response.code());
+  assert_eq!("unaffected response", response.body().string().unwrap());
+  handle.join().expect("unaffected peer thread");
+}
+
+#[test]
 fn prior_knowledge_get_rejects_malformed_rst_stream_frames() {
   let cases: &[(&str, u32, &[u8])] = &[
     ("stream-zero", 0, &[0, 0, 0, 0]),

--- a/crates/rttp-client/tests/http2_prior_knowledge.rs
+++ b/crates/rttp-client/tests/http2_prior_knowledge.rs
@@ -4002,7 +4002,7 @@ fn prior_knowledge_get_reports_stream_reset_during_response_body() {
 }
 
 #[test]
-fn prior_knowledge_get_reports_connection_abort_after_graceful_goaway() {
+fn prior_knowledge_get_reports_connection_abort_after_goaway_with_error_details() {
   let listener = TcpListener::bind("127.0.0.1:0").expect("bind h2 peer");
   let addr = listener.local_addr().expect("h2 peer addr");
 
@@ -4012,22 +4012,24 @@ fn prior_knowledge_get_reports_connection_abort_after_graceful_goaway() {
 
     write_frame(&mut stream, FRAME_HEADERS, FLAG_END_HEADERS, 1, &[0x88]);
     write_frame(&mut stream, FRAME_DATA, 0, 1, b"partial body");
-    write_frame(&mut stream, FRAME_GOAWAY, 0, 0, &[0, 0, 0, 1, 0, 0, 0, 0]);
+    write_frame(&mut stream, FRAME_GOAWAY, 0, 0, &[0, 0, 0, 1, 0, 0, 0, 11]);
   });
 
   let error = HttpClient::new()
     .get()
     .url(format!("http://{}/abort-after-goaway", addr))
     .emit_http2_prior_knowledge()
-    .expect_err("connection abort after graceful GOAWAY must fail the response");
+    .expect_err("connection abort after GOAWAY must fail the response");
 
   assert!(
     error
       .to_string()
-      .contains("HTTP/2 connection aborted during response body after GOAWAY without RST_STREAM"),
+      .contains(
+        "HTTP/2 connection aborted during response body after GOAWAY error code 11 (ENHANCE_YOUR_CALM) without RST_STREAM",
+      ),
     "unexpected error: {error}"
   );
-  handle.join().expect("graceful GOAWAY peer thread");
+  handle.join().expect("GOAWAY peer thread");
 }
 
 #[test]


### PR DESCRIPTION
Improved HTTP/2 diagnostics for RST_STREAM and incomplete responses after GOAWAY, with regression coverage for body-phase resets, unexpected aborts, and unaffected streams.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1810/
work_kind: code_work
branch: hbx-1810-rttp-http2-add-goaway-and
base: main
commit: 639f9b0869fb0420c7bf8c5fc33ec27403063976
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1810/
    url: https://plane.kahub.in/endless/browse/HBX-1810/
    close_policy: link_only
```