### PR TITLE
feat: rttp-protocol: add bounded Access-Control-Allow-Headers parser

### DIFF
--- a/crates/rttp-protocol/src/access_control_allow_headers.rs
+++ b/crates/rttp-protocol/src/access_control_allow_headers.rs
@@ -1,0 +1,165 @@
+//! Bounded, policy-free `Access-Control-Allow-Headers` response metadata parsing.
+//!
+//! This module validates the response field value only. Callers decide whether
+//! and how to apply CORS header behavior.
+
+use std::error::Error;
+use std::fmt;
+
+/// Maximum bytes accepted in each `Access-Control-Allow-Headers` field value.
+pub const MAX_ACCESS_CONTROL_ALLOW_HEADERS_VALUE_BYTES: usize = 64 * 1024;
+/// Maximum comma-separated field-name members accepted across all field values.
+pub const MAX_ACCESS_CONTROL_ALLOW_HEADERS_FIELD_NAMES: usize = 256;
+
+/// Parsed, bounded `Access-Control-Allow-Headers` response metadata.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AccessControlAllowHeaders {
+  wildcard: bool,
+  field_names: Vec<String>,
+}
+
+impl AccessControlAllowHeaders {
+  pub fn parse(value: impl AsRef<str>) -> Result<Self, AccessControlAllowHeadersParseError> {
+    Self::parse_values([value.as_ref()])
+  }
+
+  pub fn parse_values<'a, I>(values: I) -> Result<Self, AccessControlAllowHeadersParseError>
+  where
+    I: IntoIterator<Item = &'a str>,
+  {
+    let mut wildcard = false;
+    let mut field_names = Vec::new();
+    let mut field_count = 0usize;
+
+    for value in values {
+      if value.len() > MAX_ACCESS_CONTROL_ALLOW_HEADERS_VALUE_BYTES {
+        return Err(AccessControlAllowHeadersParseError::new(
+          "Access-Control-Allow-Headers header value is too large",
+        ));
+      }
+      if value.bytes().any(is_invalid_control_byte) {
+        return Err(AccessControlAllowHeadersParseError::new(
+          "invalid Access-Control-Allow-Headers control byte",
+        ));
+      }
+
+      for member in value.split(',') {
+        let field_name = member.trim_matches([' ', '\t']);
+        field_count += 1;
+        if field_count > MAX_ACCESS_CONTROL_ALLOW_HEADERS_FIELD_NAMES {
+          return Err(AccessControlAllowHeadersParseError::new(
+            "too many Access-Control-Allow-Headers field names",
+          ));
+        }
+        if field_name == "*" {
+          if wildcard || !field_names.is_empty() {
+            return Err(AccessControlAllowHeadersParseError::new(
+              "invalid Access-Control-Allow-Headers field name",
+            ));
+          }
+          wildcard = true;
+          continue;
+        }
+        if wildcard || !is_http_token(field_name) {
+          return Err(AccessControlAllowHeadersParseError::new(
+            "invalid Access-Control-Allow-Headers field name",
+          ));
+        }
+        let normalized = field_name.to_ascii_lowercase();
+        if field_names.contains(&normalized) {
+          return Err(AccessControlAllowHeadersParseError::new(
+            "duplicate Access-Control-Allow-Headers field name",
+          ));
+        }
+        field_names.push(normalized);
+      }
+    }
+
+    if !wildcard && field_names.is_empty() {
+      return Err(AccessControlAllowHeadersParseError::new(
+        "invalid Access-Control-Allow-Headers field name",
+      ));
+    }
+
+    Ok(Self {
+      wildcard,
+      field_names,
+    })
+  }
+
+  pub fn is_wildcard(&self) -> bool {
+    self.wildcard
+  }
+
+  pub fn field_names(&self) -> &[String] {
+    &self.field_names
+  }
+
+  pub fn len(&self) -> usize {
+    self.field_names.len()
+  }
+
+  pub fn is_empty(&self) -> bool {
+    self.field_names.is_empty()
+  }
+
+  pub fn header_value(&self) -> String {
+    if self.wildcard {
+      "*".to_string()
+    } else {
+      self.field_names.join(", ")
+    }
+  }
+}
+
+/// An error returned when `Access-Control-Allow-Headers` metadata is malformed or exceeds bounds.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AccessControlAllowHeadersParseError {
+  message: String,
+}
+
+impl AccessControlAllowHeadersParseError {
+  fn new(message: impl Into<String>) -> Self {
+    Self {
+      message: message.into(),
+    }
+  }
+}
+
+impl fmt::Display for AccessControlAllowHeadersParseError {
+  fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+    formatter.write_str(&self.message)
+  }
+}
+
+impl Error for AccessControlAllowHeadersParseError {}
+
+fn is_http_token(value: &str) -> bool {
+  !value.is_empty() && value.bytes().all(is_http_token_byte)
+}
+
+fn is_invalid_control_byte(byte: u8) -> bool {
+  byte != b'\t' && (byte <= 0x1f || byte == 0x7f)
+}
+
+fn is_http_token_byte(byte: u8) -> bool {
+  byte.is_ascii_alphanumeric()
+    || matches!(
+      byte,
+      b'!'
+        | b'#'
+        | b'$'
+        | b'%'
+        | b'&'
+        | b'\''
+        | b'*'
+        | b'+'
+        | b'-'
+        | b'.'
+        | b'^'
+        | b'_'
+        | b'`'
+        | b'|'
+        | b'~'
+    )
+}

--- a/crates/rttp-protocol/src/lib.rs
+++ b/crates/rttp-protocol/src/lib.rs
@@ -5,6 +5,7 @@
 
 pub mod accept_patch;
 pub mod accept_post;
+pub mod access_control_allow_headers;
 pub mod access_control_allow_methods;
 pub mod access_control_expose_headers;
 pub mod access_control_max_age;

--- a/crates/rttp-protocol/tests/access_control_allow_headers.rs
+++ b/crates/rttp-protocol/tests/access_control_allow_headers.rs
@@ -1,0 +1,89 @@
+use rttp_protocol::access_control_allow_headers::{
+  AccessControlAllowHeaders, MAX_ACCESS_CONTROL_ALLOW_HEADERS_FIELD_NAMES,
+  MAX_ACCESS_CONTROL_ALLOW_HEADERS_VALUE_BYTES,
+};
+
+#[test]
+fn access_control_allow_headers_parses_normalized_field_names() {
+  let allow_headers = AccessControlAllowHeaders::parse("X-Request-Id, ETag")
+    .expect("valid Access-Control-Allow-Headers");
+
+  assert_eq!(allow_headers.field_names(), ["x-request-id", "etag"]);
+  assert!(!allow_headers.is_wildcard());
+  assert_eq!(allow_headers.header_value(), "x-request-id, etag");
+}
+
+#[test]
+fn access_control_allow_headers_accepts_wildcard_as_the_only_member() {
+  let allow_headers =
+    AccessControlAllowHeaders::parse("*").expect("wildcard Access-Control-Allow-Headers");
+
+  assert!(allow_headers.is_wildcard());
+  assert!(allow_headers.field_names().is_empty());
+  assert_eq!(allow_headers.header_value(), "*");
+}
+
+#[test]
+fn access_control_allow_headers_combines_multiple_header_fields() {
+  let allow_headers =
+    AccessControlAllowHeaders::parse_values(["X-Request-Id, ETag", "X-RateLimit-Remaining"])
+      .expect("multiple Access-Control-Allow-Headers fields");
+
+  assert_eq!(
+    allow_headers.field_names(),
+    ["x-request-id", "etag", "x-ratelimit-remaining"]
+  );
+}
+
+#[test]
+fn access_control_allow_headers_rejects_malformed_members() {
+  for value in [
+    "",
+    "X-Request-Id,",
+    ",X-Request-Id",
+    "X-Request-Id,,ETag",
+    "X Request Id",
+    "X-Request-Id\rETag",
+    "*, X-Request-Id",
+    "X-Request-Id, *",
+    "*, *",
+  ] {
+    assert!(
+      AccessControlAllowHeaders::parse(value).is_err(),
+      "{value:?} must be rejected"
+    );
+  }
+}
+
+#[test]
+fn access_control_allow_headers_rejects_case_insensitive_duplicates() {
+  for values in [
+    vec!["X-Request-Id, x-request-id"],
+    vec!["X-Request-Id", "X-REQUEST-ID"],
+  ] {
+    assert!(
+      AccessControlAllowHeaders::parse_values(values).is_err(),
+      "duplicate field names must be rejected"
+    );
+  }
+}
+
+#[test]
+fn access_control_allow_headers_enforces_value_and_field_name_bounds() {
+  assert!(AccessControlAllowHeaders::parse(
+    "x".repeat(MAX_ACCESS_CONTROL_ALLOW_HEADERS_VALUE_BYTES + 1)
+  )
+  .is_err());
+
+  let at_limit = (0..MAX_ACCESS_CONTROL_ALLOW_HEADERS_FIELD_NAMES)
+    .map(|index| format!("x{index}"))
+    .collect::<Vec<_>>()
+    .join(",");
+  assert!(AccessControlAllowHeaders::parse(at_limit).is_ok());
+
+  let too_many = (0..=MAX_ACCESS_CONTROL_ALLOW_HEADERS_FIELD_NAMES)
+    .map(|index| format!("x{index}"))
+    .collect::<Vec<_>>()
+    .join(",");
+  assert!(AccessControlAllowHeaders::parse(too_many).is_err());
+}


### PR DESCRIPTION
Added bounded Access-Control-Allow-Headers response metadata parsing with strict validation and protocol coverage. The parser supports multiple header fields, canonical field names, and a sole wildcard without adding CORS enforcement behavior.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1830/
work_kind: code_work
branch: hbx-1830-rttp-protocol-add-bounded-access
base: main
commit: e3ad243fe29ca6cd34811e4064b1b1170c09ddbe
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1830/
    url: https://plane.kahub.in/endless/browse/HBX-1830/
    close_policy: link_only
```