### PR TITLE
feat: rttp-client: expose Access-Control-Allow-Methods response metadata

### DIFF
--- a/crates/rttp-client/src/response/mod.rs
+++ b/crates/rttp-client/src/response/mod.rs
@@ -2,6 +2,9 @@
 
 pub use self::response::*;
 
+pub use rttp_protocol::access_control_allow_methods::{
+  AccessControlAllowMethods, AccessControlAllowMethodsParseError,
+};
 pub use rttp_protocol::access_control_expose_headers::{
   AccessControlExposeHeaders, AccessControlExposeHeadersParseError,
 };

--- a/crates/rttp-client/src/response/response.rs
+++ b/crates/rttp-client/src/response/response.rs
@@ -15,6 +15,7 @@ use crate::response::ServerTiming;
 use crate::response::Trailer;
 use crate::response::WwwAuthenticate;
 use crate::types::{Cookie, Header, RoUrl};
+use rttp_protocol::access_control_allow_methods::AccessControlAllowMethods;
 use rttp_protocol::access_control_expose_headers::AccessControlExposeHeaders;
 use rttp_protocol::clear_site_data::ClearSiteData;
 use rttp_protocol::client_hints::{AcceptCh, CriticalCh};
@@ -322,6 +323,18 @@ impl Response {
       return Ok(None);
     }
     AccessControlExposeHeaders::parse_values(values.into_iter().map(String::as_str))
+      .map(Some)
+      .map_err(|parse_error| error::bad_response(parse_error.to_string()))
+  }
+
+  /// Parses bounded `Access-Control-Allow-Methods` response metadata without
+  /// applying CORS method policy.
+  pub fn access_control_allow_methods(&self) -> error::Result<Option<AccessControlAllowMethods>> {
+    let values = self.header_values("access-control-allow-methods");
+    if values.is_empty() {
+      return Ok(None);
+    }
+    AccessControlAllowMethods::parse_values(values.into_iter().map(String::as_str))
       .map(Some)
       .map_err(|parse_error| error::bad_response(parse_error.to_string()))
   }

--- a/crates/rttp-client/tests/metadata_facade.rs
+++ b/crates/rttp-client/tests/metadata_facade.rs
@@ -1,13 +1,17 @@
 use rttp_client::response::{
-  AcceptCh, AccessControlExposeHeaders, AltSvc, CrossOriginResourcePolicy, Digest,
-  HttpClearSiteData, PreferenceApplied, Priority, ReferrerPolicy, ReferrerPolicyToken,
-  ServerTiming, Trailer,
+  AcceptCh, AccessControlAllowMethods, AccessControlAllowMethodsParseError,
+  AccessControlExposeHeaders, AltSvc, CrossOriginResourcePolicy, Digest, HttpClearSiteData,
+  PreferenceApplied, Priority, ReferrerPolicy, ReferrerPolicyToken, ServerTiming, Trailer,
 };
 use rttp_client::{SecFetchDest, SecFetchMode, SecFetchSite, SecFetchUser};
 
 #[test]
 fn response_facade_exports_representative_bounded_metadata_types() {
   let accept_ch = AcceptCh::parse("Sec-CH-UA, DPR").expect("Accept-CH should parse");
+  let allow_methods = AccessControlAllowMethods::parse("GET, POST")
+    .expect("Access-Control-Allow-Methods should parse");
+  let _: AccessControlAllowMethodsParseError = AccessControlAllowMethods::parse("")
+    .expect_err("empty Access-Control-Allow-Methods should be rejected");
   let expose_headers = AccessControlExposeHeaders::parse("X-Request-Id")
     .expect("Access-Control-Expose-Headers should parse");
   let clear_site_data =
@@ -25,6 +29,7 @@ fn response_facade_exports_representative_bounded_metadata_types() {
     CrossOriginResourcePolicy::parse("same-origin").expect("CORP should parse");
 
   assert_eq!(accept_ch.client_hints(), ["Sec-CH-UA", "DPR"]);
+  assert_eq!(allow_methods.methods(), ["GET", "POST"]);
   assert_eq!(expose_headers.field_names(), ["x-request-id"]);
   assert_eq!(clear_site_data.directives().len(), 1);
   assert_eq!(digest.entries().len(), 1);

--- a/crates/rttp-client/tests/test_response.rs
+++ b/crates/rttp-client/tests/test_response.rs
@@ -2428,6 +2428,59 @@ fn test_access_control_expose_headers_response_helper_deduplicates_metadata_and_
 }
 
 #[test]
+fn test_access_control_allow_methods_response_helper_parses_repeated_metadata_only() {
+  let raw = concat!(
+    "HTTP/1.1 200 OK\r\n",
+    "Access-Control-Allow-Methods: get, POST\r\n",
+    "access-control-allow-methods: PATCH, get\r\n",
+    "Content-Length: 0\r\n",
+    "\r\n"
+  );
+  let response = Response::new(RoUrl::with("https://example.test"), raw.as_bytes().to_vec())
+    .expect("parse response with Access-Control-Allow-Methods metadata");
+
+  assert_eq!(
+    response
+      .access_control_allow_methods()
+      .expect("Access-Control-Allow-Methods should parse")
+      .expect("Access-Control-Allow-Methods should be present")
+      .methods(),
+    ["GET", "POST", "PATCH"]
+  );
+  assert_eq!(
+    response.header_values("access-control-allow-methods"),
+    [&"get, POST".to_string(), &"PATCH, get".to_string()]
+  );
+}
+
+#[test]
+fn test_access_control_allow_methods_response_helper_preserves_invalid_or_absent_metadata() {
+  let malformed = Response::new(
+    RoUrl::with("https://example.test"),
+    b"HTTP/1.1 200 OK\r\nAccess-Control-Allow-Methods: GET,,\r\nContent-Length: 0\r\n\r\n".to_vec(),
+  )
+  .expect("raw response should remain usable");
+
+  assert!(malformed.access_control_allow_methods().is_err());
+  assert_eq!(
+    malformed.header_value("Access-Control-Allow-Methods"),
+    Some(&"GET,,".to_string())
+  );
+
+  let absent = Response::new(
+    RoUrl::with("https://example.test"),
+    b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n".to_vec(),
+  )
+  .expect("parse response without Access-Control-Allow-Methods");
+  assert_eq!(
+    absent
+      .access_control_allow_methods()
+      .expect("absent Access-Control-Allow-Methods should parse"),
+    None
+  );
+}
+
+#[test]
 fn test_cross_origin_resource_policy_response_metadata_preserves_raw_headers() {
   for (value, policy) in [
     ("SAME-ORIGIN", CrossOriginResourcePolicy::SameOrigin),


### PR DESCRIPTION
rttp-client now exposes parsed Access-Control-Allow-Methods response metadata with public protocol re-exports and regression coverage for valid, absent, repeated, and malformed fields.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1826/
work_kind: code_work
branch: hbx-1826-rttp-client-expose-access-control
base: main
commit: 7da32d3eaaf356ff6143f51df12ebe6b95c1ca6d
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1826/
    url: https://plane.kahub.in/endless/browse/HBX-1826/
    close_policy: link_only
```