### PR TITLE
feat: [rttp-protocol/client] Add Cross-Origin-Resource-Policy response metadata

### DIFF
--- a/crates/rttp-client/src/response/mod.rs
+++ b/crates/rttp-client/src/response/mod.rs
@@ -12,6 +12,9 @@ pub use rttp_protocol::client_hints::{
 pub use rttp_protocol::cookie::{
   HttpCookieParseError, HttpSetCookie, HttpSetCookieAttribute, HttpSetCookies,
 };
+pub use rttp_protocol::cross_origin_resource_policy::{
+  CrossOriginResourcePolicy, CrossOriginResourcePolicyParseError,
+};
 
 mod raw_response;
 mod response;

--- a/crates/rttp-client/src/response/response.rs
+++ b/crates/rttp-client/src/response/response.rs
@@ -18,6 +18,7 @@ use crate::types::{Cookie, Header, RoUrl};
 use rttp_protocol::clear_site_data::ClearSiteData;
 use rttp_protocol::client_hints::{AcceptCh, CriticalCh};
 use rttp_protocol::cookie::HttpSetCookies;
+use rttp_protocol::cross_origin_resource_policy::CrossOriginResourcePolicy;
 use rttp_protocol::prefer::PreferenceApplied;
 use rttp_protocol::sunset::parse_sunset_values;
 
@@ -452,6 +453,17 @@ impl Response {
       return Ok(None);
     }
     ClearSiteData::parse_values(values.into_iter().map(String::as_str))
+      .map(Some)
+      .map_err(|parse_error| error::bad_response(parse_error.to_string()))
+  }
+
+  /// Parses `Cross-Origin-Resource-Policy` response metadata without enforcing resource isolation.
+  pub fn cross_origin_resource_policy(&self) -> error::Result<Option<CrossOriginResourcePolicy>> {
+    let values = self.header_values("cross-origin-resource-policy");
+    if values.is_empty() {
+      return Ok(None);
+    }
+    CrossOriginResourcePolicy::parse_values(values.into_iter().map(String::as_str))
       .map(Some)
       .map_err(|parse_error| error::bad_response(parse_error.to_string()))
   }

--- a/crates/rttp-client/tests/metadata_facade.rs
+++ b/crates/rttp-client/tests/metadata_facade.rs
@@ -1,5 +1,6 @@
 use rttp_client::response::{
-  AcceptCh, AltSvc, Digest, HttpClearSiteData, PreferenceApplied, Priority, ServerTiming, Trailer,
+  AcceptCh, AltSvc, CrossOriginResourcePolicy, Digest, HttpClearSiteData, PreferenceApplied,
+  Priority, ServerTiming, Trailer,
 };
 use rttp_client::{SecFetchDest, SecFetchMode, SecFetchSite, SecFetchUser};
 
@@ -17,6 +18,8 @@ fn response_facade_exports_representative_bounded_metadata_types() {
   let fetch_mode = SecFetchMode::parse("navigate").expect("Sec-Fetch-Mode should parse");
   let fetch_dest = SecFetchDest::parse("document").expect("Sec-Fetch-Dest should parse");
   let fetch_user = SecFetchUser::parse("?1").expect("Sec-Fetch-User should parse");
+  let cross_origin_resource_policy =
+    CrossOriginResourcePolicy::parse("same-origin").expect("CORP should parse");
 
   assert_eq!(accept_ch.client_hints(), ["Sec-CH-UA", "DPR"]);
   assert_eq!(clear_site_data.directives().len(), 1);
@@ -29,6 +32,7 @@ fn response_facade_exports_representative_bounded_metadata_types() {
   assert_eq!(fetch_mode.header_value(), "navigate");
   assert_eq!(fetch_dest.header_value(), "document");
   assert_eq!(fetch_user.header_value(), "?1");
+  assert_eq!(cross_origin_resource_policy.header_value(), "same-origin");
 }
 
 #[test]

--- a/crates/rttp-client/tests/test_response.rs
+++ b/crates/rttp-client/tests/test_response.rs
@@ -1,6 +1,7 @@
 use rttp_client::response::{
-  AltSvc, ContentDisposition, ContentEncoding, ContentLocation, ContentType, Digest,
-  HttpClearSiteData, HttpSetCookies, LinkValues, Response, RetryAfter, ServerTiming,
+  AltSvc, ContentDisposition, ContentEncoding, ContentLocation, ContentType,
+  CrossOriginResourcePolicy, Digest, HttpClearSiteData, HttpSetCookies, LinkValues, Response,
+  RetryAfter, ServerTiming,
 };
 use rttp_client::types::{Cookie, RoUrl};
 use std::io::Write;
@@ -2198,6 +2199,76 @@ fn test_client_hint_response_helpers_preserve_invalid_or_absent_metadata() {
     absent
       .critical_ch()
       .expect("absent Critical-CH should parse")
+  );
+}
+
+#[test]
+fn test_cross_origin_resource_policy_response_metadata_preserves_raw_headers() {
+  for (value, policy) in [
+    ("SAME-ORIGIN", CrossOriginResourcePolicy::SameOrigin),
+    ("same-site", CrossOriginResourcePolicy::SameSite),
+    ("Cross-Origin", CrossOriginResourcePolicy::CrossOrigin),
+  ] {
+    let raw = format!(
+      "HTTP/1.1 200 OK\r\nCross-Origin-Resource-Policy: {value}\r\nContent-Length: 0\r\n\r\n"
+    );
+    let response = Response::new(RoUrl::with("https://example.test"), raw.into_bytes())
+      .expect("raw response should parse");
+
+    assert_eq!(
+      policy,
+      response
+        .cross_origin_resource_policy()
+        .expect("CORP should parse")
+        .expect("CORP should be present")
+    );
+    assert_eq!(
+      Some(&value.to_string()),
+      response.header_value("Cross-Origin-Resource-Policy")
+    );
+  }
+}
+
+#[test]
+fn test_cross_origin_resource_policy_response_metadata_rejects_invalid_and_absent_values() {
+  let raw = concat!(
+    "HTTP/1.1 200 OK\r\n",
+    "Cross-Origin-Resource-Policy: same-origin\r\n",
+    "Cross-Origin-Resource-Policy: same-site\r\n",
+    "Content-Length: 0\r\n",
+    "\r\n"
+  );
+  let response = Response::new(RoUrl::with("https://example.test"), raw.as_bytes().to_vec())
+    .expect("raw response should remain usable");
+
+  assert!(response.cross_origin_resource_policy().is_err());
+  assert_eq!(
+    Some(&"same-origin".to_string()),
+    response.header_value("Cross-Origin-Resource-Policy")
+  );
+
+  let malformed = Response::new(
+    RoUrl::with("https://example.test"),
+    b"HTTP/1.1 200 OK\r\nCross-Origin-Resource-Policy: same origin\r\nContent-Length: 0\r\n\r\n"
+      .to_vec(),
+  )
+  .expect("raw response with malformed CORP should parse");
+  assert!(malformed.cross_origin_resource_policy().is_err());
+  assert_eq!(
+    Some(&"same origin".to_string()),
+    malformed.header_value("Cross-Origin-Resource-Policy")
+  );
+
+  let absent = Response::new(
+    RoUrl::with("https://example.test"),
+    b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n".to_vec(),
+  )
+  .expect("response without CORP should parse");
+  assert_eq!(
+    None,
+    absent
+      .cross_origin_resource_policy()
+      .expect("absent CORP should parse")
   );
 }
 

--- a/crates/rttp-protocol/src/cross_origin_resource_policy.rs
+++ b/crates/rttp-protocol/src/cross_origin_resource_policy.rs
@@ -1,0 +1,108 @@
+//! Bounded, policy-free `Cross-Origin-Resource-Policy` response metadata parsing.
+//!
+//! This module validates the response field value only. Callers decide whether
+//! and how to enforce resource isolation policy.
+
+use std::error::Error;
+use std::fmt;
+
+pub const MAX_CROSS_ORIGIN_RESOURCE_POLICY_VALUE_BYTES: usize = 64 * 1024;
+
+/// The resource-sharing policy declared by `Cross-Origin-Resource-Policy`.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum CrossOriginResourcePolicy {
+  SameOrigin,
+  SameSite,
+  CrossOrigin,
+}
+
+impl CrossOriginResourcePolicy {
+  pub fn parse(value: impl AsRef<str>) -> Result<Self, CrossOriginResourcePolicyParseError> {
+    Self::parse_values([value.as_ref()])
+  }
+
+  pub fn parse_values<'a, I>(values: I) -> Result<Self, CrossOriginResourcePolicyParseError>
+  where
+    I: IntoIterator<Item = &'a str>,
+  {
+    let value = parse_singleton(values)?;
+    if value.eq_ignore_ascii_case("same-origin") {
+      Ok(Self::SameOrigin)
+    } else if value.eq_ignore_ascii_case("same-site") {
+      Ok(Self::SameSite)
+    } else if value.eq_ignore_ascii_case("cross-origin") {
+      Ok(Self::CrossOrigin)
+    } else {
+      Err(invalid_value())
+    }
+  }
+
+  pub const fn header_value(self) -> &'static str {
+    match self {
+      Self::SameOrigin => "same-origin",
+      Self::SameSite => "same-site",
+      Self::CrossOrigin => "cross-origin",
+    }
+  }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CrossOriginResourcePolicyParseError {
+  message: String,
+}
+
+impl CrossOriginResourcePolicyParseError {
+  fn new(message: impl Into<String>) -> Self {
+    Self {
+      message: message.into(),
+    }
+  }
+}
+
+impl fmt::Display for CrossOriginResourcePolicyParseError {
+  fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+    formatter.write_str(&self.message)
+  }
+}
+
+impl Error for CrossOriginResourcePolicyParseError {}
+
+fn parse_singleton<'a, I>(values: I) -> Result<&'a str, CrossOriginResourcePolicyParseError>
+where
+  I: IntoIterator<Item = &'a str>,
+{
+  let mut values = values.into_iter();
+  let value = values.next().ok_or_else(invalid_value)?;
+  validate_bounded_value(value)?;
+  let mut has_duplicate = false;
+  for value in values {
+    has_duplicate = true;
+    validate_bounded_value(value)?;
+  }
+  if has_duplicate {
+    return Err(CrossOriginResourcePolicyParseError::new(
+      "duplicate Cross-Origin-Resource-Policy header fields",
+    ));
+  }
+  let value = value.trim_matches([' ', '\t']);
+  if value.is_empty() {
+    return Err(invalid_value());
+  }
+  Ok(value)
+}
+
+fn validate_bounded_value(value: &str) -> Result<(), CrossOriginResourcePolicyParseError> {
+  if value.len() > MAX_CROSS_ORIGIN_RESOURCE_POLICY_VALUE_BYTES {
+    return Err(CrossOriginResourcePolicyParseError::new(
+      "Cross-Origin-Resource-Policy header value is too large",
+    ));
+  }
+  if value.bytes().any(|byte| byte.is_ascii_control()) {
+    return Err(invalid_value());
+  }
+  Ok(())
+}
+
+fn invalid_value() -> CrossOriginResourcePolicyParseError {
+  CrossOriginResourcePolicyParseError::new("invalid Cross-Origin-Resource-Policy header value")
+}

--- a/crates/rttp-protocol/src/lib.rs
+++ b/crates/rttp-protocol/src/lib.rs
@@ -10,6 +10,7 @@ pub mod cache_control;
 pub mod clear_site_data;
 pub mod client_hints;
 pub mod cookie;
+pub mod cross_origin_resource_policy;
 pub mod digest;
 pub mod entity_tag;
 pub mod fetch_metadata;

--- a/crates/rttp-protocol/tests/cross_origin_resource_policy.rs
+++ b/crates/rttp-protocol/tests/cross_origin_resource_policy.rs
@@ -1,0 +1,59 @@
+use rttp_protocol::cross_origin_resource_policy::{
+  CrossOriginResourcePolicy, MAX_CROSS_ORIGIN_RESOURCE_POLICY_VALUE_BYTES,
+};
+
+#[test]
+fn cross_origin_resource_policy_parses_standard_values_case_insensitively() {
+  assert_eq!(
+    CrossOriginResourcePolicy::SameOrigin,
+    CrossOriginResourcePolicy::parse("SAME-ORIGIN").expect("same-origin should parse")
+  );
+  assert_eq!(
+    CrossOriginResourcePolicy::SameSite,
+    CrossOriginResourcePolicy::parse("same-site").expect("same-site should parse")
+  );
+  assert_eq!(
+    CrossOriginResourcePolicy::CrossOrigin,
+    CrossOriginResourcePolicy::parse("Cross-Origin").expect("cross-origin should parse")
+  );
+  assert_eq!(
+    "same-origin",
+    CrossOriginResourcePolicy::SameOrigin.header_value()
+  );
+}
+
+#[test]
+fn cross_origin_resource_policy_rejects_empty_duplicate_malformed_and_oversized_values() {
+  for value in [
+    "",
+    "same origin",
+    "same-origin, same-site",
+    "unknown",
+    "same-origin\r\nX: y",
+  ] {
+    assert!(
+      CrossOriginResourcePolicy::parse(value).is_err(),
+      "{value:?} must be rejected"
+    );
+  }
+
+  assert!(
+    CrossOriginResourcePolicy::parse_values(["same-origin", "same-site"]).is_err(),
+    "duplicate singleton fields must be rejected"
+  );
+  assert!(
+    CrossOriginResourcePolicy::parse("a".repeat(MAX_CROSS_ORIGIN_RESOURCE_POLICY_VALUE_BYTES + 1))
+      .is_err(),
+    "oversized values must be rejected"
+  );
+}
+
+#[test]
+fn cross_origin_resource_policy_checks_duplicate_values_against_its_bound() {
+  let oversized = "a".repeat(MAX_CROSS_ORIGIN_RESOURCE_POLICY_VALUE_BYTES + 1);
+
+  assert!(
+    CrossOriginResourcePolicy::parse_values(["same-origin", oversized.as_str()]).is_err(),
+    "oversized duplicate fields must not bypass validation"
+  );
+}


### PR DESCRIPTION
Added bounded typed Cross-Origin-Resource-Policy response metadata parsing and exposed it through rttp-client responses. Validation rejects duplicate, malformed, empty, and oversized fields while preserving raw headers; focused client tests and the full rttp-protocol suite pass.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1820/
work_kind: code_work
branch: hbx-1820-rttp-protocol-client-add-cross
base: main
commit: 676637d8bb7c99bc3f7ce072bb35eee4c328ec41
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1820/
    url: https://plane.kahub.in/endless/browse/HBX-1820/
    close_policy: link_only
```