### PR TITLE
feat: rttp-server: add typed Access-Control-Allow-Methods response helper

### DIFF
--- a/crates/rttp-server/src/server/response.rs
+++ b/crates/rttp-server/src/server/response.rs
@@ -1,5 +1,9 @@
 use super::*;
 
+pub use rttp_protocol::access_control_allow_methods::{
+  AccessControlAllowMethods as HttpAccessControlAllowMethods,
+  AccessControlAllowMethodsParseError as HttpAccessControlAllowMethodsParseError,
+};
 pub use rttp_protocol::alt_svc::{
   AltSvc as HttpAltSvc, AltSvcAlternative as HttpAltSvcAlternative,
   AltSvcParameter as HttpAltSvcParameter, AltSvcParseError as HttpAltSvcParseError,
@@ -674,6 +678,25 @@ impl HttpResponse {
     Ok(self)
   }
 
+  /// Validates and replaces `Access-Control-Allow-Methods` response metadata
+  /// without applying CORS policy.
+  pub fn with_access_control_allow_methods(
+    mut self,
+    value: impl AsRef<str>,
+  ) -> Result<Self, HttpAccessControlAllowMethodsParseError> {
+    let allow_methods = HttpAccessControlAllowMethods::parse(value)?;
+    self.headers.retain(|header| {
+      !header
+        .name
+        .eq_ignore_ascii_case("Access-Control-Allow-Methods")
+    });
+    self.headers.push(HttpHeader::new(
+      "Access-Control-Allow-Methods",
+      allow_methods.header_value(),
+    ));
+    Ok(self)
+  }
+
   /// Validates and replaces `Reporting-Endpoints` response metadata.
   pub fn with_reporting_endpoints<I, N, U>(
     mut self,
@@ -1126,6 +1149,27 @@ impl HttpResponse {
       return Ok(None);
     }
     HttpContentLanguages::parse_values(values).map(Some)
+  }
+
+  /// Parses attached `Access-Control-Allow-Methods` response metadata without
+  /// applying CORS policy.
+  pub fn access_control_allow_methods(
+    &self,
+  ) -> Result<Option<HttpAccessControlAllowMethods>, HttpAccessControlAllowMethodsParseError> {
+    let values: Vec<&str> = self
+      .headers
+      .iter()
+      .filter(|header| {
+        header
+          .name
+          .eq_ignore_ascii_case("Access-Control-Allow-Methods")
+      })
+      .map(|header| header.value.as_str())
+      .collect();
+    if values.is_empty() {
+      return Ok(None);
+    }
+    HttpAccessControlAllowMethods::parse_values(values).map(Some)
   }
 
   /// Parses bounded `Reporting-Endpoints` response metadata without scheduling reports.

--- a/crates/rttp-server/src/server/server_tests.rs
+++ b/crates/rttp-server/src/server/server_tests.rs
@@ -127,6 +127,56 @@ fn request_cache_control_rejects_directive_counts_across_header_fields() {
 }
 
 #[test]
+fn access_control_allow_methods_helpers_validate_replace_and_parse_response_metadata() {
+  let response = HttpResponse::ok([])
+    .header("Access-Control-Allow-Methods", "DELETE")
+    .header("access-control-allow-methods", "PATCH")
+    .with_access_control_allow_methods("get, POST")
+    .expect("Access-Control-Allow-Methods should be accepted");
+
+  let allow_methods = response
+    .access_control_allow_methods()
+    .expect("Access-Control-Allow-Methods should parse")
+    .expect("Access-Control-Allow-Methods should be present");
+  assert_eq!(["GET", "POST"], allow_methods.methods());
+  assert_eq!(
+    vec![("Access-Control-Allow-Methods", "GET, POST")],
+    response
+      .headers
+      .iter()
+      .map(|header| (header.name.as_str(), header.value.as_str()))
+      .collect::<Vec<_>>()
+  );
+}
+
+#[test]
+fn access_control_allow_methods_helpers_preserve_raw_metadata_and_report_parse_errors() {
+  let malformed = HttpResponse::ok([]).header("Access-Control-Allow-Methods", "GET POST");
+  assert!(malformed.access_control_allow_methods().is_err());
+  assert_eq!(
+    Some("GET POST"),
+    malformed
+      .headers
+      .iter()
+      .find(|header| header.name.eq_ignore_ascii_case("Access-Control-Allow-Methods"))
+      .map(|header| header.value.as_str())
+  );
+  assert!(HttpResponse::ok([])
+    .with_access_control_allow_methods("GET POST")
+    .is_err());
+}
+
+#[test]
+fn access_control_allow_methods_helpers_do_not_apply_cors_policy() {
+  assert_eq!(
+    None,
+    HttpResponse::ok([])
+      .access_control_allow_methods()
+      .expect("absent Access-Control-Allow-Methods should parse")
+  );
+}
+
+#[test]
 fn request_max_forwards_is_optional_bounded_and_preserves_invalid_headers() {
   let absent = Request::from_raw_frame(b"GET / HTTP/1.1\r\nHost: example.test\r\n\r\n")
     .expect("request should parse");

--- a/crates/rttp-server/tests/metadata_facade.rs
+++ b/crates/rttp-server/tests/metadata_facade.rs
@@ -1,11 +1,14 @@
 use rttp_server::server::{
-  HttpAcceptCh, HttpConditionalMetadata, HttpEntityTag, HttpPreferenceKind, HttpRequest,
-  HttpResponse, SecFetchDest, SecFetchMode, SecFetchSite, SecFetchUser,
+  HttpAcceptCh, HttpAccessControlAllowMethods, HttpConditionalMetadata, HttpEntityTag,
+  HttpPreferenceKind, HttpRequest, HttpResponse, SecFetchDest, SecFetchMode, SecFetchSite,
+  SecFetchUser,
 };
 
 #[test]
 fn server_facade_exports_representative_bounded_metadata_types() {
   let accept_ch: HttpAcceptCh = HttpAcceptCh::parse("Sec-CH-UA").expect("Accept-CH should parse");
+  let allow_methods: HttpAccessControlAllowMethods =
+    HttpAccessControlAllowMethods::parse("GET").expect("Access-Control-Allow-Methods should parse");
   let metadata = HttpConditionalMetadata::new().entity_tag(HttpEntityTag::strong("revision-42"));
   let response = HttpResponse::ok("")
     .with_accept_ch(["Sec-CH-UA"])
@@ -16,6 +19,7 @@ fn server_facade_exports_representative_bounded_metadata_types() {
   let fetch_user = SecFetchUser::parse("?1").expect("Sec-Fetch-User should parse");
 
   assert_eq!(accept_ch.client_hints(), ["Sec-CH-UA"]);
+  assert_eq!(allow_methods.methods(), ["GET"]);
   assert_eq!(
     metadata
       .entity_tag_value()

--- a/crates/rttp/tests/test_server_models.rs
+++ b/crates/rttp/tests/test_server_models.rs
@@ -1,15 +1,53 @@
 use std::time::{Duration, UNIX_EPOCH};
 
 use rttp::server::{
-  HttpAccept, HttpAcceptCh, HttpAcceptRanges, HttpAllowedMethods, HttpAuthorization, HttpByteRange,
-  HttpByteRangeError, HttpClearSiteData, HttpConditionalMetadata, HttpContentDisposition,
-  HttpContentLanguages, HttpContentSecurityPolicy, HttpContentType, HttpCriticalCh, HttpEntityTag,
-  HttpExpectations, HttpIfNoneMatch, HttpIfRange, HttpIfRangeRequestOutcome, HttpLinkValues,
-  HttpPermissionsPolicy, HttpReferrerPolicy, HttpReportingEndpoints, HttpRequest,
-  HttpRequestAcceptEncodings, HttpRequestCacheControl, HttpRequestTe, HttpResponse,
-  HttpResponseCacheControl, HttpResponseContentEncodings, HttpRetryAfter, HttpServerTiming,
-  HttpVary,
+  HttpAccept, HttpAcceptCh, HttpAcceptRanges, HttpAccessControlAllowMethods, HttpAllowedMethods,
+  HttpAuthorization, HttpByteRange, HttpByteRangeError, HttpClearSiteData, HttpConditionalMetadata,
+  HttpContentDisposition, HttpContentLanguages, HttpContentSecurityPolicy, HttpContentType,
+  HttpCriticalCh, HttpEntityTag, HttpExpectations, HttpIfNoneMatch, HttpIfRange,
+  HttpIfRangeRequestOutcome, HttpLinkValues, HttpPermissionsPolicy, HttpReferrerPolicy,
+  HttpReportingEndpoints, HttpRequest, HttpRequestAcceptEncodings, HttpRequestCacheControl,
+  HttpRequestTe, HttpResponse, HttpResponseCacheControl, HttpResponseContentEncodings,
+  HttpRetryAfter, HttpServerTiming, HttpVary,
 };
+
+#[test]
+fn response_access_control_allow_methods_helper_validates_and_preserves_raw_headers() {
+  let response = HttpResponse::ok("body")
+    .header("Access-Control-Allow-Methods", "DELETE")
+    .header("access-control-allow-methods", "PATCH")
+    .with_access_control_allow_methods("get, POST")
+    .expect("valid Access-Control-Allow-Methods should be accepted");
+
+  let methods: HttpAccessControlAllowMethods = response
+    .access_control_allow_methods()
+    .expect("attached Access-Control-Allow-Methods should parse")
+    .expect("Access-Control-Allow-Methods should be present");
+  assert_eq!(["GET", "POST"], methods.methods());
+  let serialized = String::from_utf8(response.to_bytes()).expect("response should serialize");
+  assert_eq!(
+    1,
+    serialized
+      .matches("\r\nAccess-Control-Allow-Methods: ")
+      .count()
+  );
+  assert!(serialized.contains("\r\nAccess-Control-Allow-Methods: GET, POST\r\n"));
+
+  assert!(HttpResponse::ok("body")
+    .with_access_control_allow_methods("GET POST")
+    .is_err());
+  let raw = HttpResponse::ok("body").header("Access-Control-Allow-Methods", "GET POST");
+  assert!(raw.access_control_allow_methods().is_err());
+  assert!(String::from_utf8(raw.to_bytes())
+    .expect("response should serialize")
+    .contains("\r\nAccess-Control-Allow-Methods: GET POST\r\n"));
+  assert_eq!(
+    None,
+    HttpResponse::ok("body")
+      .access_control_allow_methods()
+      .expect("absent Access-Control-Allow-Methods should parse")
+  );
+}
 
 #[test]
 fn response_browser_policy_helpers_preserve_metadata_without_enforcing_it() {


### PR DESCRIPTION
Added typed Access-Control-Allow-Methods response helpers backed by the protocol parser. The builder validates and case-insensitively replaces existing metadata, while the accessor parses raw values without enforcing CORS behavior. Server and compatibility-model coverage verifies emission, retrieval, replacement, malformed input, raw-header preservation, and absence. Full workspace tests pass.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1827/
work_kind: code_work
branch: hbx-1827-rttp-server-add-typed-access
base: main
commit: e59cb833c00ca0f6844e62192f563b9aff0a1562
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1827/
    url: https://plane.kahub.in/endless/browse/HBX-1827/
    close_policy: link_only
```