### PR TITLE
feat: rttp-server: add typed Access-Control-Allow-Headers response helper

### DIFF
--- a/crates/rttp-server/src/server/response.rs
+++ b/crates/rttp-server/src/server/response.rs
@@ -1,5 +1,9 @@
 use super::*;
 
+pub use rttp_protocol::access_control_allow_headers::{
+  AccessControlAllowHeaders as HttpAccessControlAllowHeaders,
+  AccessControlAllowHeadersParseError as HttpAccessControlAllowHeadersParseError,
+};
 pub use rttp_protocol::access_control_allow_methods::{
   AccessControlAllowMethods as HttpAccessControlAllowMethods,
   AccessControlAllowMethodsParseError as HttpAccessControlAllowMethodsParseError,
@@ -697,6 +701,25 @@ impl HttpResponse {
     Ok(self)
   }
 
+  /// Validates and replaces `Access-Control-Allow-Headers` response metadata
+  /// without applying CORS policy.
+  pub fn with_access_control_allow_headers(
+    mut self,
+    value: impl AsRef<str>,
+  ) -> Result<Self, HttpAccessControlAllowHeadersParseError> {
+    let allow_headers = HttpAccessControlAllowHeaders::parse(value)?;
+    self.headers.retain(|header| {
+      !header
+        .name
+        .eq_ignore_ascii_case("Access-Control-Allow-Headers")
+    });
+    self.headers.push(HttpHeader::new(
+      "Access-Control-Allow-Headers",
+      allow_headers.header_value(),
+    ));
+    Ok(self)
+  }
+
   /// Validates and replaces `Reporting-Endpoints` response metadata.
   pub fn with_reporting_endpoints<I, N, U>(
     mut self,
@@ -1170,6 +1193,27 @@ impl HttpResponse {
       return Ok(None);
     }
     HttpAccessControlAllowMethods::parse_values(values).map(Some)
+  }
+
+  /// Parses attached `Access-Control-Allow-Headers` response metadata without
+  /// applying CORS policy.
+  pub fn access_control_allow_headers(
+    &self,
+  ) -> Result<Option<HttpAccessControlAllowHeaders>, HttpAccessControlAllowHeadersParseError> {
+    let values: Vec<&str> = self
+      .headers
+      .iter()
+      .filter(|header| {
+        header
+          .name
+          .eq_ignore_ascii_case("Access-Control-Allow-Headers")
+      })
+      .map(|header| header.value.as_str())
+      .collect();
+    if values.is_empty() {
+      return Ok(None);
+    }
+    HttpAccessControlAllowHeaders::parse_values(values).map(Some)
   }
 
   /// Parses bounded `Reporting-Endpoints` response metadata without scheduling reports.

--- a/crates/rttp-server/src/server/server_tests.rs
+++ b/crates/rttp-server/src/server/server_tests.rs
@@ -150,6 +150,53 @@ fn access_control_allow_methods_helpers_validate_replace_and_parse_response_meta
 }
 
 #[test]
+fn access_control_allow_headers_helpers_validate_replace_and_parse_response_metadata() {
+  let response = HttpResponse::ok([])
+    .header("Access-Control-Allow-Headers", "X-Legacy")
+    .header("access-control-allow-headers", "X-Deprecated")
+    .with_access_control_allow_headers("X-Request-Id, ETag")
+    .expect("Access-Control-Allow-Headers should be accepted");
+
+  let allow_headers = response
+    .access_control_allow_headers()
+    .expect("Access-Control-Allow-Headers should parse")
+    .expect("Access-Control-Allow-Headers should be present");
+  assert_eq!(["x-request-id", "etag"], allow_headers.field_names());
+  assert_eq!(
+    vec![("Access-Control-Allow-Headers", "x-request-id, etag")],
+    response
+      .headers
+      .iter()
+      .map(|header| (header.name.as_str(), header.value.as_str()))
+      .collect::<Vec<_>>()
+  );
+}
+
+#[test]
+fn access_control_allow_headers_helpers_preserve_raw_metadata_and_report_parse_errors() {
+  let malformed = HttpResponse::ok([]).header("Access-Control-Allow-Headers", "X-Request Id");
+  assert!(malformed.access_control_allow_headers().is_err());
+  assert_eq!(
+    Some("X-Request Id"),
+    malformed
+      .headers
+      .iter()
+      .find(|header| header.name.eq_ignore_ascii_case("Access-Control-Allow-Headers"))
+      .map(|header| header.value.as_str())
+  );
+  assert!(HttpResponse::ok([])
+    .with_access_control_allow_headers("X-Request Id")
+    .is_err());
+  assert!(HttpResponse::ok([])
+    .with_access_control_allow_headers("*")
+    .expect("wildcard Access-Control-Allow-Headers should be accepted")
+    .access_control_allow_headers()
+    .expect("wildcard Access-Control-Allow-Headers should parse")
+    .expect("wildcard Access-Control-Allow-Headers should be present")
+    .is_wildcard());
+}
+
+#[test]
 fn access_control_allow_methods_helpers_preserve_raw_metadata_and_report_parse_errors() {
   let malformed = HttpResponse::ok([]).header("Access-Control-Allow-Methods", "GET POST");
   assert!(malformed.access_control_allow_methods().is_err());

--- a/crates/rttp-server/tests/metadata_facade.rs
+++ b/crates/rttp-server/tests/metadata_facade.rs
@@ -1,7 +1,7 @@
 use rttp_server::server::{
-  HttpAcceptCh, HttpAccessControlAllowMethods, HttpConditionalMetadata, HttpEntityTag,
-  HttpPreferenceKind, HttpRequest, HttpResponse, SecFetchDest, SecFetchMode, SecFetchSite,
-  SecFetchUser,
+  HttpAcceptCh, HttpAccessControlAllowHeaders, HttpAccessControlAllowMethods,
+  HttpConditionalMetadata, HttpEntityTag, HttpPreferenceKind, HttpRequest, HttpResponse,
+  SecFetchDest, SecFetchMode, SecFetchSite, SecFetchUser,
 };
 
 #[test]
@@ -9,6 +9,9 @@ fn server_facade_exports_representative_bounded_metadata_types() {
   let accept_ch: HttpAcceptCh = HttpAcceptCh::parse("Sec-CH-UA").expect("Accept-CH should parse");
   let allow_methods: HttpAccessControlAllowMethods =
     HttpAccessControlAllowMethods::parse("GET").expect("Access-Control-Allow-Methods should parse");
+  let allow_headers: HttpAccessControlAllowHeaders =
+    HttpAccessControlAllowHeaders::parse("X-Request-Id")
+      .expect("Access-Control-Allow-Headers should parse");
   let metadata = HttpConditionalMetadata::new().entity_tag(HttpEntityTag::strong("revision-42"));
   let response = HttpResponse::ok("")
     .with_accept_ch(["Sec-CH-UA"])
@@ -20,6 +23,7 @@ fn server_facade_exports_representative_bounded_metadata_types() {
 
   assert_eq!(accept_ch.client_hints(), ["Sec-CH-UA"]);
   assert_eq!(allow_methods.methods(), ["GET"]);
+  assert_eq!(allow_headers.field_names(), ["x-request-id"]);
   assert_eq!(
     metadata
       .entity_tag_value()

--- a/crates/rttp/tests/test_server_models.rs
+++ b/crates/rttp/tests/test_server_models.rs
@@ -1,14 +1,15 @@
 use std::time::{Duration, UNIX_EPOCH};
 
 use rttp::server::{
-  HttpAccept, HttpAcceptCh, HttpAcceptRanges, HttpAccessControlAllowMethods, HttpAllowedMethods,
-  HttpAuthorization, HttpByteRange, HttpByteRangeError, HttpClearSiteData, HttpConditionalMetadata,
-  HttpContentDisposition, HttpContentLanguages, HttpContentSecurityPolicy, HttpContentType,
-  HttpCriticalCh, HttpEntityTag, HttpExpectations, HttpIfNoneMatch, HttpIfRange,
-  HttpIfRangeRequestOutcome, HttpLinkValues, HttpPermissionsPolicy, HttpReferrerPolicy,
-  HttpReportingEndpoints, HttpRequest, HttpRequestAcceptEncodings, HttpRequestCacheControl,
-  HttpRequestTe, HttpResponse, HttpResponseCacheControl, HttpResponseContentEncodings,
-  HttpRetryAfter, HttpServerTiming, HttpVary,
+  HttpAccept, HttpAcceptCh, HttpAcceptRanges, HttpAccessControlAllowHeaders,
+  HttpAccessControlAllowMethods, HttpAllowedMethods, HttpAuthorization, HttpByteRange,
+  HttpByteRangeError, HttpClearSiteData, HttpConditionalMetadata, HttpContentDisposition,
+  HttpContentLanguages, HttpContentSecurityPolicy, HttpContentType, HttpCriticalCh, HttpEntityTag,
+  HttpExpectations, HttpIfNoneMatch, HttpIfRange, HttpIfRangeRequestOutcome, HttpLinkValues,
+  HttpPermissionsPolicy, HttpReferrerPolicy, HttpReportingEndpoints, HttpRequest,
+  HttpRequestAcceptEncodings, HttpRequestCacheControl, HttpRequestTe, HttpResponse,
+  HttpResponseCacheControl, HttpResponseContentEncodings, HttpRetryAfter, HttpServerTiming,
+  HttpVary,
 };
 
 #[test]
@@ -46,6 +47,51 @@ fn response_access_control_allow_methods_helper_validates_and_preserves_raw_head
     HttpResponse::ok("body")
       .access_control_allow_methods()
       .expect("absent Access-Control-Allow-Methods should parse")
+  );
+}
+
+#[test]
+fn response_access_control_allow_headers_helper_validates_and_preserves_raw_headers() {
+  let response = HttpResponse::ok("body")
+    .header("Access-Control-Allow-Headers", "X-Legacy")
+    .header("access-control-allow-headers", "X-Deprecated")
+    .with_access_control_allow_headers("X-Request-Id, ETag")
+    .expect("valid Access-Control-Allow-Headers should be accepted");
+
+  let headers: HttpAccessControlAllowHeaders = response
+    .access_control_allow_headers()
+    .expect("attached Access-Control-Allow-Headers should parse")
+    .expect("Access-Control-Allow-Headers should be present");
+  assert_eq!(["x-request-id", "etag"], headers.field_names());
+  let serialized = String::from_utf8(response.to_bytes()).expect("response should serialize");
+  assert_eq!(
+    1,
+    serialized
+      .matches("\r\nAccess-Control-Allow-Headers: ")
+      .count()
+  );
+  assert!(serialized.contains("\r\nAccess-Control-Allow-Headers: x-request-id, etag\r\n"));
+
+  assert!(HttpResponse::ok("body")
+    .with_access_control_allow_headers("X-Request Id")
+    .is_err());
+  let raw = HttpResponse::ok("body").header("Access-Control-Allow-Headers", "X-Request Id");
+  assert!(raw.access_control_allow_headers().is_err());
+  assert!(String::from_utf8(raw.to_bytes())
+    .expect("response should serialize")
+    .contains("\r\nAccess-Control-Allow-Headers: X-Request Id\r\n"));
+  assert!(HttpResponse::ok("body")
+    .with_access_control_allow_headers("*")
+    .expect("wildcard Access-Control-Allow-Headers should be accepted")
+    .access_control_allow_headers()
+    .expect("wildcard Access-Control-Allow-Headers should parse")
+    .expect("wildcard Access-Control-Allow-Headers should be present")
+    .is_wildcard());
+  assert_eq!(
+    None,
+    HttpResponse::ok("body")
+      .access_control_allow_headers()
+      .expect("absent Access-Control-Allow-Headers should parse")
   );
 }
 


### PR DESCRIPTION
Added typed Access-Control-Allow-Headers response metadata helpers backed by the protocol parser. The server API now emits validated normalized values, replaces existing fields case-insensitively, and exposes parsed access while retaining raw-header APIs. Server and model test suites pass.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1832/
work_kind: code_work
branch: hbx-1832-rttp-server-add-typed-access
base: main
commit: b60ca29cbc17d93752d44dd67d5934ffb410352e
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1832/
    url: https://plane.kahub.in/endless/browse/HBX-1832/
    close_policy: link_only
```