### PR TITLE
feat: RTTP: Bound buffered and decoded client response bodies

### DIFF
--- a/crates/rttp-client/src/config.rs
+++ b/crates/rttp-client/src/config.rs
@@ -1,3 +1,6 @@
+/// Default maximum number of bytes buffered for a client response body.
+pub const DEFAULT_MAX_BUFFERED_RESPONSE_BODY_BYTES: usize = 16 * 1024 * 1024;
+
 /// Local settings for the bounded prior-knowledge h2c client path.
 ///
 /// The default policy leaves both settings unadvertised, retaining the HTTP/2
@@ -44,6 +47,7 @@ pub struct Config {
   max_redirect: u32,
   verify_ssl_hostname: bool,
   verify_ssl_cert: bool,
+  max_buffered_response_body_bytes: usize,
   http2_max_frame_size: Option<usize>,
   http2_header_table_size: Option<usize>,
 }
@@ -83,6 +87,9 @@ impl Config {
   }
   pub fn verify_ssl_hostname(&self) -> bool {
     self.verify_ssl_hostname
+  }
+  pub fn max_buffered_response_body_bytes(&self) -> usize {
+    self.max_buffered_response_body_bytes
   }
   pub fn http2_max_frame_size(&self) -> Option<usize> {
     self.http2_max_frame_size
@@ -125,6 +132,7 @@ impl ConfigBuilder {
         max_redirect: 0,
         verify_ssl_hostname: true,
         verify_ssl_cert: true,
+        max_buffered_response_body_bytes: DEFAULT_MAX_BUFFERED_RESPONSE_BODY_BYTES,
         http2_max_frame_size: None,
         http2_header_table_size: None,
       },
@@ -160,6 +168,17 @@ impl ConfigBuilder {
   }
   pub fn verify_ssl_cert(&mut self, verify_ssl_cert: bool) -> &mut Self {
     self.config.verify_ssl_cert = verify_ssl_cert;
+    self
+  }
+  /// Set the maximum number of wire or decoded body bytes buffered by a response.
+  ///
+  /// This limit does not apply when callers consume a streaming response body
+  /// directly.
+  pub fn max_buffered_response_body_bytes(
+    &mut self,
+    max_buffered_response_body_bytes: usize,
+  ) -> &mut Self {
+    self.config.max_buffered_response_body_bytes = max_buffered_response_body_bytes;
     self
   }
   /// Configure local settings for the bounded prior-knowledge h2c client path.
@@ -216,6 +235,7 @@ mod tests {
       .max_redirect(5)
       .verify_ssl_hostname(false)
       .verify_ssl_cert(false)
+      .max_buffered_response_body_bytes(123)
       .http2_max_frame_size(16_384)
       .http2_header_table_size(64)
       .build();
@@ -226,6 +246,7 @@ mod tests {
     assert_eq!(config.max_redirect(), 5);
     assert!(!config.verify_ssl_hostname());
     assert!(!config.verify_ssl_cert());
+    assert_eq!(123, config.max_buffered_response_body_bytes());
     assert_eq!(Some(16_384), config.http2_max_frame_size());
     assert_eq!(Some(64), config.http2_header_table_size());
   }
@@ -234,6 +255,12 @@ mod tests {
   fn default_config_matches_builder_defaults() {
     let default_config = Config::default();
     let builder_config = Config::builder().build();
+
+    assert_eq!(
+      DEFAULT_MAX_BUFFERED_RESPONSE_BODY_BYTES,
+      default_config.max_buffered_response_body_bytes()
+    );
+    assert!(default_config.max_buffered_response_body_bytes() > 0);
 
     assert_eq!(default_config.read_timeout(), builder_config.read_timeout());
     assert_eq!(
@@ -252,6 +279,10 @@ mod tests {
     assert_eq!(
       default_config.verify_ssl_cert(),
       builder_config.verify_ssl_cert()
+    );
+    assert_eq!(
+      default_config.max_buffered_response_body_bytes(),
+      builder_config.max_buffered_response_body_bytes()
     );
     assert_eq!(
       default_config.http2_max_frame_size(),

--- a/crates/rttp-client/src/connection/async_connection.rs
+++ b/crates/rttp-client/src/connection/async_connection.rs
@@ -63,11 +63,14 @@ impl<'a, S: AsyncRead + Unpin + ?Sized> AsyncStreamingResponse<'a, S> {
     self.trailer(name).map(|header| header.value())
   }
 
-  async fn read_to_parts(mut self) -> error::Result<ResponseParts> {
+  async fn read_to_parts(mut self, max_body_bytes: usize) -> error::Result<ResponseParts> {
     let close_connection = response_connection_should_close(&self.head)?;
     let connection_reusable = response_connection_reusable(&self.head, &self.body.kind)?;
     let mut binary = self.head;
-    self.body.read_to_end(&mut binary).await?;
+    self
+      .body
+      .read_to_end_bounded(&mut binary, max_body_bytes)
+      .await?;
     Ok(ResponseParts {
       binary,
       trailers: self.body.trailers().clone(),
@@ -134,6 +137,28 @@ impl<'a, S: AsyncRead + Unpin + ?Sized> AsyncResponseBodyReader<'a, S> {
         return Ok(body.len() - start);
       }
       body.extend_from_slice(&buf[..read]);
+    }
+  }
+
+  async fn read_to_end_bounded(
+    &mut self,
+    body: &mut Vec<u8>,
+    max_body_bytes: usize,
+  ) -> error::Result<usize> {
+    let start = body.len();
+    let mut buffer = [0u8; 8 * 1024];
+    loop {
+      let body_len = body.len() - start;
+      let remaining = max_body_bytes - body_len;
+      let read_limit = buffer.len().min(remaining.saturating_add(1));
+      let read = self.read(&mut buffer[..read_limit]).await?;
+      if read == 0 {
+        return Ok(body_len);
+      }
+      if read > remaining {
+        return Err(error::body_too_large(max_body_bytes));
+      }
+      body.extend_from_slice(&buffer[..read]);
     }
   }
 
@@ -255,11 +280,12 @@ impl<'a> AsyncConnection<'a> {
       };
 
       let close_connection = parts.close_connection;
-      let response = Response::with_trailers_and_informational(
+      let response = Response::with_trailers_and_informational_and_limit(
         self.conn.rourl().clone(),
         parts.binary,
         parts.trailers,
         parts.informational_responses,
+        self.conn.config().max_buffered_response_body_bytes(),
       )?;
       let config = self.conn.config().clone();
 
@@ -317,11 +343,12 @@ impl<'a> AsyncConnection<'a> {
     let url = self.conn.url().map_err(error::builder)?;
     let parts = self.async_send_streaming_parts(&url, body).await?;
     let close_connection = parts.close_connection;
-    let response = Response::with_trailers_and_informational(
+    let response = Response::with_trailers_and_informational_and_limit(
       self.conn.rourl().clone(),
       parts.binary,
       parts.trailers,
       parts.informational_responses,
+      self.conn.config().max_buffered_response_body_bytes(),
     )?;
     self.conn.closed_set(close_connection);
     Ok(response)
@@ -444,7 +471,7 @@ impl<'a> AsyncConnection<'a> {
     let mut parts =
       async_streaming_response_after_header(stream, self.conn.expect_no_response_body(), binary)
         .await?
-        .read_to_parts()
+        .read_to_parts(self.conn.config().max_buffered_response_body_bytes())
         .await?;
     parts.informational_responses = informational_responses;
     Ok(parts)

--- a/crates/rttp-client/src/connection/block_connection.rs
+++ b/crates/rttp-client/src/connection/block_connection.rs
@@ -59,11 +59,12 @@ impl<'a> BlockConnection<'a> {
       };
 
       let close_connection = parts.close_connection;
-      let response = Response::with_trailers_and_informational(
+      let response = Response::with_trailers_and_informational_and_limit(
         self.conn.rourl().clone(),
         parts.binary,
         parts.trailers,
         parts.informational_responses,
+        self.conn.config().max_buffered_response_body_bytes(),
       )?;
       let config = self.conn.config().clone();
 
@@ -120,11 +121,12 @@ impl<'a> BlockConnection<'a> {
     let url = self.conn.url().map_err(error::builder)?;
     let parts = self.conn.block_send_streaming_parts(&url, body)?;
     let close_connection = parts.close_connection;
-    let response = Response::with_trailers_and_informational(
+    let response = Response::with_trailers_and_informational_and_limit(
       self.conn.rourl().clone(),
       parts.binary,
       parts.trailers,
       parts.informational_responses,
+      self.conn.config().max_buffered_response_body_bytes(),
     )?;
     self.conn.closed_set(close_connection);
     Ok(response)

--- a/crates/rttp-client/src/connection/connection.rs
+++ b/crates/rttp-client/src/connection/connection.rs
@@ -12,8 +12,8 @@ use url::Url;
 use crate::connection::connection_reader::{
   is_skippable_informational_status, parse_informational_response, read_response_head,
   read_response_header, read_response_parts_after_header,
-  read_response_parts_after_header_with_informational, response_status_code, ConnectionReader,
-  ResponseParts,
+  read_response_parts_after_header_with_informational_and_limit, response_status_code,
+  ConnectionReader, ResponseParts,
 };
 use crate::request::{RawRequest, RequestBody};
 use crate::response::{InformationalResponse, Response};
@@ -740,7 +740,12 @@ impl<'a> Connection<'a> {
   where
     S: io::Read,
   {
-    let mut reader = ConnectionReader::new(url, stream, self.expect_no_response_body());
+    let mut reader = ConnectionReader::new_with_limit(
+      url,
+      stream,
+      self.expect_no_response_body(),
+      self.config().max_buffered_response_body_bytes(),
+    );
     reader.response_parts()
   }
 
@@ -780,11 +785,12 @@ impl<'a> Connection<'a> {
         informational_responses.push(parse_informational_response(&header)?);
         continue;
       }
-      return read_response_parts_after_header_with_informational(
+      return read_response_parts_after_header_with_informational_and_limit(
         stream,
         self.expect_no_response_body(),
         header,
         informational_responses,
+        self.config().max_buffered_response_body_bytes(),
       )
       .map(ExpectContinueResult::Final);
     }

--- a/crates/rttp-client/src/connection/connection_reader.rs
+++ b/crates/rttp-client/src/connection/connection_reader.rs
@@ -7,6 +7,7 @@ use rttp_protocol::http1::{
 };
 use url::Url;
 
+use crate::config::DEFAULT_MAX_BUFFERED_RESPONSE_BODY_BYTES;
 use crate::error;
 use crate::response::{InformationalResponse, Response};
 use crate::types::{Header, RoUrl};
@@ -72,7 +73,11 @@ impl<'a, R: Read + ?Sized> StreamingResponse<'a, R> {
 
   pub fn read_to_response(mut self) -> error::Result<Response> {
     let mut binary = self.head.clone();
-    self.body.read_to_end(&mut binary).map_err(error::request)?;
+    read_response_body_to_end(
+      &mut self.body,
+      &mut binary,
+      DEFAULT_MAX_BUFFERED_RESPONSE_BODY_BYTES,
+    )?;
     Response::with_trailers(self.url, binary, self.body.trailers().clone())
   }
 }
@@ -190,6 +195,7 @@ pub struct ConnectionReader<'a> {
   url: &'a Url,
   reader: &'a mut dyn io::Read,
   expect_no_body: bool,
+  max_buffered_response_body_bytes: usize,
 }
 
 impl<'a> ConnectionReader<'a> {
@@ -198,20 +204,46 @@ impl<'a> ConnectionReader<'a> {
     reader: &'a mut dyn io::Read,
     expect_no_body: bool,
   ) -> ConnectionReader<'a> {
+    Self::new_with_limit(
+      url,
+      reader,
+      expect_no_body,
+      DEFAULT_MAX_BUFFERED_RESPONSE_BODY_BYTES,
+    )
+  }
+
+  pub(crate) fn new_with_limit(
+    url: &'a Url,
+    reader: &'a mut dyn io::Read,
+    expect_no_body: bool,
+    max_buffered_response_body_bytes: usize,
+  ) -> ConnectionReader<'a> {
     Self {
       url,
       reader,
       expect_no_body,
+      max_buffered_response_body_bytes,
     }
   }
 
   #[allow(dead_code)]
   pub fn binary(&mut self) -> error::Result<Vec<u8>> {
-    Ok(read_response_parts(self.reader, self.expect_no_body)?.binary)
+    Ok(
+      read_response_parts_with_limit(
+        self.reader,
+        self.expect_no_body,
+        self.max_buffered_response_body_bytes,
+      )?
+      .binary,
+    )
   }
 
   pub(crate) fn response_parts(&mut self) -> error::Result<ResponseParts> {
-    read_response_parts(self.reader, self.expect_no_body)
+    read_response_parts_with_limit(
+      self.reader,
+      self.expect_no_body,
+      self.max_buffered_response_body_bytes,
+    )
   }
 
   pub fn streaming_response(&mut self) -> error::Result<StreamingResponse<'_, dyn io::Read + '_>> {
@@ -227,40 +259,44 @@ impl<'a> ConnectionReader<'a> {
   #[allow(dead_code)]
   pub fn response(&mut self) -> error::Result<Response> {
     let parts = self.response_parts()?;
-    Response::with_trailers_and_informational(
+    Response::with_trailers_and_informational_and_limit(
       RoUrl::from(self.url.clone()),
       parts.binary,
       parts.trailers,
       parts.informational_responses,
+      self.max_buffered_response_body_bytes,
     )
   }
 
   // todo Connection reader will read more type from io::Reader, like Chunk data, and Stream data.
 }
 
-pub(crate) fn read_response_parts<R>(
+pub(crate) fn read_response_parts_with_limit<R>(
   reader: &mut R,
   expect_no_body: bool,
+  max_body_bytes: usize,
 ) -> error::Result<ResponseParts>
 where
   R: Read + ?Sized,
 {
-  read_response_parts_with_informational(reader, expect_no_body)
+  read_response_parts_with_informational_and_limit(reader, expect_no_body, max_body_bytes)
 }
 
-pub(crate) fn read_response_parts_with_informational<R>(
+pub(crate) fn read_response_parts_with_informational_and_limit<R>(
   reader: &mut R,
   expect_no_body: bool,
+  max_body_bytes: usize,
 ) -> error::Result<ResponseParts>
 where
   R: Read + ?Sized,
 {
   let (binary, informational_responses) = read_response_head_with_informational(reader)?;
-  read_response_parts_after_header_with_informational(
+  read_response_parts_after_header_with_informational_and_limit(
     reader,
     expect_no_body,
     binary,
     informational_responses,
+    max_body_bytes,
   )
 }
 
@@ -304,14 +340,21 @@ pub(crate) fn read_response_parts_after_header<R>(
 where
   R: Read + ?Sized,
 {
-  read_response_parts_after_header_with_informational(reader, expect_no_body, binary, Vec::new())
+  read_response_parts_after_header_with_informational_and_limit(
+    reader,
+    expect_no_body,
+    binary,
+    Vec::new(),
+    DEFAULT_MAX_BUFFERED_RESPONSE_BODY_BYTES,
+  )
 }
 
-pub(crate) fn read_response_parts_after_header_with_informational<R>(
+pub(crate) fn read_response_parts_after_header_with_informational_and_limit<R>(
   reader: &mut R,
   expect_no_body: bool,
   mut binary: Vec<u8>,
   informational_responses: Vec<InformationalResponse>,
+  max_body_bytes: usize,
 ) -> error::Result<ResponseParts>
 where
   R: Read + ?Sized,
@@ -324,20 +367,16 @@ where
     ResponseBodyKind::NoBody => {}
     ResponseBodyKind::Chunked => {
       let mut body_reader = ResponseBodyReader::new(reader, ResponseBodyKind::Chunked);
-      body_reader
-        .read_to_end(&mut binary)
-        .map_err(response_body_read_error)?;
+      read_response_body_to_end(&mut body_reader, &mut binary, max_body_bytes)?;
       trailers = body_reader.trailers().clone();
     }
     ResponseBodyKind::ContentLength(content_length) => {
       let mut body_reader =
         ResponseBodyReader::new(reader, ResponseBodyKind::ContentLength(content_length));
-      body_reader
-        .read_to_end(&mut binary)
-        .map_err(response_body_read_error)?;
+      read_response_body_to_end(&mut body_reader, &mut binary, max_body_bytes)?;
     }
     ResponseBodyKind::UntilEof => {
-      reader.read_to_end(&mut binary).map_err(error::request)?;
+      read_response_body_to_end(reader, &mut binary, max_body_bytes)?;
     }
   }
   Ok(ResponseParts {
@@ -347,6 +386,33 @@ where
     connection_reusable,
     close_connection,
   })
+}
+
+fn read_response_body_to_end<R>(
+  reader: &mut R,
+  binary: &mut Vec<u8>,
+  max_body_bytes: usize,
+) -> error::Result<usize>
+where
+  R: Read + ?Sized,
+{
+  let start = binary.len();
+  let mut buffer = [0u8; 8 * 1024];
+  loop {
+    let body_len = binary.len() - start;
+    let remaining = max_body_bytes - body_len;
+    let read_limit = buffer.len().min(remaining.saturating_add(1));
+    let read = reader
+      .read(&mut buffer[..read_limit])
+      .map_err(response_body_read_error)?;
+    if read == 0 {
+      return Ok(body_len);
+    }
+    if read > remaining {
+      return Err(error::body_too_large(max_body_bytes));
+    }
+    binary.extend_from_slice(&buffer[..read]);
+  }
 }
 
 pub(crate) fn response_connection_reusable(

--- a/crates/rttp-client/src/error.rs
+++ b/crates/rttp-client/src/error.rs
@@ -62,6 +62,19 @@ impl Error {
     self.source().map(|e| e.is::<TimedOut>()).unwrap_or(false)
   }
 
+  /// Returns true if a buffered response body exceeded its configured limit.
+  pub fn is_body_too_large(&self) -> bool {
+    matches!(self.inner.kind, Kind::BodyTooLarge { .. })
+  }
+
+  /// Returns the configured response body limit for a body-too-large error.
+  pub fn body_limit(&self) -> Option<usize> {
+    match self.inner.kind {
+      Kind::BodyTooLarge { limit } => Some(limit),
+      _ => None,
+    }
+  }
+
   /// Returns the status code, if the error was generated from a response.
   pub fn status(&self) -> Option<StatusCode> {
     match self.inner.kind {
@@ -120,6 +133,7 @@ impl fmt::Display for Error {
       Kind::Response => f.write_str("error receive response")?,
       Kind::Body => f.write_str("request or response body error")?,
       Kind::Decode => f.write_str("error decoding response body")?,
+      Kind::BodyTooLarge { limit } => write!(f, "buffered response body exceeded {} bytes", limit)?,
       Kind::Redirect => f.write_str("error following redirect")?,
       Kind::Status(ref code) => {
         let prefix = if code.is_client_error() {
@@ -172,6 +186,7 @@ pub(crate) enum Kind {
   Status(StatusCode),
   Body,
   Decode,
+  BodyTooLarge { limit: usize },
 }
 
 // constructors
@@ -186,6 +201,10 @@ pub(crate) fn body<E: Into<BoxError>>(e: E) -> Error {
 
 pub(crate) fn decode<E: Into<BoxError>>(e: E) -> Error {
   Error::new(Kind::Decode, Some(e))
+}
+
+pub(crate) fn body_too_large(limit: usize) -> Error {
+  Error::new(Kind::BodyTooLarge { limit }, None::<Error>)
 }
 
 pub(crate) fn request<E: Into<BoxError>>(e: E) -> Error {

--- a/crates/rttp-client/src/http2.rs
+++ b/crates/rttp-client/src/http2.rs
@@ -561,6 +561,7 @@ struct LocalSettings {
   max_frame_size: usize,
   max_frame_size_configured: bool,
   enable_connect_protocol: bool,
+  max_buffered_response_body_bytes: usize,
 }
 
 impl LocalSettings {
@@ -584,6 +585,7 @@ impl LocalSettings {
       max_frame_size,
       max_frame_size_configured: configured_max_frame_size.is_some(),
       enable_connect_protocol,
+      max_buffered_response_body_bytes: config.max_buffered_response_body_bytes(),
     })
   }
 
@@ -1578,6 +1580,15 @@ fn read_single_stream_response_with_first_frame(
         let data = data_payload(&frame)?;
         response_body_started = true;
         if include_data_payload {
+          if data.len()
+            > local_settings
+              .max_buffered_response_body_bytes
+              .saturating_sub(body.len())
+          {
+            return Err(error::body_too_large(
+              local_settings.max_buffered_response_body_bytes,
+            ));
+          }
           body.extend_from_slice(data);
         }
         let stream_update = stream_receive_window.consume(frame.payload.len())?;
@@ -1656,7 +1667,14 @@ fn read_single_stream_response_with_first_frame(
   }
 
   let status = status.ok_or_else(|| error::bad_response("missing HTTP/2 :status header"))?;
-  build_response(url, status, &headers, body, trailers)
+  build_response(
+    url,
+    status,
+    &headers,
+    body,
+    trailers,
+    local_settings.max_buffered_response_body_bytes,
+  )
 }
 
 struct ReceiveWindow {
@@ -1972,6 +1990,7 @@ fn build_response(
   headers: &[(String, String)],
   body: Vec<u8>,
   trailers: Vec<Header>,
+  max_body_bytes: usize,
 ) -> error::Result<Response> {
   let mut binary = format!("HTTP/2 {}\r\n", status).into_bytes();
   for (name, value) in headers {
@@ -1982,7 +2001,7 @@ fn build_response(
   }
   binary.extend_from_slice(b"\r\n");
   binary.extend_from_slice(&body);
-  Response::with_trailers(url, binary, trailers)
+  Response::with_trailers_and_limit(url, binary, trailers, max_body_bytes)
 }
 
 struct Frame {

--- a/crates/rttp-client/src/response/raw_response.rs
+++ b/crates/rttp-client/src/response/raw_response.rs
@@ -1,6 +1,7 @@
 use std::fmt;
 use std::io::Read;
 
+use crate::config::DEFAULT_MAX_BUFFERED_RESPONSE_BODY_BYTES;
 use crate::error;
 use crate::response::ResponseBody;
 use crate::types::{Cookie, Header, RoUrl, ToUrl};
@@ -24,13 +25,19 @@ pub struct RawResponse {
 
 impl RawResponse {
   pub fn new(url: RoUrl, binary: Vec<u8>) -> error::Result<Self> {
-    Self::with_trailers(url, binary, Vec::new())
+    Self::with_trailers_and_limit(
+      url,
+      binary,
+      Vec::new(),
+      DEFAULT_MAX_BUFFERED_RESPONSE_BODY_BYTES,
+    )
   }
 
-  pub(crate) fn with_trailers(
+  pub(crate) fn with_trailers_and_limit(
     url: RoUrl,
     binary: Vec<u8>,
     trailers: Vec<Header>,
+    max_body_bytes: usize,
   ) -> error::Result<Self> {
     let _url = url.to_url().map_err(error::builder)?;
     let mut response = RawResponse {
@@ -44,7 +51,7 @@ impl RawResponse {
       cookies: vec![],
       body: ResponseBody::new(vec![]),
     };
-    Parser::new(binary).parse(&mut response)?;
+    Parser::new(binary, max_body_bytes).parse(&mut response)?;
     Ok(response)
   }
 
@@ -143,11 +150,15 @@ impl fmt::Display for RawResponse {
 
 struct Parser {
   binary: Vec<u8>,
+  max_body_bytes: usize,
 }
 
 impl Parser {
-  pub fn new(binary: Vec<u8>) -> Self {
-    Self { binary }
+  pub fn new(binary: Vec<u8>, max_body_bytes: usize) -> Self {
+    Self {
+      binary,
+      max_body_bytes,
+    }
   }
 
   pub fn parse(self, response: &mut RawResponse) -> error::Result<()> {
@@ -171,6 +182,9 @@ impl Parser {
     }
     let header = &self.binary[..position];
     let body = self.binary[position + 4..].to_owned();
+    if body.len() > self.max_body_bytes {
+      return Err(error::body_too_large(self.max_body_bytes));
+    }
 
     self.parse_header(response, header)?;
     self.parse_body(response, body)?;
@@ -248,7 +262,7 @@ impl Parser {
     if has_single_gzip_content_encoding(response.headers_get()) {
       let mut decoder = flate2::read::GzDecoder::new(binary.as_slice());
       let mut buffer = Vec::new();
-      decoder.read_to_end(&mut buffer).map_err(error::decode)?;
+      read_decoded_body_to_end(&mut decoder, &mut buffer, self.max_body_bytes)?;
       let body = ResponseBody::new(buffer);
       response.body(body);
       return Ok(());
@@ -257,6 +271,28 @@ impl Parser {
     let body = ResponseBody::new(binary);
     response.body(body);
     Ok(())
+  }
+}
+
+fn read_decoded_body_to_end<R: Read>(
+  reader: &mut R,
+  body: &mut Vec<u8>,
+  max_body_bytes: usize,
+) -> error::Result<()> {
+  let mut buffer = [0u8; 8 * 1024];
+  loop {
+    let remaining = max_body_bytes - body.len();
+    let read_limit = buffer.len().min(remaining.saturating_add(1));
+    let read = reader
+      .read(&mut buffer[..read_limit])
+      .map_err(error::decode)?;
+    if read == 0 {
+      return Ok(());
+    }
+    if read > remaining {
+      return Err(error::body_too_large(max_body_bytes));
+    }
+    body.extend_from_slice(&buffer[..read]);
   }
 }
 

--- a/crates/rttp-client/src/response/response.rs
+++ b/crates/rttp-client/src/response/response.rs
@@ -78,14 +78,45 @@ impl Response {
     Self::with_trailers_and_informational(url, binary, trailers, Vec::new())
   }
 
+  pub(crate) fn with_trailers_and_limit(
+    url: RoUrl,
+    binary: Vec<u8>,
+    trailers: Vec<Header>,
+    max_body_bytes: usize,
+  ) -> error::Result<Self> {
+    Self::with_trailers_and_informational_and_limit(
+      url,
+      binary,
+      trailers,
+      Vec::new(),
+      max_body_bytes,
+    )
+  }
+
   pub(crate) fn with_trailers_and_informational(
     url: RoUrl,
     binary: Vec<u8>,
     trailers: Vec<Header>,
     informational_responses: Vec<InformationalResponse>,
   ) -> error::Result<Self> {
+    Self::with_trailers_and_informational_and_limit(
+      url,
+      binary,
+      trailers,
+      informational_responses,
+      crate::config::DEFAULT_MAX_BUFFERED_RESPONSE_BODY_BYTES,
+    )
+  }
+
+  pub(crate) fn with_trailers_and_informational_and_limit(
+    url: RoUrl,
+    binary: Vec<u8>,
+    trailers: Vec<Header>,
+    informational_responses: Vec<InformationalResponse>,
+    max_body_bytes: usize,
+  ) -> error::Result<Self> {
     Ok(Self {
-      raw: RawResponse::with_trailers(url, binary, trailers)?,
+      raw: RawResponse::with_trailers_and_limit(url, binary, trailers, max_body_bytes)?,
       informational_responses,
     })
   }

--- a/crates/rttp-client/tests/http2_prior_knowledge.rs
+++ b/crates/rttp-client/tests/http2_prior_knowledge.rs
@@ -4865,6 +4865,32 @@ fn spawn_h2_prior_knowledge_peer_with_response(
   (addr, handle)
 }
 
+#[test]
+fn prior_knowledge_buffered_response_enforces_exact_body_limit() {
+  for (body, should_succeed) in [(b"12345".as_slice(), true), (b"123456".as_slice(), false)] {
+    let body: &'static [u8] = Box::leak(body.to_vec().into_boxed_slice());
+    let frames: &'static [&'static [u8]] = Box::leak(vec![body].into_boxed_slice());
+    let (addr, _handle) = spawn_h2_prior_knowledge_peer_with_response(&[0x88], frames);
+    let result = HttpClient::new()
+      .get()
+      .url(format!("http://{addr}/bounded"))
+      .config(
+        Config::builder()
+          .max_buffered_response_body_bytes(5)
+          .build(),
+      )
+      .emit_http2_prior_knowledge();
+
+    if should_succeed {
+      assert_eq!(b"12345", result.unwrap().body().binary());
+    } else {
+      let error = result.unwrap_err();
+      assert!(error.is_body_too_large(), "unexpected error: {error}");
+      assert_eq!(Some(5), error.body_limit());
+    }
+  }
+}
+
 fn spawn_initial_settings_peer(
   flags: u8,
   stream_id: u32,

--- a/crates/rttp-client/tests/test_http_async.rs
+++ b/crates/rttp-client/tests/test_http_async.rs
@@ -5,13 +5,20 @@ use rttp_test_support as support;
 use std::collections::HashMap;
 
 #[cfg(feature = "async")]
+use flate2::write::GzEncoder;
+#[cfg(feature = "async")]
+use flate2::Compression;
+#[cfg(feature = "async")]
 use futures::executor::block_on;
 #[cfg(feature = "async")]
 use futures::io::{AllowStdIo, AsyncRead, AsyncReadExt, Cursor as AsyncCursor};
 #[cfg(feature = "async")]
 use rttp_client::types::Proxy;
 #[cfg(feature = "async")]
-use rttp_client::{async_streaming_response_after_header, Config, HttpClient};
+use rttp_client::{
+  async_streaming_response_after_header, Config, HttpClient,
+  DEFAULT_MAX_BUFFERED_RESPONSE_BODY_BYTES,
+};
 #[cfg(feature = "async")]
 use std::io::{Cursor, Read, Write};
 #[cfg(feature = "async")]
@@ -22,6 +29,19 @@ use std::thread;
 #[cfg(feature = "async")]
 fn client() -> HttpClient {
   HttpClient::new()
+}
+
+#[cfg(feature = "async")]
+fn buffered_response_config(limit: usize) -> Config {
+  Config::builder()
+    .max_buffered_response_body_bytes(limit)
+    .build()
+}
+
+#[cfg(feature = "async")]
+fn assert_body_too_large(error: rttp_client::error::Error, limit: usize) {
+  assert!(error.is_body_too_large(), "unexpected error: {error}");
+  assert_eq!(Some(limit), error.body_limit());
 }
 
 #[cfg(feature = "async")]
@@ -108,6 +128,125 @@ fn test_async_http() {
     let response = response.unwrap();
     assert_eq!("127.0.0.1", response.host());
     println!("{}", response);
+  });
+}
+
+#[test]
+#[cfg(feature = "async")]
+fn test_async_buffered_content_length_response_enforces_exact_body_limit() {
+  block_on(async {
+    for (body, should_succeed) in [(b"12345".as_slice(), true), (b"123456".as_slice(), false)] {
+      let mut response = format!(
+        "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+        body.len()
+      )
+      .into_bytes();
+      response.extend_from_slice(body);
+      let (addr, _handle) = support::spawn_chunked_response_server(response);
+      let result = client()
+        .url(format!("http://{addr}/fixed"))
+        .config(buffered_response_config(5))
+        .rasync()
+        .await;
+
+      if should_succeed {
+        assert_eq!(b"12345", result.unwrap().body().binary());
+      } else {
+        assert_body_too_large(result.unwrap_err(), 5);
+      }
+    }
+  });
+}
+
+#[test]
+#[cfg(feature = "async")]
+fn test_async_buffered_chunked_response_enforces_exact_body_limit() {
+  block_on(async {
+    for (chunk, should_succeed) in [("5\r\n12345\r\n", true), ("6\r\n123456\r\n", false)] {
+      let response = format!(
+        "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\nConnection: close\r\n\r\n{chunk}0\r\n\r\n"
+      );
+      let (addr, _handle) = support::spawn_chunked_response_server(response);
+      let result = client()
+        .url(format!("http://{addr}/chunked"))
+        .config(buffered_response_config(5))
+        .rasync()
+        .await;
+
+      if should_succeed {
+        assert_eq!(b"12345", result.unwrap().body().binary());
+      } else {
+        assert_body_too_large(result.unwrap_err(), 5);
+      }
+    }
+  });
+}
+
+#[test]
+#[cfg(feature = "async")]
+fn test_async_buffered_eof_delimited_response_enforces_exact_body_limit() {
+  block_on(async {
+    for (body, should_succeed) in [("12345", true), ("123456", false)] {
+      let response = format!("HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n{body}");
+      let (addr, _handle) = support::spawn_chunked_response_server(response);
+      let result = client()
+        .url(format!("http://{addr}/eof"))
+        .config(buffered_response_config(5))
+        .rasync()
+        .await;
+
+      if should_succeed {
+        assert_eq!(b"12345", result.unwrap().body().binary());
+      } else {
+        assert_body_too_large(result.unwrap_err(), 5);
+      }
+    }
+  });
+}
+
+#[test]
+#[cfg(feature = "async")]
+fn test_async_buffered_gzip_response_limits_decoded_body() {
+  let decoded = vec![b'a'; 256];
+  let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+  encoder.write_all(&decoded).unwrap();
+  let compressed = encoder.finish().unwrap();
+  assert!(compressed.len() <= 64);
+  let mut response = format!(
+    "HTTP/1.1 200 OK\r\nContent-Encoding: gzip\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+    compressed.len()
+  )
+  .into_bytes();
+  response.extend_from_slice(&compressed);
+  let (addr, _handle) = support::spawn_chunked_response_server(response);
+
+  block_on(async {
+    let error = client()
+      .url(format!("http://{addr}/gzip"))
+      .config(buffered_response_config(64))
+      .rasync()
+      .await
+      .unwrap_err();
+
+    assert_body_too_large(error, 64);
+  });
+}
+
+#[test]
+#[cfg(feature = "async")]
+fn test_async_streaming_response_can_read_body_larger_than_buffered_limit() {
+  block_on(async {
+    let body_len = DEFAULT_MAX_BUFFERED_RESPONSE_BODY_BYTES + 1;
+    let head = format!("HTTP/1.1 200 OK\r\nContent-Length: {body_len}\r\n\r\n").into_bytes();
+    let mut stream = AllowStdIo::new(Cursor::new(vec![b'x'; body_len]));
+    let mut response = async_streaming_response_after_header(&mut stream, false, head)
+      .await
+      .unwrap();
+    let mut body = Vec::new();
+
+    response.body_mut().read_to_end(&mut body).await.unwrap();
+
+    assert_eq!(body_len, body.len());
   });
 }
 

--- a/crates/rttp-client/tests/test_http_basic.rs
+++ b/crates/rttp-client/tests/test_http_basic.rs
@@ -7,12 +7,25 @@ use std::net::TcpListener;
 use std::thread;
 use std::time::Duration;
 
+use flate2::write::GzEncoder;
+use flate2::Compression;
 use rttp_client::types::{Auth, Para, Proxy, RoUrl};
 use rttp_client::ConnectionReader;
-use rttp_client::{Config, HttpClient};
+use rttp_client::{Config, HttpClient, DEFAULT_MAX_BUFFERED_RESPONSE_BODY_BYTES};
 
 fn client() -> HttpClient {
   HttpClient::new()
+}
+
+fn buffered_response_config(limit: usize) -> Config {
+  Config::builder()
+    .max_buffered_response_body_bytes(limit)
+    .build()
+}
+
+fn assert_body_too_large(error: rttp_client::error::Error, limit: usize) {
+  assert!(error.is_body_too_large(), "unexpected error: {error}");
+  assert_eq!(Some(limit), error.body_limit());
 }
 
 fn spawn_streaming_upload_capture_server() -> (std::net::SocketAddr, thread::JoinHandle<Vec<u8>>) {
@@ -228,6 +241,107 @@ fn test_gzip() {
     .header(("Accept-Encoding", "gzip, deflate"))
     .emit();
   assert!(response.is_ok());
+}
+
+#[test]
+fn test_buffered_content_length_response_enforces_exact_body_limit() {
+  for (body, should_succeed) in [(b"12345".as_slice(), true), (b"123456".as_slice(), false)] {
+    let mut response = format!(
+      "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+      body.len()
+    )
+    .into_bytes();
+    response.extend_from_slice(body);
+    let (addr, _handle) = support::spawn_chunked_response_server(response);
+    let result = client()
+      .url(format!("http://{addr}/fixed"))
+      .config(buffered_response_config(5))
+      .emit();
+
+    if should_succeed {
+      assert_eq!(b"12345", result.unwrap().body().binary());
+    } else {
+      assert_body_too_large(result.unwrap_err(), 5);
+    }
+  }
+}
+
+#[test]
+fn test_buffered_chunked_response_enforces_exact_body_limit() {
+  for (chunk, should_succeed) in [("5\r\n12345\r\n", true), ("6\r\n123456\r\n", false)] {
+    let response = format!(
+      "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\nConnection: close\r\n\r\n{chunk}0\r\n\r\n"
+    );
+    let (addr, _handle) = support::spawn_chunked_response_server(response);
+    let result = client()
+      .url(format!("http://{addr}/chunked"))
+      .config(buffered_response_config(5))
+      .emit();
+
+    if should_succeed {
+      assert_eq!(b"12345", result.unwrap().body().binary());
+    } else {
+      assert_body_too_large(result.unwrap_err(), 5);
+    }
+  }
+}
+
+#[test]
+fn test_buffered_eof_delimited_response_enforces_exact_body_limit() {
+  for (body, should_succeed) in [("12345", true), ("123456", false)] {
+    let response = format!("HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n{body}");
+    let (addr, _handle) = support::spawn_chunked_response_server(response);
+    let result = client()
+      .url(format!("http://{addr}/eof"))
+      .config(buffered_response_config(5))
+      .emit();
+
+    if should_succeed {
+      assert_eq!(b"12345", result.unwrap().body().binary());
+    } else {
+      assert_body_too_large(result.unwrap_err(), 5);
+    }
+  }
+}
+
+#[test]
+fn test_buffered_gzip_response_limits_decoded_body() {
+  let decoded = vec![b'a'; 256];
+  let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+  encoder.write_all(&decoded).unwrap();
+  let compressed = encoder.finish().unwrap();
+  assert!(compressed.len() <= 64);
+  let mut response = format!(
+    "HTTP/1.1 200 OK\r\nContent-Encoding: gzip\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+    compressed.len()
+  )
+  .into_bytes();
+  response.extend_from_slice(&compressed);
+  let (addr, _handle) = support::spawn_chunked_response_server(response);
+
+  let error = client()
+    .url(format!("http://{addr}/gzip"))
+    .config(buffered_response_config(64))
+    .emit()
+    .unwrap_err();
+
+  assert_body_too_large(error, 64);
+}
+
+#[test]
+fn test_streaming_response_can_read_body_larger_than_buffered_limit() {
+  let body_len = DEFAULT_MAX_BUFFERED_RESPONSE_BODY_BYTES + 1;
+  let mut raw = format!("HTTP/1.1 200 OK\r\nContent-Length: {body_len}\r\n\r\n").into_bytes();
+  raw.resize(raw.len() + body_len, b'x');
+  let mut cursor = Cursor::new(raw);
+  let url = url::Url::parse("http://localhost/stream").unwrap();
+  let mut reader = ConnectionReader::new(&url, &mut cursor, false);
+  let mut response = reader.streaming_response().unwrap();
+  let mut body = Vec::new();
+
+  response.body_mut().read_to_end(&mut body).unwrap();
+
+  assert_eq!(body_len, body.len());
 }
 
 #[test]


### PR DESCRIPTION
Add configurable bounds for buffered and gzip-decoded client response bodies across sync, async, and HTTP/2 paths while preserving unrestricted streaming readers for larger payloads.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1836/
work_kind: code_work
branch: hbx-1836-rttp-bound-buffered-and-decoded
base: main
commit: 083084688c0efbd8044dd7ecbb4586c8bd717c59
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1836/
    url: https://plane.kahub.in/endless/browse/HBX-1836/
    close_policy: link_only
```