### PR TITLE
feat: rttp-protocol: add bounded Access-Control-Allow-Methods parser

### DIFF
--- a/crates/rttp-protocol/src/access_control_allow_methods.rs
+++ b/crates/rttp-protocol/src/access_control_allow_methods.rs
@@ -1,0 +1,158 @@
+//! Bounded, policy-free `Access-Control-Allow-Methods` response metadata parsing.
+//!
+//! This module validates the response field value only. Callers decide whether
+//! and how to apply CORS method behavior.
+
+use std::error::Error;
+use std::fmt;
+
+/// Maximum bytes accepted in each `Access-Control-Allow-Methods` field value.
+pub const MAX_ACCESS_CONTROL_ALLOW_METHODS_VALUE_BYTES: usize = 64 * 1024;
+/// Maximum comma-separated method members accepted across all field values.
+pub const MAX_ACCESS_CONTROL_ALLOW_METHODS_METHODS: usize = 256;
+
+/// Parsed, bounded `Access-Control-Allow-Methods` response metadata.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AccessControlAllowMethods {
+  wildcard: bool,
+  methods: Vec<String>,
+}
+
+impl AccessControlAllowMethods {
+  pub fn parse(value: impl AsRef<str>) -> Result<Self, AccessControlAllowMethodsParseError> {
+    Self::parse_values([value.as_ref()])
+  }
+
+  pub fn parse_values<'a, I>(values: I) -> Result<Self, AccessControlAllowMethodsParseError>
+  where
+    I: IntoIterator<Item = &'a str>,
+  {
+    let mut wildcard = false;
+    let mut methods = Vec::new();
+    let mut method_count = 0usize;
+
+    for value in values {
+      if value.len() > MAX_ACCESS_CONTROL_ALLOW_METHODS_VALUE_BYTES {
+        return Err(AccessControlAllowMethodsParseError::new(
+          "Access-Control-Allow-Methods header value is too large",
+        ));
+      }
+      if value.bytes().any(is_invalid_control_byte) {
+        return Err(AccessControlAllowMethodsParseError::new(
+          "invalid Access-Control-Allow-Methods control byte",
+        ));
+      }
+
+      for member in value.split(',') {
+        let method = member.trim_matches([' ', '\t']);
+        method_count += 1;
+        if method_count > MAX_ACCESS_CONTROL_ALLOW_METHODS_METHODS {
+          return Err(AccessControlAllowMethodsParseError::new(
+            "too many Access-Control-Allow-Methods methods",
+          ));
+        }
+        if method == "*" {
+          wildcard = true;
+          continue;
+        }
+        if !is_http_token(method) {
+          return Err(AccessControlAllowMethodsParseError::new(
+            "invalid Access-Control-Allow-Methods method",
+          ));
+        }
+        let normalized = method.to_ascii_uppercase();
+        if !methods.contains(&normalized) {
+          methods.push(normalized);
+        }
+      }
+    }
+
+    if !wildcard && methods.is_empty() {
+      return Err(AccessControlAllowMethodsParseError::new(
+        "invalid Access-Control-Allow-Methods method",
+      ));
+    }
+
+    Ok(Self { wildcard, methods })
+  }
+
+  pub fn is_wildcard(&self) -> bool {
+    self.wildcard
+  }
+
+  pub fn methods(&self) -> &[String] {
+    &self.methods
+  }
+
+  pub fn len(&self) -> usize {
+    self.methods.len()
+  }
+
+  pub fn is_empty(&self) -> bool {
+    self.methods.is_empty()
+  }
+
+  pub fn header_value(&self) -> String {
+    if self.wildcard {
+      if self.methods.is_empty() {
+        "*".to_string()
+      } else {
+        format!("*, {}", self.methods.join(", "))
+      }
+    } else {
+      self.methods.join(", ")
+    }
+  }
+}
+
+/// An error returned when `Access-Control-Allow-Methods` metadata is malformed or exceeds bounds.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AccessControlAllowMethodsParseError {
+  message: String,
+}
+
+impl AccessControlAllowMethodsParseError {
+  fn new(message: impl Into<String>) -> Self {
+    Self {
+      message: message.into(),
+    }
+  }
+}
+
+impl fmt::Display for AccessControlAllowMethodsParseError {
+  fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+    formatter.write_str(&self.message)
+  }
+}
+
+impl Error for AccessControlAllowMethodsParseError {}
+
+fn is_http_token(value: &str) -> bool {
+  !value.is_empty() && value.bytes().all(is_http_token_byte)
+}
+
+fn is_invalid_control_byte(byte: u8) -> bool {
+  byte != b'\t' && (byte <= 0x1f || byte == 0x7f)
+}
+
+fn is_http_token_byte(byte: u8) -> bool {
+  byte.is_ascii_alphanumeric()
+    || matches!(
+      byte,
+      b'!'
+        | b'#'
+        | b'$'
+        | b'%'
+        | b'&'
+        | b'\''
+        | b'*'
+        | b'+'
+        | b'-'
+        | b'.'
+        | b'^'
+        | b'_'
+        | b'`'
+        | b'|'
+        | b'~'
+    )
+}

--- a/crates/rttp-protocol/src/lib.rs
+++ b/crates/rttp-protocol/src/lib.rs
@@ -5,6 +5,7 @@
 
 pub mod accept_patch;
 pub mod accept_post;
+pub mod access_control_allow_methods;
 pub mod access_control_expose_headers;
 pub mod alt_svc;
 pub mod cache_control;

--- a/crates/rttp-protocol/tests/access_control_allow_methods.rs
+++ b/crates/rttp-protocol/tests/access_control_allow_methods.rs
@@ -1,0 +1,71 @@
+use rttp_protocol::access_control_allow_methods::{
+  AccessControlAllowMethods, MAX_ACCESS_CONTROL_ALLOW_METHODS_METHODS,
+  MAX_ACCESS_CONTROL_ALLOW_METHODS_VALUE_BYTES,
+};
+
+#[test]
+fn access_control_allow_methods_parses_normalized_methods() {
+  let allow_methods = AccessControlAllowMethods::parse("get, POST, patch")
+    .expect("valid Access-Control-Allow-Methods");
+
+  assert_eq!(allow_methods.methods(), ["GET", "POST", "PATCH"]);
+  assert!(!allow_methods.is_wildcard());
+  assert_eq!(allow_methods.header_value(), "GET, POST, PATCH");
+}
+
+#[test]
+fn access_control_allow_methods_accepts_wildcard() {
+  let allow_methods =
+    AccessControlAllowMethods::parse("*").expect("wildcard Access-Control-Allow-Methods");
+
+  assert!(allow_methods.is_wildcard());
+  assert!(allow_methods.methods().is_empty());
+  assert_eq!(allow_methods.header_value(), "*");
+}
+
+#[test]
+fn access_control_allow_methods_combines_and_deduplicates_multiple_header_fields() {
+  let allow_methods = AccessControlAllowMethods::parse_values(["GET, post", "PATCH, GET"])
+    .expect("multiple Access-Control-Allow-Methods fields");
+
+  assert_eq!(allow_methods.methods(), ["GET", "POST", "PATCH"]);
+}
+
+#[test]
+fn access_control_allow_methods_preserves_wildcard_with_methods() {
+  let allow_methods =
+    AccessControlAllowMethods::parse("*, GET").expect("wildcard and methods should be preserved");
+
+  assert!(allow_methods.is_wildcard());
+  assert_eq!(allow_methods.methods(), ["GET"]);
+  assert_eq!(allow_methods.header_value(), "*, GET");
+}
+
+#[test]
+fn access_control_allow_methods_rejects_malformed_values() {
+  for value in ["", "GET,", ",GET", "GET,,POST", "GET POST", "GET\rPOST"] {
+    assert!(
+      AccessControlAllowMethods::parse(value).is_err(),
+      "{value:?} must be rejected"
+    );
+  }
+}
+
+#[test]
+fn access_control_allow_methods_enforces_value_and_method_count_bounds() {
+  assert!(AccessControlAllowMethods::parse(
+    "x".repeat(MAX_ACCESS_CONTROL_ALLOW_METHODS_VALUE_BYTES + 1)
+  )
+  .is_err());
+
+  let too_many = std::iter::repeat_n("GET", MAX_ACCESS_CONTROL_ALLOW_METHODS_METHODS + 1)
+    .collect::<Vec<_>>()
+    .join(",");
+  assert!(AccessControlAllowMethods::parse(too_many).is_err());
+
+  assert!(AccessControlAllowMethods::parse_values(std::iter::repeat_n(
+    "*",
+    MAX_ACCESS_CONTROL_ALLOW_METHODS_METHODS + 1,
+  ))
+  .is_err());
+}


### PR DESCRIPTION
Implemented bounded, policy-free Access-Control-Allow-Methods response metadata parsing with deterministic normalization, wildcard support, strict malformed-value rejection, and explicit size/count limits. Added focused coverage and verified the full Rust workspace.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1825/
work_kind: code_work
branch: hbx-1825-rttp-protocol-add-bounded-access
base: main
commit: a1ba4c8e4ed443dedb8d41ae2c7efb6586427676
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1825/
    url: https://plane.kahub.in/endless/browse/HBX-1825/
    close_policy: link_only
```