### PR TITLE
feat: RTTP: Make Error::is_timeout detect real I/O timeouts

### DIFF
--- a/crates/rttp-client/src/connection/async_connection.rs
+++ b/crates/rttp-client/src/connection/async_connection.rs
@@ -825,7 +825,7 @@ impl<'a> AsyncConnection<'a> {
     } else if !config.verify_ssl_hostname() {
       let verifier = rustls::client::WebPkiServerVerifier::builder(Arc::new(root_store))
         .build()
-        .map_err(|e| error::bad_ssl(e.to_string()))?;
+        .map_err(error::bad_ssl)?;
       builder
         .dangerous()
         .with_custom_certificate_verifier(Arc::new(NoHostnameVerification::new(verifier)))
@@ -849,7 +849,7 @@ impl<'a> AsyncConnection<'a> {
     let mut tls_stream = connector
       .connect(server_name, async_tcp)
       .await
-      .map_err(|e| error::bad_ssl(e.to_string()))?;
+      .map_err(error::bad_ssl)?;
 
     match self
       .async_send_expect_continue_parts(&mut tls_stream)
@@ -895,7 +895,7 @@ impl<'a> AsyncConnection<'a> {
     } else if !config.verify_ssl_hostname() {
       let verifier = rustls::client::WebPkiServerVerifier::builder(Arc::new(root_store))
         .build()
-        .map_err(|e| error::bad_ssl(e.to_string()))?;
+        .map_err(error::bad_ssl)?;
       builder
         .dangerous()
         .with_custom_certificate_verifier(Arc::new(NoHostnameVerification::new(verifier)))
@@ -919,7 +919,7 @@ impl<'a> AsyncConnection<'a> {
     let mut tls_stream = connector
       .connect(server_name, async_tcp)
       .await
-      .map_err(|e| error::bad_ssl(e.to_string()))?;
+      .map_err(error::bad_ssl)?;
 
     self
       .async_write_streaming_request(&mut tls_stream, body)

--- a/crates/rttp-client/src/connection/connection.rs
+++ b/crates/rttp-client/src/connection/connection.rs
@@ -996,7 +996,7 @@ impl<'a> Connection<'a> {
       .map_err(error::request)?;
     let mut ssl_stream = connector
       .connect(&self.host(url)?[..], stream)
-      .map_err(|_| error::bad_ssl("Native tls handshake error"))?;
+      .map_err(native_tls_handshake_error)?;
 
     match self.block_send_expect_continue_parts(&mut ssl_stream)? {
       ExpectContinueResult::NotUsed => self.block_write_stream(&mut ssl_stream)?,
@@ -1028,7 +1028,7 @@ impl<'a> Connection<'a> {
       .map_err(error::request)?;
     let mut ssl_stream = connector
       .connect(&self.host(url)?[..], stream)
-      .map_err(|_| error::bad_ssl("Native tls handshake error"))?;
+      .map_err(native_tls_handshake_error)?;
 
     self.block_write_streaming_request(&mut ssl_stream, body)?;
     self.block_read_stream_parts(url, &mut ssl_stream)
@@ -1058,7 +1058,7 @@ impl<'a> Connection<'a> {
     } else if !config.verify_ssl_hostname() {
       let verifier = WebPkiServerVerifier::builder(Arc::new(root_store))
         .build()
-        .map_err(|e| error::bad_ssl(e.to_string()))?;
+        .map_err(error::bad_ssl)?;
       builder
         .dangerous()
         .with_custom_certificate_verifier(Arc::new(NoHostnameVerification::new(verifier)))
@@ -1076,8 +1076,7 @@ impl<'a> Connection<'a> {
         .map_err(|_| error::bad_ssl(format!("Invalid server name: {}", host)))?
         .to_owned(),
     };
-    let client =
-      ClientConnection::new(rc_config, server_name).map_err(|e| error::bad_ssl(e.to_string()))?;
+    let client = ClientConnection::new(rc_config, server_name).map_err(error::bad_ssl)?;
     let mut tls = StreamOwned::new(client, stream);
 
     match self.block_send_expect_continue_parts(&mut tls)? {
@@ -1117,7 +1116,7 @@ impl<'a> Connection<'a> {
     } else if !config.verify_ssl_hostname() {
       let verifier = WebPkiServerVerifier::builder(Arc::new(root_store))
         .build()
-        .map_err(|e| error::bad_ssl(e.to_string()))?;
+        .map_err(error::bad_ssl)?;
       builder
         .dangerous()
         .with_custom_certificate_verifier(Arc::new(NoHostnameVerification::new(verifier)))
@@ -1135,12 +1134,22 @@ impl<'a> Connection<'a> {
         .map_err(|_| error::bad_ssl(format!("Invalid server name: {}", host)))?
         .to_owned(),
     };
-    let client =
-      ClientConnection::new(rc_config, server_name).map_err(|e| error::bad_ssl(e.to_string()))?;
+    let client = ClientConnection::new(rc_config, server_name).map_err(error::bad_ssl)?;
     let mut tls = StreamOwned::new(client, stream);
 
     self.block_write_streaming_request(&mut tls, body)?;
     self.block_read_stream_parts(url, &mut tls)
+  }
+}
+
+#[cfg(all(feature = "tls-native", not(feature = "tls-rustls")))]
+fn native_tls_handshake_error<S>(error: native_tls::HandshakeError<S>) -> error::Error {
+  match error {
+    native_tls::HandshakeError::Failure(error) => error::bad_ssl(error),
+    native_tls::HandshakeError::WouldBlock(_) => error::bad_ssl(io::Error::new(
+      io::ErrorKind::WouldBlock,
+      "native TLS handshake would block",
+    )),
   }
 }
 

--- a/crates/rttp-client/src/error.rs
+++ b/crates/rttp-client/src/error.rs
@@ -59,7 +59,7 @@ impl Error {
 
   /// Returns true if the error is related to a timeout.
   pub fn is_timeout(&self) -> bool {
-    self.source().map(|e| e.is::<TimedOut>()).unwrap_or(false)
+    self.source().is_some_and(is_timeout_source)
   }
 
   /// Returns the status code, if the error was generated from a response.
@@ -251,8 +251,8 @@ pub(crate) fn connection_closed() -> Error {
 }
 
 #[allow(dead_code)]
-pub(crate) fn bad_ssl(message: impl AsRef<str>) -> Error {
-  Error::new(Kind::Request, Some(message.as_ref()))
+pub(crate) fn bad_ssl<E: Into<BoxError>>(e: E) -> Error {
+  Error::new(Kind::Request, Some(e))
 }
 
 // io::Error helpers
@@ -286,3 +286,73 @@ impl fmt::Display for TimedOut {
 }
 
 impl StdError for TimedOut {}
+
+fn is_timeout_source(error: &(dyn StdError + 'static)) -> bool {
+  if error.is::<TimedOut>() {
+    return true;
+  }
+  if let Some(error) = error.downcast_ref::<io::Error>() {
+    if matches!(
+      error.kind(),
+      io::ErrorKind::TimedOut | io::ErrorKind::WouldBlock
+    ) || error
+      .get_ref()
+      .is_some_and(|error| is_timeout_source(error))
+    {
+      return true;
+    }
+  }
+  error.source().is_some_and(is_timeout_source)
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn request_io_timeout_kinds_are_timeouts() {
+    for kind in [io::ErrorKind::TimedOut, io::ErrorKind::WouldBlock] {
+      let error = request(io::Error::new(kind, "socket operation timed out"));
+
+      assert!(error.is_timeout(), "{kind:?} should be a timeout");
+    }
+  }
+
+  #[test]
+  fn nested_io_timeout_source_is_a_timeout() {
+    let timeout = io::Error::new(io::ErrorKind::TimedOut, "socket operation timed out");
+    let wrapped = io::Error::other(timeout);
+
+    assert!(request(wrapped).is_timeout());
+  }
+
+  #[test]
+  fn tls_io_timeout_is_a_timeout() {
+    let error = bad_ssl(io::Error::new(
+      io::ErrorKind::TimedOut,
+      "TLS handshake timed out",
+    ));
+
+    assert!(error.is_timeout());
+  }
+
+  #[test]
+  fn non_timeout_errors_are_not_timeouts() {
+    let errors = [
+      request(io::Error::new(
+        io::ErrorKind::ConnectionRefused,
+        "connection refused",
+      )),
+      request(io::Error::new(
+        io::ErrorKind::UnexpectedEof,
+        "unexpected EOF",
+      )),
+      decode_io(io::Error::new(io::ErrorKind::InvalidData, "decode error")),
+      builder_with_message("builder error"),
+    ];
+
+    for error in errors {
+      assert!(!error.is_timeout(), "{error:?} should not be a timeout");
+    }
+  }
+}


### PR DESCRIPTION
Make Error::is_timeout detect real and nested I/O timeouts while preserving timeout sources across TLS connection paths.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1842/
work_kind: code_work
branch: hbx-1842-rttp-make-error-is-timeout
base: main
commit: fb057322760870c6edadc3882d378c3496c557f3
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1842/
    url: https://plane.kahub.in/endless/browse/HBX-1842/
    close_policy: link_only
```