### PR TITLE
feat: RTTP: Reject invalid outbound HTTP header names and values

### DIFF
--- a/crates/rttp-client/src/connection/async_connection.rs
+++ b/crates/rttp-client/src/connection/async_connection.rs
@@ -654,7 +654,7 @@ fn parse_trailer_line(line: &[u8]) -> error::Result<Header> {
     .ok_or_else(|| error::bad_response("Invalid trailer header"))?;
   validate_response_trailer_header(name, value)?;
 
-  Ok(Header::new(name, value))
+  Ok(Header::from_http1(name, value))
 }
 
 // connection send

--- a/crates/rttp-client/src/connection/connection_reader.rs
+++ b/crates/rttp-client/src/connection/connection_reader.rs
@@ -743,7 +743,7 @@ fn parse_trailer_line(line: &[u8]) -> error::Result<Header> {
     .ok_or_else(|| error::bad_response("Invalid trailer header"))?;
   validate_response_trailer_header(name, value)?;
 
-  Ok(Header::new(name, value))
+  Ok(Header::from_http1(name, value))
 }
 
 fn to_io_error(err: error::Error) -> io::Error {

--- a/crates/rttp-client/src/request/builder/build_header.rs
+++ b/crates/rttp-client/src/request/builder/build_header.rs
@@ -33,7 +33,7 @@ impl<'a> RawBuilder<'a> {
 
     for header in self.request.headers() {
       let name = header.name();
-      let value = header.value().replace(DISPOSITION_END, "");
+      let value = header.value();
 
       builder.push_str(&format!("{}: {}{}", name, value, DISPOSITION_END));
     }

--- a/crates/rttp-client/src/request/builder/common.rs
+++ b/crates/rttp-client/src/request/builder/common.rs
@@ -39,6 +39,7 @@ impl<'a> RawBuilder<'a> {
 
 impl<'a> RawBuilder<'a> {
   pub fn raw_request_block(mut self) -> error::Result<RawRequest<'a>> {
+    self.validate_outbound_headers()?;
     let mut rourl = self.request.url().clone().ok_or(error::none_url())?;
     if rourl.traditional_get().is_none() {
       rourl.traditional(self.request.traditional());
@@ -58,6 +59,7 @@ impl<'a> RawBuilder<'a> {
 
   #[cfg(feature = "async")]
   pub async fn raw_request_async(mut self) -> error::Result<RawRequest<'a>> {
+    self.validate_outbound_headers()?;
     let mut rourl = self.request.url().clone().ok_or(error::none_url())?;
     if rourl.traditional_get().is_none() {
       rourl.traditional(self.request.traditional());
@@ -73,5 +75,12 @@ impl<'a> RawBuilder<'a> {
       header,
       body,
     })
+  }
+
+  fn validate_outbound_headers(&self) -> error::Result<()> {
+    for header in self.request.headers().iter().chain(self.request.trailers()) {
+      header.validate_outbound()?;
+    }
+    Ok(())
   }
 }

--- a/crates/rttp-client/src/types/header.rs
+++ b/crates/rttp-client/src/types/header.rs
@@ -1,5 +1,7 @@
 use std::collections::HashMap;
 
+use crate::error;
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Header {
   name: String,
@@ -14,9 +16,23 @@ pub trait IntoHeader {
 impl Header {
   pub fn new<N: AsRef<str>, V: AsRef<str>>(name: N, value: V) -> Self {
     Self {
-      name: name.as_ref().trim().into(),
-      value: value.as_ref().trim().into(),
+      name: name.as_ref().into(),
+      value: value.as_ref().into(),
     }
+  }
+
+  pub(crate) fn validate_outbound(&self) -> error::Result<()> {
+    if !is_http_token(&self.name) {
+      return Err(error::builder_with_message(
+        "Invalid outbound HTTP header name",
+      ));
+    }
+    if !self.value.bytes().all(is_header_value_byte) {
+      return Err(error::builder_with_message(
+        "Invalid outbound HTTP header value",
+      ));
+    }
+    Ok(())
   }
 
   pub(crate) fn from_http1<N: AsRef<str>, V: AsRef<str>>(name: N, value: V) -> Self {
@@ -51,27 +67,11 @@ impl Header {
 
 impl IntoHeader for &str {
   fn into_headers(&self) -> Vec<Header> {
-    self
-      .split("\n")
-      .collect::<Vec<&str>>()
-      .iter()
-      .map(|part: &&str| {
-        let pvs: Vec<&str> = part.split(":").collect::<Vec<&str>>();
-        let name = pvs.first();
-        let value = pvs
-          .iter()
-          .enumerate()
-          .filter(|(ix, _)| *ix > 0)
-          .map(|(_, v)| v.to_string())
-          .collect::<Vec<String>>()
-          .join(":");
-        Header::new(
-          name.map_or("".to_string(), |v| v.to_string()).trim(),
-          value.trim(),
-        )
-      })
-      .filter(|header: &Header| !header.name.is_empty())
-      .collect::<Vec<Header>>()
+    let header = self.split_once(':').map_or_else(
+      || Header::new(*self, ""),
+      |(name, value)| Header::new(name, value.trim_matches([' ', '\t'])),
+    );
+    vec![header]
   }
 }
 
@@ -185,3 +185,32 @@ tuple_to_header! { a b c d e f g h i j k l m n o p q r s t u v w }
 tuple_to_header! { a b c d e f g h i j k l m n o p q r s t u v w x }
 tuple_to_header! { a b c d e f g h i j k l m n o p q r s t u v w x y }
 tuple_to_header! { a b c d e f g h i j k l m n o p q r s t u v w x y z }
+
+fn is_http_token(value: &str) -> bool {
+  !value.is_empty()
+    && value.bytes().all(|byte| {
+      byte.is_ascii_alphanumeric()
+        || matches!(
+          byte,
+          b'!'
+            | b'#'
+            | b'$'
+            | b'%'
+            | b'&'
+            | b'\''
+            | b'*'
+            | b'+'
+            | b'-'
+            | b'.'
+            | b'^'
+            | b'_'
+            | b'`'
+            | b'|'
+            | b'~'
+        )
+    })
+}
+
+fn is_header_value_byte(byte: u8) -> bool {
+  byte == b'\t' || byte == b' ' || (0x21..=0x7e).contains(&byte) || byte >= 0x80
+}

--- a/crates/rttp-client/tests/http2_prior_knowledge.rs
+++ b/crates/rttp-client/tests/http2_prior_knowledge.rs
@@ -609,7 +609,7 @@ fn prior_knowledge_extended_connect_protocol_is_rejected_before_connecting() {
   assert!(
     err
       .to_string()
-      .contains("HTTP/2 prior-knowledge CONNECT or extended CONNECT is unsupported"),
+      .contains("Invalid outbound HTTP header name"),
     "unexpected error: {err}"
   );
   assert!(

--- a/crates/rttp-client/tests/test_raw_request_capture.rs
+++ b/crates/rttp-client/tests/test_raw_request_capture.rs
@@ -2,7 +2,7 @@ use rttp_test_support as support;
 
 #[cfg(feature = "async")]
 use futures::executor::block_on;
-use rttp_client::types::Proxy;
+use rttp_client::types::{Header, Proxy};
 use rttp_client::HttpClient;
 use std::io::{Read, Write};
 use std::net::{SocketAddr, TcpListener, TcpStream};
@@ -53,6 +53,145 @@ fn request_body(request: &[u8]) -> &[u8] {
     .map(|position| position + 4)
     .expect("request should contain header terminator");
   &request[body_start..]
+}
+
+#[test]
+fn outbound_headers_reject_invalid_names_and_values_before_connecting() {
+  let invalid_headers = [
+    Header::new("X Request", "safe"),
+    Header::new("X:Request", "safe"),
+    Header::new(" X-Request", "safe"),
+    Header::new("X-Request", "safe\r\ninjected"),
+    Header::new("X-Request", "safe\r"),
+    Header::new("X-Request", "safe\n"),
+    Header::new("X-Request", "safe\0value"),
+    Header::new("X-Request", "safe\u{1}value"),
+    Header::new("X-Request", "safe\u{b}value"),
+    Header::new("X-Request", "safe\u{1f}value"),
+    Header::new("X-Request", "safe\u{7f}value"),
+  ];
+
+  for header in invalid_headers {
+    let request = capture_optional_request(|base_url| {
+      let error = client()
+        .get()
+        .url(format!("{}/invalid-header", base_url))
+        .header(header)
+        .emit()
+        .expect_err("invalid outbound header must be rejected");
+      assert!(error.is_builder());
+    });
+    assert!(request.is_empty(), "invalid header must not open a socket");
+  }
+}
+
+#[test]
+fn outbound_header_convenience_apis_reject_line_breaks_before_connecting() {
+  let tuple_request = capture_optional_request(|base_url| {
+    let error = client()
+      .get()
+      .url(format!("{}/invalid-tuple-header", base_url))
+      .header(("X-Request", "safe\nvalue"))
+      .emit()
+      .expect_err("tuple header with a line break must be rejected");
+    assert!(error.is_builder());
+  });
+  assert!(tuple_request.is_empty());
+
+  let raw_request = capture_optional_request(|base_url| {
+    let error = client()
+      .get()
+      .url(format!("{}/invalid-raw-header", base_url))
+      .header("X-Request: safe\nInjected: value")
+      .emit()
+      .expect_err("raw header with a line break must be rejected");
+    assert!(error.is_builder());
+  });
+  assert!(raw_request.is_empty());
+
+  let empty_name_request = capture_optional_request(|base_url| {
+    let error = client()
+      .get()
+      .url(format!("{}/empty-raw-header-name", base_url))
+      .header(": safe")
+      .emit()
+      .expect_err("raw header with an empty name must be rejected");
+    assert!(error.is_builder());
+  });
+  assert!(empty_name_request.is_empty());
+}
+
+#[test]
+fn outbound_headers_preserve_permitted_visible_bytes_and_horizontal_tabs() {
+  let mut visible_value = (0x20..=0x7e).collect::<Vec<u8>>();
+  visible_value.extend_from_slice("\tobsé".as_bytes());
+  let visible_value = String::from_utf8(visible_value).expect("valid UTF-8 header value");
+
+  let request = capture_request(|base_url| {
+    client()
+      .get()
+      .url(format!("{}/valid-header", base_url))
+      .header(Header::new("X-Token!#$%&'*+-.^_`|~", &visible_value))
+      .header(Header::new("X-Tab", "\tinside\t"))
+      .emit()
+      .expect("valid outbound headers should be sent");
+  });
+
+  let visible_header = format!("X-Token!#$%&'*+-.^_`|~: {visible_value}\r\n");
+  assert!(request
+    .windows(visible_header.len())
+    .any(|window| window == visible_header.as_bytes()));
+  assert!(request
+    .windows(b"X-Tab: \tinside\t\r\n".len())
+    .any(|window| window == b"X-Tab: \tinside\t\r\n"));
+}
+
+#[test]
+fn outbound_trailers_reject_untrimmed_invalid_bytes() {
+  for trailer in [
+    Header::new(" X-Trace", "safe"),
+    Header::new("X-Trace", "safe\r"),
+    Header::new("X-Trace", "safe\n"),
+    Header::new("X-Trace", "safe\0value"),
+  ] {
+    let mut client = client();
+    let error = client
+      .trailer(trailer)
+      .expect_err("invalid outbound trailer must be rejected");
+    assert!(error.is_builder());
+  }
+}
+
+#[cfg(feature = "async")]
+#[test]
+fn async_outbound_headers_are_rejected_before_connecting() {
+  let request = capture_optional_request(|base_url| {
+    let error = block_on(
+      client()
+        .get()
+        .url(format!("{}/invalid-async-header", base_url))
+        .header(("X-Request", "safe\rvalue"))
+        .rasync(),
+    )
+    .expect_err("invalid async outbound header must be rejected");
+    assert!(error.is_builder());
+  });
+  assert!(request.is_empty());
+}
+
+#[cfg(feature = "http2")]
+#[test]
+fn http2_outbound_headers_are_rejected_before_connecting() {
+  let request = capture_optional_request(|base_url| {
+    let error = client()
+      .get()
+      .url(format!("{}/invalid-http2-header", base_url))
+      .header(("X-Request", "safe\u{7f}value"))
+      .emit_http2_prior_knowledge()
+      .expect_err("invalid HTTP/2 outbound header must be rejected");
+    assert!(error.is_builder());
+  });
+  assert!(request.is_empty());
 }
 
 fn read_request_head(stream: &mut TcpStream) -> Vec<u8> {


### PR DESCRIPTION
Reject invalid outbound HTTP header names and values before network connection across all supported request paths, with regression coverage for unsafe controls and permitted field bytes.

## Metadata
```yaml
version: 1
issue: https://plane.kahub.in/endless/browse/HBX-1840/
work_kind: code_work
branch: hbx-1840-rttp-reject-invalid-outbound-http-retry-default-2bb10252-67ea-4a44-a725-24fe2ae12692-attempt-1
base: main
commit: 10f5deabe8402d3753c619804681d0d347c37e4c
source_references:
  - kind: plane_issue
    canonical: https://plane.kahub.in/endless/browse/HBX-1840/
    url: https://plane.kahub.in/endless/browse/HBX-1840/
    close_policy: link_only
```