### PR TITLE
feat: rttp-client: expose Access-Control-Max-Age response metadata

### DIFF
--- a/crates/rttp-client/src/response/mod.rs
+++ b/crates/rttp-client/src/response/mod.rs
@@ -8,6 +8,9 @@ pub use rttp_protocol::access_control_allow_methods::{
 pub use rttp_protocol::access_control_expose_headers::{
   AccessControlExposeHeaders, AccessControlExposeHeadersParseError,
 };
+pub use rttp_protocol::access_control_max_age::{
+  AccessControlMaxAge, AccessControlMaxAgeParseError,
+};
 pub use rttp_protocol::clear_site_data::{
   ClearSiteData as HttpClearSiteData, ClearSiteDataDirective as HttpClearSiteDataDirective,
   ClearSiteDataParseError as HttpClearSiteDataParseError,

--- a/crates/rttp-client/src/response/response.rs
+++ b/crates/rttp-client/src/response/response.rs
@@ -17,6 +17,7 @@ use crate::response::WwwAuthenticate;
 use crate::types::{Cookie, Header, RoUrl};
 use rttp_protocol::access_control_allow_methods::AccessControlAllowMethods;
 use rttp_protocol::access_control_expose_headers::AccessControlExposeHeaders;
+use rttp_protocol::access_control_max_age::AccessControlMaxAge;
 use rttp_protocol::clear_site_data::ClearSiteData;
 use rttp_protocol::client_hints::{AcceptCh, CriticalCh};
 use rttp_protocol::cookie::HttpSetCookies;
@@ -335,6 +336,17 @@ impl Response {
       return Ok(None);
     }
     AccessControlAllowMethods::parse_values(values.into_iter().map(String::as_str))
+      .map(Some)
+      .map_err(|parse_error| error::bad_response(parse_error.to_string()))
+  }
+
+  /// Parses bounded `Access-Control-Max-Age` response metadata without applying CORS caching.
+  pub fn access_control_max_age(&self) -> error::Result<Option<AccessControlMaxAge>> {
+    let values = self.header_values("access-control-max-age");
+    if values.is_empty() {
+      return Ok(None);
+    }
+    AccessControlMaxAge::parse_values(values.into_iter().map(String::as_str))
       .map(Some)
       .map_err(|parse_error| error::bad_response(parse_error.to_string()))
   }

--- a/crates/rttp-client/tests/metadata_facade.rs
+++ b/crates/rttp-client/tests/metadata_facade.rs
@@ -1,7 +1,8 @@
 use rttp_client::response::{
   AcceptCh, AccessControlAllowMethods, AccessControlAllowMethodsParseError,
-  AccessControlExposeHeaders, AltSvc, CrossOriginResourcePolicy, Digest, HttpClearSiteData,
-  PreferenceApplied, Priority, ReferrerPolicy, ReferrerPolicyToken, ServerTiming, Trailer,
+  AccessControlExposeHeaders, AccessControlMaxAge, AccessControlMaxAgeParseError, AltSvc,
+  CrossOriginResourcePolicy, Digest, HttpClearSiteData, PreferenceApplied, Priority,
+  ReferrerPolicy, ReferrerPolicyToken, ServerTiming, Trailer,
 };
 use rttp_client::{SecFetchDest, SecFetchMode, SecFetchSite, SecFetchUser};
 
@@ -12,6 +13,9 @@ fn response_facade_exports_representative_bounded_metadata_types() {
     .expect("Access-Control-Allow-Methods should parse");
   let _: AccessControlAllowMethodsParseError = AccessControlAllowMethods::parse("")
     .expect_err("empty Access-Control-Allow-Methods should be rejected");
+  let max_age = AccessControlMaxAge::parse("60").expect("Access-Control-Max-Age should parse");
+  let _: AccessControlMaxAgeParseError =
+    AccessControlMaxAge::parse("").expect_err("empty Access-Control-Max-Age should be rejected");
   let expose_headers = AccessControlExposeHeaders::parse("X-Request-Id")
     .expect("Access-Control-Expose-Headers should parse");
   let clear_site_data =
@@ -30,6 +34,7 @@ fn response_facade_exports_representative_bounded_metadata_types() {
 
   assert_eq!(accept_ch.client_hints(), ["Sec-CH-UA", "DPR"]);
   assert_eq!(allow_methods.methods(), ["GET", "POST"]);
+  assert_eq!(max_age.seconds(), 60);
   assert_eq!(expose_headers.field_names(), ["x-request-id"]);
   assert_eq!(clear_site_data.directives().len(), 1);
   assert_eq!(digest.entries().len(), 1);

--- a/crates/rttp-client/tests/test_response.rs
+++ b/crates/rttp-client/tests/test_response.rs
@@ -2481,6 +2481,51 @@ fn test_access_control_allow_methods_response_helper_preserves_invalid_or_absent
 }
 
 #[test]
+fn test_access_control_max_age_response_helper_parses_valid_and_maximum_values() {
+  for (value, expected_seconds) in [("600", 600), ("18446744073709551615", u64::MAX)] {
+    let raw =
+      format!("HTTP/1.1 200 OK\r\nAccess-Control-Max-Age: {value}\r\nContent-Length: 0\r\n\r\n");
+    let response = Response::new(RoUrl::with("https://example.test"), raw.into_bytes())
+      .expect("parse response with Access-Control-Max-Age metadata");
+
+    assert_eq!(
+      response
+        .access_control_max_age()
+        .expect("Access-Control-Max-Age should parse")
+        .expect("Access-Control-Max-Age should be present")
+        .seconds(),
+      expected_seconds
+    );
+  }
+}
+
+#[test]
+fn test_access_control_max_age_response_helper_handles_absent_duplicate_and_malformed_metadata() {
+  let absent = Response::new(
+    RoUrl::with("https://example.test"),
+    b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n".to_vec(),
+  )
+  .expect("parse response without Access-Control-Max-Age");
+  assert_eq!(
+    absent
+      .access_control_max_age()
+      .expect("absent Access-Control-Max-Age should parse"),
+    None
+  );
+
+  for value in [
+    "Access-Control-Max-Age: 60\r\naccess-control-max-age: 120",
+    "Access-Control-Max-Age: 60 seconds",
+  ] {
+    let raw = format!("HTTP/1.1 200 OK\r\n{value}\r\nContent-Length: 0\r\n\r\n");
+    let response = Response::new(RoUrl::with("https://example.test"), raw.into_bytes())
+      .expect("raw response should remain usable");
+
+    assert!(response.access_control_max_age().is_err());
+  }
+}
+
+#[test]
 fn test_cross_origin_resource_policy_response_metadata_preserves_raw_headers() {
   for (value, policy) in [
     ("SAME-ORIGIN", CrossOriginResourcePolicy::SameOrigin),


### PR DESCRIPTION
Exposed bounded Access-Control-Max-Age response metadata through rttp-client, including facade exports and on-demand parsing with existing bad-response error handling. Added client coverage for valid, absent, duplicate, malformed, and u64-maximum values; workspace tests pass.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1829/
work_kind: code_work
branch: hbx-1829-rttp-client-expose-access-control
base: main
commit: 734efb5b72fd993be425faf11f2823a02d3b6954
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1829/
    url: https://plane.kahub.in/endless/browse/HBX-1829/
    close_policy: link_only
```