### PR TITLE
feat: RTTP: Enforce full workspace Clippy coverage in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
         run: cargo fmt --all -- --check
 
       - name: Lint
-        run: cargo clippy --all -- -D warnings
+        run: cargo clippy --workspace --all-targets --all-features -- -D warnings
 
       - name: Run tests
         run: cargo test --all-features

--- a/crates/rttp-client/src/connection/connection.rs
+++ b/crates/rttp-client/src/connection/connection.rs
@@ -943,7 +943,7 @@ impl<'a> Connection<'a> {
   {
     #[cfg(all(feature = "tls-native", feature = "tls-rustls"))]
     {
-      return self.block_send_https_rustls_parts(url, stream);
+      self.block_send_https_rustls_parts(url, stream)
     }
     #[cfg(all(feature = "tls-native", not(feature = "tls-rustls")))]
     {
@@ -967,7 +967,7 @@ impl<'a> Connection<'a> {
   {
     #[cfg(all(feature = "tls-native", feature = "tls-rustls"))]
     {
-      return self.block_send_https_rustls_streaming_parts(url, stream, body);
+      self.block_send_https_rustls_streaming_parts(url, stream, body)
     }
     #[cfg(all(feature = "tls-native", not(feature = "tls-rustls")))]
     {

--- a/crates/rttp-client/src/http2.rs
+++ b/crates/rttp-client/src/http2.rs
@@ -2652,6 +2652,7 @@ fn is_forbidden_response_trailer_name(name: &str) -> bool {
 }
 
 #[cfg(test)]
+#[allow(clippy::items_after_test_module)]
 mod tests {
   use super::*;
 

--- a/crates/rttp-client/src/request/builder/build_body_async.rs
+++ b/crates/rttp-client/src/request/builder/build_body_async.rs
@@ -44,7 +44,7 @@ impl<'a> RawBuilder<'a> {
         let file = formdata
           .file()
           .clone()
-          .ok_or(error::builder_with_message(&format!(
+          .ok_or(error::builder_with_message(format!(
             "Missing file path for field: {}",
             formdata.name()
           )))?;

--- a/crates/rttp-client/tests/test_http_basic.rs
+++ b/crates/rttp-client/tests/test_http_basic.rs
@@ -205,7 +205,7 @@ fn test_multi() {
     .header("User-Agent: Mozilla/5.0")
     .header(("Host", addr.to_string().as_str()))
     .para("name=Chico")
-    .para(&"name=文".to_string())
+    .para("name=文".to_string())
     .para(para_map)
     .form(("debug", "true", "name=Form"))
     .cookie("token=123234")
@@ -1338,7 +1338,7 @@ fn captured_request(request: Vec<u8>) -> CapturedRequest {
     .expect("captured request method")
     .to_string();
   let target = request_line_parts
-    .nth(0)
+    .next()
     .expect("captured request target")
     .to_string();
   let headers = lines

--- a/crates/rttp-protocol/src/cookie.rs
+++ b/crates/rttp-protocol/src/cookie.rs
@@ -251,13 +251,12 @@ mod tests {
     assert!(HttpCookies::parse(&oversized_value).is_err());
     assert!(HttpSetCookie::parse(&oversized_value).is_err());
 
-    let pairs = std::iter::repeat("name=value")
-      .take(MAX_COOKIE_COUNT + 1)
+    let pairs = std::iter::repeat_n("name=value", MAX_COOKIE_COUNT + 1)
       .collect::<Vec<_>>()
       .join(";");
     assert!(HttpCookies::parse(&pairs).is_err());
 
-    let fields = std::iter::repeat("name=value").take(MAX_COOKIE_COUNT + 1);
+    let fields = std::iter::repeat_n("name=value", MAX_COOKIE_COUNT + 1);
     assert!(HttpSetCookies::parse_values(fields).is_err());
   }
 

--- a/crates/rttp-test-support/src/client_helpers.rs
+++ b/crates/rttp-test-support/src/client_helpers.rs
@@ -199,6 +199,7 @@ impl GatedResponseBody {
     self.partial_body_sent.recv_timeout(timeout)
   }
 
+  #[allow(clippy::result_unit_err)]
   pub fn release_body(&self) -> Result<(), ()> {
     self
       .control
@@ -206,6 +207,7 @@ impl GatedResponseBody {
       .map_err(|_| ())
   }
 
+  #[allow(clippy::result_unit_err)]
   pub fn cancel_body(&self) -> Result<(), ()> {
     self
       .control
@@ -937,10 +939,7 @@ pub fn spawn_auth_echo_server() -> (SocketAddr, JoinHandle<()>) {
     if let Ok((mut stream, _)) = listener.accept() {
       let mut request = Vec::new();
       let mut buf = [0u8; 1024];
-      loop {
-        let Ok(read) = stream.read(&mut buf) else {
-          break;
-        };
+      while let Ok(read) = stream.read(&mut buf) {
         if read == 0 {
           break;
         }

--- a/crates/rttp-test-support/src/local_http.rs
+++ b/crates/rttp-test-support/src/local_http.rs
@@ -19,10 +19,7 @@ pub fn read_http_request<R: Read>(stream: &mut R) -> Vec<u8> {
   let mut buf = [0u8; 1024];
   let mut content_length = None;
 
-  loop {
-    let Ok(read) = stream.read(&mut buf) else {
-      break;
-    };
+  while let Ok(read) = stream.read(&mut buf) {
     if read == 0 {
       break;
     }

--- a/crates/rttp/tests/http11_compliance_matrix.rs
+++ b/crates/rttp/tests/http11_compliance_matrix.rs
@@ -646,8 +646,7 @@ fn server_response_with_retry_after_coexists_with_cache_metadata_helpers() {
     .expect("Vary should parse")
     .expect("Vary should be present")
     .field_names()
-    .iter()
-    .any(|name| *name == "accept-encoding"));
+    .contains(&"accept-encoding"));
 }
 
 #[test]
@@ -860,8 +859,7 @@ fn server_response_with_allow_coexists_with_cache_and_retry_metadata_helpers() {
     .expect("Vary should parse")
     .expect("Vary should be present")
     .field_names()
-    .iter()
-    .any(|name| *name == "accept-encoding"));
+    .contains(&"accept-encoding"));
   assert_eq!(
     Some(HttpRetryAfter::DeltaSeconds(30)),
     response.retry_after().expect("Retry-After should parse")

--- a/crates/rttp/tests/http2_feature.rs
+++ b/crates/rttp/tests/http2_feature.rs
@@ -2334,7 +2334,7 @@ fn prior_knowledge_server_policy_advertises_and_enforces_frame_and_metadata_boun
 
   write_h2_frame(&mut stream, H2_FRAME_SETTINGS, H2_FLAG_ACK, 0, &[]);
   let mut headers = h2_head_headers(b"/policy", addr.to_string().as_bytes());
-  headers.extend(h2_literal_new_name(b"x-policy-limit", &vec![b'x'; 100]));
+  headers.extend(h2_literal_new_name(b"x-policy-limit", &[b'x'; 100]));
   write_h2_frame(
     &mut stream,
     H2_FRAME_HEADERS,

--- a/tests/http11_client_server_matrix.rs
+++ b/tests/http11_client_server_matrix.rs
@@ -16,6 +16,9 @@ use rttp_server::server::{
 };
 use rttp_test_support as fixtures;
 
+type ObservedIfRangeHeaders = (Option<String>, Option<String>);
+type ObservedIfRangeHandle = thread::JoinHandle<ObservedIfRangeHeaders>;
+
 fn client() -> HttpClient {
   HttpClient::new()
 }
@@ -338,10 +341,7 @@ fn spawn_range_server() -> (std::net::SocketAddr, thread::JoinHandle<Option<Stri
 
 fn spawn_if_range_server(
   metadata: HttpConditionalMetadata,
-) -> (
-  std::net::SocketAddr,
-  thread::JoinHandle<(Option<String>, Option<String>)>,
-) {
+) -> (std::net::SocketAddr, ObservedIfRangeHandle) {
   let server = rttp_server::server::HttpServer::bind("127.0.0.1:0").expect("bind if-range server");
   let addr = server.local_addr().expect("if-range server addr");
   let (tx, rx) = mpsc::channel();
@@ -828,7 +828,7 @@ fn assert_observed_range(
 }
 
 fn assert_observed_if_range(
-  handle: thread::JoinHandle<(Option<String>, Option<String>)>,
+  handle: ObservedIfRangeHandle,
   expected_range: &str,
   expected_if_range: &str,
   name: &str,


### PR DESCRIPTION
Enforce full workspace, target, and feature Clippy coverage in CI and resolve all lint findings exposed by the expanded command without changing behavior.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1834/
work_kind: code_work
branch: hbx-1834-rttp-enforce-full-workspace-clippy
base: main
commit: a3ad337bf7caf17d3a53fbbb5ab0b9912c12e027
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1834/
    url: https://plane.kahub.in/endless/browse/HBX-1834/
    close_policy: link_only
```