### PR TITLE
feat: rttp-protocol: add bounded Access-Control-Max-Age parser

### DIFF
--- a/crates/rttp-protocol/src/access_control_max_age.rs
+++ b/crates/rttp-protocol/src/access_control_max_age.rs
@@ -1,0 +1,107 @@
+//! Bounded, policy-free `Access-Control-Max-Age` response metadata parsing.
+//!
+//! This module validates the response field value only. Callers decide whether
+//! and how to apply CORS caching behavior.
+
+use std::error::Error;
+use std::fmt;
+
+/// Maximum bytes accepted in an `Access-Control-Max-Age` field value.
+pub const MAX_ACCESS_CONTROL_MAX_AGE_VALUE_BYTES: usize = 64 * 1024;
+
+/// Parsed, bounded `Access-Control-Max-Age` response metadata.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub struct AccessControlMaxAge(u64);
+
+impl AccessControlMaxAge {
+  pub const fn new(seconds: u64) -> Self {
+    Self(seconds)
+  }
+
+  pub fn parse(value: impl AsRef<str>) -> Result<Self, AccessControlMaxAgeParseError> {
+    Self::parse_values([value.as_ref()])
+  }
+
+  pub fn parse_values<'a, I>(values: I) -> Result<Self, AccessControlMaxAgeParseError>
+  where
+    I: IntoIterator<Item = &'a str>,
+  {
+    parse_singleton(values).map(Self)
+  }
+
+  pub const fn seconds(self) -> u64 {
+    self.0
+  }
+
+  pub fn header_value(self) -> String {
+    self.0.to_string()
+  }
+}
+
+/// An error returned when `Access-Control-Max-Age` metadata is malformed or exceeds bounds.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AccessControlMaxAgeParseError {
+  message: String,
+}
+
+impl AccessControlMaxAgeParseError {
+  fn new(message: impl Into<String>) -> Self {
+    Self {
+      message: message.into(),
+    }
+  }
+}
+
+impl fmt::Display for AccessControlMaxAgeParseError {
+  fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+    formatter.write_str(&self.message)
+  }
+}
+
+impl Error for AccessControlMaxAgeParseError {}
+
+fn parse_singleton<'a, I>(values: I) -> Result<u64, AccessControlMaxAgeParseError>
+where
+  I: IntoIterator<Item = &'a str>,
+{
+  let mut values = values.into_iter();
+  let value = values.next().ok_or_else(invalid_value)?;
+  validate_bounded_value(value)?;
+  let mut has_duplicate = false;
+  for value in values {
+    has_duplicate = true;
+    validate_bounded_value(value)?;
+  }
+  if has_duplicate {
+    return Err(AccessControlMaxAgeParseError::new(
+      "duplicate Access-Control-Max-Age header fields",
+    ));
+  }
+
+  let value = value.trim_matches([' ', '\t']);
+  if value.is_empty() || !value.bytes().all(|byte| byte.is_ascii_digit()) {
+    return Err(invalid_value());
+  }
+  value.parse().map_err(|_| invalid_value())
+}
+
+fn validate_bounded_value(value: &str) -> Result<(), AccessControlMaxAgeParseError> {
+  if value.len() > MAX_ACCESS_CONTROL_MAX_AGE_VALUE_BYTES {
+    return Err(AccessControlMaxAgeParseError::new(
+      "Access-Control-Max-Age header value is too large",
+    ));
+  }
+  if value
+    .bytes()
+    .any(|byte| byte.is_ascii_control() && byte != b'\t')
+  {
+    return Err(AccessControlMaxAgeParseError::new(
+      "invalid Access-Control-Max-Age control byte",
+    ));
+  }
+  Ok(())
+}
+
+fn invalid_value() -> AccessControlMaxAgeParseError {
+  AccessControlMaxAgeParseError::new("invalid Access-Control-Max-Age header value")
+}

--- a/crates/rttp-protocol/src/lib.rs
+++ b/crates/rttp-protocol/src/lib.rs
@@ -7,6 +7,7 @@ pub mod accept_patch;
 pub mod accept_post;
 pub mod access_control_allow_methods;
 pub mod access_control_expose_headers;
+pub mod access_control_max_age;
 pub mod alt_svc;
 pub mod cache_control;
 pub mod clear_site_data;

--- a/crates/rttp-protocol/tests/access_control_max_age.rs
+++ b/crates/rttp-protocol/tests/access_control_max_age.rs
@@ -1,0 +1,43 @@
+use rttp_protocol::access_control_max_age::{
+  AccessControlMaxAge, MAX_ACCESS_CONTROL_MAX_AGE_VALUE_BYTES,
+};
+
+#[test]
+fn access_control_max_age_parses_unsigned_u64_boundaries() {
+  let zero = AccessControlMaxAge::parse("0").expect("zero delta-seconds");
+  assert_eq!(zero.seconds(), 0);
+  assert_eq!(zero.header_value(), "0");
+
+  let maximum =
+    AccessControlMaxAge::parse(u64::MAX.to_string()).expect("maximum u64 delta-seconds");
+  assert_eq!(maximum.seconds(), u64::MAX);
+  assert_eq!(maximum.header_value(), u64::MAX.to_string());
+}
+
+#[test]
+fn access_control_max_age_rejects_duplicate_and_invalid_values() {
+  assert!(AccessControlMaxAge::parse_values(["60", "120"]).is_err());
+
+  for value in [
+    "",
+    " ",
+    "60, 120",
+    "+60",
+    "-60",
+    "60.0",
+    "sixy",
+    "18446744073709551616",
+  ] {
+    assert!(
+      AccessControlMaxAge::parse(value).is_err(),
+      "{value:?} must be rejected"
+    );
+  }
+}
+
+#[test]
+fn access_control_max_age_enforces_value_bounds() {
+  assert!(
+    AccessControlMaxAge::parse("0".repeat(MAX_ACCESS_CONTROL_MAX_AGE_VALUE_BYTES + 1)).is_err()
+  );
+}


### PR DESCRIPTION
Added bounded, policy-free Access-Control-Max-Age parsing with public metadata and error types. The parser accepts a single unsigned u64 delta-seconds value, rejects invalid or oversized input, and is covered by protocol tests.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1828/
work_kind: code_work
branch: hbx-1828-rttp-protocol-add-bounded-access
base: main
commit: 61e750e69202b194790ecad6dffa3c36c8a2954f
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1828/
    url: https://plane.kahub.in/endless/browse/HBX-1828/
    close_policy: link_only
```