### PR TITLE
feat: rttp-client: expose Access-Control-Allow-Headers response metadata

### DIFF
--- a/crates/rttp-client/src/response/mod.rs
+++ b/crates/rttp-client/src/response/mod.rs
@@ -2,6 +2,9 @@
 
 pub use self::response::*;
 
+pub use rttp_protocol::access_control_allow_headers::{
+  AccessControlAllowHeaders, AccessControlAllowHeadersParseError,
+};
 pub use rttp_protocol::access_control_allow_methods::{
   AccessControlAllowMethods, AccessControlAllowMethodsParseError,
 };

--- a/crates/rttp-client/src/response/response.rs
+++ b/crates/rttp-client/src/response/response.rs
@@ -15,6 +15,7 @@ use crate::response::ServerTiming;
 use crate::response::Trailer;
 use crate::response::WwwAuthenticate;
 use crate::types::{Cookie, Header, RoUrl};
+use rttp_protocol::access_control_allow_headers::AccessControlAllowHeaders;
 use rttp_protocol::access_control_allow_methods::AccessControlAllowMethods;
 use rttp_protocol::access_control_expose_headers::AccessControlExposeHeaders;
 use rttp_protocol::access_control_max_age::AccessControlMaxAge;
@@ -324,6 +325,18 @@ impl Response {
       return Ok(None);
     }
     AccessControlExposeHeaders::parse_values(values.into_iter().map(String::as_str))
+      .map(Some)
+      .map_err(|parse_error| error::bad_response(parse_error.to_string()))
+  }
+
+  /// Parses bounded `Access-Control-Allow-Headers` response metadata without
+  /// applying CORS header policy.
+  pub fn access_control_allow_headers(&self) -> error::Result<Option<AccessControlAllowHeaders>> {
+    let values = self.header_values("access-control-allow-headers");
+    if values.is_empty() {
+      return Ok(None);
+    }
+    AccessControlAllowHeaders::parse_values(values.into_iter().map(String::as_str))
       .map(Some)
       .map_err(|parse_error| error::bad_response(parse_error.to_string()))
   }

--- a/crates/rttp-client/tests/metadata_facade.rs
+++ b/crates/rttp-client/tests/metadata_facade.rs
@@ -1,8 +1,9 @@
 use rttp_client::response::{
-  AcceptCh, AccessControlAllowMethods, AccessControlAllowMethodsParseError,
-  AccessControlExposeHeaders, AccessControlMaxAge, AccessControlMaxAgeParseError, AltSvc,
-  CrossOriginResourcePolicy, Digest, HttpClearSiteData, PreferenceApplied, Priority,
-  ReferrerPolicy, ReferrerPolicyToken, ServerTiming, Trailer,
+  AcceptCh, AccessControlAllowHeaders, AccessControlAllowHeadersParseError,
+  AccessControlAllowMethods, AccessControlAllowMethodsParseError, AccessControlExposeHeaders,
+  AccessControlMaxAge, AccessControlMaxAgeParseError, AltSvc, CrossOriginResourcePolicy, Digest,
+  HttpClearSiteData, PreferenceApplied, Priority, ReferrerPolicy, ReferrerPolicyToken,
+  ServerTiming, Trailer,
 };
 use rttp_client::{SecFetchDest, SecFetchMode, SecFetchSite, SecFetchUser};
 
@@ -13,6 +14,10 @@ fn response_facade_exports_representative_bounded_metadata_types() {
     .expect("Access-Control-Allow-Methods should parse");
   let _: AccessControlAllowMethodsParseError = AccessControlAllowMethods::parse("")
     .expect_err("empty Access-Control-Allow-Methods should be rejected");
+  let allow_headers = AccessControlAllowHeaders::parse("X-Request-Id, ETag")
+    .expect("Access-Control-Allow-Headers should parse");
+  let _: AccessControlAllowHeadersParseError = AccessControlAllowHeaders::parse("")
+    .expect_err("empty Access-Control-Allow-Headers should be rejected");
   let max_age = AccessControlMaxAge::parse("60").expect("Access-Control-Max-Age should parse");
   let _: AccessControlMaxAgeParseError =
     AccessControlMaxAge::parse("").expect_err("empty Access-Control-Max-Age should be rejected");
@@ -34,6 +39,7 @@ fn response_facade_exports_representative_bounded_metadata_types() {
 
   assert_eq!(accept_ch.client_hints(), ["Sec-CH-UA", "DPR"]);
   assert_eq!(allow_methods.methods(), ["GET", "POST"]);
+  assert_eq!(allow_headers.field_names(), ["x-request-id", "etag"]);
   assert_eq!(max_age.seconds(), 60);
   assert_eq!(expose_headers.field_names(), ["x-request-id"]);
   assert_eq!(clear_site_data.directives().len(), 1);

--- a/crates/rttp-client/tests/test_response.rs
+++ b/crates/rttp-client/tests/test_response.rs
@@ -2481,6 +2481,101 @@ fn test_access_control_allow_methods_response_helper_preserves_invalid_or_absent
 }
 
 #[test]
+fn test_access_control_allow_headers_response_helper_parses_valid_lists_wildcard_and_multiple_fields(
+) {
+  let listed = Response::new(
+    RoUrl::with("https://example.test"),
+    b"HTTP/1.1 200 OK\r\nAccess-Control-Allow-Headers: X-Request-Id, ETag\r\nContent-Length: 0\r\n\r\n".to_vec(),
+  )
+  .expect("parse response with Access-Control-Allow-Headers list");
+  assert_eq!(
+    listed
+      .access_control_allow_headers()
+      .expect("Access-Control-Allow-Headers should parse")
+      .expect("Access-Control-Allow-Headers should be present")
+      .field_names(),
+    ["x-request-id", "etag"]
+  );
+
+  let wildcard = Response::new(
+    RoUrl::with("https://example.test"),
+    b"HTTP/1.1 200 OK\r\nAccess-Control-Allow-Headers: *\r\nContent-Length: 0\r\n\r\n".to_vec(),
+  )
+  .expect("parse response with wildcard Access-Control-Allow-Headers");
+  assert!(wildcard
+    .access_control_allow_headers()
+    .expect("wildcard Access-Control-Allow-Headers should parse")
+    .expect("Access-Control-Allow-Headers should be present")
+    .is_wildcard());
+
+  let repeated = Response::new(
+    RoUrl::with("https://example.test"),
+    concat!(
+      "HTTP/1.1 200 OK\r\n",
+      "Access-Control-Allow-Headers: X-Request-Id\r\n",
+      "access-control-allow-headers: ETag, X-RateLimit-Remaining\r\n",
+      "Content-Length: 0\r\n\r\n"
+    )
+    .as_bytes()
+    .to_vec(),
+  )
+  .expect("parse response with repeated Access-Control-Allow-Headers");
+  assert_eq!(
+    repeated
+      .access_control_allow_headers()
+      .expect("repeated Access-Control-Allow-Headers should parse")
+      .expect("Access-Control-Allow-Headers should be present")
+      .field_names(),
+    ["x-request-id", "etag", "x-ratelimit-remaining"]
+  );
+  assert_eq!(
+    repeated.header_values("access-control-allow-headers"),
+    [
+      &"X-Request-Id".to_string(),
+      &"ETag, X-RateLimit-Remaining".to_string()
+    ]
+  );
+}
+
+#[test]
+fn test_access_control_allow_headers_response_helper_handles_absent_invalid_duplicate_and_bounded_metadata(
+) {
+  let absent = Response::new(
+    RoUrl::with("https://example.test"),
+    b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n".to_vec(),
+  )
+  .expect("parse response without Access-Control-Allow-Headers");
+  assert_eq!(
+    absent
+      .access_control_allow_headers()
+      .expect("absent Access-Control-Allow-Headers should parse"),
+    None
+  );
+
+  for value in [
+    "X-Request-Id,,ETag".to_string(),
+    "X-Request-Id, x-request-id".to_string(),
+    "x".repeat(64 * 1024 + 1),
+    (0..=256)
+      .map(|index| format!("x{index}"))
+      .collect::<Vec<_>>()
+      .join(","),
+  ] {
+    let raw = format!(
+      "HTTP/1.1 200 OK\r\nAccess-Control-Allow-Headers: {value}\r\nContent-Length: 0\r\n\r\n"
+    );
+    let response = Response::new(RoUrl::with("https://example.test"), raw.into_bytes())
+      .expect("raw response should remain usable");
+
+    assert!(response.access_control_allow_headers().is_err());
+    assert_eq!(
+      response.header_value("Access-Control-Allow-Headers"),
+      Some(&value)
+    );
+  }
+}
+
+#[test]
 fn test_access_control_max_age_response_helper_parses_valid_and_maximum_values() {
   for (value, expected_seconds) in [("600", 600), ("18446744073709551615", u64::MAX)] {
     let raw =


### PR DESCRIPTION
Added bounded Access-Control-Allow-Headers response metadata to rttp-client, including public protocol re-exports and response integration coverage. The accessor is policy-free, preserves raw headers, and reports malformed metadata through the existing bad-response error path.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1831/
work_kind: code_work
branch: hbx-1831-rttp-client-expose-access-control
base: main
commit: 866332c61cf03f3d6c2129b72c87092a9cfaff9c
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1831/
    url: https://plane.kahub.in/endless/browse/HBX-1831/
    close_policy: link_only
```